### PR TITLE
Add reveal component proposal

### DIFF
--- a/docs/proposals/reveal/README.md
+++ b/docs/proposals/reveal/README.md
@@ -29,7 +29,7 @@ render() {
       <button onClick={this.toggleExpanded}>{buttonText}</button>
     </Card>
   )
-}code
+}
 ```
 
 ```jsx


### PR DESCRIPTION
# What's in this PR?
A proposal for a new `Reveal` component. 

A continuation of this issue #8 

## Proposed SG1 Classes
_This will be reviewed on its own, just want to show the interface_
```css
/* -------------------------------------------------------------------------
   Reveal
   ------------------------------------------------------------------------- */
.reveal {
 //...
}

.reveal:after {
  //...
}

/* -------------------------------------------------------------------------
   Expanded State
   ------------------------------------------------------------------------- */
.reveal--expanded {
  //...
}

.reveal--expanded:after {
  //...
}
```
## An example use case:
<img width="947" alt="screen shot 2018-10-22 at 2 16 15 pm" src="https://user-images.githubusercontent.com/779421/47316745-10cf4600-d605-11e8-8f64-798b5e56e9e7.png">
We need to make it clear theres more information being collected, but also not show you it because your primary goal on the page is to customize your form.