### PR TITLE
Add workflow step to deploy docs to s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       - *sum_lockfiles
       - *restore_npm_cache
       - *npm_install
-      - run: npm run build
+      - run: npm run build -- --base "/${CIRCLE_PULL_REQUEST##*/}"
       - store_artifacts:
           path: ~/atlantis/.docz/dist
           destination: docs


### PR DESCRIPTION
This is an experiment to deploy our docs to s3 on every pull request.

This is currently deploying to my jobber s3 bucket because we ran out of room to make more buckets (we hit the 200 bucket cap).

The docs get deployed to the latest sha in the PR. i.e. http://jobber-development-crgec.s3-website-us-east-1.amazonaws.com/5088a642daf7a55a012f962b52e7c74ef7c1ad32