### PR TITLE
Fix docs generation on branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ references:
     run:
       name: Generate S3 Path
       command: |
-        echo 'export PULL_REQUEST_NUMBER=${CIRCLE_PULL_REQUEST##*/}' >> $BASH_ENV
+        echo 'export PULL_REQUEST_NUMBER=$(basename "${CIRCLE_PULL_REQUEST}")' >> $BASH_ENV
         echo 'export BASE_PATH=${PULL_REQUEST_NUMBER:-${CIRCLE_BRANCH}}' >> $BASH_ENV
 
 jobs:


### PR DESCRIPTION
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Previously no path would be generated for the output of CI's build if that CI run was not associated with a pull request. This would result in most of the bucket being blown away. Now we default to the PR number but then fallback on the branch name.

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Note in the **Deploy to S3** step here that we are falling back on the branch name.
  - https://circleci.com/gh/GetJobber/atlantis/1184
- Note that this branch has docs present.
  - http://jobber-atlantis.s3-website-us-east-1.amazonaws.com/test-just-a-branch
- Note that the PR number link from Walter is also correct and that the docs are present there.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)