### PR TITLE
Fix Refreshing on Deployed Docs

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -125,6 +125,7 @@ export default {
   ignore: ["./plop/templates/**/*"],
   codeSandbox: false,
   public: "public",
+  hashRouter: true,
   themeConfig,
   htmlContext,
   modifyBundlerConfig,


### PR DESCRIPTION
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Following https://github.com/pedronauck/docz/issues/25 and https://github.com/pedronauck/docz/issues/908 to switch to the hash router for our S3 deploys. This is currently blocked.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
