### PR TITLE
Updating autogenerated test to include an event testing example.

### DIFF
--- a/plop/templates/component/{{name}}.test.tsx
+++ b/plop/templates/component/{{name}}.test.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { {{name}} } from ".";
+
+afterEach(cleanup);
 
 it("renders a {{name}}", () => {
   const tree = renderer.create(<{{name}} text="Foo" />).toJSON();
@@ -10,4 +13,18 @@ it("renders a {{name}}", () => {
 it("renders a loud {{name}}", () => {
   const tree = renderer.create(<{{name}} text="Foo" loud />).toJSON();
   expect(tree).toMatchInlineSnapshot();
+});
+
+test("it should call the handler with the new value", () => {
+  const changeHandler = jest.fn();
+  const newValue = "Bar";
+
+  const { getByLabelText } = render(
+    <{{name}} onChange={changeHandler} placeholder={placeholder} />,
+  );
+
+  fireEvent.change(getByLabelText(placeholder), {
+    target: { value: newValue },
+  });
+  expect(changeHandler).toHaveBeenCalledWith(newValue);
 });


### PR DESCRIPTION
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- New test example in the plop template for testing events.
- Added `afterEach(cleanup)` in the test file since this caught me out early on and it seems to be required for any React testing with the library we're using.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
