### PR TITLE
tabs-should-accept-elements

### DIFF
--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -7,8 +7,13 @@ afterEach(cleanup);
 
 const omelet = (
   <Tabs>
-    <Tab label="Eggs">🍳</Tab>
-    <Tab label="Cheese">🧀</Tab>
+    <Tab label="Eggs">
+      <p>🍳</p>
+      <p>Eggs</p>
+    </Tab>
+    <Tab label="Cheese">
+      <p>🧀</p>
+    </Tab>
   </Tabs>
 );
 

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, cloneElement, useState } from "react";
+import React, { ReactElement, ReactNode, useState } from "react";
 import classnames from "classnames";
 import { Typography } from "../Typography";
 import styles from "./Tabs.css";
@@ -36,7 +36,7 @@ export function Tabs({ children }: TabsProps) {
 
 interface TabProps {
   readonly label: string;
-  readonly children: string;
+  readonly children: ReactNode | ReactNode[];
 }
 
 export function Tab({ label }: TabProps) {

--- a/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -35,7 +35,12 @@ exports[`renders Tabs 1`] = `
   <div
     className="tabContent"
   >
-    🍳
+    <p>
+      🍳
+    </p>
+    <p>
+      Eggs
+    </p>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- `Tabs` component now properly accepts things other than strings.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
