### PR TITLE
Add-Markdown-as-a-component-in-Atlantis

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/components",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -370,6 +370,11 @@
 				"postcss-value-parser": "^3.3.1"
 			}
 		},
+		"bail": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -604,6 +609,21 @@
 				}
 			}
 		},
+		"character-entities": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+		},
+		"character-entities-legacy": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+			"integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+		},
+		"character-reference-invalid": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+			"integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+		},
 		"chokidar": {
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
@@ -679,6 +699,11 @@
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true
+		},
+		"collapse-white-space": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+			"integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ=="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -1213,6 +1238,21 @@
 			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
 			"dev": true
 		},
+		"domhandler": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
+			"integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+			"requires": {
+				"domelementtype": "^2.0.1"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+				}
+			}
+		},
 		"domutils": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
@@ -1351,6 +1391,11 @@
 					}
 				}
 			}
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -2250,6 +2295,59 @@
 			"integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
 			"dev": true
 		},
+		"html-to-react": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.1.tgz",
+			"integrity": "sha512-Ys2gGxF8LBF9bD8tbnsU0xgEDOTC3Sy81mtpIH/61hSqGE1l4QetnN1yv0oAK/PuvwABmiNS+ggqvuzo+GfoiA==",
+			"requires": {
+				"domhandler": "^3.0",
+				"htmlparser2": "^4.0",
+				"lodash.camelcase": "^4.3.0",
+				"ramda": "^0.26"
+			}
+		},
+		"htmlparser2": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.0.0.tgz",
+			"integrity": "sha512-cChwXn5Vam57fyXajDtPXL1wTYc8JtLbr2TN76FYu05itVVVealxLowe2B3IEznJG4p9HAYn/0tJaRlGuEglFQ==",
+			"requires": {
+				"domelementtype": "^2.0.1",
+				"domhandler": "^3.0.0",
+				"domutils": "^2.0.0",
+				"entities": "^2.0.0"
+			},
+			"dependencies": {
+				"dom-serializer": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+					"integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"entities": "^2.0.0"
+					}
+				},
+				"domelementtype": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+				},
+				"domutils": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
+					"integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+					"requires": {
+						"dom-serializer": "^0.2.1",
+						"domelementtype": "^2.0.1",
+						"domhandler": "^3.0.0"
+					}
+				},
+				"entities": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+					"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+				}
+			}
+		},
 		"icss-replace-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
@@ -2309,8 +2407,7 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"invert-kv": {
 			"version": "1.0.0",
@@ -2344,6 +2441,20 @@
 				}
 			}
 		},
+		"is-alphabetical": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+		},
+		"is-alphanumerical": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+			"requires": {
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
+			}
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2362,8 +2473,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
 			"version": "1.1.4",
@@ -2410,6 +2520,11 @@
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 			"dev": true
+		},
+		"is-decimal": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -2463,6 +2578,11 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-hexadecimal": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
+		},
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -2494,6 +2614,11 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -2549,11 +2674,21 @@
 			"integrity": "sha512-WbEGbR5i/vSLJ/cc72kVCoM0RvKWmtmPpRXriNlhsredolym2aSTHZA02IzvDR5ewmwD0V6e9S3s9aHs6Ygw5A==",
 			"dev": true
 		},
+		"is-whitespace-character": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ=="
+		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
+		},
+		"is-word-character": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A=="
 		},
 		"isarray": {
 			"version": "0.0.1",
@@ -2622,8 +2757,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -2730,8 +2864,7 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-			"dev": true
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -2749,7 +2882,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -2792,6 +2924,19 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
+			}
+		},
+		"markdown-escapes": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw=="
+		},
+		"mdast-add-list-metadata": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
+			"integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
+			"requires": {
+				"unist-util-visit-parents": "1.1.2"
 			}
 		},
 		"mdn-data": {
@@ -3001,8 +3146,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -3136,6 +3280,19 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
+		},
+		"parse-entities": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+			"requires": {
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
 		},
 		"parse-json": {
 			"version": "4.0.0",
@@ -3772,7 +3929,6 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -3791,11 +3947,29 @@
 			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
 			"dev": true
 		},
+		"ramda": {
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+			"integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+		},
 		"react-is": {
 			"version": "16.8.6",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-			"dev": true
+			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+		},
+		"react-markdown": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.1.0.tgz",
+			"integrity": "sha512-EOHsEAN+aoP8UVz7vTHx6Z63GJfhrO9KItKlfsiBtVVS9tmSWtUaBTw73+2SObrWiOiE2Cs9qUBL7ORsvVhOrA==",
+			"requires": {
+				"html-to-react": "^1.3.4",
+				"mdast-add-list-metadata": "1.0.1",
+				"prop-types": "^15.7.2",
+				"remark-parse": "^5.0.0",
+				"unified": "^6.1.5",
+				"unist-util-visit": "^1.3.0",
+				"xtend": "^4.0.1"
+			}
 		},
 		"react-test-renderer": {
 			"version": "16.8.6",
@@ -3952,6 +4126,28 @@
 				"jsesc": "~0.5.0"
 			}
 		},
+		"remark-parse": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+			"requires": {
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^1.1.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"trim": "0.0.1",
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^1.0.0",
+				"vfile-location": "^2.0.0",
+				"xtend": "^4.0.1"
+			}
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -3967,8 +4163,12 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"replace-ext": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -4471,6 +4671,11 @@
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
 			"dev": true
 		},
+		"state-toggle": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4697,6 +4902,21 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
+		"trim": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+		},
+		"trim-trailing-lines": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
+		},
+		"trough": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
+		},
 		"ts-node": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.1.0.tgz",
@@ -4823,6 +5043,28 @@
 			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
 			"dev": true
 		},
+		"unherit": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
+			}
+		},
+		"unified": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"requires": {
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^2.0.0",
+				"x-is-string": "^0.1.0"
+			}
+		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -4869,6 +5111,47 @@
 			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
 			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
 			"dev": true
+		},
+		"unist-util-is": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+		},
+		"unist-util-remove-position": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
+			"integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
+			"requires": {
+				"unist-util-visit": "^1.1.0"
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+		},
+		"unist-util-visit": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+			"requires": {
+				"unist-util-visit-parents": "^2.0.0"
+			},
+			"dependencies": {
+				"unist-util-visit-parents": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+					"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+					"requires": {
+						"unist-util-is": "^3.0.0"
+					}
+				}
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
+			"integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
 		},
 		"universalify": {
 			"version": "0.1.2",
@@ -4983,6 +5266,30 @@
 			"integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
 			"dev": true
 		},
+		"vfile": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"requires": {
+				"is-buffer": "^1.1.4",
+				"replace-ext": "1.0.0",
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			}
+		},
+		"vfile-location": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
+			"integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ=="
+		},
+		"vfile-message": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"requires": {
+				"unist-util-stringify-position": "^1.1.1"
+			}
+		},
 		"wait-for-expect": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.2.0.tgz",
@@ -5057,11 +5364,15 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
+		"x-is-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,6 +25,7 @@
     "@types/uuid": "^3.4.5",
     "classnames": "^2.2.6",
     "lodash": "^4.17.15",
+    "react-markdown": "^4.1.0",
     "time-input-polyfill": "^1.0.6",
     "ts-xor": "^1.0.8",
     "uuid": "^3.3.2"

--- a/packages/components/src/Markdown/Markdown.mdx
+++ b/packages/components/src/Markdown/Markdown.mdx
@@ -1,0 +1,41 @@
+---
+name: Markdown
+menu: Components
+route: /components/markdown
+---
+
+import { Playground, Props } from "docz";
+import { ComponentStatus } from "@jobber/docx";
+import { Markdown } from ".";
+
+# Markdown
+
+<ComponentStatus stage="pre" responsive="no" accessible="no" />
+
+Markdown component is a text-to-HTML conversion tool with a twist! Because,
+instead of using semantic HTML tags, it uses our own atlantis component.
+
+In Jobber, Markdown is used to make text styling simpler. You can use this
+component to have italicised and/or bold text. In addition, it allows to set
+heading levels.
+
+## Example
+
+<Playground>
+  {() => {
+    const message = `# This is a level 1 heading
+
+      The _quick_ brown **fox** jumps over the _lazy-ass_ **dog**.
+
+      #### This is the end of this example.
+
+    `
+    return <Markdown text={message} />
+
+}}
+
+</Playground>
+
+# Markdown Properties
+
+<Props of={Markdown} />

--- a/packages/components/src/Markdown/Markdown.test.tsx
+++ b/packages/components/src/Markdown/Markdown.test.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { cleanup } from "@testing-library/react";
+import { Markdown } from ".";
+
+afterEach(cleanup);
+
+it("renders Text Component", () => {
+  const tree = renderer.create(<Markdown text="Paragraph" />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                                <p
+                                  className="base base greyBlueDark"
+                                >
+                                  Paragraph
+                                </p>
+                `);
+});
+
+it("renders Italicized Component", () => {
+  const tree = renderer.create(<Markdown text="_Italicized Foo_" />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                            <p
+                              className="base base greyBlueDark"
+                            >
+                              <em
+                                className="base italic"
+                              >
+                                Italicized Foo
+                              </em>
+                            </p>
+              `);
+});
+
+it("renders Bold Component", () => {
+  const tree = renderer.create(<Markdown text="**Bold Foo**" />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                            <p
+                              className="base base greyBlueDark"
+                            >
+                              <b
+                                className="base bold"
+                              >
+                                Bold Foo
+                              </b>
+                            </p>
+              `);
+});
+
+it("renders Level 1 Heading Component", () => {
+  const tree = renderer.create(<Markdown text="# Heading 1" />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                            <h1
+                              className="base jumbo black uppercase"
+                            >
+                              Heading 1
+                            </h1>
+              `);
+});
+
+it("renders Level 2 Heading Component", () => {
+  const tree = renderer.create(<Markdown text="## Heading 2" />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                            <h2
+                              className="base largest black uppercase"
+                            >
+                              Heading 2
+                            </h2>
+              `);
+});
+
+it("renders Level 3 Heading Component", () => {
+  const tree = renderer.create(<Markdown text="### Heading 3" />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                            <h3
+                              className="base larger bold"
+                            >
+                              Heading 3
+                            </h3>
+              `);
+});
+
+it("renders Level 4 Heading Component", () => {
+  const tree = renderer.create(<Markdown text="#### Heading 4" />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                            <h4
+                              className="base large bold"
+                            >
+                              Heading 4
+                            </h4>
+              `);
+});
+
+it("renders Level 5 Heading Component", () => {
+  const tree = renderer.create(<Markdown text="##### Heading 5" />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                            <h5
+                              className="base base bold"
+                            >
+                              Heading 5
+                            </h5>
+              `);
+});
+
+it("renders Level 6 Heading Component", () => {
+  const tree = renderer.create(<Markdown text="###### Heading " />).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+                            <h6>
+                              Heading
+                            </h6>
+              `);
+});
+
+it("renders a combination of Markdown components", () => {
+  const tree = renderer
+    .create(
+      <Markdown
+        text="# This is a paragraph.
+
+        The paragaraph has some **bold text** and some _italicized text_.
+
+        This is the end of this paragraph."
+      />,
+    )
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+    <h1
+      className="base jumbo black uppercase"
+    >
+      This is a paragraph. The paragaraph has some 
+      <b
+        className="base bold"
+      >
+        bold text
+      </b>
+       and some 
+      <em
+        className="base italic"
+      >
+        italicized text
+      </em>
+      . This is the end of this paragraph.
+    </h1>
+  `);
+});

--- a/packages/components/src/Markdown/Markdown.tsx
+++ b/packages/components/src/Markdown/Markdown.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable react/display-name */
+import ReactMarkdown from "react-markdown";
+import React, { ReactNode } from "react";
+import { Text } from "../Text";
+import { Emphasis } from "../Emphasis";
+import { Heading } from "../Heading";
+
+interface MarkdownProps {
+  /**
+   * Text to display.
+   */
+  readonly text: string;
+}
+
+interface HeadingProps {
+  readonly level: 1 | 2 | 3 | 4 | 5 | 6;
+  readonly children: ReactNode;
+}
+
+interface MarkdownRendererProps {
+  children: ReactNode;
+}
+
+export function Markdown({ text }: MarkdownProps) {
+  return (
+    <ReactMarkdown
+      source={text}
+      renderers={{
+        paragraph: ({ children }: MarkdownRendererProps) => (
+          <Text>{children}</Text>
+        ),
+        emphasis: ({ children }: MarkdownRendererProps) => (
+          <Emphasis variation="italic">{children}</Emphasis>
+        ),
+        strong: ({ children }: MarkdownRendererProps) => (
+          <Emphasis variation="bold">{children}</Emphasis>
+        ),
+        heading: ({ level, children }: HeadingProps) => {
+          if (level === 6) {
+            return <h6>{children}</h6>;
+          }
+          return <Heading level={level}>{children}</Heading>;
+        },
+      }}
+    />
+  );
+}

--- a/packages/components/src/Markdown/index.ts
+++ b/packages/components/src/Markdown/index.ts
@@ -1,0 +1,1 @@
+export { Markdown } from "./Markdown";


### PR DESCRIPTION
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

Added some common Markdown node types to be used in Atlantis.
These include:
- paragraph
- strong
- emphasis
- heading
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
