### PR TITLE
Use min height instead of height for buttons

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -118,17 +118,17 @@
 /* Sizes */
 
 .small {
-  height: calc(var(--base-unit) * 1.5);
+  min-height: calc(var(--base-unit) * 1.5);
   padding: var(--space-smaller) var(--space-small);
 }
 
 .base {
-  height: calc(var(--base-unit) * 2.25);
+  min-height: calc(var(--base-unit) * 2.25);
   padding: var(--space-small) calc(var(--space-base) - 4px);
 }
 
 .large {
-  height: calc(var(--base-unit) * 3);
+  min-height: calc(var(--base-unit) * 3);
   padding: var(--space-small) var(--space-base);
 }
 


### PR DESCRIPTION
## Changes

- Used min-height for sizes so it correctly sizes itself

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
