### PR TITLE
Make-the-button-be-a-type-button

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -24,11 +24,6 @@
 				"@types/yargs": "^12.0.9"
 			}
 		},
-		"@jobber/formatters": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/@jobber/formatters/-/formatters-0.0.2.tgz",
-			"integrity": "sha512-bOLWaYBs038aX1sEerNkjkwAZ+lO/7pvdk4dvsDVuA4lKUdAjpSCEl6qqjo6PfCP1ak29behsA0SkUvm4qYNRg=="
-		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1596,7 +1591,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1617,12 +1613,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1637,17 +1635,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1764,7 +1765,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1776,6 +1778,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1790,6 +1793,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1797,12 +1801,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -1821,6 +1827,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1901,7 +1908,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1913,6 +1921,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1998,7 +2007,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2034,6 +2044,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2053,6 +2064,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2096,12 +2108,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -9,6 +9,7 @@ it("renders a Button", () => {
     <button
       className="button base work primary"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold small uppercase white"
@@ -27,6 +28,7 @@ it("renders a secondary Button", () => {
     <button
       className="button base work secondary"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold small uppercase green"
@@ -45,6 +47,7 @@ it("renders a tertiary Button", () => {
     <button
       className="button base work tertiary"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold small uppercase green"
@@ -63,6 +66,7 @@ it("renders a destructuve Button", () => {
     <button
       className="button base destructive primary"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold small uppercase white"
@@ -81,6 +85,7 @@ it("renders a learning Button", () => {
     <button
       className="button base learning primary"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold small uppercase white"
@@ -99,6 +104,7 @@ it("renders a cancel Button", () => {
     <button
       className="button base cancel primary"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold small uppercase greyBlue"
@@ -117,6 +123,7 @@ it("renders a disabled Button", () => {
     <button
       className="button base work primary disabled"
       disabled={true}
+      type="button"
     >
       <span
         className="base extraBold small uppercase grey"
@@ -132,19 +139,19 @@ it("renders a Button with a link and opens in new tab", () => {
     .create(<Button label="Submit" url="💩.com" external={true} />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-    <a
-      className="button base work primary"
-      disabled={false}
-      href="💩.com"
-      target="_blank"
-    >
-      <span
-        className="base extraBold small uppercase white"
-      >
-        Submit
-      </span>
-    </a>
-  `);
+        <a
+          className="button base work primary"
+          disabled={false}
+          href="💩.com"
+          target="_blank"
+        >
+          <span
+            className="base extraBold small uppercase white"
+          >
+            Submit
+          </span>
+        </a>
+    `);
 });
 
 it("renders a Button with an icon", () => {
@@ -153,6 +160,7 @@ it("renders a Button with an icon", () => {
     <button
       className="button base hasIcon work primary"
       disabled={false}
+      type="button"
     >
       <div
         className="icon add base"
@@ -174,6 +182,7 @@ it("renders a Button with an icon on the right", () => {
     <button
       className="button base hasIcon iconOnRight work primary"
       disabled={false}
+      type="button"
     >
       <div
         className="icon add base"
@@ -193,6 +202,7 @@ it("renders a small Button", () => {
     <button
       className="button small work primary"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold smaller uppercase white"
@@ -209,6 +219,7 @@ it("renders a large Button", () => {
     <button
       className="button large work primary"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold base uppercase white"
@@ -227,6 +238,7 @@ it("renders a Button with a loading state", () => {
     <button
       className="button base work primary loading"
       disabled={false}
+      type="button"
     >
       <span
         className="base extraBold small uppercase white"

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -80,6 +80,7 @@ export function Button({
     ...(!disabled && { href: url }),
     ...(!disabled && { onClick: onClick }),
     ...(external && { target: "_blank" }),
+    ...(url === undefined && { type: "button" as "button" }),
   };
 
   const Tag = url ? "a" : "button";

--- a/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`renders a Menu 1`] = `
     disabled={false}
     id="123e4567-e89b-12d3-a456-426655440001"
     onClick={[Function]}
+    type="button"
   >
     <div
       className="icon more base"
@@ -37,6 +38,7 @@ exports[`renders a Menu with custom activator 1`] = `
     disabled={false}
     id="123e4567-e89b-12d3-a456-426655440003"
     onClick={[Function]}
+    type="button"
   >
     <span
       className="base extraBold small uppercase white"


### PR DESCRIPTION
## Changes
<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
The PR ads a button type to the button component so it does submit all the time.

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
