### PR TITLE
Fix the ol' input time on chrome.

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/components",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/components/src/InputTime/InputTime.test.tsx
+++ b/packages/components/src/InputTime/InputTime.test.tsx
@@ -9,30 +9,30 @@ afterEach(cleanup);
 it("renders a InputTime", () => {
   const tree = renderer.create(<InputTime />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-    <div
-      className="wrapper"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
-    >
-      <label
-        className="label"
-        htmlFor="123e4567-e89b-12d3-a456-426655440001"
-      >
-         
-      </label>
-      <input
-        className="formField"
-        id="123e4567-e89b-12d3-a456-426655440001"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="time"
-      />
-    </div>
-  `);
+        <div
+          className="wrapper"
+          style={
+            Object {
+              "--formField-maxLength": undefined,
+            }
+          }
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440001"
+          >
+             
+          </label>
+          <input
+            className="formField"
+            id="123e4567-e89b-12d3-a456-426655440001"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="time"
+          />
+        </div>
+    `);
 });
 
 it("renders an initial time when given 'defaultValue'", () => {
@@ -56,7 +56,7 @@ it("renders an initial time when given 'defaultValue'", () => {
       </label>
       <input
         className="formField"
-        defaultValue="11:23:00"
+        defaultValue="11:23"
         id="123e4567-e89b-12d3-a456-426655440002"
         onBlur={[Function]}
         onChange={[Function]}
@@ -94,7 +94,7 @@ it("renders correctly in a readonly state", () => {
         onFocus={[Function]}
         readOnly={true}
         type="time"
-        value="11:23:00"
+        value="11:23"
       />
     </div>
   `);
@@ -127,7 +127,7 @@ it("adds a error border when invalid", () => {
         onFocus={[Function]}
         readOnly={true}
         type="time"
-        value="11:23:00"
+        value="11:23"
       />
     </div>
   `);
@@ -136,30 +136,30 @@ it("adds a error border when invalid", () => {
 it("should set the value when given 'value' and 'onChange'", () => {
   const tree = renderer.create(<InputTime invalid />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-    <div
-      className="wrapper invalid"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
-    >
-      <label
-        className="label"
-        htmlFor="123e4567-e89b-12d3-a456-426655440005"
-      >
-         
-      </label>
-      <input
-        className="formField"
-        id="123e4567-e89b-12d3-a456-426655440005"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="time"
-      />
-    </div>
-  `);
+        <div
+          className="wrapper invalid"
+          style={
+            Object {
+              "--formField-maxLength": undefined,
+            }
+          }
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440005"
+          >
+             
+          </label>
+          <input
+            className="formField"
+            id="123e4567-e89b-12d3-a456-426655440005"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="time"
+          />
+        </div>
+    `);
 });
 
 it("should call the onChange function when the component is modified", () => {

--- a/packages/components/src/InputTime/civilTimeConversions.tsx
+++ b/packages/components/src/InputTime/civilTimeConversions.tsx
@@ -2,7 +2,7 @@ import { CivilTime } from "@std-proposal/temporal";
 
 export function civilTimeToHTMLTime(civilTime: CivilTime): string {
   const timeString = civilTime.toString();
-  return timeString.substring(0, timeString.indexOf("."));
+  return timeString.slice(0, 5);
 }
 
 export function htmlTimeToCivilTime(timeString: string): CivilTime {


### PR DESCRIPTION
Apparently typing in an input field is actually important. ;)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Typing in the InputTime in chrome now allows you to input 2 digit times.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)