### PR TITLE
fix: Hide clear in chrome

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -48,10 +48,7 @@
   appearance: none;
 }
 
-.formField::-ms-clear {
-  display: none;
-}
-
+.formField::-ms-clear,
 .formField::-webkit-clear-button {
   display: none;
 }

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -52,6 +52,10 @@
   display: none;
 }
 
+.formField::-webkit-clear-button {
+  display: none;
+}
+
 textarea.formField {
   height: auto;
   min-height: calc(var(--field--height) * 2);


### PR DESCRIPTION
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Hide clear button on `InputTime` in chrome.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
