### PR TITLE
Consistently consistent for field design from sg1 to atlantis

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -6,8 +6,8 @@
   --field--border-color: var(--color-grey--lighter);
   --field--background-color: var(--color-white);
 
-  --field--padding-top: calc(var(--space-base) - var(--space-smaller));
-  --field--padding-bottom: calc(var(--space-base) - var(--space-smaller));
+  --field--padding-top: calc(var(--space-base) - var(--space-smallest));
+  --field--padding-bottom: calc(var(--space-base) - var(--space-smallest));
   --field--padding-left: var(--space-base);
   --field--padding-right: var(--space-base);
   --field--height: var(--space-largest);
@@ -22,8 +22,6 @@
 
 .formField,
 .label {
-  width: inherit;
-  height: var(--field--height);
   box-sizing: border-box;
   margin: 0;
   padding-top: var(--field--padding-top);
@@ -37,11 +35,14 @@
 .formField {
   display: block;
   position: relative;
+  width: inherit;
+  height: var(--field--height);
   border: var(--field--border-width) solid var(--field--border-color);
   border-radius: var(--radius-base);
   outline: none;
   color: var(--field--color);
-  line-height: 1.25;
+  font-size: var(--base-unit);
+  line-height: calc(var(--base-unit) * 1.25);
   text-align: var(--field--textAlign);
   background-color: transparent;
   transition: padding var(--timing-base);
@@ -67,18 +68,19 @@ select.formField {
 }
 
 .label {
-  display: flex;
   position: absolute;
-  top: 0;
-  left: 0;
+  top: var(--field--border-width);
+  right: var(--field--border-width);
+  bottom: var(--field--border-width);
+  left: var(--field--border-width);
   overflow: hidden;
   color: var(--field--placeholder-color);
-  line-height: 1;
+  font-size: var(--base-unit);
+  line-height: calc(var(--base-unit) * 1.25);
   text-overflow: ellipsis;
   white-space: nowrap;
   pointer-events: none;
   transition: all var(--timing-quick);
-  align-items: center;
 }
 
 .inline {
@@ -89,8 +91,8 @@ select.formField {
 /* Sizes */
 
 .small {
-  --field--padding-top: var(--space-smaller);
-  --field--padding-bottom: var(--space-smaller);
+  --field--padding-top: var(--space-smallest);
+  --field--padding-bottom: var(--space-smallest);
   --field--padding-left: var(--space-small);
   --field--padding-right: var(--space-small);
   --field--height: calc(var(--space-larger) + var(--space-smaller));
@@ -136,18 +138,20 @@ select.formField {
 /* Mini Label */
 
 .miniLabel:not(.small) .formField {
-  --field--padding-top: var(--space-base);
+  --field--padding-top: calc(var(--space-base) + var(--space-smaller));
   --field--padding-bottom: var(--space-smaller);
 }
 
 .miniLabel .label {
-  --field--padding-top: var(--space-smaller);
-  --field--padding-bottom: var(--space-smaller);
+  --field--padding-top: var(--space-smallest);
+  --field--padding-bottom: var(--space-smallest);
   --field--padding-left: var(--space-base);
   --field--padding-right: var(--space-base);
+  bottom: auto;
   z-index: var(--elevation-base);
 
   height: auto;
+  color: var(--color-greyBlue);
   font-size: calc(var(--base-unit) * 0.875);
 }
 
@@ -156,7 +160,7 @@ select.formField {
 }
 
 .miniLabel.large .label {
-  --field--padding-top: var(--space-small);
+  --field--padding-top: var(--space-smallest);
   --field--padding-bottom: var(--space-small);
   --field--padding-left: var(--space-large);
   --field--padding-right: var(--space-large);

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -166,6 +166,10 @@ select.formField {
   --field--padding-right: var(--space-large);
 }
 
+.miniLabel .textareaLabel {
+  background-color: var(--color-white);
+}
+
 /**
  * The custom property --formField-maxLength is getting defined inside the
  * component.

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -10,5 +10,6 @@ export const invalid: string;
 export const hasErrorMessage: string;
 export const disabled: string;
 export const miniLabel: string;
+export const textareaLabel: string;
 export const maxLength: string;
 export const icon: string;

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -183,6 +183,11 @@ export const FormField = React.forwardRef(
 
     const Wrapper = inline ? "span" : "div";
 
+    const labelClassNames = classnames(
+      styles.label,
+      type === "textarea" && styles.textareaLabel,
+    );
+
     return (
       <>
         {errorMessage && !inline && (
@@ -193,7 +198,7 @@ export const FormField = React.forwardRef(
           className={wrapperClassNames}
           style={{ ["--formField-maxLength" as string]: maxLength || max }}
         >
-          <label className={styles.label} htmlFor={identifier}>
+          <label className={labelClassNames} htmlFor={identifier}>
             {placeholder || " "}
           </label>
           {fieldElement()}

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -9,30 +9,30 @@ it("renders a regular input for text and numbers", () => {
     .create(<InputText placeholder="Favourite colour" />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-    <div
-      className="wrapper"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
-    >
-      <label
-        className="label"
-        htmlFor="123e4567-e89b-12d3-a456-426655440001"
-      >
-        Favourite colour
-      </label>
-      <input
-        className="formField"
-        id="123e4567-e89b-12d3-a456-426655440001"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="text"
-      />
-    </div>
-  `);
+        <div
+          className="wrapper"
+          style={
+            Object {
+              "--formField-maxLength": undefined,
+            }
+          }
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440001"
+          >
+            Favourite colour
+          </label>
+          <input
+            className="formField"
+            id="123e4567-e89b-12d3-a456-426655440001"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="text"
+          />
+        </div>
+    `);
 });
 
 it("renders a textarea", () => {
@@ -51,7 +51,7 @@ it("renders a textarea", () => {
       }
     >
       <label
-        className="label"
+        className="label textareaLabel"
         htmlFor="123e4567-e89b-12d3-a456-426655440002"
       >
         Describe your favourite colour?
@@ -87,7 +87,7 @@ it("renders a textarea with 4 rows", () => {
       }
     >
       <label
-        className="label"
+        className="label textareaLabel"
         htmlFor="123e4567-e89b-12d3-a456-426655440003"
       >
         Describe your favourite colour?


### PR DESCRIPTION
## Changes

- Adjust CSS for pixel perfect alignment of form fields and also match sg1
- Ad BG to textarea mini label to prevent this ⏬  from happening

![image](https://user-images.githubusercontent.com/15986172/64284603-34e2ff80-cf17-11e9-8a53-4f1f620268a7.png)

it now looks like this ⏬ 
![image](https://user-images.githubusercontent.com/15986172/64284645-4f1cdd80-cf17-11e9-92e3-40610cfc4b37.png)


### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
