### PR TITLE
fix: firefix the firefox with align middle baseline

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -86,6 +86,7 @@ select.formField {
 .inline {
   display: inline-block;
   width: auto;
+  vertical-align: -moz-middle-with-baseline;
 }
 
 /* Sizes */


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    perf(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

- Add `vertical-align: -moz-middle-with-baseline;` to fix firefox BS
![Sep-04-2019 11-40-29](https://user-images.githubusercontent.com/15986172/64380707-cc675180-cfee-11e9-83a1-96ca85806eac.gif)


### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
