### PR TITLE
perf: BREAKING CHANGE: Add `Content` component to handle vertical rhythm and padding 

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -10,7 +10,6 @@
 .card {
   display: block;
   width: 100%;
-  padding: var(--card--base-padding);
   border: var(--border-base) solid var(--card--border-color);
   border-radius: var(--radius-base);
   overflow: auto;
@@ -43,13 +42,6 @@
 .clickable:hover,
 .clickable:focus {
   background-color: var(--color-yellow--lightest);
-}
-
-.fill {
-  margin-top: calc(-1 * var(--card--base-padding));
-  margin-bottom: calc(1 * var(--card--base-padding));
-  margin-left: calc(-1 * var(--card--base-padding));
-  margin-right: calc(-1 * var(--card--base-padding));
 }
 
 .header {

--- a/packages/components/src/Card/Card.css.d.ts
+++ b/packages/components/src/Card/Card.css.d.ts
@@ -1,5 +1,4 @@
 export const card: string;
 export const accent: string;
 export const clickable: string;
-export const fill: string;
 export const header: string;

--- a/packages/components/src/Card/Card.mdx
+++ b/packages/components/src/Card/Card.mdx
@@ -6,63 +6,61 @@ route: /components/card
 import { Playground, Props, Link } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { Card, Title } from ".";
+import { Text } from "../Text";
+import { Heading } from "../Heading";
+import { Content } from "../Content";
 
 # Card
 
 <ComponentStatus stage="rc" responsive="yes" accessible="yes" />
 
-In Jobber a card is used to group related information and tasks to make things
-easier to scan, and action upon. Cards also contain many optional sub-components
-to provide extra structure in a predictable way.
-
-## Simple Card
+A card is used to group related information and tasks to make things easier to
+scan, and action upon
 
 <Playground>
-  <Card>
-    <p>This is just…</p>
-    <p>A simple card.</p>
+  <Card title="Banana">
+    <Content padding="base">
+      <Text>
+        A banana is an edible fruit – botanically a berry – produced by several
+        kinds of large herbaceous flowering plants in the genus Musa.
+      </Text>
+    </Content>
   </Card>
 </Playground>
 
 ## Clickable Cards
 
+### Using URL
+
 <Playground>
   <Card url="#">
-    <p>I'm a link!</p>
-  </Card>
-
-  <Card onClick={(e) => { alert("😻"); console.log(e.currentTarget);}}>
-    <p>I like to be clicked!</p>
+    <Content padding="base">
+      <Heading level={4}>View All</Heading>
+      <Text>
+        See how our 20+ features can help you organize, impress, and grow.
+      </Text>
+    </Content>
   </Card>
 </Playground>
 
-## Card with Title
+### Using onClick
 
 <Playground>
-  <Card accent="jobColor">
-    <Title title="This is an exceptionally long card title" />
-
-    <p>This is the card content.</p>
-
+  <Card
+    onClick={e => {
+      alert("😻");
+      console.log(e.currentTarget);
+    }}
+  >
+    <Content padding="base">
+      <Heading level={4}>View All</Heading>
+      <Text>
+        See how our 20+ features can help you organize, impress, and grow.
+      </Text>
+    </Content>
   </Card>
 </Playground>
 
-## Card Properties
+## Props
 
 <Props of={Card} />
-
----
-
-## ▸ `Title`
-
-The `Title` defines the title of a card. This is used to provide context as to
-the content of the card.
-
-<Playground>
-  <Card>
-    <Title title="Sample Title" />
-
-  </Card>
-</Playground>
-
-<Props of={Title} />

--- a/packages/components/src/Card/Card.mdx
+++ b/packages/components/src/Card/Card.mdx
@@ -19,10 +19,18 @@ scan, and action upon
 
 <Playground>
   <Card title="Banana">
-    <Content padding="base">
+    <Content>
+      <Heading level={4}>Burro</Heading>
       <Text>
-        A banana is an edible fruit – botanically a berry – produced by several
-        kinds of large herbaceous flowering plants in the genus Musa.
+        Squatty and slightly square at the edges, these bananas are slightly
+        tangy and lemony. When ripe, the fruit is soft and the skin is yellow
+        with black spots. Also called Horse, Hog, or Orinoco bananas.
+      </Text>
+      <Heading level={4}>Cavendish</Heading>
+      <Text>
+        This is the familiar yellow banana sold in United States’ supermarkets.
+        There are also other sizes of Cavendish, including Dwarf and Giant,
+        though they are difficult to find.
       </Text>
     </Content>
   </Card>
@@ -34,7 +42,7 @@ scan, and action upon
 
 <Playground>
   <Card url="#">
-    <Content padding="base">
+    <Content>
       <Heading level={4}>View All</Heading>
       <Text>
         See how our 20+ features can help you organize, impress, and grow.
@@ -52,7 +60,7 @@ scan, and action upon
       console.log(e.currentTarget);
     }}
   >
-    <Content padding="base">
+    <Content>
       <Heading level={4}>View All</Heading>
       <Text>
         See how our 20+ features can help you organize, impress, and grow.

--- a/packages/components/src/Card/Card.test.tsx
+++ b/packages/components/src/Card/Card.test.tsx
@@ -12,14 +12,14 @@ it("renders a simple card", () => {
     )
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                        <div
-                          className="card accent purple"
-                        >
-                          <p>
-                            This is the card content.
-                          </p>
-                        </div>
-            `);
+                            <div
+                              className="card accent purple"
+                            >
+                              <p>
+                                This is the card content.
+                              </p>
+                            </div>
+              `);
 });
 
 it("renders a card", () => {
@@ -37,7 +37,7 @@ it("renders a card", () => {
       className="card accent green"
     >
       <div
-        className="header fill"
+        className="header"
       >
         <h3
           className="base extraBold large uppercase"
@@ -61,15 +61,15 @@ it("renders a link card", () => {
     )
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <a
-                  className="card accent clickable green"
-                  href="https://frend.space"
-                >
-                  <p>
-                    This is a link card.
-                  </p>
-                </a>
-        `);
+                    <a
+                      className="card accent clickable green"
+                      href="https://frend.space"
+                    >
+                      <p>
+                        This is a link card.
+                      </p>
+                    </a>
+          `);
 });
 
 it("renders a clickable card", () => {
@@ -81,17 +81,17 @@ it("renders a clickable card", () => {
     )
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-            <div
-              className="card accent clickable green"
-              onClick={[Function]}
-              role="button"
-              tabIndex={0}
-            >
-              <p>
-                This is a clickable card.
-              </p>
-            </div>
-      `);
+                <div
+                  className="card accent clickable green"
+                  onClick={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <p>
+                    This is a clickable card.
+                  </p>
+                </div>
+        `);
 });
 
 test("it should should be clickable if it's clickable", () => {

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -5,38 +5,6 @@ import { Typography } from "../Typography";
 import styles from "./Card.css";
 import colors from "./colors.css";
 
-interface HeaderProps {
-  readonly children: ReactNode;
-}
-
-function Header(props: HeaderProps) {
-  const className = classnames(styles.header, styles.fill);
-
-  return <div className={className} {...props} />;
-}
-
-interface TitleProps {
-  /**
-   * The title for the card.
-   */
-  readonly title: string;
-}
-
-export function Title({ title }: TitleProps) {
-  return (
-    <Header>
-      <Typography
-        element="h3"
-        size="large"
-        textCase="uppercase"
-        fontWeight="extraBold"
-      >
-        {title}
-      </Typography>
-    </Header>
-  );
-}
-
 interface CardProps {
   /**
    * The `accent`, if provided, will effect the color accent at the top of
@@ -44,6 +12,11 @@ interface CardProps {
    */
   readonly accent?: keyof typeof colors;
   readonly children: ReactNode | ReactNode[];
+
+  /**
+   * The title of the card.
+   */
+  readonly title?: string;
 }
 
 interface LinkCardProps extends CardProps {
@@ -56,7 +29,13 @@ interface ClickableCardProps extends CardProps {
 
 type CardPropOptions = XOR<CardProps, XOR<LinkCardProps, ClickableCardProps>>;
 
-export function Card({ accent, children, url, onClick }: CardPropOptions) {
+export function Card({
+  accent,
+  children,
+  onClick,
+  title,
+  url,
+}: CardPropOptions) {
   const className = classnames(
     styles.card,
     accent && styles.accent,
@@ -65,7 +44,6 @@ export function Card({ accent, children, url, onClick }: CardPropOptions) {
   );
 
   interface InternalProps {
-    children: ReactNode | ReactNode[];
     className: string;
     href?: string;
     role?: "button";
@@ -74,7 +52,7 @@ export function Card({ accent, children, url, onClick }: CardPropOptions) {
   }
 
   const Tag = url ? "a" : "div";
-  const props: InternalProps = { children, className };
+  const props: InternalProps = { className };
 
   if (url) {
     props.href = url;
@@ -86,5 +64,40 @@ export function Card({ accent, children, url, onClick }: CardPropOptions) {
     props.tabIndex = 0;
   }
 
-  return <Tag {...props} />;
+  return (
+    <Tag {...props}>
+      {title && <Title title={title} />}
+      {children}
+    </Tag>
+  );
+}
+
+interface TitleProps {
+  /**
+   * The title for the card.
+   */
+  readonly title: string;
+}
+
+/**
+ * **DEPRECATED** Use `title` props on the `<Card />` to add a title instead.
+ *
+ * This will be used as an internal component
+ */
+
+export function Title({ title }: TitleProps) {
+  const className = classnames(styles.header);
+
+  return (
+    <div className={className}>
+      <Typography
+        element="h3"
+        size="large"
+        textCase="uppercase"
+        fontWeight="extraBold"
+      >
+        {title}
+      </Typography>
+    </div>
+  );
 }

--- a/packages/components/src/Content/Content.mdx
+++ b/packages/components/src/Content/Content.mdx
@@ -1,0 +1,79 @@
+---
+name: Content
+menu: Components
+route: /components/content
+---
+
+import { Playground, Props } from "docz";
+import { ComponentStatus } from "@jobber/docx";
+import { Content } from ".";
+import { Text } from "../Text";
+import { Heading } from "../Heading";
+import { InputText } from "../InputText";
+import { Button } from "../Button";
+import { Tabs, Tab } from "../Tabs";
+import { Card, Title } from "../Card";
+
+# Content
+
+<ComponentStatus stage="pre" responsive="no" accessible="no" />
+
+Contents are used to give elements consistent vertical spacing and padding.
+
+<Playground>
+  <Content>
+    <Heading level={2}>Sign up!</Heading>
+    <Text>
+      Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+      vestibulum. Nulla vitae elit libero, a pharetra augue. Nullam quis risus
+      eget urna mollis ornare vel eu leo. Vestibulum id ligula porta felis
+      euismod semper. Curabitur blandit tempus porttitor.
+    </Text>
+    <InputText placeholder="Name" />
+    <InputText placeholder="Phone" />
+    <InputText placeholder="Email" />
+    <InputText
+      multiline={true}
+      placeholder="Describe yourself"
+      name="describeAge"
+    />
+    <Button
+      label="Submit"
+      onClick={() => {
+        alert("✅");
+      }}
+    />
+  </Content>
+</Playground>
+
+## Within Cards
+
+<Playground>
+  <Card>
+    <Title title="About me" />
+    <Content padding="base">
+      <Heading level={4}>My favourite food</Heading>
+      <Text>
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Nulla vitae elit libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel eu leo. Vestibulum id ligula porta felis euismod semper. Curabitur blandit tempus porttitor.
+      </Text>
+    </Content>
+
+    <Tabs>
+      <Tab label="Eggs">
+        🍳 Some eggs are laid by female animals of many different species,
+        including birds, reptiles, amphibians, mammals, and fish, and have been
+        eaten by humans for thousands of years.
+      </Tab>
+      <Tab label="Cheese">
+        🧀 Cheese is a dairy product derived from milk that is produced in a wide
+        range of flavors, textures, and forms by coagulation of the milk protein
+        casein.
+      </Tab>
+    </Tabs>
+
+  </Card>
+</Playground>
+
+## Content Properties
+
+<Props of={Content} />

--- a/packages/components/src/Content/Content.mdx
+++ b/packages/components/src/Content/Content.mdx
@@ -51,7 +51,7 @@ Contents are used to give elements consistent vertical spacing and padding.
 <Playground>
   <Card>
     <Title title="About me" />
-    <Content padding="base">
+    <Content>
       <Heading level={4}>My favourite food</Heading>
       <Text>
         Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Nulla vitae elit libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel eu leo. Vestibulum id ligula porta felis euismod semper. Curabitur blandit tempus porttitor.

--- a/packages/components/src/Content/Content.test.tsx
+++ b/packages/components/src/Content/Content.test.tsx
@@ -9,7 +9,7 @@ it("renders a Content", () => {
   const tree = renderer.create(<Content>Wazaaaaa</Content>).toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="base"
+      className="base base"
     >
       Wazaaaaa
     </div>

--- a/packages/components/src/Content/Content.test.tsx
+++ b/packages/components/src/Content/Content.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { cleanup } from "@testing-library/react";
+import { Content } from ".";
+
+afterEach(cleanup);
+
+it("renders a Content", () => {
+  const tree = renderer.create(<Content>Wazaaaaa</Content>).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+    <div
+      className="base"
+    >
+      Wazaaaaa
+    </div>
+  `);
+});

--- a/packages/components/src/Content/Content.test.tsx
+++ b/packages/components/src/Content/Content.test.tsx
@@ -8,10 +8,75 @@ afterEach(cleanup);
 it("renders a Content", () => {
   const tree = renderer.create(<Content>Wazaaaaa</Content>).toJSON();
   expect(tree).toMatchInlineSnapshot(`
+        <div
+          className="base base"
+        >
+          Wazaaaaa
+        </div>
+    `);
+});
+
+it("renders a Content with a large spacing", () => {
+  const tree = renderer
+    .create(<Content padding="large">Space me up!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
     <div
-      className="base base"
+      className="base large"
     >
-      Wazaaaaa
+      Space me up!
+    </div>
+  `);
+});
+
+it("renders a Content with a small spacing", () => {
+  const tree = renderer
+    .create(<Content padding="small">Space me down!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+    <div
+      className="base small"
+    >
+      Space me down!
+    </div>
+  `);
+});
+
+it("renders a Content with a large padding", () => {
+  const tree = renderer
+    .create(<Content padding="large">Pad me up!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+    <div
+      className="base large"
+    >
+      Pad me up!
+    </div>
+  `);
+});
+
+it("renders a Content with a small padding", () => {
+  const tree = renderer
+    .create(<Content padding="small">Pad me down!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+    <div
+      className="base small"
+    >
+      Pad me down!
+    </div>
+  `);
+});
+
+it("renders a Content with no padding", () => {
+  const tree = renderer
+    .create(<Content padding="none">Pad me none!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+    <div
+      className="base none"
+    >
+      Pad me none!
     </div>
   `);
 });

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -17,7 +17,11 @@ interface ContentProps {
   readonly spacing?: keyof typeof spacings;
 }
 
-export function Content({ children, spacing = "base", padding }: ContentProps) {
+export function Content({
+  children,
+  spacing = "base",
+  padding = "base",
+}: ContentProps) {
   const className = classnames(spacings[spacing], padding && paddings[padding]);
 
   return <div className={className}>{children}</div>;

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode } from "react";
+import classnames from "classnames";
+import spacings from "./Spacing.css";
+import paddings from "./Paddings.css";
+
+interface ContentProps {
+  readonly children: ReactNode | ReactNode[];
+  /**
+   * Determines the spacing within the component
+   */
+  readonly padding?: keyof typeof paddings;
+  /**
+   * The amount of vertical spacing between the children
+   *
+   * @default base
+   */
+  readonly spacing?: keyof typeof spacings;
+}
+
+export function Content({ children, spacing = "base", padding }: ContentProps) {
+  const className = classnames(spacings[spacing], padding && paddings[padding]);
+
+  return <div className={className}>{children}</div>;
+}

--- a/packages/components/src/Content/Paddings.css
+++ b/packages/components/src/Content/Paddings.css
@@ -9,3 +9,7 @@
 .large {
   padding: var(--space-large);
 }
+
+.none {
+  padding: 0;
+}

--- a/packages/components/src/Content/Paddings.css
+++ b/packages/components/src/Content/Paddings.css
@@ -1,0 +1,11 @@
+.base {
+  padding: var(--space-base);
+}
+
+.small {
+  padding: var(--space-small);
+}
+
+.large {
+  padding: var(--space-large);
+}

--- a/packages/components/src/Content/Paddings.css.d.ts
+++ b/packages/components/src/Content/Paddings.css.d.ts
@@ -1,3 +1,4 @@
 export const base: string;
 export const small: string;
 export const large: string;
+export const none: string;

--- a/packages/components/src/Content/Paddings.css.d.ts
+++ b/packages/components/src/Content/Paddings.css.d.ts
@@ -1,0 +1,3 @@
+export const base: string;
+export const small: string;
+export const large: string;

--- a/packages/components/src/Content/Spacing.css
+++ b/packages/components/src/Content/Spacing.css
@@ -1,0 +1,11 @@
+.base > :not(:last-child) {
+  margin-bottom: var(--space-base);
+}
+
+.small > :not(:last-child) {
+  margin-bottom: var(--space-small);
+}
+
+.large > :not(:last-child) {
+  margin-bottom: var(--space-large);
+}

--- a/packages/components/src/Content/Spacing.css.d.ts
+++ b/packages/components/src/Content/Spacing.css.d.ts
@@ -1,0 +1,3 @@
+export const base: string;
+export const small: string;
+export const large: string;

--- a/packages/components/src/Content/index.ts
+++ b/packages/components/src/Content/index.ts
@@ -1,0 +1,1 @@
+export { Content } from "./Content";

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -16,7 +16,6 @@
 .wrapper {
   position: relative;
   width: 100%;
-  margin-bottom: var(--space-base);
   background-color: var(--field--background-color);
 }
 
@@ -121,10 +120,6 @@ select.formField {
 .invalid,
 .invalid .formField:focus {
   --field--border-color: var(--color-red);
-}
-
-.hasErrorMessage {
-  margin-top: var(--space-smaller);
 }
 
 .disabled {

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -7,7 +7,6 @@ export const large: string;
 export const center: string;
 export const right: string;
 export const invalid: string;
-export const hasErrorMessage: string;
 export const disabled: string;
 export const miniLabel: string;
 export const textareaLabel: string;

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -7,30 +7,30 @@ afterEach(cleanup);
 it("renders correctly with no props", () => {
   const tree = renderer.create(<FormField />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-        <div
-          className="wrapper"
-          style={
-            Object {
-              "--formField-maxLength": undefined,
-            }
-          }
-        >
-          <label
-            className="label"
-            htmlFor="123e4567-e89b-12d3-a456-426655440001"
-          >
-             
-          </label>
-          <input
-            className="formField"
-            id="123e4567-e89b-12d3-a456-426655440001"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            type="text"
-          />
-        </div>
-    `);
+            <div
+              className="wrapper"
+              style={
+                Object {
+                  "--formField-maxLength": undefined,
+                }
+              }
+            >
+              <label
+                className="label"
+                htmlFor="123e4567-e89b-12d3-a456-426655440001"
+              >
+                 
+              </label>
+              <input
+                className="formField"
+                id="123e4567-e89b-12d3-a456-426655440001"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="text"
+              />
+            </div>
+      `);
 });
 
 it("renders correctly with a placeholder", () => {
@@ -38,119 +38,119 @@ it("renders correctly with a placeholder", () => {
     .create(<FormField placeholder="My placeholder" />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-        <div
-          className="wrapper"
-          style={
-            Object {
-              "--formField-maxLength": undefined,
-            }
-          }
-        >
-          <label
-            className="label"
-            htmlFor="123e4567-e89b-12d3-a456-426655440002"
-          >
-            My placeholder
-          </label>
-          <input
-            className="formField"
-            id="123e4567-e89b-12d3-a456-426655440002"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            type="text"
-          />
-        </div>
-    `);
+            <div
+              className="wrapper"
+              style={
+                Object {
+                  "--formField-maxLength": undefined,
+                }
+              }
+            >
+              <label
+                className="label"
+                htmlFor="123e4567-e89b-12d3-a456-426655440002"
+              >
+                My placeholder
+              </label>
+              <input
+                className="formField"
+                id="123e4567-e89b-12d3-a456-426655440002"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="text"
+              />
+            </div>
+      `);
 });
 
 it("renders correctly as small", () => {
   const tree = renderer.create(<FormField size="small" />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-        <div
-          className="wrapper small"
-          style={
-            Object {
-              "--formField-maxLength": undefined,
-            }
-          }
-        >
-          <label
-            className="label"
-            htmlFor="123e4567-e89b-12d3-a456-426655440003"
-          >
-             
-          </label>
-          <input
-            className="formField"
-            id="123e4567-e89b-12d3-a456-426655440003"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            type="text"
-          />
-        </div>
-    `);
+            <div
+              className="wrapper small"
+              style={
+                Object {
+                  "--formField-maxLength": undefined,
+                }
+              }
+            >
+              <label
+                className="label"
+                htmlFor="123e4567-e89b-12d3-a456-426655440003"
+              >
+                 
+              </label>
+              <input
+                className="formField"
+                id="123e4567-e89b-12d3-a456-426655440003"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="text"
+              />
+            </div>
+      `);
 });
 
 it("renders correctly in a readonly state", () => {
   const tree = renderer.create(<FormField readonly={true} />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-        <div
-          className="wrapper"
-          style={
-            Object {
-              "--formField-maxLength": undefined,
-            }
-          }
-        >
-          <label
-            className="label"
-            htmlFor="123e4567-e89b-12d3-a456-426655440004"
-          >
-             
-          </label>
-          <input
-            className="formField"
-            id="123e4567-e89b-12d3-a456-426655440004"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            readOnly={true}
-            type="text"
-          />
-        </div>
-    `);
+            <div
+              className="wrapper"
+              style={
+                Object {
+                  "--formField-maxLength": undefined,
+                }
+              }
+            >
+              <label
+                className="label"
+                htmlFor="123e4567-e89b-12d3-a456-426655440004"
+              >
+                 
+              </label>
+              <input
+                className="formField"
+                id="123e4567-e89b-12d3-a456-426655440004"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                readOnly={true}
+                type="text"
+              />
+            </div>
+      `);
 });
 
 it("renders correctly in a disabled state", () => {
   const tree = renderer.create(<FormField disabled={true} />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-        <div
-          className="wrapper disabled"
-          style={
-            Object {
-              "--formField-maxLength": undefined,
-            }
-          }
-        >
-          <label
-            className="label"
-            htmlFor="123e4567-e89b-12d3-a456-426655440005"
-          >
-             
-          </label>
-          <input
-            className="formField"
-            disabled={true}
-            id="123e4567-e89b-12d3-a456-426655440005"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            type="text"
-          />
-        </div>
-    `);
+            <div
+              className="wrapper disabled"
+              style={
+                Object {
+                  "--formField-maxLength": undefined,
+                }
+              }
+            >
+              <label
+                className="label"
+                htmlFor="123e4567-e89b-12d3-a456-426655440005"
+              >
+                 
+              </label>
+              <input
+                className="formField"
+                disabled={true}
+                id="123e4567-e89b-12d3-a456-426655440005"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="text"
+              />
+            </div>
+      `);
 });
 
 it("renders a field with error", () => {
@@ -167,7 +167,7 @@ it("renders a field with error", () => {
         Enter a value that is correct
       </p>,
       <div
-        className="wrapper hasErrorMessage invalid"
+        className="wrapper invalid"
         style={
           Object {
             "--formField-maxLength": undefined,

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -171,7 +171,6 @@ export const FormField = React.forwardRef(
       inline && styles.inline,
       size && styles[size],
       align && styles[align],
-      errorMessage && styles.hasErrorMessage,
       (invalid || errorMessage) && styles.invalid,
       disabled && styles.disabled,
       maxLength && styles.maxLength,

--- a/packages/components/src/InputNumber/InputNumber.mdx
+++ b/packages/components/src/InputNumber/InputNumber.mdx
@@ -8,6 +8,7 @@ import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { InputNumber } from ".";
 import { Text } from "../Text";
+import { Content } from "../Content";
 import { useState } from "react";
 
 # InputNumber
@@ -120,7 +121,7 @@ You can use `onValidate` to catch them.
     const [value, setValue] = useState(5);
     const [validationMessage, setValidationMessage] = useState("");
     return (
-      <>
+      <Content spacing="small">
         {validationMessage && <Text variation="error">{validationMessage}</Text>}
         <Text>
           Follow-up after
@@ -137,7 +138,7 @@ You can use `onValidate` to catch them.
           />
           days
         </Text>
-      </>
+      </Content>
     );
 
     function handleChange(newValue) {

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -8,34 +8,34 @@ afterEach(cleanup);
 it("renders an input type number", () => {
   const tree = renderer.create(<InputNumber value="123" />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-        Array [
-          "",
-          <div
-            className="wrapper"
-            style={
-              Object {
-                "--formField-maxLength": undefined,
-              }
-            }
-          >
-            <label
-              className="label"
-              htmlFor="123e4567-e89b-12d3-a456-426655440001"
-            >
-               
-            </label>
-            <input
-              className="formField"
-              id="123e4567-e89b-12d3-a456-426655440001"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              type="number"
-              value="123"
-            />
-          </div>,
-        ]
-    `);
+            Array [
+              "",
+              <div
+                className="wrapper"
+                style={
+                  Object {
+                    "--formField-maxLength": undefined,
+                  }
+                }
+              >
+                <label
+                  className="label"
+                  htmlFor="123e4567-e89b-12d3-a456-426655440001"
+                >
+                   
+                </label>
+                <input
+                  className="formField"
+                  id="123e4567-e89b-12d3-a456-426655440001"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="number"
+                  value="123"
+                />
+              </div>,
+            ]
+      `);
 });
 
 it("renders an error", () => {
@@ -50,7 +50,7 @@ it("renders an error", () => {
         Not a whole number
       </p>,
       <div
-        className="wrapper hasErrorMessage invalid"
+        className="wrapper invalid"
         style={
           Object {
             "--formField-maxLength": undefined,

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -125,7 +125,7 @@ Use this to allow users to provide long answers.
     }
 
     return (
-      <Content>
+      <Content padding="none">
         <InputText value={text} onChange={handleTextChange} ref={textRef} />
         <pre>{text}</pre>
         <Button label="Insert Emoji" onClick={insert} />

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -9,6 +9,7 @@ import { ComponentStatus } from "@jobber/docx";
 import { InputText } from ".";
 import { useState } from "react";
 import { Button } from "../Button";
+import { Content } from "../Content";
 import { Text } from "../Text";
 
 # Input Text
@@ -124,11 +125,11 @@ Use this to allow users to provide long answers.
     }
 
     return (
-      <>
+      <Content>
         <InputText value={text} onChange={handleTextChange} ref={textRef} />
         <pre>{text}</pre>
         <Button label="Insert Emoji" onClick={insert} />
-      </>
+      </Content>
     );
 
 }}

--- a/packages/components/src/InputTime/InputTime.mdx
+++ b/packages/components/src/InputTime/InputTime.mdx
@@ -29,7 +29,7 @@ import { InputTime } "@jobber/components/InputTime";
 ```
 
 <Playground>
-  <Content>
+  <Content padding="none">
     <InputTime defaultValue={new CivilTime(2, 35)} size="small" />
     <InputTime defaultValue={new CivilTime(2, 35)} />
     <InputTime defaultValue={new CivilTime(2, 35)} size="large" />
@@ -39,7 +39,7 @@ import { InputTime } "@jobber/components/InputTime";
 ## States
 
 <Playground>
-  <Content>
+  <Content padding="none">
     <InputTime defaultValue={new CivilTime(3, 52)} disabled={true} />
     <InputTime defaultValue={new CivilTime(5, 23)} readonly={true} />
     <InputTime defaultValue={new CivilTime(2, 35)} invalid={true} />
@@ -62,7 +62,7 @@ the last element is set the change event will fire.
       setTime(newTime);
     };
     return (
-      <Content>
+      <Content padding="none">
         <InputTime value={time} onChange={handleChange} />
         <pre>{time && time.toString()}</pre>
         <Button label="Reset" onClick={resetTime} />

--- a/packages/components/src/InputTime/InputTime.mdx
+++ b/packages/components/src/InputTime/InputTime.mdx
@@ -8,6 +8,7 @@ import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { InputTime } from ".";
 import { Button } from "../Button";
+import { Content } from "../Content";
 import { useState } from "react";
 import { CivilTime } from "@std-proposal/temporal";
 
@@ -28,21 +29,21 @@ import { InputTime } "@jobber/components/InputTime";
 ```
 
 <Playground>
-
-  <InputTime defaultValue={new CivilTime(2,35)} size="small" />
-  <InputTime defaultValue={new CivilTime(2,35)} />
-  <InputTime defaultValue={new CivilTime(2,35)} size="large" />
-
+  <Content>
+    <InputTime defaultValue={new CivilTime(2, 35)} size="small" />
+    <InputTime defaultValue={new CivilTime(2, 35)} />
+    <InputTime defaultValue={new CivilTime(2, 35)} size="large" />
+  </Content>
 </Playground>
 
 ## States
 
 <Playground>
-
-  <InputTime defaultValue={new CivilTime(3, 52)} disabled={true} />
-  <InputTime defaultValue={new CivilTime(5, 23)} readonly={true} />
-  <InputTime defaultValue={new CivilTime(2, 35)} invalid={true} />
-
+  <Content>
+    <InputTime defaultValue={new CivilTime(3, 52)} disabled={true} />
+    <InputTime defaultValue={new CivilTime(5, 23)} readonly={true} />
+    <InputTime defaultValue={new CivilTime(2, 35)} invalid={true} />
+  </Content>
 </Playground>
 
 ## Events
@@ -61,11 +62,11 @@ the last element is set the change event will fire.
       setTime(newTime);
     };
     return (
-      <>
+      <Content>
         <InputTime value={time} onChange={handleChange} />
         <pre>{time && time.toString()}</pre>
         <Button label="Reset" onClick={resetTime} />
-      </>
+      </Content>
     );
   }}
 </Playground>

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -1,6 +1,6 @@
 :root {
   --modal--width: calc(var(--base-unit) * 37.5);
-  --modal--padding: var(--space-base) var(--space-large);
+  --modal--padding: var(--space-base);
   --modal--border-color: var(--color-grey--lighter);
 }
 
@@ -54,16 +54,12 @@
   appearance: none;
 }
 
-.content,
-.actionBar {
-  padding: var(--modal--padding);
-}
-
 .actionBar {
   display: flex;
+  padding: var(--modal--padding);
+  padding-top: 0;
   flex: 1 1 100%;
   justify-content: flex-end;
-  padding-top: 0;
 }
 
 /**

--- a/packages/components/src/Modal/Modal.css.d.ts
+++ b/packages/components/src/Modal/Modal.css.d.ts
@@ -3,7 +3,6 @@ export const overlay: string;
 export const modal: string;
 export const header: string;
 export const closeButton: string;
-export const content: string;
 export const actionBar: string;
 export const leftAction: string;
 export const rightAction: string;

--- a/packages/components/src/Modal/Modal.mdx
+++ b/packages/components/src/Modal/Modal.mdx
@@ -10,6 +10,8 @@ import { useState } from "react";
 import { Modal } from ".";
 import { Button } from "../Button";
 import { Text } from "../Text";
+import { Content } from "../Content";
+import { Tabs, Tab } from "../Tabs";
 
 # Modal
 
@@ -25,13 +27,27 @@ the rest of the application until a specific action is taken.
     return (
       <>
         <Modal
-          title="We've updated Jobber"
+          title="Share and Embed"
           open={value}
           onRequestClose={() => setValue(!value)}
         >
-          <Text>
-            It's harder, better, faster, and stronger! 🤖
-          </Text>
+          <Content type="modal">
+            <Text>
+              Display your online booking request form on your website or social media
+            </Text>
+          </Content>
+          <Tabs>
+            <Tab label="Share Link">
+              <Text>
+                  Link the form on your website or social media page with the following URL:
+              </Text>
+            </Tab>
+            <Tab label="Add to Facebook">
+              <Text>
+                Follow our guide on how to add the request form into your Facebook business page by going to our Help Center.
+              </Text>
+            </Tab>
+          </Tabs>
         </Modal>
 
         <Button
@@ -56,17 +72,6 @@ You have 3 action props you can use
 <Playground>
   {() => {
     const [value, setValue] = useState(false);
-    const toggleModal = () => { setValue(!value);
-    };
-    const handlePrimaryAction = () => {
-      alert("✅");
-    };
-    const handleSecondaryAction = () => {
-      toggleModal();
-    };
-    const handleTertiaryAction = () => {
-      alert("❌");
-    };
     return (
       <>
         <Modal
@@ -77,9 +82,11 @@ You have 3 action props you can use
           tertiaryAction={{ label: "Delete", onClick: handleTertiaryAction }}
           onRequestClose={toggleModal}
         >
-          <Text>
-            Lorem ipsum dolor, sit amet consectetur adipisicing elit. Saepe vero ratione praesentium quisquam non porro ullam maiores iure, sed odio?
-          </Text>
+          <Content>
+            <Text>
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Saepe vero ratione praesentium quisquam non porro ullam maiores iure, sed odio?
+            </Text>
+          </Content>
         </Modal>
 
         <Button
@@ -88,6 +95,18 @@ You have 3 action props you can use
         />
       </>
     );
+
+    function toggleModal() { setValue(!value);
+    };
+    function handlePrimaryAction() {
+      alert("✅");
+    };
+    function handleSecondaryAction() {
+      toggleModal();
+    };
+    function handleTertiaryAction() {
+      alert("❌");
+    };
 
 }}
 

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -75,7 +75,7 @@ export function Modal({
               onRequestClose={onRequestClose}
             />
 
-            <div className={styles.content}>{children}</div>
+            {children}
 
             <Actions
               primary={primaryAction}

--- a/packages/components/src/Select/Select.mdx
+++ b/packages/components/src/Select/Select.mdx
@@ -28,7 +28,7 @@ to choose from.
 ## Sizes
 
 <Playground>
-  <Content>
+  <Content padding="none">
     <Select size="small">
       <Option value="">Small</Option>
       <Option value="sad" disabled>Tony</Option>
@@ -55,7 +55,7 @@ to choose from.
 ## States
 
 <Playground>
-  <Content>
+  <Content padding="none">
     <Select size="large" invalid={true}>
       <Option value="sad">Tony</Option>
       <Option value="old">Steve</Option>

--- a/packages/components/src/Select/Select.mdx
+++ b/packages/components/src/Select/Select.mdx
@@ -7,6 +7,7 @@ route: /components/select
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { Select, Option } from ".";
+import { Content } from "../Content";
 
 # Select
 
@@ -27,12 +28,13 @@ to choose from.
 ## Sizes
 
 <Playground>
-  <Select size="small">
-    <Option value="">Small</Option>
-    <Option value="sad" disabled>Tony</Option>
-    <Option value="old">Steve</Option>
-    <Option value="splat" label="Natasha"></Option>
-  </Select>
+  <Content>
+    <Select size="small">
+      <Option value="">Small</Option>
+      <Option value="sad" disabled>Tony</Option>
+      <Option value="old">Steve</Option>
+      <Option value="splat" label="Natasha"></Option>
+    </Select>
 
 <Select>
   <Option value="">Normal</Option>
@@ -41,25 +43,30 @@ to choose from.
   <Option value="yoink">Vision</Option>
 </Select>
 
-  <Select size="large">
-    <Option value="">Large</Option>
-    <Option value="sad">Tony</Option>
-    <Option value="old">Steve</Option>
-  </Select>
+    <Select size="large">
+      <Option value="">Large</Option>
+      <Option value="sad">Tony</Option>
+      <Option value="old">Steve</Option>
+    </Select>
+
+  </Content>
 </Playground>
 
 ## States
 
 <Playground>
-  <Select size="large" invalid={true}>
-    <Option value="sad">Tony</Option>
-    <Option value="old">Steve</Option>
-  </Select>
+  <Content>
+    <Select size="large" invalid={true}>
+      <Option value="sad">Tony</Option>
+      <Option value="old">Steve</Option>
+    </Select>
 
-  <Select size="large" disabled={true}>
-    <Option value="sad">Tony</Option>
-    <Option value="old">Steve</Option>
-  </Select>
+    <Select size="large" disabled={true}>
+      <Option value="sad">Tony</Option>
+      <Option value="old">Steve</Option>
+    </Select>
+
+  </Content>
 </Playground>
 
 ## Initial Value

--- a/packages/components/src/Tabs/Tabs.css
+++ b/packages/components/src/Tabs/Tabs.css
@@ -48,7 +48,7 @@
   padding-left: var(--tab--inset);
   padding-right: var(--tab--inset);
   border: solid var(--border-base) var(--tab--border-color);
-  border-right-width: 0;
+  border-left-width: 0;
   outline: none;
   background: transparent;
   cursor: pointer;
@@ -58,10 +58,6 @@
 .tab:hover,
 .tab:focus {
   background-color: var(--color-yellow--lightest);
-}
-
-.tab:last-child {
-  border-right-width: var(--border-base);
 }
 
 .selected {


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    perf(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## 💡 Plan to release without breaking change
- Break up content component on its own PR without default padding
- Use content component PR's on affected components like card and modal
- Do the rest of the change in this PR so once it's out, everything still looks the same. With some minor caveat that the tab would have a larger vertical spacing above it

## Changes

- Adjusted Modal, Card, FormField (which controlls all input)
- Removed border left from tabs

### Added

- Content component

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
