### PR TITLE
feat: Contentize the content. A.K.A add new content component

### DIFF
--- a/packages/components/src/Content/Content.mdx
+++ b/packages/components/src/Content/Content.mdx
@@ -1,0 +1,79 @@
+---
+name: Content
+menu: Components
+route: /components/content
+---
+
+import { Playground, Props } from "docz";
+import { ComponentStatus } from "@jobber/docx";
+import { Content } from ".";
+import { Text } from "../Text";
+import { Heading } from "../Heading";
+import { InputText } from "../InputText";
+import { Button } from "../Button";
+import { Tabs, Tab } from "../Tabs";
+import { Card, Title } from "../Card";
+
+# Content
+
+<ComponentStatus stage="pre" responsive="no" accessible="no" />
+
+Contents are used to give elements consistent vertical spacing and padding.
+
+<Playground>
+  <Content>
+    <Heading level={2}>Sign up!</Heading>
+    <Text>
+      Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+      vestibulum. Nulla vitae elit libero, a pharetra augue. Nullam quis risus
+      eget urna mollis ornare vel eu leo. Vestibulum id ligula porta felis
+      euismod semper. Curabitur blandit tempus porttitor.
+    </Text>
+    <InputText placeholder="Name" />
+    <InputText placeholder="Phone" />
+    <InputText placeholder="Email" />
+    <InputText
+      multiline={true}
+      placeholder="Describe yourself"
+      name="describeAge"
+    />
+    <Button
+      label="Submit"
+      onClick={() => {
+        alert("✅");
+      }}
+    />
+  </Content>
+</Playground>
+
+## Within Cards
+
+<Playground>
+  <Card>
+    <Title title="About me" />
+    <Content>
+      <Heading level={4}>My favourite food</Heading>
+      <Text>
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Nulla vitae elit libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel eu leo. Vestibulum id ligula porta felis euismod semper. Curabitur blandit tempus porttitor.
+      </Text>
+    </Content>
+
+    <Tabs>
+      <Tab label="Eggs">
+        🍳 Some eggs are laid by female animals of many different species,
+        including birds, reptiles, amphibians, mammals, and fish, and have been
+        eaten by humans for thousands of years.
+      </Tab>
+      <Tab label="Cheese">
+        🧀 Cheese is a dairy product derived from milk that is produced in a wide
+        range of flavors, textures, and forms by coagulation of the milk protein
+        casein.
+      </Tab>
+    </Tabs>
+
+  </Card>
+</Playground>
+
+## Content Properties
+
+<Props of={Content} />

--- a/packages/components/src/Content/Content.test.tsx
+++ b/packages/components/src/Content/Content.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { cleanup } from "@testing-library/react";
+import { Content } from ".";
+
+afterEach(cleanup);
+
+it("renders a Content", () => {
+  const tree = renderer.create(<Content>Wazaaaaa</Content>).toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+    <div
+      className="base"
+    >
+      Wazaaaaa
+    </div>
+  `);
+});
+
+it("renders a Content with a large spacing", () => {
+  const tree = renderer
+    .create(<Content padding="large">Space me up!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+        <div
+          className="base large"
+        >
+          Space me up!
+        </div>
+    `);
+});
+
+it("renders a Content with a small spacing", () => {
+  const tree = renderer
+    .create(<Content padding="small">Space me down!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+        <div
+          className="base small"
+        >
+          Space me down!
+        </div>
+    `);
+});
+
+it("renders a Content with a large padding", () => {
+  const tree = renderer
+    .create(<Content padding="large">Pad me up!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+        <div
+          className="base large"
+        >
+          Pad me up!
+        </div>
+    `);
+});
+
+it("renders a Content with a small padding", () => {
+  const tree = renderer
+    .create(<Content padding="small">Pad me down!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+        <div
+          className="base small"
+        >
+          Pad me down!
+        </div>
+    `);
+});
+
+it("renders a Content with no padding", () => {
+  const tree = renderer
+    .create(<Content padding="none">Pad me none!</Content>)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+        <div
+          className="base none"
+        >
+          Pad me none!
+        </div>
+    `);
+});

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode } from "react";
+import classnames from "classnames";
+import spacings from "./Spacing.css";
+import paddings from "./Paddings.css";
+
+interface ContentProps {
+  readonly children: ReactNode | ReactNode[];
+  /**
+   * Determines the spacing within the component
+   */
+  readonly padding?: keyof typeof paddings;
+  /**
+   * The amount of vertical spacing between the children
+   *
+   * @default base
+   */
+  readonly spacing?: keyof typeof spacings;
+}
+
+export function Content({ children, spacing = "base", padding }: ContentProps) {
+  const className = classnames(spacings[spacing], padding && paddings[padding]);
+
+  return <div className={className}>{children}</div>;
+}

--- a/packages/components/src/Content/Paddings.css
+++ b/packages/components/src/Content/Paddings.css
@@ -1,0 +1,15 @@
+.base {
+  padding: var(--space-base);
+}
+
+.small {
+  padding: var(--space-small);
+}
+
+.large {
+  padding: var(--space-large);
+}
+
+.none {
+  padding: 0;
+}

--- a/packages/components/src/Content/Paddings.css.d.ts
+++ b/packages/components/src/Content/Paddings.css.d.ts
@@ -1,0 +1,4 @@
+export const base: string;
+export const small: string;
+export const large: string;
+export const none: string;

--- a/packages/components/src/Content/Spacing.css
+++ b/packages/components/src/Content/Spacing.css
@@ -1,0 +1,11 @@
+.base > :not(:last-child) {
+  margin-bottom: var(--space-base);
+}
+
+.small > :not(:last-child) {
+  margin-bottom: var(--space-small);
+}
+
+.large > :not(:last-child) {
+  margin-bottom: var(--space-large);
+}

--- a/packages/components/src/Content/Spacing.css.d.ts
+++ b/packages/components/src/Content/Spacing.css.d.ts
@@ -1,0 +1,3 @@
+export const base: string;
+export const small: string;
+export const large: string;

--- a/packages/components/src/Content/index.ts
+++ b/packages/components/src/Content/index.ts
@@ -1,0 +1,1 @@
+export { Content } from "./Content";


### PR DESCRIPTION
## 💡 Plan to release without breaking change #115 
✔️  Break up Content component on its own PR without default padding (This PR)
🚧  Use content component PR's on affected components like card and modal (Jobber online change)
🚧  Do the rest of the change on this PR #115 so once it's out, everything still looks the same. With some minor caveat that the tab would have a larger vertical spacing above it

### Added

- Adds in `Content` component that handles vertical spacing on components. [Click here to view](https://deploy-preview-116--jobber-atlantis.netlify.com/components/content)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
