### PR TITLE
fix: Adjust small and large form fields

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -94,19 +94,24 @@ select.formField {
 /* Sizes */
 
 .small {
-  --field--padding-top: var(--space-smallest);
-  --field--padding-bottom: var(--space-smallest);
-  --field--padding-left: var(--space-small);
-  --field--padding-right: var(--space-small);
+  --field--padding-top: var(--space-small);
+  --field--padding-bottom: var(--space-small);
+  --field--padding-left: calc(var(--space-base) - var(--space-smaller));
+  --field--padding-right: calc(var(--space-base) - var(--space-smaller));
   --field--height: calc(var(--space-larger) + var(--space-smaller));
 }
 
 .large {
-  --field--padding-top: var(--space-base);
-  --field--padding-bottom: var(--space-base);
+  --field--padding-top: calc(var(--space-large) - var(--space-smallest));
+  --field--padding-bottom: calc(var(--space-large) - var(--space-smallest));
   --field--padding-left: var(--space-large);
   --field--padding-right: var(--space-large);
   --field--height: calc(var(--space-extravagant));
+}
+
+.large select {
+  --field--padding-top: var(--space-base);
+  --field--padding-bottom: var(--space-base);
 }
 
 /* Alignment */
@@ -163,10 +168,14 @@ select.formField {
 }
 
 .miniLabel.large .label {
-  --field--padding-top: var(--space-smallest);
-  --field--padding-bottom: var(--space-small);
+  --field--padding-top: var(--space-small);
+  --field--padding-bottom: var(--space-smallest);
   --field--padding-left: var(--space-large);
   --field--padding-right: var(--space-large);
+}
+
+.miniLabel.large textarea.formField {
+  --field--padding-top: var(--space-larger);
 }
 
 .miniLabel .textareaLabel {

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -35,6 +35,7 @@
 .formField {
   display: block;
   position: relative;
+  z-index: auto;
   width: inherit;
   height: var(--field--height);
   border: var(--field--border-width) solid var(--field--border-color);


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    perf(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

- Better handle on the padding for small and large fields
- Reset z-index for fields to prevent unexpected outcome when importing to jobber

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
