### PR TITLE
fix: Make entrypoints compatible with commonjs

### DIFF
--- a/packages/components/scripts/entryPoints.ts
+++ b/packages/components/scripts/entryPoints.ts
@@ -41,7 +41,23 @@ async function getEntryPoints() {
 
     entryPoints.push({
       file: `${pathParts[2]}.js`,
-      content: `export * from "./dist/${pathParts[2]}";\n`,
+      content: `"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+
+var ${pathParts[2]} = require("./dist/${pathParts[2]}");
+
+Object.keys(${pathParts[2]}).forEach(function(key) {
+  if (key === "default" || key === "__esModule") return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function get() {
+      return ${pathParts[2]}[key];
+    },
+  });
+});`,
     });
     entryPoints.push({
       file: `${pathParts[2]}.d.ts`,


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Entrypoints no longer need to be transpiled.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)