### PR TITLE
feat: Add eslint import resolver typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Everyone is a friend of Atlantis and we welcome pull requests. See the
 ### Pre-Release
 
 ```sh
-lerna publish --canary --dist-tag next --preid pre
+npm run prerelease
 ```
 
 ### For Realz

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:fix": "npm run lint:js -- --fix && npm run lint:css -- --fix && npm run lint:markdown -- --write",
     "install": "lerna bootstrap",
-    "release-the-kraken": "npm ci && lerna publish"
+    "release-the-kraken": "npm ci && lerna publish",
+    "prerelease": "lerna publish --canary --dist-tag next --preid pre"
   },
   "repository": {
     "type": "git",

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode, useState } from "react";
 import classnames from "classnames";
-import { Icon, IconColorNames } from "../Icon";
-import { Text } from "../Text";
 import styles from "./Banner.css";
 import types from "./notificationTypes.css";
+import { Icon, IconColorNames } from "../Icon";
+import { Text } from "../Text";
 
 interface BannerProps {
   readonly children: ReactNode;

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import classnames from "classnames";
 import { XOR } from "ts-xor";
+import styles from "./Button.css";
 import { Typography, TypographyOptions } from "../Typography";
 import { Icon, IconNames } from "../Icon";
-import styles from "./Button.css";
 
 export interface ButtonProps {
   readonly ariaControls?: string;

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode } from "react";
 import classnames from "classnames";
 import { XOR } from "ts-xor";
-import { Typography } from "../Typography";
 import styles from "./Card.css";
 import colors from "./colors.css";
+import { Typography } from "../Typography";
 
 interface HeaderProps {
   readonly children: ReactNode;

--- a/packages/components/src/DescriptionList/DescriptionList.tsx
+++ b/packages/components/src/DescriptionList/DescriptionList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Typography } from "../Typography";
 import styles from "./DescriptionList.css";
+import { Typography } from "../Typography";
 
 interface DescriptionListProps {
   /**

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -1,10 +1,10 @@
 import React, { ChangeEvent, ReactNode, Ref, useEffect, useState } from "react";
 import classnames from "classnames";
 import uuid from "uuid";
+import styles from "./FormField.css";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
 import { InputValidation, ValidationProps } from "../InputValidation";
-import styles from "./FormField.css";
 
 export interface FormFieldProps {
   /**

--- a/packages/components/src/InlineLabel/InlineLabel.tsx
+++ b/packages/components/src/InlineLabel/InlineLabel.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from "react";
 import classnames from "classnames";
-import { Typography } from "../Typography";
 import styles from "./InlineLabel.css";
+import { Typography } from "../Typography";
 
 interface InlineLabelProps {
   /**

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { fireEvent, render } from "@testing-library/react";
-import { InputTextRef } from "./InputText";
 import { InputText } from ".";
+import { InputTextRef } from "./InputText";
 
 it("renders a regular input for text and numbers", () => {
   const tree = renderer

--- a/packages/components/src/InputTime/InputTime.tsx
+++ b/packages/components/src/InputTime/InputTime.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 // eslint-disable-next-line import/no-internal-modules
 import supportsTime from "time-input-polyfill/supportsTime";
-import { FormField, FormFieldProps } from "../FormField";
 import { InputTimeSafari } from "./InputTimeSafari";
 import {
   civilTimeToHTMLTime,
   htmlTimeToCivilTime,
 } from "./civilTimeConversions";
 import { InputTimeProps } from "./InputTimeProps";
+import { FormField, FormFieldProps } from "../FormField";
 
 export function InputTime({
   defaultValue,

--- a/packages/components/src/InputTime/InputTimeSafari.tsx
+++ b/packages/components/src/InputTime/InputTimeSafari.tsx
@@ -2,12 +2,12 @@ import React, { useLayoutEffect } from "react";
 import TimePolyfill from "time-input-polyfill";
 // eslint-disable-next-line import/no-internal-modules
 import debounce from "lodash/debounce";
-import { FormField } from "../FormField";
 import { InputTimeProps } from "./InputTimeProps";
 import {
   civilTimeToHTMLTime,
   htmlTimeToCivilTime,
 } from "./civilTimeConversions";
+import { FormField } from "../FormField";
 
 interface PolyfilledInputElement extends HTMLInputElement {
   polyfill: { update: () => void };

--- a/packages/components/src/InputValidation/InputValidation.tsx
+++ b/packages/components/src/InputValidation/InputValidation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Text } from "../Text";
 import styles from "./InputValidation.css";
+import { Text } from "../Text";
 
 type ValidationStatus = "success" | "error" | "warn" | "info";
 

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { cleanup, fireEvent, render } from "@testing-library/react";
-import { Button } from "../Button";
 import { Menu } from ".";
+import { Button } from "../Button";
 
 afterEach(cleanup);
 jest.mock("uuid");

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -7,10 +7,10 @@ import React, {
 } from "react";
 import uuid from "uuid";
 import classnames from "classnames";
+import styles from "./Menu.css";
 import { Button } from "../Button";
 import { Typography } from "../Typography";
 import { Icon, IconNames } from "../Icon";
-import styles from "./Menu.css";
 
 interface MenuProps {
   /**

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -2,11 +2,11 @@ import React, { ReactNode, useEffect } from "react";
 import ReactDOM from "react-dom";
 import classnames from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
+import styles from "./Modal.css";
+import sizes from "./Sizes.css";
 import { Icon } from "../Icon";
 import { Typography } from "../Typography";
 import { Button, ButtonProps } from "../Button";
-import styles from "./Modal.css";
-import sizes from "./Sizes.css";
 
 interface ModalProps {
   /**

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import classnames from "classnames";
-import { Typography } from "../Typography";
 import styles from "./Switch.css";
+import { Typography } from "../Typography";
 
 interface SwitchProps {
   readonly value?: boolean;

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -7,8 +7,8 @@ import React, {
   useState,
 } from "react";
 import classnames from "classnames";
-import { Typography } from "../Typography";
 import styles from "./Tabs.css";
+import { Typography } from "../Typography";
 
 interface TabsProps {
   readonly children: ReactElement | ReactElement[];

--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
   ],
   settings: {
     react: { version: "detect" },
+    "import/resolver": { typescript: {} },
   },
   parserOptions: {
     ecmaFeatures: { jsx: true },

--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -28,7 +28,13 @@ module.exports = {
     sourceType: "module",
   },
   rules: {
-    "import/order": "error",
+    "import/order": [
+      "error",
+      {
+        groups: ["builtin", "external", "internal", "index", "sibling"],
+        "newlines-between": "never",
+      },
+    ],
     "import/no-default-export": "error",
     "import/no-unresolved": ["error", { ignore: [".css$"] }],
     "import/namespace": "error",

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -2,4 +2,4 @@
 
 ## Installing
 
-1. `npm install --save-dev @jobber/eslint-config`
+`npm install --save-dev @jobber/eslint-config`

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/eslint-config",
-	"version": "0.0.4",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -33,6 +33,11 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
+		},
+		"@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "2.1.0",
@@ -440,6 +445,31 @@
 			"requires": {
 				"debug": "^2.6.9",
 				"resolve": "^1.5.0"
+			}
+		},
+		"eslint-import-resolver-typescript": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-1.1.1.tgz",
+			"integrity": "sha512-jqSfumQ+H5y3FUJ6NjRkbOQSUOlbBucGTN3ELymOtcDBbPjVdm/luvJuCfCaIXGh8sEF26ma1qVdtDgl9ndhUg==",
+			"requires": {
+				"debug": "^4.0.1",
+				"resolve": "^1.4.0",
+				"tsconfig-paths": "^3.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
 			}
 		},
 		"eslint-module-utils": {
@@ -925,6 +955,21 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
+		},
+		"json5": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"requires": {
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
 		},
 		"jsx-ast-utils": {
 			"version": "2.2.1",
@@ -1541,6 +1586,24 @@
 			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
+			}
+		},
+		"tsconfig-paths": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"tslib": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,6 +10,7 @@
     "@typescript-eslint/eslint-plugin": "^2.1.0",
     "@typescript-eslint/parser": "^2.1.0",
     "eslint-config-prettier": "^6.2.0",
+    "eslint-import-resolver-typescript": "^1.1.1",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-no-null": "^1.0.2",


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Improved import order specification.
- Improved prerelease flow.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Use `eslint-import-resolver-typescript` to resolve typescript code.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)