### PR TITLE
fix: Make feature switch description support markdown

### DIFF
--- a/packages/components/src/FeatureSwitch/FeatureSwitch.test.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.test.tsx
@@ -48,6 +48,21 @@ it("renders a subdued FeatureSwitch content", () => {
   expect(tree).toMatchSnapshot();
 });
 
+it("renders a FeatureSwitch markdown description", () => {
+  const tree = renderer
+    .create(
+      <FeatureSwitch
+        enabled={true}
+        externalLink={true}
+        description="Send a [notification](www.fakeurl.com) to your _client_ following up on an **outstanding quote**."
+      >
+        Dis dem content yo
+      </FeatureSwitch>,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test("it should call the switch handler with the new value", () => {
   const switchHandler = jest.fn();
   const content = "Send a thing?";

--- a/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
@@ -8,6 +8,7 @@ import { Content } from "../Content";
 import { Switch } from "../Switch";
 import { Button } from "../Button";
 import { Emphasis } from "../Emphasis";
+import { Markdown } from "../Markdown";
 
 interface FeatureSwitchProps {
   readonly children?: ReactNode | ReactNode[];
@@ -19,8 +20,17 @@ interface FeatureSwitchProps {
 
   /**
    * Defines if the feature should be ON or OFF by default.
+   *
+   * @default false
    */
   readonly enabled?: boolean;
+
+  /**
+   * Defines if the links in the description should open in a new tab.
+   *
+   * @default false
+   */
+  readonly externalLink?: boolean;
 
   /**
    * Feature title.
@@ -51,7 +61,8 @@ interface FeatureSwitchProps {
 export function FeatureSwitch({
   children,
   description,
-  enabled,
+  enabled = false,
+  externalLink = false,
   onEdit,
   onSwitch,
   hasSaveIndicator = false,
@@ -70,7 +81,13 @@ export function FeatureSwitch({
         <div className={styles.content}>
           <Content>
             {title && <Heading level={4}>{title}</Heading>}
-            <Text>{description}</Text>
+            <Text>
+              <Markdown
+                content={description}
+                basicUsage={true}
+                externalLink={externalLink}
+              />
+            </Text>
           </Content>
         </div>
         <div className={styles.action}>

--- a/packages/components/src/FeatureSwitch/__snapshots__/FeatureSwitch.test.tsx.snap
+++ b/packages/components/src/FeatureSwitch/__snapshots__/FeatureSwitch.test.tsx.snap
@@ -1,5 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders a FeatureSwitch markdown description 1`] = `
+<div
+  className="padded base"
+>
+  <div
+    className="container"
+  >
+    <div
+      className="content"
+    >
+      <div
+        className="padded base"
+      >
+        <p
+          className="base regular base greyBlueDark"
+        >
+          Send a 
+          <a
+            href="www.fakeurl.com"
+            target="_blank"
+          >
+            notification
+          </a>
+           to your 
+          <em
+            className="base regular italic"
+          >
+            client
+          </em>
+           following up on an 
+          <b
+            className="base bold"
+          >
+            outstanding quote
+          </b>
+          .
+        </p>
+      </div>
+    </div>
+    <div
+      className="action"
+    >
+      <button
+        aria-checked={true}
+        aria-label="Send a [notification](www.fakeurl.com) to your _client_ following up on an **outstanding quote**."
+        className="track isChecked"
+        onClick={[Function]}
+        role="switch"
+        type="button"
+      >
+        <span
+          className="toggle"
+        >
+          <span
+            className="label"
+          >
+            <span
+              className="base bold small uppercase white"
+            >
+              On
+            </span>
+          </span>
+          <span
+            className="pip"
+          />
+          <span
+            className="label"
+          >
+            <span
+              className="base bold small uppercase greyBlue"
+            >
+              Off
+            </span>
+          </span>
+        </span>
+      </button>
+      <input
+        type="hidden"
+        value="true"
+      />
+    </div>
+  </div>
+  <div
+    className="container"
+  >
+    <div
+      className="featureContent content enabled"
+    >
+      Dis dem content yo
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders a full FeatureSwitch 1`] = `
 <div
   className="padded base"


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

### Added

- Allow markdown on feature switch description
![image](https://user-images.githubusercontent.com/15986172/65550613-30d64c00-dedd-11e9-82ba-e2499126445b.png)


### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
