### PR TITLE
fix: when the time leaps; the safari changes

### DIFF
--- a/packages/components/src/FormatTime/FormatTime.tsx
+++ b/packages/components/src/FormatTime/FormatTime.tsx
@@ -18,10 +18,14 @@ export function FormatTime({ time, use24HourClock }: FormatTimeProps) {
 }
 
 function formatCivilTime(time: CivilTime, use24HourClock: boolean) {
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
+  const currentMonth = currentDate.getMonth();
+  const currentDay = currentDate.getDay();
   const date = new Date(
-    0,
-    1,
-    1,
+    currentYear,
+    currentMonth,
+    currentDay,
     time.hour,
     time.minute,
     time.second,


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

- Feed `FormatTime` the current year, month, and day to prevent leap seconds from messing with it

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
