### PR TITLE
fix(components): Make feature switch save indicator show up when `enabled` changes

### DIFF
--- a/packages/components/src/FeatureSwitch/FeatureSwitch.css
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.css
@@ -6,6 +6,7 @@
   flex: 1 1 auto;
   align-self: center;
   padding-right: var(--space-base);
+  transition: opacity var(--timing-base);
 }
 
 .action {

--- a/packages/components/src/FeatureSwitch/FeatureSwitch.mdx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.mdx
@@ -12,7 +12,7 @@ import { useState } from "react";
 
 # Feature Switch
 
-<ComponentStatus stage="rc" responsive="yes" accessible="yes" />
+<ComponentStatus stage="ready" responsive="yes" accessible="yes" />
 
 Allow users to switch a feature on or off.
 

--- a/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import classnames from "classnames";
 import styles from "./FeatureSwitch.css";
@@ -61,7 +61,7 @@ interface FeatureSwitchProps {
 export function FeatureSwitch({
   children,
   description,
-  enabled = false,
+  enabled,
   externalLink = false,
   onEdit,
   onSwitch,
@@ -74,6 +74,14 @@ export function FeatureSwitch({
     styles.content,
     enabled && styles.enabled,
   );
+
+  // Check if the component is mounted
+  const [didMount, setDidMount] = useState(false);
+  useEffect(() => setDidMount(true), []);
+
+  useEffect(() => {
+    didMount && hasSaveIndicator && setSavedIndicator(true);
+  }, [enabled]);
 
   return (
     <Content>
@@ -138,7 +146,6 @@ export function FeatureSwitch({
 
   function handleSwitch(newValue: boolean) {
     onSwitch && onSwitch(newValue);
-    setSavedIndicator(true);
   }
 
   function handleAnimationComplete() {

--- a/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
@@ -14,7 +14,8 @@ interface FeatureSwitchProps {
   readonly children?: ReactNode | ReactNode[];
 
   /**
-   * Feature description.
+   * Feature description. This supports basic markdown node types such as
+   * `_italic_`, `**bold**`, and `[link name](url)`
    */
   readonly description: string;
 
@@ -38,7 +39,8 @@ interface FeatureSwitchProps {
   readonly title?: string;
 
   /**
-   * Determines if a save indicator should show up when toggling the switch.
+   * Determines if a save indicator should show up when the `enabled` prop
+   * changes. This means, it would only work for controlled components.
    *
    * @default false
    */
@@ -74,14 +76,7 @@ export function FeatureSwitch({
     styles.content,
     enabled && styles.enabled,
   );
-
-  // Check if the component is mounted
-  const [didMount, setDidMount] = useState(false);
-  useEffect(() => setDidMount(true), []);
-
-  useEffect(() => {
-    didMount && hasSaveIndicator && setSavedIndicator(true);
-  }, [enabled]);
+  shouldShowSavedIndicator();
 
   return (
     <Content>
@@ -146,6 +141,15 @@ export function FeatureSwitch({
 
   function handleSwitch(newValue: boolean) {
     onSwitch && onSwitch(newValue);
+  }
+
+  function shouldShowSavedIndicator() {
+    // Check if the component is mounted
+    const [didMount, setDidMount] = useState(false);
+    useEffect(() => setDidMount(true), []);
+    useEffect(() => {
+      didMount && hasSaveIndicator && setSavedIndicator(true);
+    }, [enabled]);
   }
 
   function handleAnimationComplete() {


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

- Use `useEffect` to catch when the component mounts so `saved` indicator doesn't show on mount
- Use `useEffect` to determine when should `saved` indicator show up

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
