### PR TITLE
docs: link the contributing section correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+---
+name: Contributing
+route: /CONTRIBUTING.md
+---
+
 # Contributing
 
 # How can you contribute?

--- a/doczrc.js
+++ b/doczrc.js
@@ -142,7 +142,7 @@ export default {
   typescript: true,
   port: 3333,
   menu: ["Atlantis", "Patterns", "Components"],
-  files: "{README.md,**/*.mdx}",
+  files: "{README.md,CONTRIBUTING.md,**/*.mdx}",
   ignore: [...privateComponentReadmies(), "./plop/templates/**/*"],
   codeSandbox: false,
   public: "public",


### PR DESCRIPTION
## Changes
The contributing section works 👍 

### Fixed
Added the CONTRIBUTING.md to the doczrc.js so it can be recognized and give the file a proper route so it can be linked to. The contributing section was also added to the side nav

## Testing

Run the repo locally and notice the contributing section actually links. 

---


![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
