### PR TITLE
fix(components): The time formatter actually works for GB now and README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ developers to quickly build beautiful and consistent interfaces for our users.
 
 ## Development
 
+###### Requires npm v5.7.1 or higher
+
 To install Atlantis locally for development:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ developers to quickly build beautiful and consistent interfaces for our users.
 
 ## Development
 
-###### Requires npm v5.7.1 or higher
+##### Prerequisites
+
+- `node@10` or higher
+- `npm@6` or higher
 
 To install Atlantis locally for development:
 

--- a/packages/components/src/FormatTime/FormatTime.tsx
+++ b/packages/components/src/FormatTime/FormatTime.tsx
@@ -14,10 +14,10 @@ interface FormatTimeProps {
 }
 
 export function FormatTime({ time, use24HourClock }: FormatTimeProps) {
-  return <>{formatCivilTime(time, !!use24HourClock)}</>;
+  return <>{formatCivilTime(time, use24HourClock)}</>;
 }
 
-function formatCivilTime(time: CivilTime, use24HourClock: boolean) {
+function formatCivilTime(time: CivilTime, use24HourClock?: boolean) {
   const currentDate = new Date();
   const currentYear = currentDate.getFullYear();
   const currentMonth = currentDate.getMonth();
@@ -32,8 +32,8 @@ function formatCivilTime(time: CivilTime, use24HourClock: boolean) {
     time.millisecond,
   );
 
-  return date.toLocaleTimeString(undefined, {
-    hour12: !use24HourClock,
+  return date.toLocaleTimeString(navigator.language, {
+    hour12: typeof use24HourClock === "boolean" ? !use24HourClock : undefined,
     minute: "2-digit",
     hour: "numeric",
   });


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- a line to the read me specifying what version of npm is needed

### Changed

- <!-- things -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Changed the way use24HourClock was used. It should more accurately hold its value now. 
- Had to manually add the locale to the "toLocaleTimeString" function

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
