### PR TITLE
feat: modal title becomes optional and hides header if undefined

### DIFF
--- a/packages/components/src/Modal/Modal.test.tsx
+++ b/packages/components/src/Modal/Modal.test.tsx
@@ -9,16 +9,22 @@ test("modal shows the children and a close button", () => {
   const content = "Dis be a content 🎉";
   const handleClose = jest.fn();
 
-  const { getByLabelText, getByText } = render(
+  const { getByLabelText, getByText, queryByTestId } = render(
     <Modal title={title} open={true} onRequestClose={handleClose}>
       {content}
     </Modal>,
   );
   expect(getByText(title)).toBeTruthy();
   expect(getByText(content)).toBeTruthy();
+  expect(queryByTestId("modal-header")).not.toBeNull();
 
   fireEvent.click(getByLabelText("Close modal"));
   expect(handleClose).toHaveBeenCalledTimes(1);
+});
+
+test("modal without a title doesn't show the header", () => {
+  const { queryByTestId } = render(<Modal open={true}>Content</Modal>);
+  expect(queryByTestId("modal-header")).toBeNull();
 });
 
 test("modal doesn't show up", () => {

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -19,6 +19,7 @@ interface ModalProps {
    * @default true
    */
   readonly dismissible?: boolean;
+  readonly showTitle?: boolean;
   readonly children: ReactNode;
   readonly primaryAction?: ButtonProps;
   readonly secondaryAction?: ButtonProps;
@@ -31,6 +32,7 @@ export function Modal({
   title,
   size,
   dismissible = true,
+  showTitle = true,
   children,
   primaryAction,
   secondaryAction,
@@ -69,12 +71,13 @@ export function Modal({
               stiffness: 300,
             }}
           >
-            <Header
-              title={title}
-              dismissible={dismissible}
-              onRequestClose={onRequestClose}
-            />
-
+            {showTitle && (
+              <Header
+                title={title}
+                dismissible={dismissible}
+                onRequestClose={onRequestClose}
+              />
+            )}
             {children}
 
             <Actions

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -117,7 +117,7 @@ interface HeaderProps {
 
 function Header({ title, dismissible, onRequestClose }: HeaderProps) {
   return (
-    <div className={styles.header}>
+    <div className={styles.header} data-testid="modal-header">
       <Typography
         element="h3"
         size="large"

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -19,7 +19,6 @@ interface ModalProps {
    * @default true
    */
   readonly dismissible?: boolean;
-  readonly showTitle?: boolean;
   readonly children: ReactNode;
   readonly primaryAction?: ButtonProps;
   readonly secondaryAction?: ButtonProps;

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -12,7 +12,7 @@ interface ModalProps {
   /**
    * @default false
    */
-  readonly title: string;
+  readonly title?: string;
   readonly open?: boolean;
   readonly size?: keyof typeof sizes;
   /**
@@ -32,7 +32,6 @@ export function Modal({
   title,
   size,
   dismissible = true,
-  showTitle = true,
   children,
   primaryAction,
   secondaryAction,
@@ -71,7 +70,7 @@ export function Modal({
               stiffness: 300,
             }}
           >
-            {showTitle && (
+            {title != undefined && (
               <Header
                 title={title}
                 dismissible={dismissible}


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Modal: `title` is now an optional prop, and will now hide the Header if the title is not provided 

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
