### PR TITLE
docs: makes Natasha visible in lists -- patch release

### DIFF
--- a/packages/components/src/Select/Select.mdx
+++ b/packages/components/src/Select/Select.mdx
@@ -43,7 +43,7 @@ import { Select, Option } from "@jobber/components/Select";
       Tony
     </Option>
     <Option value="old">Steve</Option>
-    <Option value="splat" label="Natasha"></Option>
+    <Option value="splat">Natasha</Option>
   </Select>
 </Playground>
 
@@ -56,7 +56,7 @@ import { Select, Option } from "@jobber/components/Select";
       Tony
     </Option>
     <Option value="old">Steve</Option>
-    <Option value="splat" label="Natasha"></Option>
+    <Option value="splat">Natasha</Option>
   </Select>
 </Playground>
 


### PR DESCRIPTION
Natasha was inside of labels and that was making her not show up in example lists.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
