### PR TITLE
docs: Change meridiam to period (am/pm)

### DIFF
--- a/packages/components/src/InputTime/InputTime.mdx
+++ b/packages/components/src/InputTime/InputTime.mdx
@@ -58,8 +58,8 @@ import { InputTime } "@jobber/components/InputTime";
 ## Events
 
 If the input starts empty the `ChangeEvent` isn't fired until a full time is
-set. Setting just the hour or minute or _meridiam_ won't fire the event. When
-the last element is set the change event will fire.
+set. Setting just the hour or minute or _period_ (AM/PM) won't fire the event. 
+When the last element is set the change event will fire.
 
 <Playground>
   {() => {


### PR DESCRIPTION
Meridiam (sic) was unclear about what it referred to. Period is not great either, but adding AM/PM helps.

---

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
