### PR TITLE
docs: clarifies the variable names used in `Modal` examples

### DIFF
--- a/packages/components/src/Modal/Modal.mdx
+++ b/packages/components/src/Modal/Modal.mdx
@@ -27,13 +27,13 @@ import { Modal } from "@jobber/components/Modal";
 
 <Playground>
   {() => {
-    const [value, setValue] = useState(false);
+    const [modalOpen, setModalOpen] = useState(false);
     return (
       <>
         <Modal
           title="We've updated Jobber"
-          open={value}
-          onRequestClose={() => setValue(!value)}
+          open={modalOpen}
+          onRequestClose={() => setModalOpen(false)}
         >
           <Content>
             <Text>
@@ -44,7 +44,7 @@ import { Modal } from "@jobber/components/Modal";
 
         <Button
           label="Open Modal"
-          onClick={() => setValue(!value)}
+          onClick={() => setModalOpen(true)}
         />
       </>
     );
@@ -69,12 +69,12 @@ You have 3 action props you can use
 
 <Playground>
   {() => {
-    const [value, setValue] = useState(false);
+    const [modalOpen, setModalOpen] = useState(false);
     return (
       <>
         <Modal
           title="Hold the phone!"
-          open={value}
+          open={modalOpen}
           primaryAction={{ label: "Submit", onClick: handlePrimaryAction }}
           secondaryAction={{ label: "Cancel", onClick: handleSecondaryAction }}
           tertiaryAction={{ label: "Delete", onClick: handleTertiaryAction }}
@@ -94,13 +94,14 @@ You have 3 action props you can use
       </>
     );
 
-    function toggleModal() { setValue(!value);
+    function toggleModal() {
+      setModalOpen(!modalOpen);
     };
     function handlePrimaryAction() {
       alert("✅");
     };
     function handleSecondaryAction() {
-      toggleModal();
+      setModalOpen(false);
     };
     function handleTertiaryAction() {
       alert("❌");


### PR DESCRIPTION
The `Modal` examples previously used generic variable names (`value`) for controlling the toggle state. Improved those and also made most show/hide calls more explicit to keep things explicit.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
