### PR TITLE
docs: Updated input text example to use age and setAge

### DIFF
--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -38,11 +38,11 @@ Use this to allow users to provide short answers.
 
 <Playground>
   {() => {
-    const [value, setValue] = useState("Veintisiete");
+    const [age, setAge] = useState("Veintisiete");
     return (
       <InputText
-        value={value}
-        onChange={setValue}
+        value={age}
+        onChange={setAge}
         name="age"
         placeholder="Age in words"
       />
@@ -69,34 +69,34 @@ shouldn't replace server-side validation.
 
 <Playground>
   {() => {
-    const [value, setValue] = useState("");
+    const [age, setAge] = useState("");
     return (
       <InputText
-        value={value}
+        value={age}
         onChange={handleChange}
         name="age"
         placeholder="What's your age"
         validations={[
           {
-            shouldShow: value.length > 2 && value.length < 10 && isNaN(value),
+            shouldShow: age.length > 2 && age.length < 10 && isNaN(age),
             message: "Now that's a word, keep going!",
             status: "success"
           },
           {
-            shouldShow: value.length >= 10,
+            shouldShow: age.length >= 10,
             message: "You sure you're that old?",
             status: "warn"
           },
           {
-            shouldShow: value.length > 0 && !isNaN(value),
+            shouldShow: age.length > 0 && !isNaN(age),
             message: "Type your age in words",
             status: "error"
           }
         ]}
       />
     );
-    function handleChange(newValue) {
-      setValue(newValue);
+    function handleChange(newAge) {
+      setAge(newAge);
     }
   }}
 </Playground>


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
- Updated documentation to use age instead of value for the examples on the input text component.

### Added

- <!-- new features -->

### Changed

-  Updated documentation to use age instead of value for the examples on the input text component.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
