### PR TITLE
fix(components): Don't allow Card component to scroll

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -12,7 +12,6 @@
   width: 100%;
   border: var(--border-base) solid var(--card--border-color);
   border-radius: var(--radius-base);
-  overflow: auto;
   outline-color: var(--color-outline);
   background-color: var(--card--background-color);
 }


### PR DESCRIPTION
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- 

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Removed `overflow: auto;` from Card component so that the card can't scroll

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
