### PR TITLE
feat(components): Adding debounce functionality for the Autocomplete component

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/components",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { debounce } from "lodash";
 import styles from "./Autocomplete.css";
 import { Menu } from "./Menu";
 import { Option } from "./Option";
@@ -14,6 +15,11 @@ interface AutocompleteProps {
    * Set Autocomplete value.
    */
   readonly value: Option | undefined;
+
+  /**
+   * Set Autocomplete value.
+   */
+  readonly debounceTime: number | undefined;
 
   /**
    * Hint text that goes above the value once the form is filled out.
@@ -37,6 +43,7 @@ interface AutocompleteProps {
 export function Autocomplete({
   initialOptions = [],
   value,
+  debounceTime,
   onChange,
   getOptions,
   placeholder,
@@ -44,6 +51,10 @@ export function Autocomplete({
   const [options, setOptions] = useState(initialOptions);
   const [menuVisible, setMenuVisible] = useState(false);
   const [inputText, setInputText] = useState((value && value.label) || "");
+
+  const debouncedSetOptions = debounceTime
+    ? useRef(debounce(setOptions, debounceTime)).current
+    : setOptions;
 
   useEffect(() => {
     if (value) {
@@ -74,7 +85,7 @@ export function Autocomplete({
   async function updateInput(newText: string) {
     setInputText(newText);
     if (newText) {
-      setOptions(await getOptions(newText));
+      debouncedSetOptions(await getOptions(newText));
     } else {
       setOptions(initialOptions);
     }

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -17,11 +17,6 @@ interface AutocompleteProps {
   readonly value: Option | undefined;
 
   /**
-   * Debounce delay time for the setOptions requests
-   */
-  readonly debounceTime: number | undefined;
-
-  /**
    * Hint text that goes above the value once the form is filled out.
    */
   readonly placeholder: string;
@@ -43,7 +38,6 @@ interface AutocompleteProps {
 export function Autocomplete({
   initialOptions = [],
   value,
-  debounceTime,
   onChange,
   getOptions,
   placeholder,
@@ -52,9 +46,7 @@ export function Autocomplete({
   const [menuVisible, setMenuVisible] = useState(false);
   const [inputText, setInputText] = useState((value && value.label) || "");
 
-  const debouncedSetOptions = debounceTime
-    ? useRef(debounce(setOptions, debounceTime)).current
-    : setOptions;
+  const debouncedSetOptions = useRef(debounce(setOptions, 150)).current;
 
   useEffect(() => {
     if (value) {

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -17,7 +17,7 @@ interface AutocompleteProps {
   readonly value: Option | undefined;
 
   /**
-   * Set Autocomplete value.
+   * Debounce delay time for the setOptions requests
    */
   readonly debounceTime: number | undefined;
 

--- a/packages/design/package-lock.json
+++ b/packages/design/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/design",
-	"version": "0.4.3",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/eslint-config",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/stylelint-config/package-lock.json
+++ b/packages/stylelint-config/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/stylelint-config",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
## Changes

- Added a debounce import from lodash
- Changed `setOptions` to be wrapped in debounce.

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
- Debounced method for fetching results

### Changed
- How setOption works

### Removed

### Fixed

### Security

## Testing

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
