### PR TITLE
docs: update variation on text component example to match component

### DIFF
--- a/packages/components/src/Text/Text.mdx
+++ b/packages/components/src/Text/Text.mdx
@@ -63,7 +63,7 @@ only be used right after a page title.
   <br />
   <Text variation="error">Name is required</Text>
   <br />
-  <Text variation="warning">Your message is over 160 characters</Text>
+  <Text variation="warn">Your message is over 160 characters</Text>
   <br />
   <Text variation="info">
     Drag to rearrange the order that fields show up in Jobber


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- In the Text Component docs, the example at the bottom used `warning` variation but the component expects `warn`. Updated this to be correct and actually highlight in yellow now

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
