### PR TITLE
fix: generated plop code now passes tests

### DIFF
--- a/plop/templates/component/{{name}}.test.tsx
+++ b/plop/templates/component/{{name}}.test.tsx
@@ -16,15 +16,17 @@ it("renders a loud {{name}}", () => {
 });
 
 test("it should call the handler with the new value", () => {
-  const changeHandler = jest.fn();
-  const newValue = "Bar";
+  const clickHandler = jest.fn();
+  const text = "Foo";
+  const { getByText } = render(<{{name}} onClick={clickHandler} text={text} />);
 
-  const { getByLabelText } = render(
-    <{{name}} onChange={changeHandler} placeholder={placeholder} />,
-  );
+  fireEvent.click(getByText(text));
+  expect(clickHandler).toHaveBeenCalled();
 
-  fireEvent.change(getByLabelText(placeholder), {
-    target: { value: newValue },
-  });
-  expect(changeHandler).toHaveBeenCalledWith(newValue);
+  // E.g. If you need a change event, rather than a click event:
+  //
+  // fireEvent.change(getByLabelText(placeholder), {
+  //   target: { value: newValue },
+  // });
+  // expect(changeHandler).toHaveBeenCalledWith(newValue);
 });

--- a/plop/templates/component/{{name}}.tsx
+++ b/plop/templates/component/{{name}}.tsx
@@ -13,10 +13,15 @@ interface {{name}}Props {
    * Text to display.
    */
   readonly text: string;
+
+  /**
+   * Click handler.
+   */
+  onClick?(): void;
 }
 
-export function {{name}}({ loud = false, text }: {{name}}Props) {
+export function {{name}}({ loud = false, text, onClick }: {{name}}Props) {
   const className = classnames(styles.{{camelCase name}}, { [styles.bold]: loud });
 
-  return <div className={className}>{text}</div>;
+  return <div className={className} onClick={onClick}>{text}</div>;
 }


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Adapt the plop template so that the sample test file passes CI.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
