### PR TITLE
feat: showClose prop added to Banner

### DIFF
--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -54,3 +54,13 @@ import { Banner } from "@jobber/components/Banner";
 <Playground>
   <Banner type="error">Hulk smash has been unsuccessful</Banner>
 </Playground>
+
+---
+
+## Show Close
+
+<Playground>
+  <Banner type="notice" showClose={false}>
+    Hulk smash was super effective
+  </Banner>
+</Playground>

--- a/packages/components/src/Banner/Banner.test.tsx
+++ b/packages/components/src/Banner/Banner.test.tsx
@@ -133,6 +133,26 @@ it("renders a warning banner", () => {
   `);
 });
 
+it("renders a success banner with no button to close", () => {
+  const tree = renderer
+    .create(
+      <Banner type="success" showClose={false}>
+        Success
+      </Banner>,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot(`
+    <div
+      className="flash success"
+    >
+      <p
+        className="base regular base greyBlueDark"
+      >
+        Success
+    </div>
+  `);
+});
+
 test("it should call the handler with a number value", () => {
   const changeHandler = jest.fn();
 

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -8,6 +8,7 @@ import { Text } from "../Text";
 interface BannerProps {
   readonly children: ReactNode;
   readonly type: "notice" | "success" | "warning" | "error";
+  readonly showClose?: boolean;
   onDismiss?(): void;
 }
 
@@ -15,7 +16,12 @@ interface IconColorMap {
   [variation: string]: IconColorNames;
 }
 
-export function Banner({ children, type, onDismiss }: BannerProps) {
+export function Banner({
+  children,
+  type,
+  onDismiss,
+  showClose = true,
+}: BannerProps) {
   const [showFlash, setShowFlash] = useState(true);
 
   const iconColors: IconColorMap = {
@@ -32,13 +38,15 @@ export function Banner({ children, type, onDismiss }: BannerProps) {
         <div className={flashClassNames}>
           <Text>{children}</Text>
 
-          <button
-            className={styles.closeButton}
-            onClick={handleClose}
-            aria-label="Close"
-          >
-            <Icon name="cross" color={iconColors[type]} />
-          </button>
+          {showClose && (
+            <button
+              className={styles.closeButton}
+              onClick={handleClose}
+              aria-label="Close"
+            >
+              <Icon name="cross" color={iconColors[type]} />
+            </button>
+          )}
         </div>
       )}
     </>

--- a/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a success banner with no button to close: 
+    <div
+      className="flash success"
+    >
+      <p
+        className="base regular base greyBlueDark"
+      >
+        Success
+    </div>
+   1`] = `
+<div
+  className="flash success"
+>
+  <p
+    className="base regular base greyBlueDark"
+  >
+    Success
+  </p>
+</div>
+`;


### PR DESCRIPTION
## Changes
![Screen Shot 2019-10-30 at 12 20 55 PM](https://user-images.githubusercontent.com/10747839/67886826-c2099580-fb0f-11e9-9e6d-ef1c334a5161.png)

### Added
- Added new prop to hide the close button called `onShow` to the Banner Component
- Added associated test for the new prop

### Changed
The Banner Component

### Deprecated
n/a

### Removed
n/a

### Fixed
n/a

### Security
n/a

## Testing
Render component, use the onShow property

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
