### PR TITLE
fix(components): Changing the way we load `debounce` to avoid loading all of lodash.

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import { debounce } from "lodash";
+// eslint-disable-next-line import/no-internal-modules
+import debounce from "lodash/debounce";
 import styles from "./Autocomplete.css";
 import { Menu } from "./Menu";
 import { Option } from "./Option";


### PR DESCRIPTION
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Loading autocomplete component in Jobber clobbers underscore.

Doing `import { debounce } from "lodash";` seems to always load all of lodash regardless of if you're only using part of it or not. Even though TypeScript seems to complain about `import debounce from "lodash/debounce" it seems to be the right way to load it to only get the functions you need.

Executing all of `lodash` was causing problems on production because a side-effect of loading `lodash` is that it will put itself on window as `_`. But we're already using `underscore` in Jobber, so this then clobbers the existing underscore instance.

Mostly this was fine until we hit some code that executes a function that existins in `underscore`, but doesn't exist in lodash.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
