### PR TITLE
fix: Stop font from being loaded twice

### DIFF
--- a/packages/components/src/Typography/css/Typography.css
+++ b/packages/components/src/Typography/css/Typography.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css?family=Poppins:800,900|Source+Sans+Pro:400,400i,700,700i&display=swap");
-
 :root {
   --typography--fontFamily-normal: "Source Sans Pro", Helvetica, Arial,
     sans-serif;


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- This is a fix to prevent fonts from being loaded twice 
https://jobber.atlassian.net/secure/RapidBoard.jspa?rapidView=55&modal=detail&selectedIssue=JOB-16638
### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
