### PR TITLE
feat(components): add onClick function to tabs

### DIFF
--- a/packages/components/src/Tabs/Tabs.mdx
+++ b/packages/components/src/Tabs/Tabs.mdx
@@ -23,7 +23,7 @@ import { Tabs, Tab } from "@jobber/components/Tabs";
 
 <Playground>
   <Tabs>
-    <Tab label="Eggs">
+    <Tab label="Eggs" onClick={() => alert("I had eggs for breakfast.")}>
       🍳 Some eggs are laid by female animals of many different species,
       including birds, reptiles, amphibians, mammals, and fish, and have been
       eaten by humans for thousands of years.

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -5,13 +5,14 @@ import { Tab, Tabs } from ".";
 
 afterEach(cleanup);
 
+let count = 0;
 const omelet = (
   <Tabs>
     <Tab label="Eggs">
       <p>🍳</p>
       <p>Eggs</p>
     </Tab>
-    <Tab label="Cheese">
+    <Tab label="Cheese" onClick={() => count++}>
       <p>🧀</p>
     </Tab>
   </Tabs>
@@ -35,4 +36,14 @@ test("it should switch tabs", () => {
   fireEvent.click(getByText("Eggs"));
   expect(queryByText("🍳")).toBeTruthy();
   expect(queryByText("🧀")).toBeFalsy();
+});
+
+test("it should handle tab onClick", () => {
+  const { getByText } = render(omelet);
+  count = 0;
+
+  fireEvent.click(getByText("Cheese"));
+  expect(count).toBe(1);
+  fireEvent.click(getByText("Cheese"));
+  expect(count).toBe(2);
 });

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -97,7 +97,9 @@ export function InternalTab({
   label,
   selected,
   activateTab,
-  onClick = () => undefined,
+  onClick = () => {
+    return;
+  },
 }: InternalTabProps) {
   const className = classnames(styles.tab, { [styles.selected]: selected });
   const color = selected ? "green" : undefined;

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -63,7 +63,8 @@ export function Tabs({ children }: TabsProps) {
             <InternalTab
               label={tab.props.label}
               selected={activeTab === index}
-              onClick={activateTab(index)}
+              activateTab={activateTab(index)}
+              onClick={tab.props.onClick}
             />
           ))}
         </div>
@@ -78,6 +79,7 @@ export function Tabs({ children }: TabsProps) {
 interface TabProps {
   readonly label: string;
   readonly children: ReactNode | ReactNode[];
+  onClick?(): void;
 }
 
 export function Tab({ label }: TabProps) {
@@ -87,15 +89,28 @@ export function Tab({ label }: TabProps) {
 interface InternalTabProps {
   readonly label: string;
   readonly selected: boolean;
-  onClick(): void;
+  activateTab(): void;
+  onClick?(): void;
 }
 
-export function InternalTab({ label, selected, onClick }: InternalTabProps) {
+export function InternalTab({
+  label,
+  selected,
+  activateTab,
+  onClick = () => undefined,
+}: InternalTabProps) {
   const className = classnames(styles.tab, { [styles.selected]: selected });
   const color = selected ? "green" : undefined;
-
   return (
-    <button type="button" role="tab" className={className} onClick={onClick}>
+    <button
+      type="button"
+      role="tab"
+      className={className}
+      onClick={() => {
+        activateTab();
+        onClick();
+      }}
+    >
       <Typography element="span" size="base" textColor={color}>
         {label}
       </Typography>


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(pencil): stop graphite breaking when too much pressure applied — Patch Release
    feat(pencil): add 'graphiteWidth' option — (Minor) Feature Release
    feat(pencil): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
-->

## Changes

Allows tabs to have an `onClick` function when changing tabs.

### Added

- `onClick` prop to `InternalTab`
- Runs new `onClick` function along side the `activateTab` function

### Changed

- Moves `activateTab` function from the `onClick` prop to its on prop on `InternalTab`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
