### PR TITLE
fix(components): make SGA buttons have similar size and padding to SG1 buttons

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -16,7 +16,7 @@
   display: inline-flex;
   min-height: calc(var(--base-unit) * 2.25);
   box-sizing: border-box;
-  padding: var(--space-small) calc(var(--space-base) - 4px);
+  padding: var(--space-smaller) calc(var(--space-base) - 4px);
   border: 1px solid transparent;
   border-radius: var(--radius-base);
   color: transparent;
@@ -119,17 +119,19 @@
 
 .small {
   min-height: calc(var(--base-unit) * 1.5);
-  padding: var(--space-smaller) var(--space-small);
+  padding-left: var(--space-small);
+  padding-right: var(--space-small);
 }
 
 .base {
   min-height: calc(var(--base-unit) * 2.25);
-  padding: var(--space-small) calc(var(--space-base) - 4px);
+  padding: var(--space-smaller) calc(var(--space-base) - 4px);
 }
 
 .large {
   min-height: calc(var(--base-unit) * 3);
-  padding: var(--space-small) var(--space-base);
+  padding-left: var(--space-base);
+  padding-right: var(--space-base);
 }
 
 .hasIcon {

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -119,8 +119,7 @@
 
 .small {
   min-height: calc(var(--base-unit) * 1.5);
-  padding-left: var(--space-small);
-  padding-right: var(--space-small);
+  padding: var(--space-smaller) var(--space-small);
 }
 
 .base {
@@ -130,8 +129,7 @@
 
 .large {
   min-height: calc(var(--base-unit) * 3);
-  padding-left: var(--space-base);
-  padding-right: var(--space-base);
+  padding: var(--space-small) var(--space-base);
 }
 
 .hasIcon {

--- a/packages/components/src/Typography/css/FontSizes.css
+++ b/packages/components/src/Typography/css/FontSizes.css
@@ -29,7 +29,7 @@
 
 .small {
   font-size: var(--typography--fontSize-small);
-  line-height: var(--typography--lineHeight-tighter);
+  line-height: var(--typography--lineHeight-tiny);
 }
 
 .smaller {

--- a/packages/components/src/Typography/css/Typography.css
+++ b/packages/components/src/Typography/css/Typography.css
@@ -18,6 +18,7 @@
   --typography--lineHeight-tighter: 1.143;
   --typography--lineHeight-tightest: 1.12;
   --typography--lineHeight-miniscule: 1.08;
+  --typography--lineHeight-tiny: 1;
 }
 
 @media (--handhelds) {


### PR DESCRIPTION
## Motivations

When buttons with long titles are compressed, their sizing and internal padding behaviour loses parity with their sg-1 counterparts. Below is a screenshot of two sg-1 buttons on the sides and an atlantis button in the middle. You will see that the middle one is noticeably different than the others. This PR was made to address this.
![Screen Shot 2019-12-19 at 9 28 01 AM](https://user-images.githubusercontent.com/34727471/71205081-ec014d80-225e-11ea-9837-222b6c52caa5.png)


## Changes

![Screen Shot 2019-12-19 at 12 56 43 PM](https://user-images.githubusercontent.com/34727471/71205142-0b987600-225f-11ea-9d6f-9ba48b7b0c2e.png)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
