### PR TITLE
fix: Show component class names when viewing docs.

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -28,7 +28,9 @@ const modifyBundlerConfig = config => {
       {
         loader: require.resolve("css-loader"),
         options: {
-          modules: true,
+          modules: {
+            localIdentName: "[name]__[local]__[hash:md5:5]",
+          },
           importLoaders: 1,
         },
       },

--- a/doczrc.js
+++ b/doczrc.js
@@ -29,7 +29,7 @@ const modifyBundlerConfig = config => {
         loader: require.resolve("css-loader"),
         options: {
           modules: {
-            localIdentName: "[name]__[local]__[hash:md5:5]",
+            localIdentName: "[name]__[local]__[hash:base64]",
           },
           importLoaders: 1,
         },

--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -12,7 +12,7 @@ export default {
       declarationDir: "dist",
     }),
     postcss({
-      modules: true,
+      modules: { generateScopedName: "[hash:base64]" },
       plugins: [
         require("postcss-import"),
         require("autoprefixer"),


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  Where SCOPE above is one of:
    - components
    - generators
    - design
    - eslint
    - stylelint
-->

## Motivations

<!-- Why did you do what you did? -->

Allow CSS to be better inspected.

https://github.com/webpack-contrib/css-loader#object
https://github.com/webpack/loader-utils#interpolatename

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Classnames will be human readable when inspecting elements in Docz now.

### Security

- <!-- in case of vulnerabilities -->

## Testing

- [ ] Need to verify a package build.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
