### PR TITLE
fix(components): set button bg color for tertiary buttons to white, not transparent

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -9,7 +9,10 @@
   --button--color-destructive--hover: var(--color-red--dark);
 
   --button--color-cancel: var(--color-greyBlue);
+  --button--bg-color-cancel: var(--color-white);
   --button--color-disabled: var(--color-grey--lighter);
+  --button--color-secondary: var(--color-white);
+  --button--color-tertiary: var(--color-white);
 }
 
 .button {
@@ -72,6 +75,7 @@
 
 .cancel {
   border-color: var(--button--color-cancel);
+  background-color: var(--button--bg-color-cancel);
 }
 
 .cancel:focus,
@@ -86,18 +90,18 @@
 }
 
 .secondary {
-  background-color: transparent;
+  background-color: var(--button--color-secondary);
 }
 
 .secondary:hover,
 .secondary:focus {
-  background-color: transparent;
+  background-color: var(--button--color-secondary);
   filter: brightness(80%);
 }
 
 .tertiary {
-  border-color: transparent;
-  background-color: transparent;
+  border-color: var(--button--color-tertiary);
+  background-color: var(--button--color-tertiary);
 }
 
 .tertiary:hover,


### PR DESCRIPTION
## Motivations

This sets the "ghost" and secondary buttons to have a white background color instead of being transparent. This should display more clearly under a variety of different backgrounds/conditions.

---

### Screenshots
Examples of wrapping the button with a `<div>` that has a red background (see testing section below).

![image](https://user-images.githubusercontent.com/6612596/72957086-7dcd1080-3d5f-11ea-9359-9881e36942d7.png)
![image](https://user-images.githubusercontent.com/6612596/72957058-6130d880-3d5f-11ea-88b3-f231315cc594.png)
![image](https://user-images.githubusercontent.com/6612596/72957021-36df1b00-3d5f-11ea-923b-e42953dfc25a.png)
![image](https://user-images.githubusercontent.com/6612596/72957011-2b8bef80-3d5f-11ea-901a-8ce8fdd13899.png)

---

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- "cancel", "secondary" and "tertiary" types of buttons now have a white background (i.e. button fill) color.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing
View the Button component Docz page.
Wrap the following around each of the button examples to confirm expected behavior
`<div style={{"background-color": "red", padding: "10px"}}>`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
