### PR TITLE
fix(components): buttons set zero margin explicitly

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -16,6 +16,7 @@
   display: inline-flex;
   min-height: calc(var(--base-unit) * 2.25);
   box-sizing: border-box;
+  margin: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-base);
   color: transparent;


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  Where SCOPE above is one of:
    - components
    - generators
    - design
    - eslint
    - stylelint
-->

## Motivations

This zeros out the margin for the `Button` component so that Browser defaults (like Safari's) don't get used.

## Changes

### Added

- <!-- new features -->

### Changed

- For more consistent support across browsers, we're explicitly zeroing out the margin on `Button`. Safari was adding some padding by default, but NO WAY Safari.


### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

1. Load the Atlantis docs viewer for the `Button` component.
2. Using the browser tools, inspect the rendered value for the margin of the Buttons. Confirm it is zero.
3. Visually inspect the three loading buttons in the example to make sure they have no margin between them: `/components/button#loading`

Tested in:
 - [x] Safari current
 - [x] Chrome current
 - [x] Firefox current


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
