### PR TITLE
fix: Skip CI on Publish Commits

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,7 @@
   "command": {
     "version": {
       "conventionalCommits": true,
+      "message": "chore(release): Publish\n[ci skip]",
       "allowBranch": ["master"]
     },
     "publish": {


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  Where SCOPE above is one of:
    - components
    - generators
    - design
    - eslint
    - stylelint
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Publish commits do not need to trigger CI.

### Security

- <!-- in case of vulnerabilities -->

## Testing

https://circleci.com/docs/2.0/triggers/#skip-builds
https://github.com/lerna/lerna/tree/master/commands/version#--message-msg

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
