### PR TITLE
chore: Back to automatic releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,19 +178,12 @@ workflows:
       - build_docs:
           requires:
             - install_dependencies
-      - hold:
-          filters:
-            branches:
-              only: "master"
-          type: approval # requires that an in-app button be clicked by an appropriate member of the project to continue.
-          requires:
-            - lint_javascript
-            - lint_css
-            - test
-            - build_docs
       - release:
           filters:
             branches:
               only: "master"
           requires:
-            - hold
+            - lint_javascript
+            - lint_css
+            - test
+            - build_docs

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,12 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* Show component class names when viewing docs. ([#188](https://github.com/GetJobber/atlantis/issues/188)) ([fd15b21](https://github.com/GetJobber/atlantis/commit/fd15b215dd4e5b22a2d7ab7247a90b5855a8660e))
-
-
-### Features
-
-* Readily Release Releases ([#189](https://github.com/GetJobber/atlantis/issues/189)) ([f12f518](https://github.com/GetJobber/atlantis/commit/f12f518443d5c4640d4d6cb95dc6b199b404bf8d))
+* Buttons consistently have no margin. ([#192](https://github.com/GetJobber/atlantis/issues/192)) ([86a0b3c](https://github.com/GetJobber/atlantis/commit/86a0b3caf7f5bf9c20823c7339a79987f0b36957))
 
 
 


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  Where SCOPE above is one of:
    - components
    - generators
    - design
    - eslint
    - stylelint
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Back to automatic releases now that the release loop is broken.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
