### PR TITLE
fix(components): Readme `import` Typos

### DIFF
--- a/packages/components/src/Table/Table.mdx
+++ b/packages/components/src/Table/Table.mdx
@@ -28,7 +28,7 @@ table.
 Multiple [Cell types](#cell-types) are provided for common formats.
 
 ```ts
-import { Table, Header, Footer, Row, Cell } from "@jobber/components/Modal";
+import { Table, Header, Footer, Row, Cell } from "@jobber/components/Table";
 ```
 
 <Playground>

--- a/packages/components/src/Typography/Typography.mdx
+++ b/packages/components/src/Typography/Typography.mdx
@@ -13,7 +13,7 @@ import { Typography } from ".";
 Base component that defines typographic standards across Jobber
 
 ```ts
-import { Modal } from "@jobber/components/Modal";
+import { Typography } from "@jobber/components/Typography";
 ```
 
 <Playground>


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  Where SCOPE above is one of:
    - components
    - generators
    - design
    - eslint
    - stylelint
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- These Readmes had the wrong module name in them. Now they don't.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
