### PR TITLE
fix: CircleCI badge mis-reporting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
           name: Release Packages
           command: |
             if git log --max-count=1 --pretty=%s | grep -q "chore(release): Publish"; then
-              echo "Skiping run on release commit."
+              echo "Skipping run on release commit."
             else
               npm run ci:release
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,8 +154,13 @@ jobs:
           name: Authenticate with npm
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/atlantis/.npmrc
       - run:
-          name: Publishing
-          command: npm run ci:release
+          name: Release Packages
+          command: |
+            if git log --max-count=1 --pretty=%s | grep -q "chore(release): Publish"; then
+              echo "Skiping run on release commit."
+            else
+              npm run ci:release
+            fi
 
 workflows:
   version: 2

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   "command": {
     "version": {
       "conventionalCommits": true,
-      "message": "chore(release): Publish\n[ci skip]",
+      "message": "chore(release): Publish",
       "allowBranch": ["master"]
     },
     "publish": {


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  Where SCOPE above is one of:
    - components
    - generators
    - design
    - eslint
    - stylelint
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Circle reports skipped builds as failed. These changes allow us to avoid Circle's built in skipping mechanisms.

### Security

- <!-- in case of vulnerabilities -->

## Testing

The script logic is testable by making a little file containing the following, running it with commit messages.

```sh
if git log --max-count=1 --pretty=%s | grep -q "A COMMIT TO LOOK FOR"; then
  echo "Skiping run on release commit."
else
  echo "do release"
fi
```

Also, confirm that `echo $?` is `0` regardless.


## Reference

https://discuss.circleci.com/t/status-badges-for-skipped-builds-show-as-failed/30182

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
