### PR TITLE
fix(components): fix typo in Tabs documentation — Patch Release

### DIFF
--- a/packages/components/src/Tabs/Tabs.mdx
+++ b/packages/components/src/Tabs/Tabs.mdx
@@ -12,7 +12,7 @@ import { Tabs, Tab } from ".";
 
 <ComponentStatus stage="ready" responsive="yes" accessible="yes" />
 
-In Jobber a tabs are used to alternate amongst related views within the same
+In Jobber tabs are used to alternate amongst related views within the same
 context.
 
 ## Simple Example


### PR DESCRIPTION
## Motivations

`a tabs` should just be `tabs`

## Changes

Deleted `a `

### Added

n/a

### Changed

n/a

### Deprecated

n/a

### Removed

n/a

### Fixed

n/a

### Security

n/a

## Testing

Go to the docs

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
