### PR TITLE
docs: Add responsive section 2 component proposal

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,34 @@
 <!--
-  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
-  Full list of types:
-    https://github.com/commitizen/conventional-commit-types/blob/master/index.json
+  Atlantis uses Conventional Commits to track versions.
+  Pull request titles should follow the following format.
+
+  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>
 
   eg.
     fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
     feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
     feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release
 
-  Where SCOPE above is one of:
+  TYPE should consist of:
+    - fix: a commit of the type fix patches a bug in your codebase
+    - feat: a commit of the type feat introduces a new feature to the codebase
+    - docs: documentation only changes
+    - build: improvements to the build system
+    - refactor: a change that neither fixes a bug nor introduces a feature
+    - chore: other changes that don't modify src or test files
+
+  SCOPE should be one of:
     - components
     - generators
     - design
     - eslint
     - stylelint
+
+  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.
+
+  Further Reading:
+    - https://www.conventionalcommits.org
+    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
 -->
 
 ## Motivations

--- a/docs/proposals/TEMPLATE.md
+++ b/docs/proposals/TEMPLATE.md
@@ -9,6 +9,17 @@ _{Describe the design goal of this component. What is the design purpose of this
 component? How do its responsibilities relate to other components? Is there
 anything else that is important to describe?}_
 
+## Accessibility
+
+_{Describe the accessibility concerns for the component. Should it be keyboard
+navigatable? Should it capture input, what should a screen reader see when it's
+focused?}_
+
+## Responsiveness & Mobile
+
+_{How should the component behave on mobile devices or tablets. How does it
+respond to different screen sizes. How does it handle touch only interactions?}_
+
 ## Wireframe
 
 _{Insert a low fidelity wireframe of the components behaviour, enough for
@@ -26,9 +37,3 @@ _{Provide a table in the following format of the component's public API}_
 | name | type | default | description |
 | ---- | ---- | ------- | ----------- |
 | ...  | ...  | ...     | ...         |
-
-## Accessibility
-
-_{Describe the accessibility concerns for the component. Should it be keyboard
-navigatable? Should it capture input, what should a screen reader see when it's
-focused?}_


### PR DESCRIPTION
<!--
  Be sure to follow https://www.conventionalcommits.org for your Pull Request title.
  Full list of types:
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  Where SCOPE above is one of:
    - components
    - generators
    - design
    - eslint
    - stylelint
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Add `Responsive` section to the component proposal.

### Changed

- Reordered the component proposal to bring accessibility and responsiveness earlier in the process.
- Clarified PR template.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
