### PR TITLE
feat(components): Add FormatDate component

### DIFF
--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -1,0 +1,31 @@
+---
+name: FormatDate
+menu: Components
+route: /components/date-formatter
+---
+
+import { Playground, Props } from "docz";
+import { ComponentStatus } from "@jobber/docx";
+import { CivilDate } from "@std-proposal/temporal";
+import { FormatDate } from ".";
+
+# FormatDate
+
+<ComponentStatus stage="pre" responsive="yes" accessible="yes" />
+
+In Jobber a FormatDate is used to ensure that the date is displayed in the
+expected format. No text styling is applied, this simply formats the date.
+
+## Simple Example
+
+```ts
+import { FormatDate } from "@jobber/components/FormatDate";
+```
+
+<Playground>
+  <FormatDate date={new CivilDate(2020, 2, 26)} />
+</Playground>
+
+## Props
+
+<Props of={FormatDate} />

--- a/packages/components/src/FormatDate/FormatDate.test.tsx
+++ b/packages/components/src/FormatDate/FormatDate.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { cleanup } from "@testing-library/react";
+import { CivilDate } from "@std-proposal/temporal";
+import { FormatDate } from "./FormatDate";
+
+afterEach(cleanup);
+
+it("renders a FormatDate", () => {
+  const tree = renderer
+    .create(<FormatDate date={new CivilDate(2020, 2, 26)} />)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`"Feb 26, 2020"`);
+});

--- a/packages/components/src/FormatDate/FormatDate.tsx
+++ b/packages/components/src/FormatDate/FormatDate.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { CivilDate } from "@std-proposal/temporal";
+
+interface FormatDateProps {
+  /**
+   * Date to be displayed.
+   */
+  readonly date: CivilDate;
+}
+
+export function FormatDate(date: FormatDateProps) {
+  return <>{strFormatDate(date.date)}</>;
+}
+
+function strFormatDate(date: CivilDate) {
+  const monthNames = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+
+  return monthNames[date.month - 1] + " " + date.day + ", " + date.year;
+}

--- a/packages/components/src/FormatDate/FormatDate.tsx
+++ b/packages/components/src/FormatDate/FormatDate.tsx
@@ -12,21 +12,10 @@ export function FormatDate(date: FormatDateProps) {
   return <>{strFormatDate(date.date)}</>;
 }
 
-function strFormatDate(date: CivilDate) {
-  const monthNames = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
-
-  return monthNames[date.month - 1] + " " + date.day + ", " + date.year;
+function strFormatDate({ year, month, day }: CivilDate) {
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/packages/components/src/FormatDate/index.ts
+++ b/packages/components/src/FormatDate/index.ts
@@ -1,0 +1,1 @@
+export { FormatDate } from "./FormatDate";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - generators
    - design
    - eslint
    - stylelint

  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We need to format dates in Atlantis. Currently, only date format supported is:
MMM d, yyyy
ex. Feb 26, 2020

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- FormatDate Component

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
