### PR TITLE
docs: Remove scheme from search URL

### DIFF
--- a/docs/getting-started-with-react/getGIF.ts
+++ b/docs/getting-started-with-react/getGIF.ts
@@ -4,7 +4,7 @@ export const loadingGIF =
   "https://media.giphy.com/media/l3nWhI38IWDofyDrW/giphy.gif";
 
 export async function getGIF(topic: string) {
-  const searchURL = `http://api.giphy.com/v1/gifs/random?tag=${topic}&rating=PG&api_key=${gifKey}`;
+  const searchURL = `//api.giphy.com/v1/gifs/random?tag=${topic}&rating=PG&api_key=${gifKey}`;
   const response = await fetch(searchURL);
   const json = await response.json();
   return json.data.images.original.url;


### PR DESCRIPTION
## Motivations

The Gif Gift example wouldn't return any search results due to mixed mode content.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fixed example in React Guide so that it now returns results on https schemes

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
