### PR TITLE
chore: Upgrade docz - Elevation 

### DIFF
--- a/packages/design/src/Elevations.mdx
+++ b/packages/design/src/Elevations.mdx
@@ -11,7 +11,7 @@ The following table lists all elements that has a z-index specified on it.
 export function Value({ of: type }) {
   const styles = getComputedStyle(document.documentElement);
   const getValue = styles.getPropertyValue(`--elevation-${type}`);
-  return <>{getValue}</>;
+  return <span>{getValue}</span>;
 }
 
 | Component        | Value                  |

--- a/packages/design/src/Elevations.mdx
+++ b/packages/design/src/Elevations.mdx
@@ -11,7 +11,7 @@ The following table lists all elements that has a z-index specified on it.
 export function Value({ of: type }) {
   const styles = getComputedStyle(document.documentElement);
   const getValue = styles.getPropertyValue(`--elevation-${type}`);
-  return <span>{getValue}</span>;
+  return <React.Fragment>{getValue}</React.Fragment>;
 }
 
 | Component        | Value                  |


### PR DESCRIPTION
## Motivations

After the docz upgrade, the `Design` > `Elevation` was no longer working. This was due to React Fragment shorthand not being available in the `.mdx` file.

## Changes


### Added

- <!-- new features -->

### Changed

- Replaces fragment with `<React.Fragment>`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
