### PR TITLE
chore: Upgrade Docz - Allows the option props to render on the page

### DIFF
--- a/packages/components/src/Select/Option.tsx
+++ b/packages/components/src/Select/Option.tsx
@@ -11,10 +11,17 @@ interface InputSelectProps {
   readonly value?: string;
 }
 
-export function Option({ children, disabled, value }: InputSelectProps) {
+function SelectOption({ children, disabled, value }: InputSelectProps) {
   return (
     <option disabled={disabled} value={value}>
       {children}
     </option>
   );
 }
+
+/**
+ * Whatever mechanism that docz is using to parse out props fails if this
+ * component is called Option internally. We have opened an issue with them
+ * to find out more information.
+ */
+export { SelectOption as Option };


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - generators
    - design
    - eslint
    - stylelint

  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

After the upgrade the props for the `Option` component were not showing due to the way that docz renders props.

## Changes

- Changes the name of the component from `Option` to `SelectOption`
- Exports `SelectOption` as `Option`

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
