### PR TITLE
chore: Fixes the mobile menu on docz viewer

### DIFF
--- a/src/gatsby-theme-docz/components/Header/index.js
+++ b/src/gatsby-theme-docz/components/Header/index.js
@@ -1,10 +1,3 @@
-/** @jsx jsx */
-import { jsx } from "theme-ui";
-import * as styles from "./styles";
-import { HeaderButtons } from "../HeaderButtons";
+import React from "react";
 
-export const Header = () => (
-  <div sx={styles.buttons}>
-    <HeaderButtons />
-  </div>
-);
+export const Header = () => <React.Fragment />;

--- a/src/gatsby-theme-docz/components/Header/styles.js
+++ b/src/gatsby-theme-docz/components/Header/styles.js
@@ -1,6 +1,0 @@
-export const buttons = {
-  position: "fixed",
-  top: 2,
-  right: 2,
-  zIndex: "999",
-};

--- a/src/gatsby-theme-docz/components/HeaderButtons/index.js
+++ b/src/gatsby-theme-docz/components/HeaderButtons/index.js
@@ -1,35 +1,43 @@
 /** @jsx jsx */
-import { jsx } from "theme-ui";
+import { Box, jsx } from "theme-ui";
 import { useConfig, useCurrentDoc } from "docz";
 import { Github } from "gatsby-theme-docz/src/components/Icons";
+import t from "prop-types";
 import { Button } from "@jobber/components/Button";
 import { Tooltip } from "@jobber/components/Tooltip";
+import { Icon } from "@jobber/components/Icon";
 import * as styles from "./styles";
 import { DeferRender } from "../DeferRender";
 
-export const HeaderButtons = () => {
-  const {
-    repository,
-    themeConfig: { showMarkdownEditButton },
-  } = useConfig();
-  const { edit = true, ...doc } = useCurrentDoc();
+export const HeaderButtons = ({ open, openMenu, closeMenu }) => {
+  const { repository } = useConfig();
+  const { ...doc } = useCurrentDoc();
 
   return (
     <DeferRender>
-      <div sx={styles.buttons}>
-        {repository && (
-          <Tooltip message="View 🔱Atlantis on Github">
-            <Button
-              label={<Github size={18} />}
-              type="secondary"
-              url={repository}
-            />
-          </Tooltip>
-        )}
-        {showMarkdownEditButton && edit && doc.link && (
-          <Button icon="edit" color="white" label="Edit page" url={doc.link} />
-        )}
-      </div>
+      <Box sx={styles.buttons}>
+        <Box sx={styles.menu}>
+          <Button
+            label={<Icon color="white" name={open ? "remove" : "menu"} />}
+            type="primary"
+            onClick={() => (open ? closeMenu() : openMenu())}
+          />
+        </Box>
+        <Tooltip message="View 🔱Atlantis on Github">
+          <Button
+            label={<Github size={18} />}
+            type="secondary"
+            url={repository}
+          />
+        </Tooltip>
+        <Button icon="edit" color="white" label="Edit page" url={doc.link} />
+      </Box>
     </DeferRender>
   );
+};
+
+HeaderButtons.propTypes = {
+  open: t.bool,
+  openMenu: t.func,
+  closeMenu: t.func,
 };

--- a/src/gatsby-theme-docz/components/HeaderButtons/styles.js
+++ b/src/gatsby-theme-docz/components/HeaderButtons/styles.js
@@ -1,5 +1,22 @@
+import { media } from "gatsby-theme-docz/src/theme/breakpoints";
+
 export const buttons = {
+  padding: "var(--space-base) var(--space-larger)",
+  display: "flex",
+  justifyContent: "flex-end",
+
   "& > a": {
-    marginX: "var(--space-smallest)",
+    marginLeft: "var(--space-smaller)",
+  },
+};
+
+export const menu = {
+  display: "none",
+  flex: "0",
+  marginRight: "auto",
+  marginLeft: 0,
+
+  [media.tablet]: {
+    display: "block",
   },
 };

--- a/src/gatsby-theme-docz/components/Sidebar/index.js
+++ b/src/gatsby-theme-docz/components/Sidebar/index.js
@@ -8,6 +8,7 @@ import { NavLink } from "gatsby-theme-docz/src/components/NavLink";
 import { NavGroup } from "gatsby-theme-docz/src/components/NavGroup";
 import { Logo } from "gatsby-theme-docz/src/components/Logo";
 import * as styles from "./styles";
+import { HeaderButtons } from "../HeaderButtons";
 
 export const Sidebar = React.forwardRef((props, ref) => {
   const [query, setQuery] = useState("");
@@ -18,22 +19,24 @@ export const Sidebar = React.forwardRef((props, ref) => {
 
   useEffect(() => {
     if (ref.current && currentDocRef.current) {
+      console.log("os", currentDocRef.current.offsetTop);
       ref.current.scrollTo(0, currentDocRef.current.offsetTop);
     }
   }, []);
   return (
     <>
+      <Box onClick={props.onClick} sx={styles.overlay(props)} />
       <Box ref={ref} sx={styles.wrapper(props)} data-testid="sidebar">
-        <div sx={styles.logo}>
+        <Box sx={styles.logo}>
           <Logo />
-        </div>
-        <div sx={styles.search}>
+        </Box>
+        <Box sx={styles.search}>
           <NavSearch
             placeholder="Type to search..."
             value={query}
             onChange={handleChange}
           />
-        </div>
+        </Box>
         {menus &&
           menus.map(menu => {
             if (!menu.route) {
@@ -41,7 +44,7 @@ export const Sidebar = React.forwardRef((props, ref) => {
             }
             if (menu.route === currentDoc.route) {
               return (
-                <div sx={styles.topLevelMenuWrapper} key={menu.id}>
+                <Box sx={styles.topLevelMenuWrapper} key={menu.id}>
                   <NavLink
                     item={menu}
                     ref={currentDocRef}
@@ -49,17 +52,24 @@ export const Sidebar = React.forwardRef((props, ref) => {
                   >
                     {menu.name}
                   </NavLink>
-                </div>
+                </Box>
               );
             }
             return (
-              <div sx={styles.topLevelMenuWrapper} key={menu.id}>
+              <Box sx={styles.topLevelMenuWrapper} key={menu.id}>
                 <NavLink item={menu} sx={styles.topLevelMenuItem}>
                   {menu.name}
                 </NavLink>
-              </div>
+              </Box>
             );
           })}
+      </Box>
+      <Box sx={styles.buttons}>
+        <HeaderButtons
+          open={props.open}
+          closeMenu={props.onClick}
+          openMenu={props.onFocus}
+        />
       </Box>
     </>
   );

--- a/src/gatsby-theme-docz/components/Sidebar/styles.js
+++ b/src/gatsby-theme-docz/components/Sidebar/styles.js
@@ -5,17 +5,27 @@ export * from "gatsby-theme-docz/src/components/Sidebar/styles";
 
 // Override what we need to.
 import * as styles from "gatsby-theme-docz/src/components/Sidebar/styles";
+import { media } from "gatsby-theme-docz/src/theme/breakpoints";
 
 const MENU_PADDING = "32px";
 
 export const overlay = ({ open }) => ({
   ...styles.overlay({ open: open }),
+  display: open ? "block" : "none",
   top: 0,
 });
 
 export const wrapper = ({ open }) => ({
   ...styles.wrapper({ open: open }),
   p: MENU_PADDING,
+  borderRight: "none",
+
+  [media.tablet]: {
+    ...styles.wrapper({ open })[media.tablet],
+    top: 0,
+    background: "var(--color-greyBlue--dark)",
+    boxShadow: open ? "0 0 10px rgba(0,0,0, 0.3)" : "none",
+  },
 });
 
 export const logo = {
@@ -56,3 +66,12 @@ export const topLevelMenuWrapper = theme => ({
 export const topLevelMenuItem = theme => ({
   ...theme.navigation.level1,
 });
+
+export const buttons = {
+  position: "fixed",
+  top: 0,
+  right: 0,
+  zIndex: "99",
+  transition: "width 300ms",
+  width: "100%",
+};


### PR DESCRIPTION
## Motivations

Docz viewer currently has no way to view the menu on tablet/mobile.

![image](https://user-images.githubusercontent.com/46460840/77935209-641fdc00-726e-11ea-8ccb-ef31014430f3.png)

This will add a mobile menu along with a button to toggle

![image](https://user-images.githubusercontent.com/46460840/77935610-e5776e80-726e-11ea-9277-ffdb8140aaab.png)

![image](https://user-images.githubusercontent.com/46460840/77935637-f0320380-726e-11ea-896b-592a02704a88.png)

## Changes

Adds a button to toggle the mobile menu when on a tablet or mobile size screen.

### Added

- Mobile menu button
- So logic to the `HeaderButtons` component

### Changed

- Moved `HeaderButtons` from `Header` to `Sidebar`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- Header component markup
- Header component styling

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
