### PR TITLE
feat(components): Adds FormatEmail component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,55 +60,45 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
-      "integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
+      "integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.5",
+        "browserslist": "^4.9.1",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.9.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.0.tgz",
-          "integrity": "sha512-seffIXhwgB84+OCeT/aMjpZnsAsYDiMSC+CEs3UkF8iU64BZGYcu+TZYs/IBpo4nRi0vJywUJWYdbTsOhFTweg==",
+          "version": "4.11.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+          "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001030",
-            "electron-to-chromium": "^1.3.361",
-            "node-releases": "^1.1.50"
+            "caniuse-lite": "^1.0.30001038",
+            "electron-to-chromium": "^1.3.390",
+            "node-releases": "^1.1.53",
+            "pkg-up": "^2.0.0"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001030",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001030.tgz",
-          "integrity": "sha512-QGK0W4Ft/Ac+zTjEiRJfwDNATvS3fodDczBXrH42784kcfqcDKpEPfN08N0HQjrAp8He/Jw8QiSS9QRn7XAbUw==",
+          "version": "1.0.30001043",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001043.tgz",
+          "integrity": "sha512-MrBDRPJPDBYwACtSQvxg9+fkna5jPXhJlKmuxenl/ml9uf8LHKlDmLpElu+zTW/bEz7lC1m0wTDD7jiIB+hgFg==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.363",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.363.tgz",
-          "integrity": "sha512-4w19wPBkeunBjOA53lNFT36IdOD3Tk1OoIDtTX+VToJUUDX42QfuhtsNKXv25wmSnoBOExM3kTbj7/WDNBwHuQ==",
+          "version": "1.3.413",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.413.tgz",
+          "integrity": "sha512-Jm1Rrd3siqYHO3jftZwDljL2LYQafj3Kki5r+udqE58d0i91SkjItVJ5RwlJn9yko8i7MOcoidVKjQlgSdd1hg==",
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.50",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.50.tgz",
-          "integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
+          "version": "1.1.53",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+          "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==",
+          "dev": true
         }
       }
     },
@@ -33679,6 +33669,60 @@
       "dev": true,
       "requires": {
         "find-up": "^3.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
       }
     },
     "please-upgrade-node": {

--- a/packages/components/src/FormatEmail/FormatEmail.css
+++ b/packages/components/src/FormatEmail/FormatEmail.css
@@ -1,0 +1,3 @@
+.email {
+  font-style: normal;
+}

--- a/packages/components/src/FormatEmail/FormatEmail.css.d.ts
+++ b/packages/components/src/FormatEmail/FormatEmail.css.d.ts
@@ -1,0 +1,1 @@
+export const email: string;

--- a/packages/components/src/FormatEmail/FormatEmail.mdx
+++ b/packages/components/src/FormatEmail/FormatEmail.mdx
@@ -1,0 +1,29 @@
+---
+name: FormatEmail
+menu: Components
+route: /components/format-email
+---
+
+import { Playground, Props } from "docz";
+import { ComponentStatus } from "@jobber/docx";
+import { FormatEmail } from ".";
+
+# Format Email
+
+<ComponentStatus stage="rc" responsive="yes" accessible="yes" />
+
+A component to ensure that an email address is displayed in the expected format.
+There is no styling applied, this simply just returns a semantically formatted
+email address.
+
+```ts
+import { FormatEmail } from "@jobber/components/FormatEmail";
+```
+
+<Playground>
+  <FormatEmail email="myemail@address.me" />
+</Playground>
+
+## Props
+
+<Props of={FormatEmail} />

--- a/packages/components/src/FormatEmail/FormatEmail.test.tsx
+++ b/packages/components/src/FormatEmail/FormatEmail.test.tsx
@@ -4,6 +4,7 @@ import { cleanup } from "@testing-library/react";
 import { FormatEmail } from ".";
 
 afterEach(cleanup);
+
 it("renders a FormatEmail", () => {
   const tree = renderer
     .create(<FormatEmail email="email@address.me" />)

--- a/packages/components/src/FormatEmail/FormatEmail.test.tsx
+++ b/packages/components/src/FormatEmail/FormatEmail.test.tsx
@@ -11,9 +11,9 @@ it("renders a FormatEmail", () => {
   expect(tree).toMatchSnapshot();
 });
 
-it("renders a FormatEmail in an address tag", () => {
-  const tree = renderer
-    .create(<FormatEmail email="email@address.me" />)
-    .toJSON();
-  expect(tree.type).toBe("address");
-});
+// it("renders a FormatEmail in an address tag", () => {
+//   const tree = renderer
+//     .create(<FormatEmail email="email@address.me" />)
+//     .toJSON();
+//   expect(tree.type).toBe("address");
+// });

--- a/packages/components/src/FormatEmail/FormatEmail.test.tsx
+++ b/packages/components/src/FormatEmail/FormatEmail.test.tsx
@@ -11,9 +11,9 @@ it("renders a FormatEmail", () => {
   expect(tree).toMatchSnapshot();
 });
 
-// it("renders a FormatEmail in an address tag", () => {
-//   const tree = renderer
-//     .create(<FormatEmail email="email@address.me" />)
-//     .toJSON();
-//   expect(tree.type).toBe("address");
-// });
+it("renders a FormatEmail in an address tag", () => {
+  const tree = renderer
+    .create(<FormatEmail email="email@address.me" />)
+    .toJSON();
+  expect(tree.type).toBe("address");
+});

--- a/packages/components/src/FormatEmail/FormatEmail.test.tsx
+++ b/packages/components/src/FormatEmail/FormatEmail.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { cleanup } from "@testing-library/react";
+import { FormatEmail } from ".";
+
+afterEach(cleanup);
+it("renders a FormatEmail", () => {
+  const tree = renderer
+    .create(<FormatEmail email="email@address.me" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders a FormatEmail in an address tag", () => {
+  const tree = renderer
+    .create(<FormatEmail email="email@address.me" />)
+    .toJSON();
+  expect(tree.type).toBe("address");
+});

--- a/packages/components/src/FormatEmail/FormatEmail.tsx
+++ b/packages/components/src/FormatEmail/FormatEmail.tsx
@@ -11,5 +11,5 @@ interface FormatEmailProps {
 
 export function FormatEmail({ email }: FormatEmailProps) {
   const className = classnames(styles.email);
-  return <div className={className}>{email}</div>;
+  return <address className={className}>{email}</address>;
 }

--- a/packages/components/src/FormatEmail/FormatEmail.tsx
+++ b/packages/components/src/FormatEmail/FormatEmail.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import classnames from "classnames";
+import styles from "./FormatEmail.css";
+
+interface FormatEmailProps {
+  /**
+   * Email address to format
+   */
+  readonly email?: string;
+}
+
+export function FormatEmail({ email }: FormatEmailProps) {
+  const className = classnames(styles.email);
+  return <address className={className}>{email}</address>;
+}

--- a/packages/components/src/FormatEmail/FormatEmail.tsx
+++ b/packages/components/src/FormatEmail/FormatEmail.tsx
@@ -6,10 +6,10 @@ interface FormatEmailProps {
   /**
    * Email address to format
    */
-  readonly email?: string;
+  readonly email: string;
 }
 
 export function FormatEmail({ email }: FormatEmailProps) {
   const className = classnames(styles.email);
-  return <address className={className}>{email}</address>;
+  return <div className={className}>{email}</div>;
 }

--- a/packages/components/src/FormatEmail/__snapshots__/FormatEmail.test.tsx.snap
+++ b/packages/components/src/FormatEmail/__snapshots__/FormatEmail.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a FormatEmail 1`] = `
-<div
+<address
   className="email"
 >
   email@address.me
-</div>
+</address>
 `;

--- a/packages/components/src/FormatEmail/__snapshots__/FormatEmail.test.tsx.snap
+++ b/packages/components/src/FormatEmail/__snapshots__/FormatEmail.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a FormatEmail 1`] = `
+<address
+  className="email"
+>
+  email@address.me
+</address>
+`;

--- a/packages/components/src/FormatEmail/__snapshots__/FormatEmail.test.tsx.snap
+++ b/packages/components/src/FormatEmail/__snapshots__/FormatEmail.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a FormatEmail 1`] = `
-<address
+<div
   className="email"
 >
   email@address.me
-</address>
+</div>
 `;

--- a/packages/components/src/FormatEmail/index.ts
+++ b/packages/components/src/FormatEmail/index.ts
@@ -1,0 +1,1 @@
+export { FormatEmail } from "./FormatEmail";


### PR DESCRIPTION
## Motivations

We would like a way to make sure that we are formatting email addresses the same way throughout Jobber. `<FormatEmail />` will take an email address and return a formatted email address.

## Changes

- Adds new FormatEmail component

### Added

- FormatEmail component

### Changed

### Deprecated

### Removed

### Fixed

### Security

## Testing

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
