### PR TITLE
chore(deps): Update typescript to 3.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2208,6 +2208,8 @@
         },
         "@jobber/formatters": {
           "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/@jobber/formatters/-/formatters-0.0.4.tgz",
+          "integrity": "sha512-AaTKOBm/1zXJ0ZQSs6BJFRBkPH2VrJxVKSD7TfqjDn6hm+puGdcFfQDn8L8WbS4s1Jp7ci0pbMIDZqJcoRyFWg==",
           "dev": true,
           "dependencies": {
             "typescript": {
@@ -7829,7 +7831,7 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^2.1.0",
-        "@typescript-eslint/parser": "^2.1.0",
+        "@typescript-eslint/parser": "^2.29.0",
         "eslint-config-prettier": "^6.2.0",
         "eslint-import-resolver-typescript": "^1.1.1",
         "eslint-plugin-import": "^2.18.2",
@@ -40028,9 +40030,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "typography-breakpoint-constants": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "stylelint-junit-formatter": "^0.2.1",
     "theme-ui": "^0.3.1",
     "typed-css-modules-loader": "^0.0.17",
-    "typescript": "^3.5.2"
+    "typescript": "^3.8.3"
   },
   "husky": {
     "hooks": {

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -72,14 +72,94 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.1.0.tgz",
-			"integrity": "sha512-0+hzirRJoqE1T4lSSvCfKD+kWjIpDWfbGBiisK5CENcr+22pPkHB2sfV1giON+UxHV4A08SSrQonZk7X2zIQdw==",
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.29.0.tgz",
+			"integrity": "sha512-H78M+jcu5Tf6m/5N8iiFblUUv+HJDguMSdFfzwa6vSg9lKR8Mk9BsgeSjO8l2EshKnJKcbv0e8IDDOvSNjl0EA==",
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.1.0",
-				"@typescript-eslint/typescript-estree": "2.1.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"@typescript-eslint/experimental-utils": "2.29.0",
+				"@typescript-eslint/typescript-estree": "2.29.0",
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"@typescript-eslint/experimental-utils": {
+					"version": "2.29.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.29.0.tgz",
+					"integrity": "sha512-H/6VJr6eWYstyqjWXBP2Nn1hQJyvJoFdDtsHxGiD+lEP7piGnGpb/ZQd+z1ZSB1F7dN+WsxUDh8+S4LwI+f3jw==",
+					"requires": {
+						"@types/json-schema": "^7.0.3",
+						"@typescript-eslint/typescript-estree": "2.29.0",
+						"eslint-scope": "^5.0.0",
+						"eslint-utils": "^2.0.0"
+					}
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "2.29.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.29.0.tgz",
+					"integrity": "sha512-3YGbtnWy4az16Egy5Fj5CckkVlpIh0MADtAQza+jiMADRSKkjdpzZp/5WuvwK/Qib3Z0HtzrDFeWanS99dNhnA==",
+					"requires": {
+						"debug": "^4.1.1",
+						"eslint-visitor-keys": "^1.1.0",
+						"glob": "^7.1.6",
+						"is-glob": "^4.0.1",
+						"lodash": "^4.17.15",
+						"semver": "^6.3.0",
+						"tsutils": "^3.17.1"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"eslint-scope": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-utils": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+					"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+					"requires": {
+						"eslint-visitor-keys": "^1.1.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+				},
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
@@ -1013,8 +1093,7 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash.unescape": {
 			"version": "4.0.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^2.1.0",
-    "@typescript-eslint/parser": "^2.1.0",
+    "@typescript-eslint/parser": "^2.29.0",
     "eslint-config-prettier": "^6.2.0",
     "eslint-import-resolver-typescript": "^1.1.1",
     "eslint-plugin-import": "^2.18.2",


### PR DESCRIPTION
We want to keep typescript up to date and take advantages of the new things available. 

## Motivations


## Changes

- Update typescript to 3.8.3

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
