### PR TITLE
docs(components): Update Switch design docs

### DIFF
--- a/packages/components/src/Switch/Switch.mdx
+++ b/packages/components/src/Switch/Switch.mdx
@@ -29,7 +29,17 @@ import { Switch } from "@jobber/components/Switch";
 
 ---
 
+## Design & Usage Guidelines
+
+The switch is a useful component for manipulating settings with binary (true/false, yes/no, on/off) conditions. For this reason its' label is limited to ON/OFF.
+
+### Switches, Checkboxes and Radio Buttons
+
+A switch, a checkbox, and a pair of radio buttons can seem similar in theory, as all can represent an `either/or decision` for the user. Use a switch when the user must make a decision to turn something on or off, and a single checkbox when a user is opting in to a choice. A pair of radio buttons can be used to help the user decide between two discrete options, such as “fixed price” and “per visit” invoicing options.
+
 ## Controlled Switch
+
+A controlled switch can turn something on or off, and can be controlled by another UI element on the page. This can useful for two-way interactions where manipulating another part of the interface should logically drive the same state change.
 
 <Playground>
   {() => {
@@ -51,6 +61,8 @@ import { Switch } from "@jobber/components/Switch";
 
 ## Disabled
 
+A disabled switch cannot be operated by the user. If presenting a disabled "On" switch to the user, the context and ability for the user to enable the switch must be apparent to avoid creating a sense that the user has lost control of the interface.
+
 <Playground>
-  <Switch value={true} ariaLabel="Visible to clients" disabled={true} />
+  <Switch value={false} ariaLabel="Visible to clients" disabled={true} />
 </Playground>

--- a/packages/components/src/Switch/Switch.mdx
+++ b/packages/components/src/Switch/Switch.mdx
@@ -61,7 +61,7 @@ A controlled switch can turn something on or off, and can be controlled by anoth
 
 ## Disabled
 
-A disabled switch cannot be operated by the user. If presenting a disabled "On" switch to the user, the context and ability for the user to enable the switch must be apparent to avoid creating a sense that the user has lost control of the interface.
+A disabled switch cannot be operated by the user. If presenting a disabled "On" switch to the user, provide a clear description for the user on how to enable the switch to avoid creating a sense that the user has lost control of the interface.
 
 <Playground>
   <Switch value={false} ariaLabel="Visible to clients" disabled={true} />


### PR DESCRIPTION
## Motivations

Improve Switch design docs, especially since Radio Button is likely on the near horizon and the usage guidelines provide some disambiguation.

## Changes

Adding design guidelines, tweaking some others.

### Added

Design guidelines

### Changed

Content around Controlled and Disabled variants


![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
