### PR TITLE
chore(deps): Update typescript in components

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -19,6 +19,21 @@
 			"integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==",
 			"dev": true
 		},
+		"@emotion/is-prop-valid": {
+			"version": "0.8.8",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+			"optional": true,
+			"requires": {
+				"@emotion/memoize": "0.7.4"
+			}
+		},
+		"@emotion/memoize": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+			"optional": true
+		},
 		"@jest/types": {
 			"version": "24.8.0",
 			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
@@ -52,14 +67,22 @@
 			"integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw=="
 		},
 		"@popmotion/popcorn": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.2.tgz",
-			"integrity": "sha512-wu0tEwK3KUZ9BoqfcqC3DfdfRDws/oHXwZKJMVtuhXSrF/PtqvilsPjAk93nh8M+orAnbe8ZyxQmop9+4oJs2g==",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz",
+			"integrity": "sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==",
 			"requires": {
 				"@popmotion/easing": "^1.0.1",
 				"framesync": "^4.0.1",
 				"hey-listen": "^1.0.8",
-				"style-value-types": "^3.1.6"
+				"style-value-types": "^3.1.7",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+				}
 			}
 		},
 		"@popperjs/core": {
@@ -1668,24 +1691,25 @@
 			}
 		},
 		"framer-motion": {
-			"version": "1.6.5",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.6.5.tgz",
-			"integrity": "sha512-Plg25ywwVI6bu2M/9Q9pIljudMRNDnlXF+wYOvZomxqzujqAL+dnMv9CxammZaDje88qMDULzuySFXxp2fcC0g==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.10.3.tgz",
+			"integrity": "sha512-VooCzGWg7brSO4Gc0YwpY5AadJe4OPS74ZyOlOHWll5rMXCoOc6Ia3uDQ6RfOJlwCP/D9TQuRGtboyJiVXjVcw==",
 			"requires": {
+				"@emotion/is-prop-valid": "^0.8.2",
 				"@popmotion/easing": "^1.0.2",
 				"@popmotion/popcorn": "^0.4.2",
 				"framesync": "^4.0.4",
 				"hey-listen": "^1.0.8",
 				"popmotion": "9.0.0-beta-8",
 				"style-value-types": "^3.1.6",
-				"stylefire": "^6.0.10",
+				"stylefire": "^7.0.2",
 				"tslib": "^1.10.0"
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
 				}
 			}
 		},
@@ -1699,9 +1723,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
 				}
 			}
 		},
@@ -3554,9 +3578,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
 				}
 			}
 		},
@@ -5390,22 +5414,38 @@
 			"dev": true
 		},
 		"style-value-types": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.6.tgz",
-			"integrity": "sha512-AxcfUr/06AHyyyxkNB1O8ypvwa8/qK+sxwelxEN5x+jxW+RXutRE2TuHEQbFq9OBY7ym83CPKvVIsGd6lvKb0Q==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.7.tgz",
+			"integrity": "sha512-jPaG5HcAPs3vetSwOJozrBXxuHo9tjZVnbRyBjxqb00c2saIoeuBJc1/2MtvB8eRZy41u/BBDH0CpfzWixftKg==",
 			"requires": {
-				"hey-listen": "^1.0.8"
+				"hey-listen": "^1.0.8",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+				}
 			}
 		},
 		"stylefire": {
-			"version": "6.0.10",
-			"resolved": "https://registry.npmjs.org/stylefire/-/stylefire-6.0.10.tgz",
-			"integrity": "sha512-SAJnUk4L9EKt/WSliztk1iZCzcNOJDR69xO8gblRjQwjybgMWONsY7KpcMBt65xU1UZaiyPDK5CoLf9wXLJldQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
+			"integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
 			"requires": {
-				"@popmotion/popcorn": "^0.4.2",
+				"@popmotion/popcorn": "^0.4.4",
 				"framesync": "^4.0.0",
 				"hey-listen": "^1.0.8",
-				"style-value-types": "^3.1.6"
+				"style-value-types": "^3.1.7",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+				}
 			}
 		},
 		"stylehacks": {
@@ -5694,9 +5734,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"unherit": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,7 +27,7 @@
     "@types/uuid": "^3.4.5",
     "@use-it/event-listener": "^0.1.3",
     "classnames": "^2.2.6",
-    "framer-motion": "^1.6.5",
+    "framer-motion": "^1.10.3",
     "lodash": "^4.17.15",
     "react-markdown": "^4.1.0",
     "time-input-polyfill": "^1.0.7",
@@ -60,7 +60,7 @@
     "rollup-plugin-typescript2": "^0.21.0",
     "ts-node": "^8.1.0",
     "typed-css-modules": "^0.3.6",
-    "typescript": "^3.5.2",
+    "typescript": "^3.8.3",
     "uuid": "^3.3.2"
   },
   "peerDependencies": {

--- a/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
@@ -109,7 +109,6 @@ export function FeatureSwitch({
                 transition={{
                   delay: 0.2,
                   type: "spring",
-                  duration: 0.2,
                   damping: 20,
                   stiffness: 300,
                 }}

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -178,10 +178,7 @@ export const FormField = React.forwardRef(
       value,
       validations,
     }: FormFieldProps,
-    ref:
-      | Ref<HTMLInputElement>
-      | Ref<HTMLTextAreaElement>
-      | Ref<HTMLSelectElement>,
+    ref: Ref<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
   ) => {
     const [hasMiniLabel, setHasMiniLabel] = useState(
       shouldShowMiniLabel(defaultValue, value),

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -36,7 +36,7 @@ function InputTextInternal(
   props: InputTextPropOptions,
   ref: Ref<InputTextRef>,
 ) {
-  const inputRef = createRef<HTMLTextAreaElement>();
+  const inputRef = createRef<HTMLTextAreaElement | HTMLInputElement>();
 
   useImperativeHandle(ref, () => ({
     insert: (text: string) => {
@@ -69,7 +69,10 @@ function InputTextInternal(
 
 export const InputText = forwardRef(InputTextInternal);
 
-function insertAtCursor(input: HTMLTextAreaElement, newText: string) {
+function insertAtCursor(
+  input: HTMLTextAreaElement | HTMLInputElement,
+  newText: string,
+) {
   const start = input.selectionStart || 0;
   const end = input.selectionEnd || 0;
   const text = input.value;

--- a/packages/components/src/InputTime/time-input-polyfill.d.ts
+++ b/packages/components/src/InputTime/time-input-polyfill.d.ts
@@ -8,8 +8,6 @@ declare module "time-input-polyfill" {
   export = TimePolyfill;
 }
 
-declare function supportsTime(): boolean;
-
 declare module "time-input-polyfill/supportsTime" {
-  export = supportsTime;
+  export const supportsTime: boolean;
 }

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -66,7 +66,6 @@ export function Tooltip({ message, children }: TooltipProps) {
                 exit="startOrStop"
                 transition={{
                   type: "spring",
-                  duration: 0.2,
                   damping: 20,
                   stiffness: 300,
                 }}


### PR DESCRIPTION
## Motivations

We recently updated typescript in Atlantis, however missed updating it in the components package. This PR updates typescript in components.

While updating typescript we found a few type bugs in components that caused `npm ci` to fail. These bugs have also been resolved in this PR to allow `npm ci` to finish running.

## Changes

- Update typescript
- Update framer-motion

### Added


### Changed


### Deprecated


### Removed


### Fixed

- Type declaration on InputText and FormField

### Security


## Testing


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
