### PR TITLE
feat(components): add action buttons to Page component 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2165,7 +2165,7 @@
         "@types/uuid": "^3.4.5",
         "@use-it/event-listener": "^0.1.3",
         "classnames": "^2.2.6",
-        "framer-motion": "^1.6.5",
+        "framer-motion": "^1.10.3",
         "lodash": "^4.17.15",
         "react-markdown": "^4.1.0",
         "time-input-polyfill": "^1.0.7",
@@ -7821,7 +7821,6 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^2.1.0",
-        "@typescript-eslint/parser": "^2.29.0",
         "eslint-config-prettier": "^6.2.0",
         "eslint-import-resolver-typescript": "^1.1.1",
         "eslint-plugin-import": "^2.18.2",
@@ -10535,18 +10534,6 @@
         "@types/json-schema": "^7.0.3",
         "@typescript-eslint/typescript-estree": "2.1.0",
         "eslint-scope": "^4.0.0"
-      }
-    },
-    "@typescript-eslint/parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.1.0.tgz",
-      "integrity": "sha512-0+hzirRJoqE1T4lSSvCfKD+kWjIpDWfbGBiisK5CENcr+22pPkHB2sfV1giON+UxHV4A08SSrQonZk7X2zIQdw==",
-      "dev": true,
-      "requires": {
-        "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.1.0",
-        "@typescript-eslint/typescript-estree": "2.1.0",
-        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -23,7 +23,7 @@ interface MenuProps {
   readonly items: SectionProps[];
 }
 
-interface SectionProps {
+export interface SectionProps {
   /**
    * Defines the section header to further explain the group of actions.
    */

--- a/packages/components/src/Menu/index.ts
+++ b/packages/components/src/Menu/index.ts
@@ -1,1 +1,1 @@
-export { Menu } from "./Menu";
+export { Menu, SectionProps } from "./Menu";

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -16,21 +16,11 @@
   max-width: calc(var(--base-unit) * 64);
 }
 
-.actionGroup {
-  text-align: right;
-  vertical-align: top;
+.titleBar {
+  display: flex;
+  justify-content: space-between;
 }
 
 .actionGroup > :not(:last-child) {
   margin: 0 var(--space-small) 0 0;
-}
-
-.titleBar {
-  display: flex;
-  border-top: 1px solid red;
-}
-
-.titleBar > * {
-  flex: auto;
-  justify-content: space-between;
 }

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -22,5 +22,6 @@
 }
 
 .actionGroup > :not(:last-child) {
-  margin: 0 var(--space-small) 0 0;
+  margin: 0;
+  margin-right: var(--space-small);
 }

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -15,3 +15,22 @@
 .narrow {
   max-width: calc(var(--base-unit) * 64);
 }
+
+.actionGroup {
+  text-align: right;
+  vertical-align: top;
+}
+
+.actionGroup > :not(:last-child) {
+  margin: 0 var(--space-small) 0 0;
+}
+
+.titleBar {
+  display: flex;
+  border-top: 1px solid red;
+}
+
+.titleBar > * {
+  flex: auto;
+  justify-content: space-between;
+}

--- a/packages/components/src/Page/Page.css.d.ts
+++ b/packages/components/src/Page/Page.css.d.ts
@@ -2,5 +2,5 @@ export const page: string;
 export const fill: string;
 export const standard: string;
 export const narrow: string;
-export const actionGroup: string;
 export const titleBar: string;
+export const actionGroup: string;

--- a/packages/components/src/Page/Page.css.d.ts
+++ b/packages/components/src/Page/Page.css.d.ts
@@ -2,3 +2,5 @@ export const page: string;
 export const fill: string;
 export const standard: string;
 export const narrow: string;
+export const actionGroup: string;
+export const titleBar: string;

--- a/packages/components/src/Page/Page.mdx
+++ b/packages/components/src/Page/Page.mdx
@@ -33,3 +33,48 @@ import { Page } from "@jobber/components/Page";
 <Props of={Page} />
 
 ---
+
+## Page with Actions
+
+<Playground>
+  <Page
+    title="Get to work!"
+    intro="This isn't just talk. Get into action with some buttons and menus."
+    primaryAction={{ label: "Send Food", onClick: () => alert("🥨") }}
+    secondaryAction={{ label: "Send Drink", onClick: () => alert("🍹") }}
+    moreActionsMenu={[
+      {
+        actions: [
+          {
+            label: "Edit",
+            icon: "edit",
+            onClick: () => {
+              alert("✏️");
+            }
+          }
+        ]
+      },
+      {
+        header: "Send as...",
+        actions: [
+          {
+            label: "Text Message",
+            icon: "sms",
+            onClick: () => {
+              alert("📱");
+            }
+          },
+          {
+            label: "Email",
+            icon: "email",
+            onClick: () => {
+              alert("📨");
+            }
+          }
+        ]
+      }
+    ]}
+  >
+    <Text>Page content here</Text>
+  </Page>
+</Playground>

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -1,55 +1,126 @@
 import React from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import renderer from "react-test-renderer";
 import { Page } from ".";
+import { SectionProps } from "../Menu";
+
+afterEach(cleanup);
 
 it("renders a Page", () => {
-  const tree = renderer
-    .create(
+  const tree = renderer.create(
+    <Page
+      title="Notifications"
+      intro="Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us/articles/115009737128)."
+    >
+      Sup
+    </Page>,
+  );
+
+  expect(tree).toMatchSnapshot();
+});
+
+describe("When actions are provided", () => {
+  it("renders a Page with action buttons and a menu", () => {
+    const sampleActionMenu: SectionProps[] = [
+      {
+        header: "Send as...",
+        actions: [
+          {
+            label: "Text Message",
+            icon: "sms",
+            onClick: () => {},
+          },
+          {
+            label: "Email",
+            icon: "email",
+            onClick: () => {},
+          },
+        ],
+      },
+      {
+        actions: [
+          {
+            label: "Edit",
+            icon: "edit",
+            onClick: () => {},
+          },
+        ],
+      },
+    ];
+
+    const tree = renderer
+      .create(
+        <Page
+          title="Notifications"
+          intro="Improve job completion rates."
+          primaryAction={{ label: "Send Food", onClick: () => {} }}
+          secondaryAction={{
+            label: "Send Drink",
+            onClick: () => {},
+          }}
+          moreActionsMenu={sampleActionMenu}
+        >
+          Sup
+        </Page>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("triggers the correct primary action on click", () => {
+    const handlePrimaryAction = jest.fn();
+    const handleSecondaryAction = jest.fn();
+
+    const { getByText } = render(
       <Page
-        title="Notifications"
-        intro="Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us/articles/115009737128)."
+        title="Always Watching"
+        intro="This be an intro."
+        primaryAction={{ label: "First Do", onClick: handlePrimaryAction }}
+        secondaryAction={{
+          label: "Second Do",
+          onClick: handleSecondaryAction,
+        }}
       >
         Sup
       </Page>,
-    )
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-    <div
-      className="page standard"
-    >
-      <div
-        className="padded base"
+    );
+
+    fireEvent.click(getByText("First Do"));
+    expect(handlePrimaryAction).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByText("Second Do"));
+    expect(handleSecondaryAction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("When moreActions are provided", () => {
+  it("renders a Page with a moreAction menu", () => {
+    const handleMenuAction = jest.fn();
+
+    const simpleActionMenu: SectionProps[] = [
+      {
+        actions: [
+          {
+            label: "Text Message",
+            onClick: handleMenuAction,
+          },
+        ],
+      },
+    ];
+    const { getByText } = render(
+      <Page
+        title="The Eye"
+        intro="Huh, guess so."
+        moreActionsMenu={simpleActionMenu}
       >
-        <div
-          className="padded large"
-        >
-          <div
-            className="titleBar"
-          >
-            <h1
-              className="base black jumbo uppercase blue"
-            >
-              Notifications
-            </h1>
-          </div>
-          <p
-            className="base regular larger greyBlueDark"
-          >
-            Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our 
-            <a
-              href="https://help.getjobber.com/hc/en-us/articles/115009737128"
-            >
-              Help Center
-            </a>
-            .
-          </p>
-        </div>
-        <div
-          className="padded base"
-        >
-          Sup
-        </div>
-      </div>
-    </div>
-  `);
+        Sup
+      </Page>,
+    );
+
+    // Open the Menu
+    fireEvent.click(getByText("More Actions"));
+
+    fireEvent.click(getByText("Text Message"));
+    expect(handleMenuAction).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -23,11 +23,15 @@ it("renders a Page", () => {
         <div
           className="padded large"
         >
-          <h1
-            className="base black jumbo uppercase blue"
+          <div
+            className="titleBar"
           >
-            Notifications
-          </h1>
+            <h1
+              className="base black jumbo uppercase blue"
+            >
+              Notifications
+            </h1>
+          </div>
           <p
             className="base regular larger greyBlueDark"
           >

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -42,6 +42,7 @@ export interface PageProps {
 
   /**
    * Page title secondary action button settings.
+   *   Only shown if there is a primaryAction.
    */
   readonly secondaryAction?: ButtonProps;
 
@@ -64,6 +65,10 @@ export function Page({
 
   const showMenu = moreActionsMenu.length > 0;
   const showActionGroup = showMenu || primaryAction;
+
+  if (secondaryAction != undefined) {
+    secondaryAction = Object.assign({ type: "secondary" }, secondaryAction);
+  }
 
   return (
     <div className={pageStyles}>

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -6,7 +6,7 @@ import { Text } from "../Text";
 import { Content } from "../Content";
 import { Markdown } from "../Markdown";
 
-interface PageProps {
+export interface PageProps {
   readonly children: ReactNode | ReactNode[];
 
   /**

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -5,6 +5,8 @@ import { Heading } from "../Heading";
 import { Text } from "../Text";
 import { Content } from "../Content";
 import { Markdown } from "../Markdown";
+import { Button, ButtonProps } from "../Button";
+import { Menu, SectionProps } from "../Menu";
 
 export interface PageProps {
   readonly children: ReactNode | ReactNode[];
@@ -32,6 +34,21 @@ export interface PageProps {
    * @default standard
    */
   readonly width?: "fill" | "standard" | "narrow";
+
+  /**
+   * Page title primary action button settings.
+   */
+  readonly primaryAction?: ButtonProps;
+
+  /**
+   * Page title secondary action button settings.
+   */
+  readonly secondaryAction?: ButtonProps;
+
+  /**
+   * Page title Action menu.
+   */
+  readonly moreActionsMenu?: SectionProps[];
 }
 
 export function Page({
@@ -39,14 +56,29 @@ export function Page({
   intro,
   children,
   width = "standard",
+  primaryAction,
+  secondaryAction,
+  moreActionsMenu,
 }: PageProps) {
-  const className = classnames(styles.page, styles[width]);
+  const pageStyles = classnames(styles.page, styles[width]);
+
+  const showMenu = moreActionsMenu && moreActionsMenu.length > 0;
+  const showActionGroup = showMenu || primaryAction;
 
   return (
-    <div className={className}>
+    <div className={pageStyles}>
       <Content>
         <Content spacing="large">
-          <Heading level={1}>{title}</Heading>
+          <div className={styles.titleBar}>
+            <Heading level={1}>{title}</Heading>
+            {showActionGroup && (
+              <div className={styles.actionGroup}>
+                {primaryAction && <Button {...primaryAction} />}
+                {secondaryAction && <Button {...secondaryAction} />}
+                {showMenu && <Menu items={moreActionsMenu}></Menu>}
+              </div>
+            )}
+          </div>
           <Text variation="intro">
             <Markdown content={intro} basicUsage={true} />
           </Text>

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -58,11 +58,11 @@ export function Page({
   width = "standard",
   primaryAction,
   secondaryAction,
-  moreActionsMenu,
+  moreActionsMenu = [],
 }: PageProps) {
   const pageStyles = classnames(styles.page, styles[width]);
 
-  const showMenu = moreActionsMenu && moreActionsMenu.length > 0;
+  const showMenu = moreActionsMenu.length > 0;
   const showActionGroup = showMenu || primaryAction;
 
   return (

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -34,13 +34,13 @@ exports[`When actions are provided renders a Page with action buttons and a menu
             </span>
           </button>
           <button
-            className="button base work primary"
+            className="button base work secondary"
             disabled={false}
             onClick={[Function]}
             type="button"
           >
             <span
-              className="base extraBold small uppercase white"
+              className="base extraBold small uppercase green"
             >
               Send Drink
             </span>

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`When actions are provided renders a Page with action buttons and a menu 1`] = `
+<div
+  className="page standard"
+>
+  <div
+    className="padded base"
+  >
+    <div
+      className="padded large"
+    >
+      <div
+        className="titleBar"
+      >
+        <h1
+          className="base black jumbo uppercase blue"
+        >
+          Notifications
+        </h1>
+        <div
+          className="actionGroup"
+        >
+          <button
+            className="button base work primary"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span
+              className="base extraBold small uppercase white"
+            >
+              Send Food
+            </span>
+          </button>
+          <button
+            className="button base work primary"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span
+              className="base extraBold small uppercase white"
+            >
+              Send Drink
+            </span>
+          </button>
+          <div
+            className="wrapper"
+          >
+            <button
+              aria-controls="123e4567-e89b-12d3-a456-426655440002"
+              aria-expanded={false}
+              aria-haspopup={true}
+              className="button base hasIcon work secondary"
+              disabled={false}
+              id="123e4567-e89b-12d3-a456-426655440001"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                className="icon base"
+                viewBox="0 0 1024 1024"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  className="green"
+                  d="M170.667 512c0-47.13 38.205-85.333 85.333-85.333s85.333 38.204 85.333 85.333c0 47.13-38.205 85.333-85.333 85.333s-85.333-38.204-85.333-85.333zM426.667 512c0-47.13 38.204-85.333 85.333-85.333s85.333 38.204 85.333 85.333c0 47.13-38.204 85.333-85.333 85.333s-85.333-38.204-85.333-85.333zM768 426.667c-47.13 0-85.333 38.204-85.333 85.333s38.204 85.333 85.333 85.333c47.13 0 85.333-38.204 85.333-85.333s-38.204-85.333-85.333-85.333z"
+                />
+              </svg>
+              <span
+                className="base extraBold small uppercase green"
+              >
+                More Actions
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <p
+        className="base regular larger greyBlueDark"
+      >
+        Improve job completion rates.
+      </p>
+    </div>
+    <div
+      className="padded base"
+    >
+      Sup
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders a Page 1`] = `
+<div
+  className="page standard"
+>
+  <div
+    className="padded base"
+  >
+    <div
+      className="padded large"
+    >
+      <div
+        className="titleBar"
+      >
+        <h1
+          className="base black jumbo uppercase blue"
+        >
+          Notifications
+        </h1>
+      </div>
+      <p
+        className="base regular larger greyBlueDark"
+      >
+        Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our 
+        <a
+          href="https://help.getjobber.com/hc/en-us/articles/115009737128"
+        >
+          Help Center
+        </a>
+        .
+      </p>
+    </div>
+    <div
+      className="padded base"
+    >
+      Sup
+    </div>
+  </div>
+</div>
+`;

--- a/packages/formatters/package-lock.json
+++ b/packages/formatters/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/formatters",
-	"version": "0.0.2",
+	"version": "0.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
This adds primary and secondary action buttons and a menu as optional parts of the `<Page>` component. This will render them in the standard action button and action menu way. 

## Motivations
- This uses `ButtonProps` for flexibility and consistency across other places in the library.
- The CSS and markup are contained in the Page for now. In future work, we can bring it out into an ActionBar component.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `<Page>` can now take a `primaryAction` (`ButtonProps` type), `secondaryAction`  (`ButtonProps` type) and an `actionMenu` prop (`SectionProps[]` type).

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
