### PR TITLE
feat(components): ProgressBar can have a size

### DIFF
--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -1,19 +1,17 @@
 :root {
-  --progress-bar--borderRadius: 1rem;
   --progress-bar--backgroundColor: var(--color-grey--lightest);
   --progress-bar--barColor: var(--color-lime);
 }
 
-.container {
+.container,
+.content {
   width: 100%;
   height: var(--progress-bar--height);
-  border-radius: var(--progress-bar--borderRadius);
+  border-radius: calc(var(--progress-bar--height) / 2);
   background: var(--progress-bar--backgroundColor);
 }
 
 .content {
-  height: var(--progress-bar--height);
-  border-radius: var(--progress-bar--borderRadius);
   background-color: var(--progress-bar--barColor);
   transition: width var(--timing-slower) ease-out;
 }

--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -1,5 +1,6 @@
 :root {
   --progress-bar--borderRadius: 1rem;
+  --progress-bar--height: 1rem;
   --progress-bar--backgroundColor: var(--color-grey--lightest);
   --progress-bar--barColor: var(--color-lime);
 }

--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -1,6 +1,5 @@
 :root {
   --progress-bar--borderRadius: 1rem;
-  --progress-bar--height: 1rem;
   --progress-bar--backgroundColor: var(--color-grey--lightest);
   --progress-bar--barColor: var(--color-lime);
 }

--- a/packages/components/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.test.tsx
@@ -9,4 +9,11 @@ describe("with props", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it("accepts small size", () => {
+    const tree = renderer
+      .create(<ProgressBar currentStep={2} totalSteps={3} size={"small"} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -15,7 +15,8 @@ interface ProgressBarProps {
   readonly totalSteps: number;
 
   /**
-   * Changes the size to small
+   * Set the size of the progress bar
+   * @default base
    */
   readonly size?: keyof typeof sizes;
 }
@@ -23,13 +24,13 @@ interface ProgressBarProps {
 export function ProgressBar({
   currentStep,
   totalSteps,
-  size,
+  size = "base",
 }: ProgressBarProps) {
   const percentage = ((currentStep - 1) / (totalSteps - 1)) * 100;
   const widthPercent = Math.min(100, Math.max(0, percentage));
   const progressBarContainerClassName = classnames(
     styles.container,
-    size && sizes[size],
+    sizes[size],
   );
   const progressBarContentClassName = classnames(styles.content);
 

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import styles from "./ProgressBar.css";
+import sizes from "./Sizes.css";
 
 interface ProgressBarProps {
   /**
@@ -12,12 +13,25 @@ interface ProgressBarProps {
    * The total steps to use. For percentages you can set this to 100.
    */
   readonly totalSteps: number;
+
+  /**
+   * Changes the size to small, medium or large.
+   * @default medium
+   */
+  readonly size?: keyof typeof sizes;
 }
 
-export function ProgressBar({ currentStep, totalSteps }: ProgressBarProps) {
+export function ProgressBar({
+  currentStep,
+  totalSteps,
+  size,
+}: ProgressBarProps) {
   const percentage = ((currentStep - 1) / (totalSteps - 1)) * 100;
   const widthPercent = Math.min(100, Math.max(0, percentage));
-  const progressBarContainerClassName = classnames(styles.container);
+  const progressBarContainerClassName = classnames(
+    styles.container,
+    size && sizes[size],
+  );
   const progressBarContentClassName = classnames(styles.content);
 
   return (

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -15,8 +15,7 @@ interface ProgressBarProps {
   readonly totalSteps: number;
 
   /**
-   * Changes the size to small, medium or large.
-   * @default medium
+   * Changes the size to small
    */
   readonly size?: keyof typeof sizes;
 }

--- a/packages/components/src/ProgressBar/Sizes.css
+++ b/packages/components/src/ProgressBar/Sizes.css
@@ -1,4 +1,4 @@
-.smaller {
+.small {
   --progress-bar--height: var(--space-smaller);
 }
 

--- a/packages/components/src/ProgressBar/Sizes.css
+++ b/packages/components/src/ProgressBar/Sizes.css
@@ -1,0 +1,11 @@
+.small {
+  --progress-bar--height: 0.5rem;
+}
+
+.medium {
+  --progress-bar--height: 1rem;
+}
+
+.large {
+  --progress-bar--height: 1.5rem;
+}

--- a/packages/components/src/ProgressBar/Sizes.css
+++ b/packages/components/src/ProgressBar/Sizes.css
@@ -1,11 +1,3 @@
 .small {
   --progress-bar--height: 0.5rem;
 }
-
-.medium {
-  --progress-bar--height: 1rem;
-}
-
-.large {
-  --progress-bar--height: 1.5rem;
-}

--- a/packages/components/src/ProgressBar/Sizes.css
+++ b/packages/components/src/ProgressBar/Sizes.css
@@ -1,3 +1,7 @@
-.small {
-  --progress-bar--height: 0.5rem;
+.smaller {
+  --progress-bar--height: var(--space-smaller);
+}
+
+.base {
+  --progress-bar--height: var(--space-base);
 }

--- a/packages/components/src/ProgressBar/Sizes.css.d.ts
+++ b/packages/components/src/ProgressBar/Sizes.css.d.ts
@@ -1,3 +1,1 @@
 export const small: string;
-export const medium: string;
-export const large: string;

--- a/packages/components/src/ProgressBar/Sizes.css.d.ts
+++ b/packages/components/src/ProgressBar/Sizes.css.d.ts
@@ -1,0 +1,3 @@
+export const small: string;
+export const medium: string;
+export const large: string;

--- a/packages/components/src/ProgressBar/Sizes.css.d.ts
+++ b/packages/components/src/ProgressBar/Sizes.css.d.ts
@@ -1,1 +1,2 @@
-export const small: string;
+export const smaller: string;
+export const base: string;

--- a/packages/components/src/ProgressBar/Sizes.css.d.ts
+++ b/packages/components/src/ProgressBar/Sizes.css.d.ts
@@ -1,2 +1,2 @@
-export const smaller: string;
+export const small: string;
 export const base: string;

--- a/packages/components/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/components/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`with props renders correctly 1`] = `
 <div
-  className="container"
+  className="container base"
 >
   <div
     className="content"

--- a/packages/components/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/components/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`with props accepts small size 1`] = `
+<div
+  className="container small"
+>
+  <div
+    className="content"
+    style={
+      Object {
+        "width": "50%",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`with props renders correctly 1`] = `
 <div
   className="container base"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The progress bar was only one size that was too large when using it in smaller spaces. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

ProgressBar can have a small size, which is half the size of the default ProgressBar. 

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
