### PR TITLE
fix(components): Padding Update to RadioGroup Component

### DIFF
--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -12,6 +12,7 @@
 .label {
   display: inline-flex;
   align-items: center;
+  padding-bottom: 0.5rem;
 }
 
 .input + .label::before {
@@ -37,4 +38,8 @@
 .radioGroup {
   display: inline-flex;
   flex-direction: column;
+}
+/* This to override the styling being applied by playground. */
+.inputWrapper {
+  line-height: normal;
 }

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -80,7 +80,7 @@ function InternalRadioOption({
 }: InternalRadioOptionProps) {
   const inputId = value.toString();
   return (
-    <div>
+    <div className={styles.inputWrapper}>
       <input
         onChange={handleChange}
         type="radio"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Small update to add more padding between each radio button option.

## Changes

#Before
![Screen Shot 2020-05-07 at 2 19 13 PM](https://user-images.githubusercontent.com/51099295/81340963-fdac8b80-906d-11ea-9574-53c04fc711c3.png)

#After
![Screen Shot 2020-05-07 at 2 20 23 PM](https://user-images.githubusercontent.com/51099295/81340974-03a26c80-906e-11ea-96f3-1cc68341be27.png)

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
