### PR TITLE
fix: Build css types on save

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -9,7 +9,7 @@ const projectPlugin = () =>
       const config = getConfig();
 
       /**
-       * Generate css types on save.
+       * Generate css types on `.css` file save.
        */
       config.module.rules.push({
         enforce: "pre",

--- a/doczrc.js
+++ b/doczrc.js
@@ -9,6 +9,16 @@ const projectPlugin = () =>
       const config = getConfig();
 
       /**
+       * Generate css types on save.
+       */
+      config.module.rules.push({
+        enforce: "pre",
+        test: /\.css$/,
+        exclude: /node_modules/,
+        loader: require.resolve("typed-css-modules-loader"),
+      });
+
+      /**
        * Gatsby does not like that we use css modules. To fix this we need
        * to change some of the webpack config around how we handle css.
        * 😢 More info here: https://github.com/gatsbyjs/gatsby/issues/16129

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
+    "prestart": "cd packages/components && npm run build:cssTypes",
     "start": "docz dev",
     "start:withPrivateComponents": "PRIVATE_COMPONENTS=visible docz dev",
     "test": "jest",

--- a/packages/formatters/package-lock.json
+++ b/packages/formatters/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"typescript": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-			"integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		}
 	}

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -13,6 +13,6 @@
     "dist/*"
   ],
   "devDependencies": {
-    "typescript": "^3.4.5"
+    "typescript": "^3.8.3"
   }
 }


### PR DESCRIPTION

## Motivations

When you are working in Atlantis and save a `css` file, we would like the types to generate. This used to happen, and then all of the sudden it didn't anymore. 

This PR makes that happen again!

It also contains an idea to build the types on `npm start`. The idea behind this is that you get your css types built when you start Atlantis.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Adds prestart command to package.json

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Builds css types on save

### Security

- <!-- in case of vulnerabilities -->

## Testing

- `npm start`, see that types are generated.
- add a new css class to a css file and save it. See that the type is added to the `.css.d.ts` file\\
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
