### PR TITLE
fix(generators): correct proposal template URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ related to `Atlantis`. There most common types of issues are:
 
 **_What should be in a proposal?_**
 
-Please use the [proposal template](docs/proposals/TEMPLATE.md) as a guide for
-writing proposals.
+Please use the [proposal template](https://github.com/GetJobber/atlantis/blob/master/docs/proposals/TEMPLATE.md) 
+as a guide for writing proposals.
 
 **_What is the process for submitting a proposal?_**
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  ## Motivations

The "proposal template" link in our contribution guidelines redirects to the "home" page in Atlantis, instead of the template in Github.

## Changes

### Changed

- URL from atlantis internal to Github

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
