### PR TITLE
feat(components): Add routing Link to Button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10319,6 +10319,27 @@
         "@types/react": "*"
       }
     },
+    "@types/react-router": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.7.tgz",
+      "integrity": "sha512-2ouP76VQafKjtuc0ShpwUebhHwJo0G6rhahW9Pb8au3tQTjYXd2jta4wv6U2tGLR/I42yuG00+UXjNYY0dTzbg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.5.tgz",
+      "integrity": "sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
     "@types/rimraf": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2163,6 +2163,7 @@
         "@std-proposal/temporal": "0.0.1",
         "@types/color": "^3.0.1",
         "@types/lodash": "^4.14.136",
+        "@types/react-router-dom": "^5.1.5",
         "@types/uuid": "^3.4.5",
         "@use-it/event-listener": "^0.1.3",
         "classnames": "^2.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2161,13 +2161,17 @@
         "@jobber/formatters": "^0.0.4",
         "@popperjs/core": "^2.0.6",
         "@std-proposal/temporal": "0.0.1",
+        "@types/color": "^3.0.1",
         "@types/lodash": "^4.14.136",
         "@types/uuid": "^3.4.5",
         "@use-it/event-listener": "^0.1.3",
         "classnames": "^2.2.6",
+        "color": "^3.1.2",
         "framer-motion": "^1.10.3",
         "lodash": "^4.17.15",
+        "react-image-lightbox": "^5.1.1",
         "react-markdown": "^4.1.0",
+        "react-router-dom": "^5.2.0",
         "time-input-polyfill": "^1.0.7",
         "ts-xor": "^1.0.8",
         "uuid": "^3.3.2"
@@ -2222,24 +2226,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
           "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
-        },
-        "@popmotion/easing": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
-          "integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==",
-          "dev": true
-        },
-        "@popmotion/popcorn": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.2.tgz",
-          "integrity": "sha512-wu0tEwK3KUZ9BoqfcqC3DfdfRDws/oHXwZKJMVtuhXSrF/PtqvilsPjAk93nh8M+orAnbe8ZyxQmop9+4oJs2g==",
-          "dev": true,
-          "requires": {
-            "@popmotion/easing": "^1.0.1",
-            "framesync": "^4.0.1",
-            "hey-listen": "^1.0.8",
-            "style-value-types": "^3.1.6"
-          }
         },
         "@popperjs/core": {
           "version": "2.0.6",
@@ -2907,34 +2893,12 @@
           }
         },
         "color": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
-          "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+          "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
           "requires": {
             "color-convert": "^1.9.1",
             "color-string": "^1.5.2"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "color-string": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-          "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-          "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
           }
         },
         "commander": {
@@ -3690,48 +3654,6 @@
             "map-cache": "^0.2.2"
           }
         },
-        "framer-motion": {
-          "version": "1.6.5",
-          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.6.5.tgz",
-          "integrity": "sha512-Plg25ywwVI6bu2M/9Q9pIljudMRNDnlXF+wYOvZomxqzujqAL+dnMv9CxammZaDje88qMDULzuySFXxp2fcC0g==",
-          "dev": true,
-          "requires": {
-            "@popmotion/easing": "^1.0.2",
-            "@popmotion/popcorn": "^0.4.2",
-            "framesync": "^4.0.4",
-            "hey-listen": "^1.0.8",
-            "popmotion": "9.0.0-beta-8",
-            "style-value-types": "^3.1.6",
-            "stylefire": "^6.0.10",
-            "tslib": "^1.10.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-              "dev": true
-            }
-          }
-        },
-        "framesync": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.4.tgz",
-          "integrity": "sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==",
-          "dev": true,
-          "requires": {
-            "hey-listen": "^1.0.8",
-            "tslib": "^1.10.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-              "dev": true
-            }
-          }
-        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -4430,12 +4352,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
           "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
-        },
-        "hey-listen": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-          "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-          "dev": true
         },
         "hosted-git-info": {
           "version": "2.7.1",
@@ -5445,28 +5361,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "popmotion": {
-          "version": "9.0.0-beta-8",
-          "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-beta-8.tgz",
-          "integrity": "sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==",
-          "dev": true,
-          "requires": {
-            "@popmotion/easing": "^1.0.1",
-            "@popmotion/popcorn": "^0.4.2",
-            "framesync": "^4.0.4",
-            "hey-listen": "^1.0.8",
-            "style-value-types": "^3.1.6",
-            "tslib": "^1.10.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-              "dev": true
-            }
-          }
         },
         "posix-character-classes": {
           "version": "0.1.1",
@@ -6850,21 +6744,6 @@
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
-        "simple-swizzle": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-          "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-          "requires": {
-            "is-arrayish": "^0.3.1"
-          },
-          "dependencies": {
-            "is-arrayish": {
-              "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-              "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-            }
-          }
-        },
         "snapdragon": {
           "version": "0.8.2",
           "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -7120,27 +6999,6 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
           "integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw=="
-        },
-        "style-value-types": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.6.tgz",
-          "integrity": "sha512-AxcfUr/06AHyyyxkNB1O8ypvwa8/qK+sxwelxEN5x+jxW+RXutRE2TuHEQbFq9OBY7ym83CPKvVIsGd6lvKb0Q==",
-          "dev": true,
-          "requires": {
-            "hey-listen": "^1.0.8"
-          }
-        },
-        "stylefire": {
-          "version": "6.0.10",
-          "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-6.0.10.tgz",
-          "integrity": "sha512-SAJnUk4L9EKt/WSliztk1iZCzcNOJDR69xO8gblRjQwjybgMWONsY7KpcMBt65xU1UZaiyPDK5CoLf9wXLJldQ==",
-          "dev": true,
-          "requires": {
-            "@popmotion/popcorn": "^0.4.2",
-            "framesync": "^4.0.0",
-            "hey-listen": "^1.0.8",
-            "style-value-types": "^3.1.6"
-          }
         },
         "stylehacks": {
           "version": "4.0.3",
@@ -7821,6 +7679,7 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^2.1.0",
+        "@typescript-eslint/parser": "^2.29.0",
         "eslint-config-prettier": "^6.2.0",
         "eslint-import-resolver-typescript": "^1.1.1",
         "eslint-plugin-import": "^2.18.2",
@@ -9824,6 +9683,25 @@
         }
       }
     },
+    "@popmotion/easing": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
+      "integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==",
+      "dev": true
+    },
+    "@popmotion/popcorn": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz",
+      "integrity": "sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==",
+      "dev": true,
+      "requires": {
+        "@popmotion/easing": "^1.0.1",
+        "framesync": "^4.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "^3.1.7",
+        "tslib": "^1.10.0"
+      }
+    },
     "@reach/router": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.3.tgz",
@@ -10210,6 +10088,24 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/color": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.1.tgz",
+      "integrity": "sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==",
+      "dev": true,
+      "requires": {
+        "@types/color-convert": "*"
+      }
+    },
+    "@types/color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -10534,6 +10430,95 @@
         "@types/json-schema": "^7.0.3",
         "@typescript-eslint/typescript-estree": "2.1.0",
         "eslint-scope": "^4.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
+      "integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "2.34.0",
+        "@typescript-eslint/typescript-estree": "2.34.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "2.34.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
+          "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/typescript-estree": "2.34.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "2.34.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+          "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "eslint-visitor-keys": "^1.1.0",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "@typescript-eslint/typescript-estree": {
@@ -15230,7 +15215,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -15238,14 +15222,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -19541,6 +19523,12 @@
         "clone-regexp": "^2.1.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=",
+      "dev": true
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -20224,6 +20212,33 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "framer-motion": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.11.0.tgz",
+      "integrity": "sha512-DkJFWAHIv57L4xu8Ufq9GMs9Ifqpgt5Yi55pc4NQos8TUGomgbLlnwpO1IXK85X5K1dVNKuTZMiqjWZLeOfG/A==",
+      "dev": true,
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "@popmotion/easing": "^1.0.2",
+        "@popmotion/popcorn": "^0.4.2",
+        "framesync": "^4.0.4",
+        "hey-listen": "^1.0.8",
+        "popmotion": "9.0.0-beta-8",
+        "style-value-types": "^3.1.6",
+        "stylefire": "^7.0.2",
+        "tslib": "^1.10.0"
+      }
+    },
+    "framesync": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.4.tgz",
+      "integrity": "sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==",
+      "dev": true,
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^1.10.0"
       }
     },
     "fresh": {
@@ -26302,6 +26317,26 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
+    "hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
+      "dev": true
+    },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -31600,6 +31635,33 @@
       "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
       "dev": true
     },
+    "mini-create-react-context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.2.tgz",
@@ -33795,6 +33857,20 @@
         "ts-pnp": "^1.1.6"
       }
     },
+    "popmotion": {
+      "version": "9.0.0-beta-8",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-beta-8.tgz",
+      "integrity": "sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==",
+      "dev": true,
+      "requires": {
+        "@popmotion/easing": "^1.0.1",
+        "@popmotion/popcorn": "^0.4.2",
+        "framesync": "^4.0.4",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "^3.1.6",
+        "tslib": "^1.10.0"
+      }
+    },
     "portfinder": {
       "version": "1.0.25",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
@@ -35829,6 +35905,16 @@
         }
       }
     },
+    "react-image-lightbox": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-image-lightbox/-/react-image-lightbox-5.1.1.tgz",
+      "integrity": "sha512-GprldD8AqpRb2hsOdns3sI7Xeo9hJlcybDxuli4RB+ml1J/GaFaUuRkT/7IrTLv2+4vkR74ahz2LD0HOUHI7wA==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.6.2",
+        "react-modal": "^3.8.1"
+      }
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
@@ -35865,6 +35951,29 @@
           "requires": {
             "fbjs": "^0.8.0",
             "gud": "^1.0.0"
+          }
+        }
+      }
+    },
+    "react-modal": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
+      "integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
+      "dev": true,
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -35906,6 +36015,56 @@
         "prop-types": "^15.7.2",
         "raf-schd": "^4.0.2",
         "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-simple-code-editor": {
@@ -37082,6 +37241,12 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+      "dev": true
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -37729,7 +37894,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -37737,8 +37901,7 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -38746,6 +38909,16 @@
         "inline-style-parser": "0.1.1"
       }
     },
+    "style-value-types": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.7.tgz",
+      "integrity": "sha512-jPaG5HcAPs3vetSwOJozrBXxuHo9tjZVnbRyBjxqb00c2saIoeuBJc1/2MtvB8eRZy41u/BBDH0CpfzWixftKg==",
+      "dev": true,
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^1.10.0"
+      }
+    },
     "styled-system": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",
@@ -38765,6 +38938,19 @@
         "@styled-system/typography": "^5.1.2",
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
+      }
+    },
+    "stylefire": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
+      "integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
+      "dev": true,
+      "requires": {
+        "@popmotion/popcorn": "^0.4.4",
+        "framesync": "^4.0.0",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "^3.1.7",
+        "tslib": "^1.10.0"
       }
     },
     "stylehacks": {
@@ -39454,6 +39640,18 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "dev": true
+    },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
+      "dev": true
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "dev": true
     },
     "title-case": {
@@ -40821,6 +41019,12 @@
       "requires": {
         "builtins": "^1.0.3"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/lodash": "^4.14.149",
     "@types/react": "^16.9.9",
     "@types/react-dom": "^16.9.2",
-    "@types/react-router-dom": "^5.1.5",
     "css-loader": "^3.4.2",
     "docz": "^2.3.0-alpha.13",
     "docz-core": "^2.3.0-alpha.12",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-helmet-async": "^1.0.4",
+    "react-router-dom": "^5.2.0",
     "style-loader": "^0.23.1",
     "stylelint": "^11.1.1",
     "stylelint-junit-formatter": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/lodash": "^4.14.149",
     "@types/react": "^16.9.9",
     "@types/react-dom": "^16.9.2",
+    "@types/react-router-dom": "^5.1.5",
     "css-loader": "^3.4.2",
     "docz": "^2.3.0-alpha.13",
     "docz-core": "^2.3.0-alpha.12",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -221,6 +221,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/history": {
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.6.tgz",
+			"integrity": "sha512-GRTZLeLJ8ia00ZH8mxMO8t0aC9M1N9bN461Z2eaRurJo6Fpa+utgCwLzI4jQHcrdzuzp5WPN9jRwpsCQ1VhJ5w=="
+		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -265,8 +270,7 @@
 		"@types/prop-types": {
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-f8JzJNWVhKtc9dg/dyDNfliTKNOJSLa7Oht/ElZdF/UbMUmAH3rLmAk3ODNjw0mZajDEgatA03tRjB4+Dp/tzA==",
-			"dev": true
+			"integrity": "sha512-f8JzJNWVhKtc9dg/dyDNfliTKNOJSLa7Oht/ElZdF/UbMUmAH3rLmAk3ODNjw0mZajDEgatA03tRjB4+Dp/tzA=="
 		},
 		"@types/q": {
 			"version": "1.5.2",
@@ -278,7 +282,6 @@
 			"version": "16.9.2",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.2.tgz",
 			"integrity": "sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==",
-			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
@@ -291,6 +294,25 @@
 			"dev": true,
 			"requires": {
 				"@types/react": "*"
+			}
+		},
+		"@types/react-router": {
+			"version": "5.1.7",
+			"resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.7.tgz",
+			"integrity": "sha512-2ouP76VQafKjtuc0ShpwUebhHwJo0G6rhahW9Pb8au3tQTjYXd2jta4wv6U2tGLR/I42yuG00+UXjNYY0dTzbg==",
+			"requires": {
+				"@types/history": "*",
+				"@types/react": "*"
+			}
+		},
+		"@types/react-router-dom": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.5.tgz",
+			"integrity": "sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==",
+			"requires": {
+				"@types/history": "*",
+				"@types/react": "*",
+				"@types/react-router": "*"
 			}
 		},
 		"@types/react-test-renderer": {
@@ -1286,8 +1308,7 @@
 		"csstype": {
 			"version": "2.6.6",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
-			"integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==",
-			"dev": true
+			"integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
 		},
 		"debug": {
 			"version": "2.6.9",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -44,6 +44,11 @@
 				"@types/yargs": "^12.0.9"
 			}
 		},
+		"@jobber/formatters": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@jobber/formatters/-/formatters-0.0.4.tgz",
+			"integrity": "sha512-AaTKOBm/1zXJ0ZQSs6BJFRBkPH2VrJxVKSD7TfqjDn6hm+puGdcFfQDn8L8WbS4s1Jp7ci0pbMIDZqJcoRyFWg=="
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -8,7 +8,6 @@
 			"version": "7.6.3",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
 			"integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
@@ -2477,6 +2476,27 @@
 			"resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
 			"integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
 		},
+		"history": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+			"integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"loose-envify": "^1.2.0",
+				"resolve-pathname": "^3.0.0",
+				"tiny-invariant": "^1.0.2",
+				"tiny-warning": "^1.0.0",
+				"value-equal": "^1.0.1"
+			}
+		},
+		"hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"requires": {
+				"react-is": "^16.7.0"
+			}
+		},
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -2899,8 +2919,7 @@
 		"isarray": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-			"dev": true
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -3217,6 +3236,15 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
+		},
+		"mini-create-react-context": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+			"integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"tiny-warning": "^1.0.3"
+			}
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -3570,6 +3598,14 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+			"requires": {
+				"isarray": "0.0.1"
+			}
 		},
 		"path-type": {
 			"version": "2.0.0",
@@ -4664,6 +4700,37 @@
 				"warning": "^4.0.3"
 			}
 		},
+		"react-router": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+			"integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"history": "^4.9.0",
+				"hoist-non-react-statics": "^3.1.0",
+				"loose-envify": "^1.3.1",
+				"mini-create-react-context": "^0.4.0",
+				"path-to-regexp": "^1.7.0",
+				"prop-types": "^15.6.2",
+				"react-is": "^16.6.0",
+				"tiny-invariant": "^1.0.2",
+				"tiny-warning": "^1.0.0"
+			}
+		},
+		"react-router-dom": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+			"integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"history": "^4.9.0",
+				"loose-envify": "^1.3.1",
+				"prop-types": "^15.6.2",
+				"react-router": "5.2.0",
+				"tiny-invariant": "^1.0.2",
+				"tiny-warning": "^1.0.0"
+			}
+		},
 		"react-test-renderer": {
 			"version": "16.9.0",
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.9.0.tgz",
@@ -4788,8 +4855,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.3",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-			"dev": true
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -4909,6 +4975,11 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
 			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
 			"dev": true
+		},
+		"resolve-pathname": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+			"integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -5601,6 +5672,16 @@
 			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
 		},
+		"tiny-invariant": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+			"integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+		},
+		"tiny-warning": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -5977,6 +6058,11 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
+		},
+		"value-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+			"integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
 		},
 		"vendors": {
 			"version": "1.0.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,6 +33,7 @@
     "lodash": "^4.17.15",
     "react-image-lightbox": "^5.1.1",
     "react-markdown": "^4.1.0",
+    "react-router-dom": "^5.2.0",
     "time-input-polyfill": "^1.0.7",
     "ts-xor": "^1.0.8",
     "uuid": "^3.3.2"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,6 +25,7 @@
     "@std-proposal/temporal": "0.0.1",
     "@types/color": "^3.0.1",
     "@types/lodash": "^4.14.136",
+    "@types/react-router-dom": "^5.1.5",
     "@types/uuid": "^3.4.5",
     "@use-it/event-listener": "^0.1.3",
     "classnames": "^2.2.6",

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -116,7 +116,9 @@
 .disabled,
 .disabled:hover {
   border-color: var(--button--color-disabled);
+  user-select: none;
   background-color: var(--button--color-disabled);
+  pointer-events: none;
   cursor: not-allowed;
 }
 

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -6,6 +6,9 @@ route: /components/button
 
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
+import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import { Card } from "@jobber/components/Card";
+import { Content } from "@jobber/components/Content";
 import { Button } from ".";
 
 # Button
@@ -202,4 +205,29 @@ A way to communicate to the user that a background action is being performed.
     loading={true}
   />
   <Button label="Canceling..." variation="cancel" loading={true} />
+</Playground>
+
+## Routing
+
+<Playground>
+  {() => {
+    return (
+      <Router basename="/components/button">
+        <Button label="Home" to="/" /> <Button label="Office" to="/office" />{" "}
+        <Button label="Dentist" to="/dentist" />
+        <hr />
+        <Switch>
+          <Route exact path="/">
+            This is my home.
+          </Route>
+          <Route exact path="/office">
+            Office
+          </Route>
+          <Route exact path="/dentist">
+            Dentist
+          </Route>
+        </Switch>
+      </Router>
+    );
+  }}
 </Playground>

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -23,6 +23,8 @@ import { Button } from "@jobber/components/Button";
 <Playground>
   <Button
     label="Submit"
+    ariaHaspopup={true}
+    id="EDDY"
     onClick={() => {
       alert("✅");
     }}
@@ -215,7 +217,7 @@ that the url will change to the appropriate route.
   {() => {
     return (
       <Router basename="/components/button">
-        <Button label="Home" to="/" />
+        <Button label="Home" to="/" id="EDDY" />
         <Button label="Office" to="/office" />
         <Button label="Dentist" to="/dentist" />
         <hr />

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -7,8 +7,6 @@ route: /components/button
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
-import { Card } from "@jobber/components/Card";
-import { Content } from "@jobber/components/Content";
 import { Button } from ".";
 
 # Button

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -6,7 +6,7 @@ route: /components/button
 
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
-import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { Card } from "@jobber/components/Card";
 import { Content } from "@jobber/components/Content";
 import { Button } from ".";

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -213,8 +213,9 @@ A way to communicate to the user that a background action is being performed.
   {() => {
     return (
       <Router basename="/components/button">
-        <Button label="Home" to="/" /> <Button label="Office" to="/office" />{" "}
-        <Button label="Dentist" to="/dentist" />
+        <Button label="Home" to="/" url="https://getjobber.com/" />
+        <Button label="Office" to="/office" external />
+        <Button label="Dentist" to="/dentist" disabled />
         <hr />
         <Switch>
           <Route exact path="/">

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -207,25 +207,29 @@ A way to communicate to the user that a background action is being performed.
   <Button label="Canceling..." variation="cancel" loading={true} />
 </Playground>
 
-## Routing
+## Client Side Routing
+
+A `Button` can be used for client side routing as well. When using a Button to
+handle the client side routing, use the `to` prop. Notice when you click below
+that the url will change to the appropriate route.
 
 <Playground>
   {() => {
     return (
       <Router basename="/components/button">
-        <Button label="Home" to="/" url="https://getjobber.com/" />
-        <Button label="Office" to="/office" external />
-        <Button label="Dentist" to="/dentist" disabled />
+        <Button label="Home" to="/" />
+        <Button label="Office" to="/office" />
+        <Button label="Dentist" to="/dentist" />
         <hr />
         <Switch>
           <Route exact path="/">
-            This is my home.
+            This is my home, time to get cozy.
           </Route>
           <Route exact path="/office">
-            Office
+            This is my office, time to get to work.
           </Route>
           <Route exact path="/dentist">
-            Dentist
+            This is the dentist, time to get my teeth fixed.
           </Route>
         </Switch>
       </Router>

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -23,8 +23,6 @@ import { Button } from "@jobber/components/Button";
 <Playground>
   <Button
     label="Submit"
-    ariaHaspopup={true}
-    id="EDDY"
     onClick={() => {
       alert("✅");
     }}
@@ -217,7 +215,7 @@ that the url will change to the appropriate route.
   {() => {
     return (
       <Router basename="/components/button">
-        <Button label="Home" to="/" id="EDDY" />
+        <Button label="Home" to="/" />
         <Button label="Office" to="/office" />
         <Button label="Dentist" to="/dentist" />
         <hr />

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -1,23 +1,24 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { fireEvent, render } from "@testing-library/react";
+import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 import { Button } from ".";
 
 it("renders a Button", () => {
   const tree = renderer.create(<Button label="Submit" />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button base work primary"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold small uppercase white"
-                  >
-                    Submit
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button base work primary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold small uppercase white"
+                      >
+                        Submit
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a secondary Button", () => {
@@ -25,18 +26,18 @@ it("renders a secondary Button", () => {
     .create(<Button label="Submit" type="secondary" />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button base work secondary"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold small uppercase green"
-                  >
-                    Submit
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button base work secondary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold small uppercase green"
+                      >
+                        Submit
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a tertiary Button", () => {
@@ -44,18 +45,18 @@ it("renders a tertiary Button", () => {
     .create(<Button label="Submit" type="tertiary" />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button base work tertiary"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold small uppercase green"
-                  >
-                    Submit
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button base work tertiary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold small uppercase green"
+                      >
+                        Submit
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a destructuve Button", () => {
@@ -63,18 +64,18 @@ it("renders a destructuve Button", () => {
     .create(<Button label="Submit" variation="destructive" />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button base destructive primary"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold small uppercase white"
-                  >
-                    Submit
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button base destructive primary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold small uppercase white"
+                      >
+                        Submit
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a learning Button", () => {
@@ -82,18 +83,18 @@ it("renders a learning Button", () => {
     .create(<Button label="Submit" variation="learning" />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button base learning primary"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold small uppercase white"
-                  >
-                    Submit
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button base learning primary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold small uppercase white"
+                      >
+                        Submit
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a cancel Button", () => {
@@ -101,18 +102,18 @@ it("renders a cancel Button", () => {
     .create(<Button label="Submit" variation="cancel" />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button base cancel primary"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold small uppercase greyBlue"
-                  >
-                    Submit
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button base cancel primary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold small uppercase greyBlue"
+                      >
+                        Submit
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a disabled Button", () => {
@@ -120,18 +121,18 @@ it("renders a disabled Button", () => {
     .create(<Button label="Submit" disabled={true} />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button base work primary disabled"
-                  disabled={true}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold small uppercase grey"
-                  >
-                    Submit
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button base work primary disabled"
+                      disabled={true}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold small uppercase grey"
+                      >
+                        Submit
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a Button with a link and opens in new tab", () => {
@@ -139,46 +140,46 @@ it("renders a Button with a link and opens in new tab", () => {
     .create(<Button label="Submit" url="💩.com" external={true} />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                    <a
-                      className="button base work primary"
-                      disabled={false}
-                      href="💩.com"
-                      target="_blank"
-                    >
-                      <span
-                        className="base extraBold small uppercase white"
-                      >
-                        Submit
-                      </span>
-                    </a>
-          `);
+                        <a
+                          className="button base work primary"
+                          disabled={false}
+                          href="💩.com"
+                          target="_blank"
+                        >
+                          <span
+                            className="base extraBold small uppercase white"
+                          >
+                            Submit
+                          </span>
+                        </a>
+            `);
 });
 
 it("renders a Button with an icon", () => {
   const tree = renderer.create(<Button label="Add" icon="add" />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-    <button
-      className="button base hasIcon work primary"
-      disabled={false}
-      type="button"
-    >
-      <svg
-        className="icon base"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          className="white"
-          d="M512 128c-23.565 0-42.667 19.103-42.667 42.667v298.667h-298.667c-23.564 0-42.667 19.102-42.667 42.667s19.103 42.667 42.667 42.667h298.667v298.667c0 23.565 19.102 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-298.667h298.667c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-298.667v-298.667c0-23.564-19.102-42.667-42.667-42.667z"
-        />
-      </svg>
-      <span
-        className="base extraBold small uppercase white"
-      >
-        Add
-      </span>
-    </button>
-  `);
+        <button
+          className="button base hasIcon work primary"
+          disabled={false}
+          type="button"
+        >
+          <svg
+            className="icon base"
+            viewBox="0 0 1024 1024"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              className="white"
+              d="M512 128c-23.565 0-42.667 19.103-42.667 42.667v298.667h-298.667c-23.564 0-42.667 19.102-42.667 42.667s19.103 42.667 42.667 42.667h298.667v298.667c0 23.565 19.102 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-298.667h298.667c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-298.667v-298.667c0-23.564-19.102-42.667-42.667-42.667z"
+            />
+          </svg>
+          <span
+            className="base extraBold small uppercase white"
+          >
+            Add
+          </span>
+        </button>
+    `);
 });
 
 it("renders a Button with an icon on the right", () => {
@@ -186,62 +187,62 @@ it("renders a Button with an icon on the right", () => {
     .create(<Button label="Add" icon="add" iconOnRight={true} />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-    <button
-      className="button base hasIcon iconOnRight work primary"
-      disabled={false}
-      type="button"
-    >
-      <svg
-        className="icon base"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          className="white"
-          d="M512 128c-23.565 0-42.667 19.103-42.667 42.667v298.667h-298.667c-23.564 0-42.667 19.102-42.667 42.667s19.103 42.667 42.667 42.667h298.667v298.667c0 23.565 19.102 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-298.667h298.667c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-298.667v-298.667c0-23.564-19.102-42.667-42.667-42.667z"
-        />
-      </svg>
-      <span
-        className="base extraBold small uppercase white"
-      >
-        Add
-      </span>
-    </button>
-  `);
+        <button
+          className="button base hasIcon iconOnRight work primary"
+          disabled={false}
+          type="button"
+        >
+          <svg
+            className="icon base"
+            viewBox="0 0 1024 1024"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              className="white"
+              d="M512 128c-23.565 0-42.667 19.103-42.667 42.667v298.667h-298.667c-23.564 0-42.667 19.102-42.667 42.667s19.103 42.667 42.667 42.667h298.667v298.667c0 23.565 19.102 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-298.667h298.667c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-298.667v-298.667c0-23.564-19.102-42.667-42.667-42.667z"
+            />
+          </svg>
+          <span
+            className="base extraBold small uppercase white"
+          >
+            Add
+          </span>
+        </button>
+    `);
 });
 
 it("renders a small Button", () => {
   const tree = renderer.create(<Button label="Add" size="small" />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button small work primary"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold smaller uppercase white"
-                  >
-                    Add
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button small work primary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold smaller uppercase white"
+                      >
+                        Add
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a large Button", () => {
   const tree = renderer.create(<Button label="Add" size="large" />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button large work primary"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold base uppercase white"
-                  >
-                    Add
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button large work primary"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold base uppercase white"
+                      >
+                        Add
+                      </span>
+                    </button>
+          `);
 });
 
 it("renders a Button with a loading state", () => {
@@ -249,18 +250,18 @@ it("renders a Button with a loading state", () => {
     .create(<Button label="Adding" loading={true} />)
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
-                <button
-                  className="button base work primary loading"
-                  disabled={false}
-                  type="button"
-                >
-                  <span
-                    className="base extraBold small uppercase white"
-                  >
-                    Adding
-                  </span>
-                </button>
-        `);
+                    <button
+                      className="button base work primary loading"
+                      disabled={false}
+                      type="button"
+                    >
+                      <span
+                        className="base extraBold small uppercase white"
+                      >
+                        Adding
+                      </span>
+                    </button>
+          `);
 });
 
 test("it should call the handler on click", () => {
@@ -281,4 +282,65 @@ test("it shouldn't call the handler on click when disabled", () => {
 
   fireEvent.click(getByText(label));
   expect(clickHandler).toHaveBeenCalledTimes(0);
+});
+
+it("renders a Link as a Button for routing", () => {
+  const tree = renderer
+    .create(
+      <Router>
+        <Button label="Adding" to="/jobber" />
+      </Router>,
+    )
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`
+    <a
+      className="button base work primary"
+      disabled={false}
+      href="/jobber"
+      onClick={[Function]}
+    >
+      <span
+        className="base extraBold small uppercase white"
+      >
+        Adding
+      </span>
+    </a>
+  `);
+});
+
+it("routes when buttons are clicked", () => {
+  const { queryByText } = render(
+    <Router>
+      <Button label="One" to="/" />
+      <Button label="Two" to="/two" />
+      <Button label="Three" to="/three" />
+      <Switch>
+        <Route exact path="/">
+          Uno
+        </Route>
+        <Route exact path="/two">
+          Dos
+        </Route>
+        <Route exact path="/three">
+          Tres
+        </Route>
+      </Switch>
+    </Router>,
+  );
+
+  expect(queryByText("Uno")).toBeInstanceOf(HTMLElement);
+  expect(queryByText("Dos")).not.toBeInstanceOf(HTMLElement);
+  expect(queryByText("Tres")).not.toBeInstanceOf(HTMLElement);
+
+  fireEvent.click(queryByText("Two"));
+
+  expect(queryByText("Uno")).not.toBeInstanceOf(HTMLElement);
+  expect(queryByText("Dos")).toBeInstanceOf(HTMLElement);
+  expect(queryByText("Tres")).not.toBeInstanceOf(HTMLElement);
+
+  fireEvent.click(queryByText("Three"));
+
+  expect(queryByText("Uno")).not.toBeInstanceOf(HTMLElement);
+  expect(queryByText("Dos")).not.toBeInstanceOf(HTMLElement);
+  expect(queryByText("Tres")).toBeInstanceOf(HTMLElement);
 });

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -6,262 +6,85 @@ import { Button } from ".";
 
 it("renders a Button", () => {
   const tree = renderer.create(<Button label="Submit" />).toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button base work primary"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold small uppercase white"
-                      >
-                        Submit
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a secondary Button", () => {
   const tree = renderer
     .create(<Button label="Submit" type="secondary" />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button base work secondary"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold small uppercase green"
-                      >
-                        Submit
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a tertiary Button", () => {
   const tree = renderer
     .create(<Button label="Submit" type="tertiary" />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button base work tertiary"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold small uppercase green"
-                      >
-                        Submit
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a destructuve Button", () => {
   const tree = renderer
     .create(<Button label="Submit" variation="destructive" />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button base destructive primary"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold small uppercase white"
-                      >
-                        Submit
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a learning Button", () => {
   const tree = renderer
     .create(<Button label="Submit" variation="learning" />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button base learning primary"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold small uppercase white"
-                      >
-                        Submit
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a cancel Button", () => {
   const tree = renderer
     .create(<Button label="Submit" variation="cancel" />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button base cancel primary"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold small uppercase greyBlue"
-                      >
-                        Submit
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a disabled Button", () => {
   const tree = renderer
     .create(<Button label="Submit" disabled={true} />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button base work primary disabled"
-                      disabled={true}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold small uppercase grey"
-                      >
-                        Submit
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a Button with a link and opens in new tab", () => {
   const tree = renderer
     .create(<Button label="Submit" url="💩.com" external={true} />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                        <a
-                          className="button base work primary"
-                          disabled={false}
-                          href="💩.com"
-                          target="_blank"
-                        >
-                          <span
-                            className="base extraBold small uppercase white"
-                          >
-                            Submit
-                          </span>
-                        </a>
-            `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a Button with an icon", () => {
   const tree = renderer.create(<Button label="Add" icon="add" />).toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-        <button
-          className="button base hasIcon work primary"
-          disabled={false}
-          type="button"
-        >
-          <svg
-            className="icon base"
-            viewBox="0 0 1024 1024"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              className="white"
-              d="M512 128c-23.565 0-42.667 19.103-42.667 42.667v298.667h-298.667c-23.564 0-42.667 19.102-42.667 42.667s19.103 42.667 42.667 42.667h298.667v298.667c0 23.565 19.102 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-298.667h298.667c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-298.667v-298.667c0-23.564-19.102-42.667-42.667-42.667z"
-            />
-          </svg>
-          <span
-            className="base extraBold small uppercase white"
-          >
-            Add
-          </span>
-        </button>
-    `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a Button with an icon on the right", () => {
   const tree = renderer
     .create(<Button label="Add" icon="add" iconOnRight={true} />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-        <button
-          className="button base hasIcon iconOnRight work primary"
-          disabled={false}
-          type="button"
-        >
-          <svg
-            className="icon base"
-            viewBox="0 0 1024 1024"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              className="white"
-              d="M512 128c-23.565 0-42.667 19.103-42.667 42.667v298.667h-298.667c-23.564 0-42.667 19.102-42.667 42.667s19.103 42.667 42.667 42.667h298.667v298.667c0 23.565 19.102 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-298.667h298.667c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-298.667v-298.667c0-23.564-19.102-42.667-42.667-42.667z"
-            />
-          </svg>
-          <span
-            className="base extraBold small uppercase white"
-          >
-            Add
-          </span>
-        </button>
-    `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a small Button", () => {
   const tree = renderer.create(<Button label="Add" size="small" />).toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button small work primary"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold smaller uppercase white"
-                      >
-                        Add
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a large Button", () => {
   const tree = renderer.create(<Button label="Add" size="large" />).toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button large work primary"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold base uppercase white"
-                      >
-                        Add
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("renders a Button with a loading state", () => {
   const tree = renderer
     .create(<Button label="Adding" loading={true} />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-                    <button
-                      className="button base work primary loading"
-                      disabled={false}
-                      type="button"
-                    >
-                      <span
-                        className="base extraBold small uppercase white"
-                      >
-                        Adding
-                      </span>
-                    </button>
-          `);
+  expect(tree).toMatchSnapshot();
 });
 
 test("it should call the handler on click", () => {
@@ -292,20 +115,7 @@ it("renders a Link as a Button for routing", () => {
       </Router>,
     )
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-    <a
-      className="button base work primary"
-      disabled={false}
-      href="/jobber"
-      onClick={[Function]}
-    >
-      <span
-        className="base extraBold small uppercase white"
-      >
-        Adding
-      </span>
-    </a>
-  `);
+  expect(tree).toMatchSnapshot();
 });
 
 it("routes when buttons are clicked", () => {

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -23,10 +23,16 @@ interface ButtonFoundationProps {
 }
 
 interface ButtonLinkProps extends ButtonFoundationProps {
+  /**
+   * Used to create an 'href' on an anchor tag.
+   */
   readonly url?: string;
 }
 
 interface ButtonRouteProps extends ButtonFoundationProps {
+  /**
+   * Used for client side routing. Only use when inside a routed component.
+   */
   readonly to?: string;
 }
 

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -22,18 +22,18 @@ interface ButtonFoundationProps {
   onClick?(): void;
 }
 
-interface ButtonLinkProps extends ButtonFoundationProps {
+interface ButtonAnchorProps extends ButtonFoundationProps {
   /**
    * Used to create an 'href' on an anchor tag.
    */
   readonly url?: string;
 }
 
-interface ButtonRouteProps extends ButtonFoundationProps {
+interface ButtonLinkProps extends ButtonFoundationProps {
   /**
    * Used for client side routing. Only use when inside a routed component.
    */
-  readonly to: string;
+  readonly to?: string;
 }
 
 interface BaseActionProps extends ButtonFoundationProps {
@@ -55,27 +55,28 @@ export type ButtonProps = XOR<
   BaseActionProps,
   XOR<DestructiveActionProps, CancelActionProps>
 > &
-  XOR<ButtonLinkProps, ButtonRouteProps>;
+  XOR<ButtonLinkProps, ButtonAnchorProps>;
 
-export function Button({
-  ariaControls,
-  ariaHaspopup,
-  ariaExpanded,
-  disabled = false,
-  external,
-  fullWidth,
-  icon,
-  iconOnRight,
-  id,
-  label,
-  loading,
-  onClick,
-  size = "base",
-  type = "primary",
-  url,
-  to,
-  variation = "work",
-}: ButtonProps) {
+export function Button(props: ButtonProps) {
+  const {
+    ariaControls,
+    ariaHaspopup,
+    ariaExpanded,
+    disabled = false,
+    external,
+    fullWidth,
+    icon,
+    iconOnRight,
+    id,
+    loading,
+    onClick,
+    size = "base",
+    type = "primary",
+    url,
+    to,
+    variation = "work",
+  } = props;
+
   const buttonClassNames = classnames(styles.button, styles[size], {
     [styles.hasIcon]: icon,
     [styles.iconOnRight]: iconOnRight,
@@ -90,23 +91,41 @@ export function Button({
     className: buttonClassNames,
     disabled,
     id,
-    ...(to && { to }),
     ...(!disabled && { href: url }),
     ...(!disabled && { onClick: onClick }),
     ...(external && { target: "_blank" }),
     ...(url === undefined &&
       to === undefined && { type: "button" as "button" }),
+    "aria-controls": ariaControls,
+    "aria-haspopup": ariaHaspopup,
+    "aria-expanded": ariaExpanded,
   };
 
-  const Tag = getTag() as "a" | "button";
+  const buttonInternals = <ButtonInternals {...props} />;
 
+  if (to) {
+    return (
+      <Link {...tagProps} to={to}>
+        {buttonInternals}
+      </Link>
+    );
+  }
+
+  const Tag = url ? "a" : "button";
+
+  return <Tag {...tagProps}>{buttonInternals}</Tag>;
+}
+
+function ButtonInternals({
+  label,
+  icon,
+  variation = "work",
+  type = "primary",
+  disabled,
+  size = "base",
+}: ButtonProps) {
   return (
-    <Tag
-      {...tagProps}
-      aria-controls={ariaControls}
-      aria-haspopup={ariaHaspopup}
-      aria-expanded={ariaExpanded}
-    >
+    <>
       {icon && (
         <Icon
           name={icon}
@@ -123,14 +142,8 @@ export function Button({
       >
         {label}
       </Typography>
-    </Tag>
+    </>
   );
-
-  function getTag() {
-    if (url) return "a";
-    if (to) return Link;
-    return "button";
-  }
 }
 
 function getTypeSizes(size: string) {

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -33,7 +33,7 @@ interface ButtonRouteProps extends ButtonFoundationProps {
   /**
    * Used for client side routing. Only use when inside a routed component.
    */
-  readonly to?: string;
+  readonly to: string;
 }
 
 interface BaseActionProps extends ButtonFoundationProps {
@@ -52,8 +52,8 @@ interface CancelActionProps extends ButtonFoundationProps {
 }
 
 export type ButtonProps = XOR<
-  ButtonFoundationProps,
-  XOR<BaseActionProps, XOR<DestructiveActionProps, CancelActionProps>>
+  BaseActionProps,
+  XOR<DestructiveActionProps, CancelActionProps>
 > &
   XOR<ButtonLinkProps, ButtonRouteProps>;
 
@@ -90,7 +90,7 @@ export function Button({
     className: buttonClassNames,
     disabled,
     id,
-    ...(!disabled && { to }),
+    ...(to && { to }),
     ...(!disabled && { href: url }),
     ...(!disabled && { onClick: onClick }),
     ...(external && { target: "_blank" }),
@@ -98,7 +98,7 @@ export function Button({
       to === undefined && { type: "button" as "button" }),
   };
 
-  const Tag = getTag();
+  const Tag = getTag() as "a" | "button";
 
   return (
     <Tag

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -84,11 +84,12 @@ export function Button({
     className: buttonClassNames,
     disabled,
     id,
-    to,
+    ...(!disabled && { to }),
     ...(!disabled && { href: url }),
     ...(!disabled && { onClick: onClick }),
     ...(external && { target: "_blank" }),
-    ...(url === undefined && { type: "button" as "button" }),
+    ...(url === undefined &&
+      to === undefined && { type: "button" as "button" }),
   };
 
   const Tag = getTag();

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import { XOR } from "ts-xor";
+import { Link } from "react-router-dom";
 import styles from "./Button.css";
 import { Typography } from "../Typography";
 import { Icon, IconNames } from "../Icon";
@@ -18,8 +19,15 @@ interface ButtonFoundationProps {
   readonly label: string;
   readonly loading?: boolean;
   readonly size?: "small" | "base" | "large";
-  readonly url?: string;
   onClick?(): void;
+}
+
+interface ButtonLinkProps extends ButtonFoundationProps {
+  readonly url?: string;
+}
+
+interface ButtonRouteProps extends ButtonFoundationProps {
+  readonly to?: string;
 }
 
 interface BaseActionProps extends ButtonFoundationProps {
@@ -40,7 +48,8 @@ interface CancelActionProps extends ButtonFoundationProps {
 export type ButtonProps = XOR<
   ButtonFoundationProps,
   XOR<BaseActionProps, XOR<DestructiveActionProps, CancelActionProps>>
->;
+> &
+  XOR<ButtonLinkProps, ButtonRouteProps>;
 
 export function Button({
   ariaControls,
@@ -58,6 +67,7 @@ export function Button({
   size = "base",
   type = "primary",
   url,
+  to,
   variation = "work",
 }: ButtonProps) {
   const buttonClassNames = classnames(styles.button, styles[size], {
@@ -70,20 +80,22 @@ export function Button({
     [styles.loading]: loading,
   });
 
-  const props = {
+  const tagProps = {
     className: buttonClassNames,
-    disabled: disabled,
-    id: id,
+    disabled,
+    id,
+    to,
     ...(!disabled && { href: url }),
     ...(!disabled && { onClick: onClick }),
     ...(external && { target: "_blank" }),
     ...(url === undefined && { type: "button" as "button" }),
   };
 
-  const Tag = url ? "a" : "button";
+  const Tag = getTag();
+
   return (
     <Tag
-      {...props}
+      {...tagProps}
       aria-controls={ariaControls}
       aria-haspopup={ariaHaspopup}
       aria-expanded={ariaExpanded}
@@ -106,6 +118,12 @@ export function Button({
       </Typography>
     </Tag>
   );
+
+  function getTag() {
+    if (url) return "a";
+    if (to) return Link;
+    return "button";
+  }
 }
 
 function getTypeSizes(size: string) {

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,219 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a Button 1`] = `
+<button
+  className="button base work primary"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold small uppercase white"
+  >
+    Submit
+  </span>
+</button>
+`;
+
+exports[`renders a Button with a link and opens in new tab 1`] = `
+<a
+  className="button base work primary"
+  disabled={false}
+  href="💩.com"
+  target="_blank"
+>
+  <span
+    className="base extraBold small uppercase white"
+  >
+    Submit
+  </span>
+</a>
+`;
+
+exports[`renders a Button with a loading state 1`] = `
+<button
+  className="button base work primary loading"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold small uppercase white"
+  >
+    Adding
+  </span>
+</button>
+`;
+
+exports[`renders a Button with an icon 1`] = `
+<button
+  className="button base hasIcon work primary"
+  disabled={false}
+  type="button"
+>
+  <svg
+    className="icon base"
+    viewBox="0 0 1024 1024"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      className="white"
+      d="M512 128c-23.565 0-42.667 19.103-42.667 42.667v298.667h-298.667c-23.564 0-42.667 19.102-42.667 42.667s19.103 42.667 42.667 42.667h298.667v298.667c0 23.565 19.102 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-298.667h298.667c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-298.667v-298.667c0-23.564-19.102-42.667-42.667-42.667z"
+    />
+  </svg>
+  <span
+    className="base extraBold small uppercase white"
+  >
+    Add
+  </span>
+</button>
+`;
+
+exports[`renders a Button with an icon on the right 1`] = `
+<button
+  className="button base hasIcon iconOnRight work primary"
+  disabled={false}
+  type="button"
+>
+  <svg
+    className="icon base"
+    viewBox="0 0 1024 1024"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      className="white"
+      d="M512 128c-23.565 0-42.667 19.103-42.667 42.667v298.667h-298.667c-23.564 0-42.667 19.102-42.667 42.667s19.103 42.667 42.667 42.667h298.667v298.667c0 23.565 19.102 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-298.667h298.667c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-298.667v-298.667c0-23.564-19.102-42.667-42.667-42.667z"
+    />
+  </svg>
+  <span
+    className="base extraBold small uppercase white"
+  >
+    Add
+  </span>
+</button>
+`;
+
+exports[`renders a Link as a Button for routing 1`] = `
+<a
+  className="button base work primary"
+  disabled={false}
+  href="/jobber"
+  onClick={[Function]}
+>
+  <span
+    className="base extraBold small uppercase white"
+  >
+    Adding
+  </span>
+</a>
+`;
+
+exports[`renders a cancel Button 1`] = `
+<button
+  className="button base cancel primary"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold small uppercase greyBlue"
+  >
+    Submit
+  </span>
+</button>
+`;
+
+exports[`renders a destructuve Button 1`] = `
+<button
+  className="button base destructive primary"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold small uppercase white"
+  >
+    Submit
+  </span>
+</button>
+`;
+
+exports[`renders a disabled Button 1`] = `
+<button
+  className="button base work primary disabled"
+  disabled={true}
+  type="button"
+>
+  <span
+    className="base extraBold small uppercase grey"
+  >
+    Submit
+  </span>
+</button>
+`;
+
+exports[`renders a large Button 1`] = `
+<button
+  className="button large work primary"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold base uppercase white"
+  >
+    Add
+  </span>
+</button>
+`;
+
+exports[`renders a learning Button 1`] = `
+<button
+  className="button base learning primary"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold small uppercase white"
+  >
+    Submit
+  </span>
+</button>
+`;
+
+exports[`renders a secondary Button 1`] = `
+<button
+  className="button base work secondary"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold small uppercase green"
+  >
+    Submit
+  </span>
+</button>
+`;
+
+exports[`renders a small Button 1`] = `
+<button
+  className="button small work primary"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold smaller uppercase white"
+  >
+    Add
+  </span>
+</button>
+`;
+
+exports[`renders a tertiary Button 1`] = `
+<button
+  className="button base work tertiary"
+  disabled={false}
+  type="button"
+>
+  <span
+    className="base extraBold small uppercase green"
+  >
+    Submit
+  </span>
+</button>
+`;


### PR DESCRIPTION
## Motivations

In an SPA we need are able to do client side routing. We want to be able to use the `Button` component as a link for our router.

This PR adds a `to` prop that will allow the `Button` component be used as a `Link` component for `react-router`.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `to` prop to Button
- Capability to use Button in client side routing

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
