### PR TITLE
fix(components): Update tooltip accessibility status

### DIFF
--- a/packages/components/src/Tooltip/Tooltip.mdx
+++ b/packages/components/src/Tooltip/Tooltip.mdx
@@ -12,7 +12,7 @@ import { Card } from "../Card";
 
 # Tooltip
 
-<ComponentStatus stage="rc" responsive="yes" accessible="yes" />
+<ComponentStatus stage="rc" responsive="yes" accessible="no" />
 
 Tooltips provide in-context information that briefly explain the function of a UI
 element.


### PR DESCRIPTION
## Motivations

Tooltip does not pass basic [keyboard navigation](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=111%2C122%2C131%2C132%2C133%2C141%2C143%2C144%2C148%2C1410%2C1411%2C1412%2C1413#content-on-hover-or-focus) standards, as it is not able to be triggered by focusing the element it is bound to. 

## Changes

### Changed

- Changes accessibility status to "no"

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
