### PR TITLE
feat(components): Add disabled prop to feature switch

### DIFF
--- a/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
@@ -20,6 +20,13 @@ interface FeatureSwitchProps {
   readonly description: string;
 
   /**
+   * Determines if the switch is disabled
+   *
+   * @default false
+   */
+  readonly disabled?: boolean;
+
+  /**
    * Defines if the feature should be ON or OFF by default.
    *
    * @default false
@@ -63,6 +70,7 @@ interface FeatureSwitchProps {
 export function FeatureSwitch({
   children,
   description,
+  disabled,
   enabled,
   externalLink = false,
   onEdit,
@@ -98,6 +106,7 @@ export function FeatureSwitch({
             value={enabled}
             onChange={handleSwitch}
             ariaLabel={description}
+            disabled={disabled}
           />
           <AnimatePresence>
             {hasSaveIndicator && savedIndicator && (


### PR DESCRIPTION
## Motivations

We should be able to pass a disabled prop through FeatureSwitch so that the switch can be disabled!

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- optional `disabled` prop in `FeatureSwitch` 
### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

--- Add the disabled prop to the FeatureSwitch and watch the magic happen 🎉 

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
