### PR TITLE
fix(components): Export Page Props from index

### DIFF
--- a/packages/components/src/Page/index.ts
+++ b/packages/components/src/Page/index.ts
@@ -1,1 +1,1 @@
-export { Page } from "./Page";
+export { Page, PageProps } from "./Page";


### PR DESCRIPTION
## Motivations

We exported PageProps, but forgot to export PageProps from index.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Export `PageProps` from index of `Page` component

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
