### PR TITLE
feat(components): Adjust table styling

### DIFF
--- a/packages/components/src/Table/Cells/Cell.css
+++ b/packages/components/src/Table/Cells/Cell.css
@@ -1,4 +1,6 @@
 .cell {
+  padding: var(--horizontal-inset) calc(var(--horizontal-inset) / 2)
+    var(--horizontal-inset) calc(var(--horizontal-inset) / 2);
   text-align: left;
 }
 
@@ -21,6 +23,7 @@
 .cell:first-child {
   padding-left: var(--horizontal-inset);
 }
+
 .cell:last-child {
   padding-right: var(--horizontal-inset);
 }

--- a/packages/components/src/Table/Cells/Cell.css
+++ b/packages/components/src/Table/Cells/Cell.css
@@ -1,6 +1,5 @@
 .cell {
-  padding: var(--horizontal-inset) calc(var(--horizontal-inset) / 2)
-    var(--horizontal-inset) calc(var(--horizontal-inset) / 2);
+  padding: var(--horizontal-inset) calc(var(--horizontal-inset) / 2);
   text-align: left;
 }
 

--- a/packages/components/src/Table/Table.css
+++ b/packages/components/src/Table/Table.css
@@ -4,9 +4,9 @@
   --horizontal-inset: var(--space-base);
   width: 100%;
 
-  border: solid 1px var(--border-color);
+  box-shadow: 0 0 0 1px var(--border-color);
   border-collapse: collapse;
-  border-radius: var(--space-smallest);
+  border-radius: var(--radius-base);
 }
 
 .row:not(:last-child) {

--- a/packages/components/src/Table/Table.css
+++ b/packages/components/src/Table/Table.css
@@ -1,10 +1,12 @@
 .table {
   --border-color: var(--color-grey--lighter);
   --header-border-color: var(--color-blue);
-  --horizontal-inset: 0.5rem;
-
+  --horizontal-inset: var(--space-base);
   width: 100%;
+
+  border: solid 1px var(--border-color);
   border-collapse: collapse;
+  border-radius: var(--space-smallest);
 }
 
 .row:not(:last-child) {

--- a/packages/components/src/Table/Table.css
+++ b/packages/components/src/Table/Table.css
@@ -4,7 +4,7 @@
   --horizontal-inset: var(--space-base);
   width: 100%;
 
-  box-shadow: 0 0 0 1px var(--border-color);
+  box-shadow: 0 0 0 var(--border-base) var(--border-color);
   border-collapse: collapse;
   border-radius: var(--radius-base);
 }

--- a/packages/components/src/Table/Table.mdx
+++ b/packages/components/src/Table/Table.mdx
@@ -36,8 +36,8 @@ import { Table, Header, Footer, Row, Cell } from "@jobber/components/Table";
     <Header>
       <Cell>Ship</Cell>
       <Cell>Class</Cell>
-      <Cell>Cost</Cell>
-      <Cell>Crew</Cell>
+      <Cell align="right">Cost</Cell>
+      <Cell align="right">Crew</Cell>
     </Header>
     <Row>
       <Cell>Nostromo</Cell>


### PR DESCRIPTION
## Motivations

We should bake in common presentation elements to the `table` component so the teams implementing don't need to resolve styling every time

## Changes

### Added

- Border to the tables

### Changed

- Padding on cells

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
