### PR TITLE
feat(components): Export AvatarProps from avatar

### DIFF
--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -38,7 +38,7 @@ interface AvatarWithInitialsProps extends AvatarFoundationProps {
   readonly initials: string;
 }
 
-type AvatarProps = XOR<AvatarWithImageProps, AvatarWithInitialsProps>;
+export type AvatarProps = XOR<AvatarWithImageProps, AvatarWithInitialsProps>;
 
 export function Avatar({
   imageUrl,

--- a/packages/components/src/Avatar/index.ts
+++ b/packages/components/src/Avatar/index.ts
@@ -1,1 +1,1 @@
-export { Avatar } from "./Avatar";
+export { Avatar, AvatarProps } from "./Avatar";


### PR DESCRIPTION
## Motivations

When using an Avatar in Jobber, we require the Avatar props for typing

## Changes

Exports the `AvatarProps` type from Avatar.

### Added

- Export `AvatarProps` type from Avatar.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
