### PR TITLE
feat(components): Export ActionProps from menu

### DIFF
--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -129,7 +129,7 @@ function SectionHeader({ text }: SectionHeaderProps) {
   );
 }
 
-interface ActionProps {
+export interface ActionProps {
   /**
    * Action label
    */

--- a/packages/components/src/Menu/index.ts
+++ b/packages/components/src/Menu/index.ts
@@ -1,1 +1,1 @@
-export { Menu, SectionProps } from "./Menu";
+export { Menu, SectionProps, ActionProps } from "./Menu";


### PR DESCRIPTION
## Motivations

I would like to use a `Menu` in Jobber, but first I need the `ActionProps` so that the types are not bonkers

## Changes

- Export `ActionProps` from `Menu`

### Added

- Export `ActionProps` from `Menu`

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
