### PR TITLE
docs(components): fix card page hierarchy

### DIFF
--- a/packages/components/src/Card/Card.mdx
+++ b/packages/components/src/Card/Card.mdx
@@ -52,9 +52,9 @@ A card should be the smallest-possible self-contained section of content. If you
 
 ---
 
-# Usage
+## Usage
 
-## Clickable with URL
+### Clickable with URL
 
 <Playground>
   <Card url="#">
@@ -67,7 +67,7 @@ A card should be the smallest-possible self-contained section of content. If you
   </Card>
 </Playground>
 
-## Clickable with onClick
+### Clickable with onClick
 
 <Playground>
   <Card


### PR DESCRIPTION
## Motivations

You should only have a single h1 per page

## Changes

### Changed

Bump usage down to h2, bump its' children down to h3

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
