### PR TITLE
Upgrade Prettier to 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7688,7 +7688,7 @@
         "eslint-plugin-no-null": "^1.0.2",
         "eslint-plugin-prettier": "^3.0.1",
         "eslint-plugin-react": "^7.14.3",
-        "prettier": "^1.18.2"
+        "prettier": "^2.0.5"
       },
       "dependencies": {
         "@typescript-eslint/experimental-utils": {
@@ -7721,6 +7721,12 @@
             "@typescript-eslint/experimental-utils": "^1.13.0"
           }
         },
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
+        },
         "semver": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -7740,7 +7746,7 @@
       "version": "file:packages/stylelint-config",
       "dev": true,
       "requires": {
-        "prettier": "^1.17.0",
+        "prettier": "^2.0.5",
         "style-search": "^0.1.0",
         "stylelint-color-format": "^0.2.0",
         "stylelint-config-css-modules": "^1.4.0",
@@ -7748,6 +7754,14 @@
         "stylelint-declaration-block-no-ignored-properties": "^2.0.0",
         "stylelint-order": "^3.0.0",
         "stylelint-prettier": "^1.0.6"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
+        }
       }
     },
     "@lerna/add": {
@@ -17719,6 +17733,14 @@
             "unist-util-find": "^1.0.1",
             "unist-util-is": "^3.0.0",
             "unist-util-visit": "^1.4.1"
+          },
+          "dependencies": {
+            "prettier": {
+              "version": "1.19.1",
+              "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+              "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+              "dev": true
+            }
           }
         },
         "fast-glob": {
@@ -18307,6 +18329,12 @@
             "array-includes": "^3.0.3",
             "object.assign": "^4.1.0"
           }
+        },
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
         },
         "unified": {
           "version": "8.4.2",
@@ -35180,9 +35208,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "postcss": "^7.0.17",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.6.0",
-    "prettier": "^1.18.2",
+    "prettier": "^2.0.5",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -44,11 +44,6 @@
 				"@types/yargs": "^12.0.9"
 			}
 		},
-		"@jobber/formatters": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@jobber/formatters/-/formatters-0.0.4.tgz",
-			"integrity": "sha512-AaTKOBm/1zXJ0ZQSs6BJFRBkPH2VrJxVKSD7TfqjDn6hm+puGdcFfQDn8L8WbS4s1Jp7ci0pbMIDZqJcoRyFWg=="
-		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -1354,9 +1354,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+			"integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.14.3",
-    "prettier": "^1.18.2"
+    "prettier": "^2.0.5"
   },
   "devDependencies": {
     "eslint": "^6.3.0"

--- a/packages/stylelint-config/package-lock.json
+++ b/packages/stylelint-config/package-lock.json
@@ -108,9 +108,9 @@
 			}
 		},
 		"prettier": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.1.tgz",
-			"integrity": "sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg=="
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+			"integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "main": "stylelint.config.js",
   "dependencies": {
-    "prettier": "^1.17.0",
+    "prettier": "^2.0.5",
     "style-search": "^0.1.0",
     "stylelint-color-format": "^0.2.0",
     "stylelint-config-css-modules": "^1.4.0",


### PR DESCRIPTION
This PR upgrades Prettier from 1.7 and 1.8 to the 2.0 latest version.
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Prettiness](https://media.giphy.com/media/qZR32lm5bZgvm/giphy.gif)
