### PR TITLE
fix(components): update button padding on icon button

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -141,8 +141,8 @@
 
 /* Icon */
 
-.hasIcon {
-  width: calc(var(--base-unit)*2.25);
+.onlyIcon {
+  width: calc(var(--base-unit) * 2.25);
   padding: 0;
 }
 

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -147,6 +147,7 @@
 }
 
 .hasIconAndLabel {
+  width: auto;
   padding: 0 var(--space-base);
 }
 

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -142,7 +142,8 @@
 /* Icon */
 
 .hasIcon {
-  padding: 0 var(--space-small);
+  width: 2.25rem;
+  padding: 0;
 }
 
 .hasIconAndLabel {

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -142,7 +142,7 @@
 /* Icon */
 
 .hasIcon {
-  width: 2.25rem;
+  width: calc(var(--base-unit)*2.25);
   padding: 0;
 }
 

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -140,6 +140,11 @@
 }
 
 /* Icon */
+
+.hasIcon {
+  padding: 0 var(--space-small);
+}
+
 .hasIconAndLabel {
   padding: 0 var(--space-base);
 }

--- a/packages/components/src/Button/Button.css.d.ts
+++ b/packages/components/src/Button/Button.css.d.ts
@@ -10,6 +10,7 @@ export const disabled: string;
 export const small: string;
 export const base: string;
 export const large: string;
+export const hasIcon: string;
 export const hasIconAndLabel: string;
 export const iconOnRight: string;
 export const fullWidth: string;

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -95,7 +95,7 @@ export function Button(props: ButtonProps) {
   } = props;
 
   const buttonClassNames = classnames(styles.button, styles[size], {
-    [styles.hasIcon]: icon,
+    [styles.onlyIcon]: icon && !label,
     [styles.hasIconAndLabel]: icon && label,
     [styles.iconOnRight]: iconOnRight,
     [styles[variation]]: variation,

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -95,6 +95,7 @@ export function Button(props: ButtonProps) {
   } = props;
 
   const buttonClassNames = classnames(styles.button, styles[size], {
+    [styles.hasIcon]: icon,
     [styles.hasIconAndLabel]: icon && label,
     [styles.iconOnRight]: iconOnRight,
     [styles[variation]]: variation,

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`renders a Button 1`] = `
 exports[`renders a Button that is just an icon 1`] = `
 <button
   aria-label="Person"
-  className="button base work primary"
+  className="button base onlyIcon work primary"
   disabled={false}
   type="button"
 >


### PR DESCRIPTION
## Changes

Reduced left and right padding on icon button so that these buttons have a square shape rather than a slightly-wider-than-tall rectangular shape

### Changed

- reduced left and right padding on `hasIcon` button that does not also have a label

![Random photo of Atlantis](https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Square_-_black_simple.svg/1200px-Square_-_black_simple.svg.png)
