### PR TITLE
feat(components): DescriptionList takes Elements.

### DIFF
--- a/packages/components/src/DescriptionList/DescriptionList.mdx
+++ b/packages/components/src/DescriptionList/DescriptionList.mdx
@@ -6,6 +6,8 @@ route: /components/description-list
 
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
+import { CivilDate } from "@std-proposal/temporal";
+import { FormatDate } from "@jobber/components/FormatDate";
 import { DescriptionList } from ".";
 
 # Description List
@@ -27,3 +29,16 @@ import { DescriptionList } from "@jobber/components/DescriptionList";
 <Props of={DescriptionList} />
 
 ---
+
+## Passing an Element
+
+You are able to pass a react element in as the second term of the data tuple.
+
+<Playground>
+  <DescriptionList
+    data={[
+      ["Issued", <FormatDate date={new CivilDate(2018, 12, 8)} />],
+      ["Due", <FormatDate date={new CivilDate(2019, 1, 6)} />]
+    ]}
+  />
+</Playground>

--- a/packages/components/src/DescriptionList/DescriptionList.test.tsx
+++ b/packages/components/src/DescriptionList/DescriptionList.test.tsx
@@ -10,38 +10,12 @@ it("renders an object as a list of key value pairs", () => {
       />,
     )
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-    <dl
-      className="descriptionList"
-    >
-      <div
-        className="termGroup"
-      >
-        <dd
-          className="base regular base blue"
-        >
-          Issued
-        </dd>
-        <dt
-          className="base regular base greyBlue"
-        >
-          2018-12-08
-        </dt>
-      </div>
-      <div
-        className="termGroup"
-      >
-        <dd
-          className="base regular base blue"
-        >
-          Due
-        </dd>
-        <dt
-          className="base regular base greyBlue"
-        >
-          2019-01-06
-        </dt>
-      </div>
-    </dl>
-  `);
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders an object as a list of key value pairs with an element", () => {
+  const tree = renderer
+    .create(<DescriptionList data={[["Foo", <>Foo</>], ["Bar", <>Bar</>]]} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/packages/components/src/DescriptionList/DescriptionList.tsx
+++ b/packages/components/src/DescriptionList/DescriptionList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import styles from "./DescriptionList.css";
 import { Typography } from "../Typography";
 
@@ -7,7 +7,7 @@ interface DescriptionListProps {
    * A tuple where the first item is the string to display as the term
    * and the second value is the string to display as the definition
    */
-  data: [string, string][];
+  data: [string, string | ReactNode][];
 }
 
 export function DescriptionList({ data }: DescriptionListProps) {

--- a/packages/components/src/DescriptionList/__snapshots__/DescriptionList.test.tsx.snap
+++ b/packages/components/src/DescriptionList/__snapshots__/DescriptionList.test.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders an object as a list of key value pairs 1`] = `
+<dl
+  className="descriptionList"
+>
+  <div
+    className="termGroup"
+  >
+    <dd
+      className="base regular base blue"
+    >
+      Issued
+    </dd>
+    <dt
+      className="base regular base greyBlue"
+    >
+      2018-12-08
+    </dt>
+  </div>
+  <div
+    className="termGroup"
+  >
+    <dd
+      className="base regular base blue"
+    >
+      Due
+    </dd>
+    <dt
+      className="base regular base greyBlue"
+    >
+      2019-01-06
+    </dt>
+  </div>
+</dl>
+`;
+
+exports[`renders an object as a list of key value pairs with an element 1`] = `
+<dl
+  className="descriptionList"
+>
+  <div
+    className="termGroup"
+  >
+    <dd
+      className="base regular base blue"
+    >
+      Foo
+    </dd>
+    <dt
+      className="base regular base greyBlue"
+    >
+      Foo
+    </dt>
+  </div>
+  <div
+    className="termGroup"
+  >
+    <dd
+      className="base regular base blue"
+    >
+      Bar
+    </dd>
+    <dt
+      className="base regular base greyBlue"
+    >
+      Bar
+    </dt>
+  </div>
+</dl>
+`;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- DescriptionList can now take an element as the second part of the tuple.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
