### PR TITLE
docs(components): tweak wording on inputGroup description

### DIFF
--- a/packages/components/src/InputGroup/InputGroup.mdx
+++ b/packages/components/src/InputGroup/InputGroup.mdx
@@ -15,10 +15,10 @@ import { CivilTime } from "@std-proposal/temporal";
 
 <ComponentStatus stage="rc" responsive="no" accessible="yes" />
 
-Group a different kinds fields to show a visual relationship. If a number of
-form fields once submitted make up a group of content (ie. an address, or first
-and last name becoming a full name) they are great candidates for an input
-group.
+Use InputGroup to show a visual relationship between related input fields. If a number of
+form fields, once submitted, make up a group of content (ie. an address, or first
+and last name becoming a full name, start and end times of an event) they are great 
+candidates for an InputGroup.
 
 <Playground>
   <InputGroup flowDirection="horizontal">
@@ -27,7 +27,7 @@ group.
   </InputGroup>
 </Playground>
 
-## InputGroup Properties
+## Props
 
 <Props of={InputGroup} />
 


### PR DESCRIPTION
## Motivations

The description offers pretty solid directions on usage, just wanted to clean up some grammar.

## Changes

Copy in description

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
