### PR TITLE
fix(hooks): Uses the polyfilled version of resizeObserver

### DIFF
--- a/packages/components/src/Page/Page.mdx
+++ b/packages/components/src/Page/Page.mdx
@@ -7,13 +7,16 @@ route: /components/page
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { Page } from ".";
+import { Content } from "@jobber/components/Content";
 import { Text } from "../Text";
 
 # Page
 
 <ComponentStatus stage="pre" responsive="no" accessible="yes" />
 
-Use Page to build the outermost "main content" container of a view. Page comes complete with the ability to add the page title, along with actions and a description as needed.
+Use Page to build the outermost "main content" container of a view. Page comes
+complete with the ability to add the page title, along with actions and a
+description as needed.
 
 ```ts
 import { Page } from "@jobber/components/Page";
@@ -30,7 +33,9 @@ import { Page } from "@jobber/components/Page";
 
 ## Design Usage and Guidelines
 
-Using Page is pretty straightforward - after any navigational elements, Page should contain the content the user will be engaging with. If there is any sort of footer, it should exist after Page.
+Using Page is pretty straightforward - after any navigational elements, Page
+should contain the content the user will be engaging with. If there is any sort
+of footer, it should exist after Page.
 
 ## Props
 
@@ -80,7 +85,7 @@ Using Page is pretty straightforward - after any navigational elements, Page sho
     ]}
   >
     <Content>
-    <Text>Page content here</Text>
+      <Text>Page content here</Text>
     </Content>
   </Page>
 </Playground>

--- a/packages/hooks/src/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver.ts
@@ -1,5 +1,7 @@
 import { useMemo, useState } from "react";
-import useResizeObserverPackage from "use-resize-observer";
+// Importing the polyfilled version of ResizeObserver
+// eslint-disable-next-line import/no-internal-modules
+import useResizeObserverPackage from "use-resize-observer/polyfilled";
 import { throttle } from "lodash";
 
 interface ObservedSize {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations


## Changes

UseResizeObserver isnt working in older browsers. This will polyfill it so that it works in older browsers

### Added

- <!-- new features -->

### Changed

- ResizeObserver to polyfilled version

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- `useResiszeObserver` hook causing issues in older browsers

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
