### PR TITLE
feat(components): add FormatRelativeDateTime

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -115,21 +115,6 @@
 				}
 			}
 		},
-		"@jobber/formatters": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@jobber/formatters/-/formatters-0.0.4.tgz",
-			"integrity": "sha512-AaTKOBm/1zXJ0ZQSs6BJFRBkPH2VrJxVKSD7TfqjDn6hm+puGdcFfQDn8L8WbS4s1Jp7ci0pbMIDZqJcoRyFWg=="
-		},
-		"@jobber/hooks": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@jobber/hooks/-/hooks-0.2.0.tgz",
-			"integrity": "sha512-z11BoQKC8gcnFsgQwZUB1euWRqkMW4fX2bhK/PTGhHpMJz/RDniLyjkHxWgn23fP0evv33FPdGgsdjLvVKM90Q==",
-			"requires": {
-				"lodash": "^4.17.15",
-				"resize-observer-polyfill": "^1.5.1",
-				"use-resize-observer": "^6.1.0"
-			}
-		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -5373,11 +5358,6 @@
 			"integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
 			"dev": true
 		},
-		"resize-observer-polyfill": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-		},
 		"resolve": {
 			"version": "1.10.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
@@ -6438,14 +6418,6 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
-		},
-		"use-resize-observer": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-6.1.0.tgz",
-			"integrity": "sha512-SiPcWHiIQ1CnHmb6PxbYtygqiZXR0U9dNkkbpX9VYnlstUwF8+QqpUTrzh13pjPwcjMVGR+QIC+nvF5ujfFNng==",
-			"requires": {
-				"resize-observer-polyfill": "^1.5.1"
-			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
@@ -1,7 +1,7 @@
 ---
 name: FormatRelativeDateTime
 menu: Components
-route: /components/datetime-formatter
+route: /components/format-relative-date-time
 ---
 
 import { Playground, Props } from "docz";

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
@@ -6,7 +6,7 @@ route: /components/format-relative-date-time
 
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
-import { CivilDate } from "@std-proposal/temporal";
+import { CivilDateTime } from "@std-proposal/temporal";
 import { FormatRelativeDateTime } from ".";
 
 # FormatRelativeDateTime
@@ -14,10 +14,18 @@ import { FormatRelativeDateTime } from ".";
 <ComponentStatus stage="pre" responsive="yes" accessible="yes" />
 
 A FormatRelateDateTime displays the date and time using relative wording or
-approximate values.
+approximate values. Note. This component only represents current date and dates
+in the past. No future dating.
 
-Rules: If the message was received less than an hour ago the format is x minutes
-ago
+## Simple Example
+
+```ts
+import { FormatRelativeDateTime } from "@jobber/components/FormatRelativeDateTime";
+```
+
+## Rules
+
+If the message was received less than an hour ago the format is x minutes ago
 
 If the message was received today, but more than an hour ago, the format becomes
 the time it was received
@@ -31,14 +39,8 @@ previous, the format is Month Date
 If the message was received exactly one year ago or more than one year ago, the
 format is Month Day, Year
 
-## Simple Example
-
-```ts
-import { FormatRelativeDateTime } from "@jobber/components/FormatRelativeDateTime";
-```
-
 <Playground>
-  <FormatRelativeDateTime date={new CivilDate(2020, 2, 26)} />
+  <FormatRelativeDateTime date={new CivilDateTime(2020, 2, 26, 14, 29, 39)} />
 </Playground>
 
 ## Props

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
@@ -1,0 +1,31 @@
+---
+name: FormatRelativeDateTime
+menu: Components
+route: /components/datetime-formatter
+---
+
+import { Playground, Props } from "docz";
+import { ComponentStatus } from "@jobber/docx";
+import { CivilDate } from "@std-proposal/temporal";
+import { FormatRelativeDateTime } from ".";
+
+# FormatRelativeDateTime
+
+<ComponentStatus stage="pre" responsive="yes" accessible="yes" />
+
+In Jobber a FormatDate is used to ensure that the date is displayed in the
+expected format. No text styling is applied, this simply formats the date.
+
+## Simple Example
+
+```ts
+import { FormatRelativeDateTime } from "@jobber/components/FormatRelativeDateTime";
+```
+
+<Playground>
+  <FormatRelativeDateTime date={new CivilDate(2020, 2, 26)} />
+</Playground>
+
+## Props
+
+<Props of={FormatRelativeDateTime} />

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
@@ -13,8 +13,23 @@ import { FormatRelativeDateTime } from ".";
 
 <ComponentStatus stage="pre" responsive="yes" accessible="yes" />
 
-In Jobber a FormatDate is used to ensure that the date is displayed in the
-expected format. No text styling is applied, this simply formats the date.
+A FormatRelateDateTime displays the date and time using relative wording or
+approximate values.
+
+Rules: If the message was received less than an hour ago the format is x minutes
+ago
+
+If the message was received today, but more than an hour ago, the format becomes
+the time it was received
+
+If the message was received this within the last six days, the format is Sun,
+Mon, Tue, Wed, Thu, Fri, Sat
+
+If the message was received between six days ago and yesterday’s date one year
+previous, the format is Month Date
+
+If the message was received exactly one year ago or more than one year ago, the
+format is Month Day, Year
 
 ## Simple Example
 

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { cleanup } from "@testing-library/react";
-import { CivilDateTime } from "@std-proposal/temporal";
+import { CivilDateTime, Instant, ZonedDateTime } from "@std-proposal/temporal";
 import { FormatRelativeDateTime } from "./FormatRelativeDateTime";
 
 afterEach(cleanup);
@@ -10,15 +10,15 @@ beforeEach(() => {
 });
 
 it("renders x minutes ago when less than an hour ago", () => {
-  const testDate = new Date(Date.now());
-  testDate.setMinutes(testDate.getMinutes() - 5);
+  const testDate = getNowUTC(); //new Date(Date.now());
+  testDate.setMinutes(testDate.getMinutes() - 1);
 
   const civilTestDate = getCivilTime(testDate);
 
   const tree = renderer
     .create(<FormatRelativeDateTime date={civilTestDate} />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`"5 minutes ago"`);
+  expect(tree).toMatchInlineSnapshot(`"59 minutes ago"`);
 });
 
 it("renders 1 minute ago when less than a minute ago", () => {
@@ -35,14 +35,14 @@ it("renders 1 minute ago when less than a minute ago", () => {
 
 it("renders the time when less than a day ago", () => {
   const testDate = new Date(Date.now());
-  testDate.setHours(testDate.getHours() - 5);
+  testDate.setHours(testDate.getHours() - 9);
 
   const civilTestDate = getCivilTime(testDate);
 
   const tree = renderer
     .create(<FormatRelativeDateTime date={civilTestDate} />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot('"8:58:35 AM"');
+  expect(tree).toMatchInlineSnapshot('"10:58:42 AM"');
 });
 
 it("renders the day when less than 7 days ago", () => {
@@ -94,23 +94,39 @@ it("renders the month day, year when over a year ago", () => {
   expect(tree).toMatchInlineSnapshot('"Jun 25, 2018"');
 });
 
-function getCivilTime(date: Date) {
-  const testYear = date.getFullYear();
-  const testMonth = date.getMonth() + 1;
-  const testDay = date.getDate();
-  const testHour = date.getHours();
-  const testMinute = date.getMinutes();
-  const testSecond = 35; // Want to make sure we don't have flakiness around 0 and 59
+function getNowUTC() {
+  const utcDate = new Date(Date.now());
+  utcDate.setMinutes(-1 * utcDate.getTimezoneOffset());
 
-  const civilTestDate = new CivilDateTime(
-    testYear,
-    testMonth,
-    testDay,
-    testHour,
-    testMinute,
-    testSecond,
-  );
-  civilTestDate.withZone("America/Edmonton");
-
-  return civilTestDate;
+  console.log("offset: " + utcDate.getTimezoneOffset());
+  return utcDate;
 }
+
+function getCivilTime(date: Date) {
+  const instant = Instant.fromEpochMilliseconds(date.getTime());
+  // const zonedDT = ZonedDateTime.fromEpochMilliseconds(date.getTime(), "UTC");
+  const zoneDT = new ZonedDateTime(instant, "UTC");
+
+  return CivilDateTime.fromZonedDateTime(zoneDT);
+}
+// todo[jz] Delete before review
+// function getCivilTimex(date: Date) {
+//   const testYear = date.getFullYear();
+//   const testMonth = date.getMonth() + 1;
+//   const testDay = date.getDate();
+//   const testHour = date.getHours();
+//   const testMinute = date.getMinutes();
+//   const testSecond = 35; // Want to make sure we don't have flakiness around 0 and 59
+
+//   const civilTestDate = new CivilDateTime(
+//     testYear,
+//     testMonth,
+//     testDay,
+//     testHour,
+//     testMinute,
+//     testSecond,
+//   );
+//   civilTestDate.withZone("UTC");
+
+//   return civilTestDate;
+// }

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { cleanup } from "@testing-library/react";
-import { CivilDateTime, Instant, ZonedDateTime } from "@std-proposal/temporal";
+import { CivilDateTime } from "@std-proposal/temporal";
 import { FormatRelativeDateTime } from "./FormatRelativeDateTime";
 
 afterEach(cleanup);
@@ -10,15 +10,15 @@ beforeEach(() => {
 });
 
 it("renders x minutes ago when less than an hour ago", () => {
-  const testDate = getNowUTC(); //new Date(Date.now());
-  testDate.setMinutes(testDate.getMinutes() - 1);
+  const testDate = new Date(Date.now());
+  testDate.setMinutes(testDate.getMinutes() - 5);
 
   const civilTestDate = getCivilTime(testDate);
 
   const tree = renderer
     .create(<FormatRelativeDateTime date={civilTestDate} />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot(`"59 minutes ago"`);
+  expect(tree).toMatchInlineSnapshot(`"5 minutes ago"`);
 });
 
 it("renders 1 minute ago when less than a minute ago", () => {
@@ -39,10 +39,15 @@ it("renders the time when less than a day ago", () => {
 
   const civilTestDate = getCivilTime(testDate);
 
+  const hours = testDate.getHours();
+  const minutes = testDate.getMinutes();
+  const expectedStr = hours + ":" + minutes + ":35 AM";
+
   const tree = renderer
     .create(<FormatRelativeDateTime date={civilTestDate} />)
     .toJSON();
-  expect(tree).toMatchInlineSnapshot('"10:58:42 AM"');
+
+  expect(tree).toEqual(expectedStr);
 });
 
 it("renders the day when less than 7 days ago", () => {
@@ -94,39 +99,39 @@ it("renders the month day, year when over a year ago", () => {
   expect(tree).toMatchInlineSnapshot('"Jun 25, 2018"');
 });
 
-function getNowUTC() {
-  const utcDate = new Date(Date.now());
-  utcDate.setMinutes(-1 * utcDate.getTimezoneOffset());
+// function getNowUTC() {
+//   const utcDate = new Date(Date.now());
+//   utcDate.setMinutes(-1 * utcDate.getTimezoneOffset());
 
-  console.log("offset: " + utcDate.getTimezoneOffset());
-  return utcDate;
-}
-
-function getCivilTime(date: Date) {
-  const instant = Instant.fromEpochMilliseconds(date.getTime());
-  // const zonedDT = ZonedDateTime.fromEpochMilliseconds(date.getTime(), "UTC");
-  const zoneDT = new ZonedDateTime(instant, "UTC");
-
-  return CivilDateTime.fromZonedDateTime(zoneDT);
-}
-// todo[jz] Delete before review
-// function getCivilTimex(date: Date) {
-//   const testYear = date.getFullYear();
-//   const testMonth = date.getMonth() + 1;
-//   const testDay = date.getDate();
-//   const testHour = date.getHours();
-//   const testMinute = date.getMinutes();
-//   const testSecond = 35; // Want to make sure we don't have flakiness around 0 and 59
-
-//   const civilTestDate = new CivilDateTime(
-//     testYear,
-//     testMonth,
-//     testDay,
-//     testHour,
-//     testMinute,
-//     testSecond,
-//   );
-//   civilTestDate.withZone("UTC");
-
-//   return civilTestDate;
+//   console.log("offset: " + utcDate.getTimezoneOffset());
+//   return utcDate;
 // }
+
+// function getCivilTime(date: Date) {
+//   const instant = Instant.fromEpochMilliseconds(date.getTime());
+//   // const zonedDT = ZonedDateTime.fromEpochMilliseconds(date.getTime(), "UTC");
+//   const zoneDT = new ZonedDateTime(instant, "UTC");
+
+//   return CivilDateTime.fromZonedDateTime(zoneDT);
+// }
+// todo[jz] Delete before review
+function getCivilTime(date: Date) {
+  const testYear = date.getFullYear();
+  const testMonth = date.getMonth() + 1;
+  const testDay = date.getDate();
+  const testHour = date.getHours();
+  const testMinute = date.getMinutes();
+  const testSecond = 35; // Want to make sure we don't have flakiness around 0 and 59
+
+  const civilTestDate = new CivilDateTime(
+    testYear,
+    testMonth,
+    testDay,
+    testHour,
+    testMinute,
+    testSecond,
+  );
+  civilTestDate.withZone("UTC");
+
+  return civilTestDate;
+}

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -99,22 +99,6 @@ it("renders the month day, year when over a year ago", () => {
   expect(tree).toMatchInlineSnapshot('"Jun 25, 2018"');
 });
 
-// function getNowUTC() {
-//   const utcDate = new Date(Date.now());
-//   utcDate.setMinutes(-1 * utcDate.getTimezoneOffset());
-
-//   console.log("offset: " + utcDate.getTimezoneOffset());
-//   return utcDate;
-// }
-
-// function getCivilTime(date: Date) {
-//   const instant = Instant.fromEpochMilliseconds(date.getTime());
-//   // const zonedDT = ZonedDateTime.fromEpochMilliseconds(date.getTime(), "UTC");
-//   const zoneDT = new ZonedDateTime(instant, "UTC");
-
-//   return CivilDateTime.fromZonedDateTime(zoneDT);
-// }
-// todo[jz] Delete before review
 function getCivilTime(date: Date) {
   const testYear = date.getFullYear();
   const testMonth = date.getMonth() + 1;

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -110,7 +110,7 @@ function getCivilTime(date: Date) {
     testMinute,
     testSecond,
   );
-  civilTestDate.withZone("UTC");
+  civilTestDate.withZone("America/Edmonton");
 
   return civilTestDate;
 }

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { cleanup } from "@testing-library/react";
+import { CivilDateTime } from "@std-proposal/temporal";
+import { FormatRelativeDateTime } from "./FormatRelativeDateTime";
+
+afterEach(cleanup);
+beforeEach(() => {
+  Date.now = jest.fn(() => 1593115122000);
+});
+
+it("renders x minutes ago when less than an hour ago", () => {
+  const testDate = new Date(Date.now());
+  testDate.setMinutes(testDate.getMinutes() - 5);
+
+  const civilTestDate = getCivilTime(testDate);
+
+  const tree = renderer
+    .create(<FormatRelativeDateTime date={civilTestDate} />)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`"5 minutes ago"`);
+});
+
+it("renders 1 minute ago when less than a minute ago", () => {
+  const testDate = new Date(Date.now());
+  testDate.setSeconds(testDate.getSeconds() - 25);
+
+  const civilTestDate = getCivilTime(testDate);
+
+  const tree = renderer
+    .create(<FormatRelativeDateTime date={civilTestDate} />)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot(`"1 minute ago"`);
+});
+
+it("renders the time when less than a day ago", () => {
+  const testDate = new Date(Date.now());
+  testDate.setHours(testDate.getHours() - 5);
+
+  const civilTestDate = getCivilTime(testDate);
+
+  const tree = renderer
+    .create(<FormatRelativeDateTime date={civilTestDate} />)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot('"8:58:35 AM"');
+});
+
+it("renders the day when less than 7 days ago", () => {
+  const testDate = new Date(Date.now());
+  testDate.setDate(testDate.getDate() - 3);
+
+  const civilTestDate = getCivilTime(testDate);
+
+  const tree = renderer
+    .create(<FormatRelativeDateTime date={civilTestDate} />)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot('"Mon"');
+});
+
+it("renders the month and date when less than 1 year ago", () => {
+  const testDate = new Date(Date.now());
+  testDate.setDate(testDate.getDate() - 60);
+
+  console.log("testDate: " + testDate);
+  const civilTestDate = getCivilTime(testDate);
+
+  const tree = renderer
+    .create(<FormatRelativeDateTime date={civilTestDate} />)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot('"Apr 26"');
+});
+
+it("renders the month and date when yesterday's date 1 year previous (border case)", () => {
+  const testDate = new Date(Date.now());
+  testDate.setFullYear(testDate.getFullYear() - 1);
+  testDate.setDate(testDate.getDate() + 2); //The +2 vs. +1 is a fudge for leap year
+
+  const civilTestDate = getCivilTime(testDate);
+
+  const tree = renderer
+    .create(<FormatRelativeDateTime date={civilTestDate} />)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot('"Jun 27"');
+});
+
+it("renders the month day, year when over a year ago", () => {
+  const testDate = new Date(Date.now());
+  testDate.setFullYear(testDate.getFullYear() - 2);
+
+  const civilTestDate = getCivilTime(testDate);
+
+  const tree = renderer
+    .create(<FormatRelativeDateTime date={civilTestDate} />)
+    .toJSON();
+  expect(tree).toMatchInlineSnapshot('"Jun 25, 2018"');
+});
+
+function getCivilTime(date: Date) {
+  const testYear = date.getFullYear();
+  const testMonth = date.getMonth() + 1;
+  const testDay = date.getDate();
+  const testHour = date.getHours();
+  const testMinute = date.getMinutes();
+  const testSecond = 35; // Want to make sure we don't have flakiness around 0 and 59
+
+  const civilTestDate = new CivilDateTime(
+    testYear,
+    testMonth,
+    testDay,
+    testHour,
+    testMinute,
+    testSecond,
+  );
+
+  return civilTestDate;
+}

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -61,7 +61,6 @@ it("renders the month and date when less than 1 year ago", () => {
   const testDate = new Date(Date.now());
   testDate.setDate(testDate.getDate() - 60);
 
-  console.log("testDate: " + testDate);
   const civilTestDate = getCivilTime(testDate);
 
   const tree = renderer
@@ -111,6 +110,7 @@ function getCivilTime(date: Date) {
     testMinute,
     testSecond,
   );
+  civilTestDate.withZone("UTC");
 
   return civilTestDate;
 }

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -131,7 +131,6 @@ function getCivilTime(date: Date) {
     testMinute,
     testSecond,
   );
-  civilTestDate.withZone("UTC");
 
   return civilTestDate;
 }

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -19,13 +19,11 @@ export function FormatRelativeDateTime(
     case "less than an hour":
       return showMinutes(Math.round(delta / 60));
     case "less then a day":
-      return <>{inputDate.toLocaleTimeString()}</>;
+      return inputDate.toLocaleTimeString();
     case "less than a week":
-      return <>{strFormatDate(inputDate, { weekday: "short" })}</>;
+      return strFormatDate(inputDate, { weekday: "short" });
     case "less than a year":
-      return (
-        <>{strFormatDate(inputDate, { month: "short", day: "numeric" })}</>
-      );
+      return strFormatDate(inputDate, { month: "short", day: "numeric" });
     default:
       return (
         <>
@@ -61,8 +59,8 @@ function strFormatDate(date: Date, options: { [key: string]: string }) {
 
 function showMinutes(minutes: number) {
   if (minutes <= 1) {
-    return <>{"1 minute ago"}</>;
+    return "1 minute ago";
   } else {
-    return <>{minutes + " minutes ago"}</>;
+    return minutes + " minutes ago";
   }
 }

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { CivilDateTime } from "@std-proposal/temporal";
+
+interface FormatRelativeDateTimeProps {
+  /**
+   * Date to be displayed.
+   */
+  readonly date: CivilDateTime;
+}
+
+export function FormatRelativeDateTime(
+  civilDateTime: FormatRelativeDateTimeProps,
+) {
+  const now = Date.now() / 1000; //seconds
+  const inputDate = new Date(civilDateTime.date.toJSON());
+  const delta = now - inputDate.getTime() / 1000; //seconds;
+
+  switch (relativeTimeRange(delta)) {
+    case "less than an hour":
+      return showMinutes(Math.round(delta / 60));
+    case "less then a day":
+      return <>{inputDate.toLocaleTimeString()}</>;
+    case "less than a week":
+      return <>{strFormatDate(inputDate, { weekday: "short" })}</>;
+    case "less than a year":
+      return (
+        <>{strFormatDate(inputDate, { month: "short", day: "numeric" })}</>
+      );
+    default:
+      return (
+        <>
+          {strFormatDate(inputDate, {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })}
+        </>
+      );
+  }
+}
+
+function relativeTimeRange(delta: number) {
+  delta = delta / 60;
+  if (delta < 60) return "less than an hour";
+
+  delta = delta / 60;
+  if (delta < 24) return "less then a day";
+
+  delta = delta / 24;
+  if (delta < 7) return "less than a week";
+
+  delta = delta / 365;
+  if (delta < 1) return "less than a year";
+
+  return "a year or more";
+}
+
+function strFormatDate(date: Date, options: { [key: string]: string }) {
+  return date.toLocaleDateString(undefined, options);
+}
+
+function showMinutes(minutes: number) {
+  if (minutes < 1) {
+    return <>{"1 minute ago"}</>;
+  } else {
+    return <>{minutes + " minutes ago"}</>;
+  }
+}

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -12,8 +12,18 @@ export function FormatRelativeDateTime(
   civilDateTime: FormatRelativeDateTimeProps,
 ) {
   const now = Date.now() / 1000; //seconds
+  console.log("Civil JSON: " + civilDateTime.date.toJSON());
   const inputDate = new Date(civilDateTime.date.toJSON());
+  console.log("inputDate: " + inputDate);
   const delta = now - inputDate.getTime() / 1000; //seconds;
+  console.log(
+    "Now: " +
+      new Date(now * 1000) +
+      ", inputDate: " +
+      inputDate +
+      ", delta: " +
+      delta,
+  );
 
   switch (relativeTimeRange(delta)) {
     case "less than an hour":

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -60,7 +60,7 @@ function strFormatDate(date: Date, options: { [key: string]: string }) {
 }
 
 function showMinutes(minutes: number) {
-  if (minutes < 1) {
+  if (minutes <= 1) {
     return <>{"1 minute ago"}</>;
   } else {
     return <>{minutes + " minutes ago"}</>;

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -12,18 +12,8 @@ export function FormatRelativeDateTime(
   civilDateTime: FormatRelativeDateTimeProps,
 ) {
   const now = Date.now() / 1000; //seconds
-  console.log("Civil JSON: " + civilDateTime.date.toJSON());
   const inputDate = new Date(civilDateTime.date.toJSON());
-  console.log("inputDate: " + inputDate);
   const delta = now - inputDate.getTime() / 1000; //seconds;
-  console.log(
-    "Now: " +
-      new Date(now * 1000) +
-      ", inputDate: " +
-      inputDate +
-      ", delta: " +
-      delta,
-  );
 
   switch (relativeTimeRange(delta)) {
     case "less than an hour":

--- a/packages/components/src/FormatRelativeDateTime/index.ts
+++ b/packages/components/src/FormatRelativeDateTime/index.ts
@@ -1,0 +1,1 @@
+export { FormatRelativeDateTime } from "./FormatRelativeDateTime";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We needed a way to display date times in a relate manor. E.g. 4 minutes ago, 1 year ago
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- FormatRelativeDateTime

### Changed

-none

### Deprecated

- none

### Removed

- none

### Fixed

- none

### Security

- none

## Testing

Use the new component

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
