### PR TITLE
feat(hooks): useResizeObserver custom sizes

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -114,7 +114,7 @@ export default {
     "Atlantis is a design system for Jobber. The primary objective for Atlantis is to provide a system of reusable components to help developers to quickly build beautiful and consistent interfaces for our users.",
   typescript: true,
   port: 3333,
-  menu: ["Atlantis", "Patterns", "Components"],
+  menu: ["Atlantis", "Patterns", "Components", "Hooks", "Design"],
   files: "{README.md,CONTRIBUTING.md,**/*.mdx,packages/*/CHANGELOG.md}",
   ignore: [
     ...privateComponentReadmes(),

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -49,10 +49,6 @@
   flex: 1;
 }
 
-.actionButton + .actionButton {
-  margin-left: var(--space-small);
-}
-
 .actionButton > div {
   width: 100%;
 }
@@ -68,5 +64,9 @@
 }
 
 .titleBar.medium .actionButton {
+  margin-left: var(--space-small);
+}
+
+.titleBar.small .actionButton + .actionButton {
   margin-left: var(--space-small);
 }

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -10,7 +10,7 @@ jest.mock("@jobber/hooks", () => {
       { current: undefined },
       { width: 1000, height: 100 },
     ],
-    defaultSizes: {
+    Breakpoints: {
       base: 640,
       small: 500,
       smaller: 265,

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -10,6 +10,13 @@ jest.mock("@jobber/hooks", () => {
       { current: undefined },
       { width: 1000, height: 100 },
     ],
+    defaultSizes: {
+      base: 640,
+      small: 500,
+      smaller: 265,
+      large: 750,
+      larger: 1024,
+    },
   };
 });
 

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -69,7 +69,6 @@ export function Page({
     { width: titleBarWidth = defaultSizes.large },
   ] = useResizeObserver<HTMLDivElement>();
 
-  console.log(defaultSizes);
   const titleBarClasses = classnames(styles.titleBar, {
     [styles.small]: titleBarWidth > defaultSizes.smaller,
     [styles.medium]: titleBarWidth > defaultSizes.small,

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 import classnames from "classnames";
-import { defaultSizes, useResizeObserver } from "@jobber/hooks";
+import { Breakpoints, useResizeObserver } from "@jobber/hooks";
 import styles from "./Page.css";
 import { Heading } from "../Heading";
 import { Text } from "../Text";
@@ -66,13 +66,13 @@ export function Page({
   const pageStyles = classnames(styles.page, styles[width]);
   const [
     titleBarRef,
-    { width: titleBarWidth = defaultSizes.large },
+    { width: titleBarWidth = Breakpoints.large },
   ] = useResizeObserver<HTMLDivElement>();
 
   const titleBarClasses = classnames(styles.titleBar, {
-    [styles.small]: titleBarWidth > defaultSizes.smaller,
-    [styles.medium]: titleBarWidth > defaultSizes.small,
-    [styles.large]: titleBarWidth > defaultSizes.large,
+    [styles.small]: titleBarWidth > Breakpoints.smaller,
+    [styles.medium]: titleBarWidth > Breakpoints.small,
+    [styles.large]: titleBarWidth > Breakpoints.large,
   });
 
   const showMenu = moreActionsMenu.length > 0;

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 import classnames from "classnames";
-import { useResizeObserver } from "@jobber/hooks";
+import { defaultSizes, useResizeObserver } from "@jobber/hooks";
 import styles from "./Page.css";
 import { Heading } from "../Heading";
 import { Text } from "../Text";
@@ -53,12 +53,6 @@ export interface PageProps {
   readonly moreActionsMenu?: SectionProps[];
 }
 
-const pageSizes = {
-  small: 265,
-  base: 500,
-  large: 750,
-};
-
 // eslint-disable-next-line max-statements
 export function Page({
   title,
@@ -70,16 +64,16 @@ export function Page({
   moreActionsMenu = [],
 }: PageProps) {
   const pageStyles = classnames(styles.page, styles[width]);
-  const [titleBarRef, { width: titleBarWidth }] = useResizeObserver<
-    HTMLDivElement
-  >({ width: pageSizes });
+  const [
+    titleBarRef,
+    { width: titleBarWidth = defaultSizes.large },
+  ] = useResizeObserver<HTMLDivElement>();
 
-  console.log("TITLEWIDTH", titleBarWidth);
-
+  console.log(defaultSizes);
   const titleBarClasses = classnames(styles.titleBar, {
-    [styles.small]: titleBarWidth && titleBarWidth === "small",
-    [styles.medium]: titleBarWidth && titleBarWidth === "base",
-    [styles.large]: titleBarWidth && titleBarWidth === "large",
+    [styles.small]: titleBarWidth > defaultSizes.smaller,
+    [styles.medium]: titleBarWidth > defaultSizes.small,
+    [styles.large]: titleBarWidth > defaultSizes.large,
   });
 
   const showMenu = moreActionsMenu.length > 0;

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -53,6 +53,13 @@ export interface PageProps {
   readonly moreActionsMenu?: SectionProps[];
 }
 
+const pageSizes = {
+  small: 265,
+  base: 500,
+  large: 750,
+};
+
+// eslint-disable-next-line max-statements
 export function Page({
   title,
   intro,
@@ -65,12 +72,14 @@ export function Page({
   const pageStyles = classnames(styles.page, styles[width]);
   const [titleBarRef, { width: titleBarWidth }] = useResizeObserver<
     HTMLDivElement
-  >();
+  >({ width: pageSizes });
+
+  console.log("TITLEWIDTH", titleBarWidth);
 
   const titleBarClasses = classnames(styles.titleBar, {
-    [styles.small]: titleBarWidth && titleBarWidth > 265,
-    [styles.medium]: titleBarWidth && titleBarWidth > 500,
-    [styles.large]: titleBarWidth && titleBarWidth > 750,
+    [styles.small]: titleBarWidth && titleBarWidth === "small",
+    [styles.medium]: titleBarWidth && titleBarWidth === "base",
+    [styles.large]: titleBarWidth && titleBarWidth === "large",
   });
 
   const showMenu = moreActionsMenu.length > 0;

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`When actions are provided renders a Page with action buttons and a menu
       className="padded large"
     >
       <div
-        className="titleBar small medium large"
+        className="titleBar"
       >
         <h1
           className="base black jumbo uppercase blue"
@@ -115,7 +115,7 @@ exports[`renders a Page 1`] = `
       className="padded large"
     >
       <div
-        className="titleBar small medium large"
+        className="titleBar"
       >
         <h1
           className="base black jumbo uppercase blue"

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`When actions are provided renders a Page with action buttons and a menu
       className="padded large"
     >
       <div
-        className="titleBar"
+        className="titleBar small medium large"
       >
         <h1
           className="base black jumbo uppercase blue"
@@ -115,7 +115,7 @@ exports[`renders a Page 1`] = `
       className="padded large"
     >
       <div
-        className="titleBar"
+        className="titleBar small medium large"
       >
         <h1
           className="base black jumbo uppercase blue"

--- a/packages/hooks/src/useResizeObserver.mdx
+++ b/packages/hooks/src/useResizeObserver.mdx
@@ -22,14 +22,16 @@ import { useResizeObserver } from "@jobber/hooks";
 
 <Playground>
   {() => {
-    const [ref, { width, height }] = useResizeObserver();
-    const title = width > 500 ? "This is big" : "This is small";
+    const [
+      ref,
+      { width, exactWidth, exactHeight, height }
+    ] = useResizeObserver();
     return (
       <div ref={ref}>
-        <Card title={title}>
+        <Card title={`I am a ${width} width & a ${height} height`}>
           <Content>
-            <Text>Width: {width}</Text>
-            <Text>Height: {height}</Text>
+            <Text>Exact Width: {exactWidth}</Text>
+            <Text>Exact Height: {exactHeight}</Text>
           </Content>
         </Card>
       </div>

--- a/packages/hooks/src/useResizeObserver.mdx
+++ b/packages/hooks/src/useResizeObserver.mdx
@@ -30,8 +30,8 @@ import { useResizeObserver } from "@jobber/hooks";
       <div ref={ref}>
         <Card title={`Check out my àçƈéñŦ`} accent={getAccent()}>
           <Content>
-            <Text>Width: {width}</Text>
-            <Text>Height: {height}</Text>
+            <Text>Width Step: {width}</Text>
+            <Text>Height Step: {height}</Text>
             <Text>Exact Width: {exactWidth}</Text>
             <Text>Exact Height: {exactHeight}</Text>
           </Content>
@@ -90,13 +90,13 @@ want to use `defaultSizes`.
       large: 768
     };
     const [ref, { width, exactWidth }] = useResizeObserver({
-      width: customWidths
+      widths: customWidths
     });
     return (
       <div ref={ref}>
         <Card title={`Width: ${getCurrentWidth()}`} accent={getAccent()}>
           <Content>
-            <Text>Width: {width}</Text>
+            <Text>Width Step: {width}</Text>
             <Text>Exact Width: {exactWidth}</Text>
           </Content>
         </Card>

--- a/packages/hooks/src/useResizeObserver.mdx
+++ b/packages/hooks/src/useResizeObserver.mdx
@@ -6,7 +6,7 @@ route: /hooks/use-resize-observer
 
 import { Playground } from "docz";
 import { useState } from "react";
-import { useResizeObserver, defaultSizes } from "./useResizeObserver";
+import { useResizeObserver, Breakpoints } from "./useResizeObserver";
 import { Text } from "@jobber/components/Text";
 import { Card } from "@jobber/components/Card";
 import { Content } from "@jobber/components/Content";
@@ -39,11 +39,11 @@ import { useResizeObserver } from "@jobber/hooks";
       </div>
     );
     function getAccent() {
-      if (exactWidth < defaultSizes.smaller) return "red";
-      if (width < defaultSizes.small) return "orange";
-      if (width < defaultSizes.base) return "yellow";
-      if (width < defaultSizes.large) return "green";
-      if (width < defaultSizes.larger) return "lightBlue";
+      if (exactWidth < Breakpoints.smaller) return "red";
+      if (width < Breakpoints.small) return "orange";
+      if (width < Breakpoints.base) return "yellow";
+      if (width < Breakpoints.large) return "green";
+      if (width < Breakpoints.larger) return "lightBlue";
       return "purple";
     }
   }}
@@ -60,19 +60,19 @@ const [ref, { width, height }] = useResizeObserver<HTMLDivElement>();
 return <div ref={ref}>...</div>;
 ```
 
-## defaultSizes
+## Breakpoints
 
-`useResizeObserver` exports an object of `defaultSizes`. This can be used for
+`useResizeObserver` exports an object of `Breakpoints`. This can be used for
 high level components such as `Page`
 
 ```tsx
-import { defaultSizes } from "@jobber/hooks";
+import { Breakpoints } from "@jobber/hooks";
 ```
 
-### The defaultSizes object:
+### The `Breakpoints` object:
 
 export function Sizes() {
-  return <code>{JSON.stringify(defaultSizes)}</code>;
+  return <code>{JSON.stringify(Breakpoints)}</code>;
 }
 
 <Sizes />
@@ -80,7 +80,7 @@ export function Sizes() {
 ## Custom Sizes
 
 `useResizeObserver` can take a custom `width` or `height` object if you do not
-want to use `defaultSizes`.
+want to use `Breakpoints`.
 
 <Playground>
   {() => {

--- a/packages/hooks/src/useResizeObserver.mdx
+++ b/packages/hooks/src/useResizeObserver.mdx
@@ -79,7 +79,7 @@ export function Sizes() {
 
 ## Custom Sizes
 
-`useResizeObserver` can take a custom `width` or `height` object if you do not
+`useResizeObserver` can take a custom `widths` or `heights` object if you do not
 want to use `Breakpoints`.
 
 <Playground>

--- a/packages/hooks/src/useResizeObserver.mdx
+++ b/packages/hooks/src/useResizeObserver.mdx
@@ -6,7 +6,7 @@ route: /hooks/use-resize-observer
 
 import { Playground } from "docz";
 import { useState } from "react";
-import { useResizeObserver } from "./useResizeObserver";
+import { useResizeObserver, defaultSizes } from "./useResizeObserver";
 import { Text } from "@jobber/components/Text";
 import { Card } from "@jobber/components/Card";
 import { Content } from "@jobber/components/Content";
@@ -26,10 +26,18 @@ import { useResizeObserver } from "@jobber/hooks";
       ref,
       { width, exactWidth, exactHeight, height }
     ] = useResizeObserver();
+    const currentWidth = Object.keys(defaultSizes).find(
+      key => defaultSizes[key] === width
+    );
+    const currentHeight = Object.keys(defaultSizes).find(
+      key => defaultSizes[key] === height
+    );
     return (
       <div ref={ref}>
-        <Card title={`I am a ${width} width & a ${height} height`}>
+        <Card title={`Width: ${currentWidth} | Height: ${currentHeight}`}>
           <Content>
+            <Text>Width: {width}</Text>
+            <Text>Height: {height}</Text>
             <Text>Exact Width: {exactWidth}</Text>
             <Text>Exact Height: {exactHeight}</Text>
           </Content>
@@ -49,3 +57,56 @@ to represent the `ref`. In the example below, we pass it the type of
 const [ref, { width, height }] = useResizeObserver<HTMLDivElement>();
 return <div ref={ref}>...</div>;
 ```
+
+## defaultSizes
+
+`useResizeObserver` exports an object of `defaultSizes`. This can be used for
+high level components such as `Page`
+
+```tsx
+import { defaultSizes } from "@jobber/hooks";
+```
+
+### The defaultSizes object:
+
+export function Sizes() {
+  return <code>{JSON.stringify(defaultSizes)}</code>;
+}
+
+<Sizes />
+
+## Custom Sizes
+
+`useResizeObserver` can take a custom `width` or `height` object if you do not
+want to use `defaultSizes`.
+
+<Playground>
+  {() => {
+    const customWidths = {
+      small: 480,
+      medium: 640,
+      large: 768
+    };
+    const [ref, { width, exactWidth }] = useResizeObserver({
+      width: customWidths
+    });
+    const currentWidth = Object.keys(customWidths).find(
+      key => customWidths[key] === width
+    );
+    return (
+      <div ref={ref}>
+        <Card title={`Width: ${currentWidth}`} accent={getAccent(currentWidth)}>
+          <Content>
+            <Text>Width: {width}</Text>
+            <Text>Exact Width: {exactWidth}</Text>
+          </Content>
+        </Card>
+      </div>
+    );
+    function getAccent(size) {
+      if (width < customWidths.medium) return "red";
+      if (width < customWidths.large) return "green";
+      return "indigo";
+    }
+  }}
+</Playground>

--- a/packages/hooks/src/useResizeObserver.mdx
+++ b/packages/hooks/src/useResizeObserver.mdx
@@ -26,15 +26,9 @@ import { useResizeObserver } from "@jobber/hooks";
       ref,
       { width, exactWidth, exactHeight, height }
     ] = useResizeObserver();
-    const currentWidth = Object.keys(defaultSizes).find(
-      key => defaultSizes[key] === width
-    );
-    const currentHeight = Object.keys(defaultSizes).find(
-      key => defaultSizes[key] === height
-    );
     return (
       <div ref={ref}>
-        <Card title={`Width: ${currentWidth} | Height: ${currentHeight}`}>
+        <Card title={`Check out my àçƈéñŦ`} accent={getAccent()}>
           <Content>
             <Text>Width: {width}</Text>
             <Text>Height: {height}</Text>
@@ -44,6 +38,14 @@ import { useResizeObserver } from "@jobber/hooks";
         </Card>
       </div>
     );
+    function getAccent() {
+      if (exactWidth < defaultSizes.smaller) return "red";
+      if (width < defaultSizes.small) return "orange";
+      if (width < defaultSizes.base) return "yellow";
+      if (width < defaultSizes.large) return "green";
+      if (width < defaultSizes.larger) return "lightBlue";
+      return "purple";
+    }
   }}
 </Playground>
 
@@ -90,12 +92,9 @@ want to use `defaultSizes`.
     const [ref, { width, exactWidth }] = useResizeObserver({
       width: customWidths
     });
-    const currentWidth = Object.keys(customWidths).find(
-      key => customWidths[key] === width
-    );
     return (
       <div ref={ref}>
-        <Card title={`Width: ${currentWidth}`} accent={getAccent(currentWidth)}>
+        <Card title={`Width: ${getCurrentWidth()}`} accent={getAccent()}>
           <Content>
             <Text>Width: {width}</Text>
             <Text>Exact Width: {exactWidth}</Text>
@@ -103,10 +102,13 @@ want to use `defaultSizes`.
         </Card>
       </div>
     );
-    function getAccent(size) {
+    function getAccent() {
       if (width < customWidths.medium) return "red";
       if (width < customWidths.large) return "green";
       return "indigo";
+    }
+    function getCurrentWidth() {
+      return Object.keys(customWidths).find(key => customWidths[key] === width);
     }
   }}
 </Playground>

--- a/packages/hooks/src/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver.ts
@@ -24,9 +24,10 @@ interface ResizeObserverProps {
 
 const wait = 100;
 
-export function useResizeObserver<T extends HTMLElement>(
-  { widths = Breakpoints, heights = Breakpoints } = {} as ResizeObserverProps,
-) {
+export function useResizeObserver<T extends HTMLElement>({
+  widths = Breakpoints,
+  heights = Breakpoints,
+}: ResizeObserverProps = {}) {
   const [exactSize, setSize] = useState<ObservedSize>({
     width: undefined,
     height: undefined,

--- a/packages/hooks/src/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver.ts
@@ -18,14 +18,14 @@ interface ObservedSize {
 }
 
 interface ResizeObserverProps {
-  width?: object;
-  height?: object;
+  widths?: object;
+  heights?: object;
 }
 
 const wait = 100;
 
 export function useResizeObserver<T extends HTMLElement>(
-  { width = defaultSizes, height = defaultSizes } = {} as ResizeObserverProps,
+  { widths = defaultSizes, heights = defaultSizes } = {} as ResizeObserverProps,
 ) {
   const [exactSize, setSize] = useState<ObservedSize>({
     width: undefined,
@@ -40,8 +40,8 @@ export function useResizeObserver<T extends HTMLElement>(
   const exactHeight = exactSize.height;
 
   const sizes = {
-    width: getSize(width, exactSize.width),
-    height: getSize(height, exactSize.height),
+    width: getSize(widths, exactSize.width),
+    height: getSize(heights, exactSize.height),
     exactWidth,
     exactHeight,
   };

--- a/packages/hooks/src/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver.ts
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import useResizeObserverPackage from "use-resize-observer/polyfilled";
 import { throttle } from "lodash";
 
-export const defaultSizes = {
+export const Breakpoints = {
   base: 640,
   small: 500,
   smaller: 265,
@@ -25,7 +25,7 @@ interface ResizeObserverProps {
 const wait = 100;
 
 export function useResizeObserver<T extends HTMLElement>(
-  { widths = defaultSizes, heights = defaultSizes } = {} as ResizeObserverProps,
+  { widths = Breakpoints, heights = Breakpoints } = {} as ResizeObserverProps,
 ) {
   const [exactSize, setSize] = useState<ObservedSize>({
     width: undefined,

--- a/packages/hooks/src/useResizeObserver.ts
+++ b/packages/hooks/src/useResizeObserver.ts
@@ -9,10 +9,17 @@ interface ObservedSize {
   height: number | undefined;
 }
 
+interface ResizeObserverProps {
+  width?: object;
+  height?: object;
+}
+
 const wait = 100;
 
-export function useResizeObserver<T extends HTMLElement>() {
-  const [size, setSize] = useState<ObservedSize>({
+export function useResizeObserver<T extends HTMLElement>(
+  { width, height } = {} as ResizeObserverProps,
+) {
+  const [exactSize, setSize] = useState<ObservedSize>({
     width: undefined,
     height: undefined,
   });
@@ -20,5 +27,49 @@ export function useResizeObserver<T extends HTMLElement>() {
   const { ref } = useResizeObserverPackage<T>({
     onResize,
   });
-  return [ref, size] as const;
+
+  const defaultSizes = {
+    smaller: 265,
+    small: 500,
+    base: 640,
+    large: 750,
+    larger: 1024,
+  };
+
+  const exactWidth = exactSize.width;
+  const exactHeight = exactSize.height;
+  const sizes = {
+    width: getSizeKey(width || defaultSizes, exactSize.width),
+    height: getSizeKey(height || defaultSizes, exactSize.height),
+    exactWidth,
+    exactHeight,
+  };
+
+  return [ref, sizes] as const;
+}
+
+/**
+ * To get the proper size we want to make sure that our value is greater
+ * then the comparable, but less then the next largest number in our
+ * object.
+ */
+function getSizeKey(sizes: object, comparable: number | undefined) {
+  if (!comparable || !sizes) {
+    return;
+  }
+
+  /**
+   * Sort the values of our object so that we know they are in proper
+   * order to be compared by
+   */
+  const values = Object.values(sizes)
+    .sort((a, b) => a - b)
+    .reverse();
+
+  const consideredValues = values.filter(value => value <= comparable);
+  const properSize = consideredValues[0] || Object.keys(sizes)[0];
+
+  return Object.keys(sizes).find(
+    key => sizes[key as keyof object] === properSize,
+  );
 }

--- a/src/gatsby-theme-docz/components/Playground/index.js
+++ b/src/gatsby-theme-docz/components/Playground/index.js
@@ -1,0 +1,110 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable max-statements */
+/* eslint-disable react/display-name */
+/* eslint-disable import/no-extraneous-dependencies */
+/** @jsx jsx */
+import { Box, jsx } from "theme-ui";
+import { useCallback, useState } from "react";
+import { useConfig } from "docz";
+import { LiveEditor, LiveError, LivePreview, LiveProvider } from "react-live";
+import { Resizable } from "re-resizable";
+import copy from "copy-text-to-clipboard";
+import ReactResizeDetector from "react-resize-detector";
+import { IframeWrapper } from "gatsby-theme-docz/src/components/Playground/IframeWrapper";
+import { usePrismTheme } from "gatsby-theme-docz/src/utils/theme";
+import * as Icons from "gatsby-theme-docz/src/components/Icons";
+import * as styles from "./styles";
+
+const getResizableProps = (width, setWidth) => ({
+  minWidth: 260,
+  maxWidth: "100%",
+  size: { width: width, height: "auto" },
+  style: { margin: "0 auto" },
+  enable: { right: true },
+  onResizeStop: (e, direction, ref) => setWidth(ref.style.width),
+});
+
+const transformCode = code => {
+  if (code.startsWith("()") || code.startsWith("class")) return code;
+  return `<React.Fragment>${code}</React.Fragment>`;
+};
+
+export const Playground = ({ code, scope, language, useScoping = false }) => {
+  const {
+    themeConfig: {
+      showPlaygroundEditor,
+      showLiveError,
+      showLivePreview,
+      useScopingInPlayground,
+    },
+  } = useConfig();
+
+  // Makes sure scope is only given on mount to avoid infinite re-render on hot reloads
+  const [scopeOnMount] = useState(scope);
+  const [previewHeight, setPreviewHeight] = useState();
+  const [editorHeight, setEditorHeight] = useState();
+  const [showingCode, setShowingCode] = useState(showPlaygroundEditor);
+  const [width, setWidth] = useState(896);
+  const theme = usePrismTheme();
+  const resizableProps = getResizableProps(width, setWidth);
+
+  const copyCode = () => copy(code);
+  const toggleCode = () => setShowingCode(s => !s);
+
+  const Wrapper = useCallback(
+    useScoping || useScopingInPlayground
+      ? props => <IframeWrapper {...props}>{props.children}</IframeWrapper>
+      : props => (
+          <Box sx={styles.previewInner(showingCode)}>{props.children}</Box>
+        ),
+    [useScoping],
+  );
+
+  return (
+    <Box sx={styles.wrapper}>
+      <Resizable {...resizableProps} data-testid="playground">
+        <LiveProvider
+          code={code}
+          scope={scopeOnMount}
+          transformCode={transformCode}
+          language={language}
+          theme={theme}
+        >
+          <Box sx={styles.previewWrapper}>
+            <Wrapper height={previewHeight}>
+              {showLivePreview && (
+                <LivePreview sx={styles.preview} data-testid="live-preview" />
+              )}
+              <ReactResizeDetector
+                handleHeight
+                onResize={({ height }) => setPreviewHeight(height)}
+              />
+            </Wrapper>
+            <Box sx={styles.buttons}>
+              <button sx={styles.button} onClick={copyCode}>
+                <Icons.Clipboard size={12} />
+              </button>
+              <button sx={styles.button} onClick={toggleCode}>
+                <Icons.Code size={12} />
+              </button>
+            </Box>
+          </Box>
+          {showingCode && (
+            <Wrapper height={editorHeight}>
+              <Box sx={styles.editor(theme)}>
+                <LiveEditor data-testid="live-editor" />
+              </Box>
+              <ReactResizeDetector
+                handleHeight
+                onResize={({ height }) => setEditorHeight(height)}
+              />
+            </Wrapper>
+          )}
+          {showLiveError && (
+            <LiveError sx={styles.error} data-testid="live-error" />
+          )}
+        </LiveProvider>
+      </Resizable>
+    </Box>
+  );
+};

--- a/src/gatsby-theme-docz/components/Playground/styles.js
+++ b/src/gatsby-theme-docz/components/Playground/styles.js
@@ -41,7 +41,7 @@ export const previewInner = (content, showingCode) => {
     ...styles.previewInner(content, showingCode),
     borderRadius: "4px 4px 0 0",
 
-    ":not(:first-child)": {
+    ":not(:first-of-type)": {
       borderTopWidth: 0,
       borderRadius: "0 0 4px 4px",
     },

--- a/src/gatsby-theme-docz/components/Playground/styles.js
+++ b/src/gatsby-theme-docz/components/Playground/styles.js
@@ -6,6 +6,17 @@ export * from "gatsby-theme-docz/src/components/Playground/styles";
 
 // Override what we need to.
 import * as styles from "gatsby-theme-docz/src/components/Playground/styles";
+import { media } from "gatsby-theme-docz/src/theme/breakpoints";
+
+export const wrapper = {
+  width: "calc(100vw - 300px)",
+  marginLeft: "calc(-50vw + 480px + 120px )",
+
+  [media.desktop]: {
+    width: "100%",
+    marginLeft: 0,
+  },
+};
 
 export const previewWrapper = {
   ...styles.previewWrapper,

--- a/src/gatsby-theme-docz/components/Sidebar/styles.js
+++ b/src/gatsby-theme-docz/components/Sidebar/styles.js
@@ -57,7 +57,7 @@ export const search = {
 };
 
 export const topLevelMenuWrapper = theme => ({
-  "& a:not(:first-child)": {
+  "& a:not(:first-of-type)": {
     ...theme.navigation.level3,
     ml: 0,
   },


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We wanted a better way to use `useResizeObserver` that would allow for some default comparisons, as well as allow the component to set its own breakpoints.

## Changes

`useResizeObserver` will now return the breakpoint size as well as exact size of the component.

### Added

- Custom breakpoints to `useResizeObserver`

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
