### PR TITLE
fix(components): Add fragments to FormatRelativeDateTime

### DIFF
--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -17,13 +17,15 @@ export function FormatRelativeDateTime(
 
   switch (relativeTimeRange(delta)) {
     case "less than an hour":
-      return showMinutes(Math.round(delta / 60));
+      return <>{showMinutes(Math.round(delta / 60))}</>;
     case "less then a day":
-      return inputDate.toLocaleTimeString();
+      return <>{inputDate.toLocaleTimeString()}</>;
     case "less than a week":
-      return strFormatDate(inputDate, { weekday: "short" });
+      return <>{strFormatDate(inputDate, { weekday: "short" })}</>;
     case "less than a year":
-      return strFormatDate(inputDate, { month: "short", day: "numeric" });
+      return (
+        <>{strFormatDate(inputDate, { month: "short", day: "numeric" })}</>
+      );
     default:
       return (
         <>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

Add React fragments to the `FormatRelativeDateTime` component

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Add React fragments to the `FormatRelativeDateTime` component

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
