### PR TITLE
  feat(components): InputText Automatic Resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 
 **/tsconfig.tsbuildinfo
 .DS_Store
+.idea

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -72,7 +72,6 @@
 
 textarea.formField {
   height: auto;
-  min-height: calc(var(--field--height) * 2);
   resize: vertical;
 }
 

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -154,7 +154,7 @@ select.formField {
 
 .miniLabel:not(.small) .formField {
   --field--padding-top: calc(var(--space-base) + var(--space-smaller));
-  --field--padding-bottom: var(--space-smaller);
+  --field--padding-bottom: var(--space-small);
 }
 
 .miniLabel .label {

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -172,7 +172,7 @@ export const FormField = React.forwardRef(
       onValidation,
       placeholder,
       readonly,
-      rows = 3,
+      rows,
       size,
       type = "text",
       value,

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -172,7 +172,7 @@ export const FormField = React.forwardRef(
       onValidation,
       placeholder,
       readonly,
-      rows,
+      rows = 3,
       size,
       type = "text",
       value,

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -52,13 +52,27 @@ Use this to allow users to provide short answers.
 
 ## Multiline
 
-Use this to allow users to provide long answers.
+Use this to allow users to provide long answers. The default number of rows is
+three.
 
 <Playground>
   <InputText
     multiline={true}
     placeholder="Describe your age"
     name="describeAge"
+  />
+</Playground>
+
+## Multiline with Minimum and Maximum
+
+This is to allow flexibility in the displayed textarea size as the user types.
+The textarea will start at a specified minimum and grow to a specified maximum.
+
+<Playground>
+  <InputText
+    defaultValue="Rocinante"
+    multiline={true}
+    rows={{ min: 1, max: 5 }}
   />
 </Playground>
 

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -72,7 +72,7 @@ The textarea will start at a specified minimum and grow to a specified maximum.
   <InputText
     defaultValue="Rocinante"
     multiline={true}
-    rows={{ min: 1, max: 5 }}
+    rows={{ min: 3, max: 6 }}
   />
 </Playground>
 

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -72,7 +72,7 @@ The textarea will start at a specified minimum and grow to a specified maximum.
   <InputText
     defaultValue="Rocinante"
     multiline={true}
-    rows={{ min: 3, max: 6 }}
+    rows={{ min: 1, max: 4 }}
   />
 </Playground>
 

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { fireEvent, render } from "@testing-library/react";
 import { InputText } from ".";
-import { InputTextRef, calculateRows } from "./InputText";
+import { InputTextRef } from "./InputText";
 
 it("renders a regular input for text and numbers", () => {
   const tree = renderer
@@ -147,17 +147,4 @@ test("it should handle inserting text", () => {
 
   textRef.current.insert("sure");
   expect(changeHandler).toHaveBeenCalledWith(secondResult);
-});
-
-describe("When calculate rows receives a scroll height and line height", () => {
-  it("calculates the appropriate number of rows to render (1)", () => {
-    const scrollHeight = 44;
-    const lineHeight = 20;
-    expect(calculateRows(scrollHeight, lineHeight)).toBe(1);
-  });
-  it("calculates the appropriate number of rows to render (3)", () => {
-    const scrollHeight = 84;
-    const lineHeight = 20;
-    expect(calculateRows(scrollHeight, lineHeight)).toBe(3);
-  });
 });

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { fireEvent, render } from "@testing-library/react";
 import { InputText } from ".";
-import { InputTextRef } from "./InputText";
+import { InputTextRef, calculateRows } from "./InputText";
 
 it("renders a regular input for text and numbers", () => {
   const tree = renderer
@@ -62,6 +62,7 @@ it("renders a textarea", () => {
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
+        rows={3}
       />
     </div>
   `);
@@ -146,4 +147,17 @@ test("it should handle inserting text", () => {
 
   textRef.current.insert("sure");
   expect(changeHandler).toHaveBeenCalledWith(secondResult);
+});
+
+describe("When calculate rows receives a scroll height and line height", () => {
+  it("calculates the appropriate number of rows to render (1)", () => {
+    const scrollHeight = 44;
+    const lineHeight = 20;
+    expect(calculateRows(scrollHeight, lineHeight)).toBe(1);
+  });
+  it("calculates the appropriate number of rows to render (3)", () => {
+    const scrollHeight = 84;
+    const lineHeight = 20;
+    expect(calculateRows(scrollHeight, lineHeight)).toBe(3);
+  });
 });

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -100,12 +100,11 @@ function InputTextInternal(
   }
 
   function getLineHeight(textArea: HTMLTextAreaElement) {
-    const { fontSize, lineHeight } = window.getComputedStyle(textArea);
-    const lh =
-      lineHeight === "normal"
-        ? parseFloat(fontSize) * 1.2
-        : parseFloat(lineHeight);
-    return lh;
+    const lineHeight = window
+      .getComputedStyle(textArea)
+      .getPropertyValue("line-height");
+
+    return parseInt(lineHeight, 10);
   }
 
   function insertText(text: string) {

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -31,9 +31,9 @@ interface MultilineProps extends BaseProps {
 
   /**
    * Specifies the visible height of a long answer form field. Can be in the
-   * form of a single number to set a static height, or an associative array
-   * with a min and max keys indicating the minimum number of visible rows, and
-   * the maximum number of visible rows.
+   * form of a single number to set a static height, or an object with a min
+   * and max keys indicating the minimum number of visible rows, and the
+   * maximum number of visible rows.
    */
   readonly rows?: number | RowRange;
 }

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -95,16 +95,27 @@ function InputTextInternal(
   }
 
   function textAreaHeight(textArea: HTMLTextAreaElement) {
-    const maxHeight = rowRange.max * getLineHeight(textArea);
-    return Math.min(textArea.scrollHeight, maxHeight);
-  }
+    const {
+      lineHeight,
+      borderBottomWidth,
+      borderTopWidth,
+      paddingBottom,
+      paddingTop,
+    } = window.getComputedStyle(textArea);
 
-  function getLineHeight(textArea: HTMLTextAreaElement) {
-    const lineHeight = window
-      .getComputedStyle(textArea)
-      .getPropertyValue("line-height");
+    const maxHeight =
+      rowRange.max * parseFloat(lineHeight) +
+      parseFloat(borderTopWidth) +
+      parseFloat(borderBottomWidth) +
+      parseFloat(paddingTop) +
+      parseFloat(paddingBottom);
 
-    return parseInt(lineHeight, 10);
+    const scrollHeight =
+      textArea.scrollHeight +
+      parseFloat(borderTopWidth) +
+      parseFloat(borderBottomWidth);
+
+    return Math.min(scrollHeight, maxHeight);
   }
 
   function insertText(text: string) {

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -79,32 +79,29 @@ function InputTextInternal(
 
   function handleChange(newValue: string) {
     props.onChange && props.onChange(newValue);
-    if (inputRef && inputRef.current instanceof HTMLTextAreaElement) {
-      const textareaLineHeight = parseInt(
-        window
-          .getComputedStyle(inputRef.current)
-          .getPropertyValue("line-height"),
-        10,
-      );
-      const textareaScrollHeight = inputRef.current.scrollHeight;
-      const calculateRows = Math.floor(
-        textareaScrollHeight / textareaLineHeight - 2,
-      );
-      console.log("scroll height", textareaScrollHeight);
-      console.log("line height", textareaLineHeight);
-      console.log("calculatedRows", calculateRows);
-      console.log("currentRows", currentRows);
-
-      // if (props.rows.max > calculateRows && calculateRows > props.rows.min) {
-      //   setRows(calculateRows);
-      // }
-
-      if (props.rows.max > calculateRows && calculateRows > currentRows) {
-        setRows(calculateRows);
-      } else if (calculateRows < currentRows && currentRows > props.rows.min) {
-        setRows(calculateRows);
+    if (
+      props.rows &&
+      inputRef &&
+      inputRef.current instanceof HTMLTextAreaElement
+    ) {
+      if (
+        calculateRows() >= props.rows.min &&
+        calculateRows() <= props.rows.max
+      ) {
+        setRows(calculateRows());
       }
     }
+  }
+
+  function calculateRows() {
+    const currentRef = inputRef.current as HTMLTextAreaElement;
+    const textareaLineHeight = parseInt(
+      window.getComputedStyle(currentRef).getPropertyValue("line-height"),
+      10,
+    );
+    const textareaScrollHeight = currentRef.scrollHeight;
+
+    return Math.floor(textareaScrollHeight / textareaLineHeight) - 1;
   }
 
   function insertText(text: string) {

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -8,6 +8,11 @@ import React, {
 import { XOR } from "ts-xor";
 import { FormField, FormFieldProps } from "../FormField";
 
+interface MultiRows {
+  min: number;
+  max: number;
+}
+
 /**
  * The following is the same as:
  *   type BaseProps = Omit<FormFieldProps, "type" | "children">;
@@ -33,7 +38,7 @@ interface MultilineProps extends BaseProps {
   /**
    * Specifies the visible height of a long answer form field.
    */
-  readonly rows?: number | { min: number; max: number };
+  readonly rows?: number | MultiRows;
 }
 
 type InputTextPropOptions = XOR<BaseProps, MultilineProps>;
@@ -56,7 +61,7 @@ function InputTextInternal(
     },
   }));
 
-  const [currentRows, setRows] = useState(initializeRows);
+  const [currentRows, setRows] = useState(initializeRows());
 
   return (
     <FormField
@@ -70,7 +75,7 @@ function InputTextInternal(
 
   function initializeRows() {
     if (!props.rows) return;
-    if (props.rows.type === "number" && props.rows > 0) {
+    if (typeof props.rows === "number") {
       return props.rows;
     } else {
       return props.rows.min;
@@ -79,8 +84,9 @@ function InputTextInternal(
 
   function handleChange(newValue: string) {
     props.onChange && props.onChange(newValue);
+    if (!props.rows) return;
     if (
-      props.rows &&
+      typeof props.rows !== "number" &&
       inputRef &&
       inputRef.current instanceof HTMLTextAreaElement
     ) {

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -90,24 +90,23 @@ function InputTextInternal(
       inputRef &&
       inputRef.current instanceof HTMLTextAreaElement
     ) {
+      const currentRef = inputRef.current as HTMLTextAreaElement;
+      const textareaLineHeight = parseInt(
+        window.getComputedStyle(currentRef).getPropertyValue("line-height"),
+        10,
+      );
+      const textareaScrollHeight = currentRef.scrollHeight;
+      const calculatedRows = calculateRows(
+        textareaScrollHeight,
+        textareaLineHeight,
+      );
       if (
-        calculateRows() >= props.rows.min &&
-        calculateRows() <= props.rows.max
+        calculatedRows >= props.rows.min &&
+        calculatedRows <= props.rows.max
       ) {
-        setRows(calculateRows());
+        setRows(calculatedRows);
       }
     }
-  }
-
-  function calculateRows() {
-    const currentRef = inputRef.current as HTMLTextAreaElement;
-    const textareaLineHeight = parseInt(
-      window.getComputedStyle(currentRef).getPropertyValue("line-height"),
-      10,
-    );
-    const textareaScrollHeight = currentRef.scrollHeight;
-
-    return Math.floor(textareaScrollHeight / textareaLineHeight) - 1;
   }
 
   function insertText(text: string) {
@@ -117,6 +116,10 @@ function InputTextInternal(
       props.onChange && props.onChange(input.value);
     }
   }
+}
+
+export function calculateRows(scrollHeight: number, lineHeight: number) {
+  return Math.floor(scrollHeight / lineHeight) - 1;
 }
 
 export const InputText = forwardRef(InputTextInternal);

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -77,7 +77,7 @@ function InputTextInternal(
     }
   }
 
-  function getRowRange() {
+  function getRowRange(): RowRange {
     if (props.rows === undefined) {
       return { min: 3, max: 3 };
     } else if (typeof props.rows === "object") {

--- a/packages/components/src/InputText/index.ts
+++ b/packages/components/src/InputText/index.ts
@@ -1,1 +1,1 @@
-export * from "./InputText";
+export { InputText, InputTextRef } from "./InputText";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
We need to be able to have a textarea that would start as 1 line tall, and grow to a set amount, and then become scrollable if more room was needed beyond that set maximum. 

The current implementation almost allowed us to do this, however it wouldn't allow us to set a minimum number of rows.

## Changes

Instead of just rows as a single number being passed into the InputText component, now we have the ability to pass in an associative array which has a min and max key, corresponding to the minimum and maximum number of rows that would like to be shown.

### Added

handleChange and calculateRows functions which actively monitor and calculates how many rows should be shown for a multiline text area **with** a set maximum and minimum number of rows.

### Changed

The only change in existing functionality is the removal of the min-height for text area so that we could have a minimum value less than 3. Instead we set the default rows value to be 3 for multiline, which can be overrided with any value. Essentially it behaves the exact same as before but now you can have less than 3 rows in the textarea for use cases such as ours.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Added a jest test to ensure that the calculations were correct.

**QA**
From the input text page in Atlantis, try using the following code snippet in one of the testing areas.
`<InputText defaultValue="Rocinante" multiline rows={{min:1, max:6}} />`

Play with the min and max sizes to see different behaviours. 
Test to make sure that the behaviour of Rows as a single number still works and multiline still works as a standalone with a default number of visible rows of 3.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
