### PR TITLE
fix(components): removed seconds from time in FormatRelativeDateTime

### DIFF
--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
@@ -28,7 +28,7 @@ import { FormatRelativeDateTime } from "@jobber/components/FormatRelativeDateTim
 If the message was received less than an hour ago the format is x minutes ago
 
 If the message was received today, but more than an hour ago, the format becomes
-the time it was received
+the hours and minutes it was received at
 
 If the message was received this within the last six days, the format is Sun,
 Mon, Tue, Wed, Thu, Fri, Sat

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -41,7 +41,7 @@ it("renders the time when less than a day ago", () => {
 
   const hours = testDate.getHours();
   const minutes = testDate.getMinutes();
-  const expectedStr = hours + ":" + minutes + ":35 AM";
+  const expectedStr = hours + ":" + minutes + " AM";
 
   const tree = renderer
     .create(<FormatRelativeDateTime date={civilTestDate} />)

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -19,7 +19,14 @@ export function FormatRelativeDateTime(
     case "less than an hour":
       return <>{showMinutes(Math.round(delta / 60))}</>;
     case "less then a day":
-      return <>{inputDate.toLocaleTimeString()}</>;
+      return (
+        <>
+          {inputDate.toLocaleTimeString(undefined, {
+            hour: "numeric",
+            minute: "numeric",
+          })}
+        </>
+      );
     case "less than a week":
       return <>{strFormatDate(inputDate, { weekday: "short" })}</>;
     case "less than a year":


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Spec did not want seconds when showing just the time. I missed that.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- none

### Changed

- When showing just the time, now shows hours and minutes. No seconds. Eg. "9:45 AM"

### Deprecated

- none

### Removed

- none

### Fixed

- none

### Security

- none

## Testing

Display a time less than day ago, but more than an hour ago.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
