### PR TITLE
feat(design): Change system colour for sendInvoice and paidInvoice icons

### DIFF
--- a/packages/design/src/icons/Icon.css
+++ b/packages/design/src/icons/Icon.css
@@ -59,17 +59,14 @@
 }
 
 .invoice,
-.invoiceLater {
+.invoiceLater,
+.sendInvoice,
+.paidInvoice {
   fill: var(--color-invoice);
 }
 
 .badInvoice {
   fill: var(--color-red);
-}
-
-.sendInvoice,
-.paidInvoice {
-  fill: var(--color-green);
 }
 
 .payment,


### PR DESCRIPTION
## Motivations
We want these variants of the invoice icon to have the same purple colour as the other invoice icons

## Changes
`sendInvoice` and `paidInvoice` are now purple
![image](https://user-images.githubusercontent.com/59576300/87333787-dacda600-c4fa-11ea-83fc-00fb3ec8c2d8.png)


### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
