### PR TITLE
feat(components): expose focus method in InputText — (Minor) Feature Release

### DIFF
--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -188,6 +188,30 @@ shouldn't replace server-side validation.
   }}
 </Playground>
 
+## Focus
+
+<Playground>
+  {() => {
+    const textARef = React.createRef();
+    const textBRef = React.createRef();
+    const focusA = () => {
+      textARef.current.focus();
+    };
+    const focusB = () => {
+      textBRef.current.focus();
+    };
+    return (
+      <Content>
+        <InputText value="Text input A" ref={textARef} />
+        <InputText value="Text input B" ref={textBRef} />
+        <Button label="Focus text input A" onClick={focusA} />
+        <br />
+        <Button label="Focus text input B" onClick={focusB} />
+      </Content>
+    );
+  }}
+</Playground>
+
 ## Using onValidation
 
 If you need to capture the error message and render it outside of the component.

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -16,6 +16,7 @@ type BaseProps = Pick<
 export interface InputTextRef {
   insert(text: string): void;
   blur(): void;
+  focus(): void;
 }
 
 interface MultilineProps extends BaseProps {
@@ -46,6 +47,12 @@ function InputTextInternal(
       const input = inputRef.current;
       if (input) {
         input.blur();
+      }
+    },
+    focus: () => {
+      const input = inputRef.current;
+      if (input) {
+        input.focus();
       }
     },
   }));


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

 - Need to set focus to InputText on demand.

### Added

- InputTextRef now provide access to `focus`

## Testing

 - Added sample code to playground.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
