### PR TITLE
docs(components): Update disabled state docs on checkbox

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.mdx
+++ b/packages/components/src/Checkbox/Checkbox.mdx
@@ -91,7 +91,7 @@ discrete options, such as “fixed price” and “per visit” invoicing option
 
 ## Disabled
 
-A disabled checbkbox cannot be operated by the user. Your primary goal should be to avoid disabled states in an interface, but some cases may require that an element be disabled.
+A disabled checkbox cannot be operated by the user. Your primary goal should be to avoid disabled states in an interface, but some cases may require that an element be disabled.
 
 If presenting a disabled "checked" checkbox to the user, provide a clear description for the user on how to enable the checkbox to avoid creating a sense that the user has lost control of the interface.
 

--- a/packages/components/src/Checkbox/Checkbox.mdx
+++ b/packages/components/src/Checkbox/Checkbox.mdx
@@ -91,6 +91,10 @@ discrete options, such as “fixed price” and “per visit” invoicing option
 
 ## Disabled
 
+A disabled checbkbox cannot be operated by the user. Your primary goal should be to avoid disabled states in an interface, but some cases may require that an element be disabled.
+
+If presenting a disabled "checked" checkbox to the user, provide a clear description for the user on how to enable the checkbox to avoid creating a sense that the user has lost control of the interface.
+
 <Playground>
   <Checkbox
     disabled={true}


### PR DESCRIPTION
## Motivations

- make more consistent with docs on Switch
- introduce clearer language around accessibility expectations for disabled elements

## Changes

### Added

- more detail on `disabled` checkbox

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
