### PR TITLE
feat(components): Time and Date formatters now accept `Date` Objects and ISO Strings

### DIFF
--- a/packages/components/src/FormatDate/FormatDate.test.tsx
+++ b/packages/components/src/FormatDate/FormatDate.test.tsx
@@ -8,8 +8,8 @@ afterEach(cleanup);
 
 Object.entries({
   CivilDate: new CivilDate(2020, 2, 26),
-  ISO8601DateString: "2019-03-30T00:45Z",
-  Date: new Date("2019-03-30T00:45Z"),
+  ISO8601DateString: "2019-03-30T00:45",
+  Date: new Date("2019-03-30T00:45"),
 }).forEach(([inputType, value]) => {
   it(`renders a FormatDate from ${inputType}`, () => {
     const tree = renderer.create(<FormatDate date={value} />).toJSON();

--- a/packages/components/src/FormatDate/FormatDate.test.tsx
+++ b/packages/components/src/FormatDate/FormatDate.test.tsx
@@ -6,9 +6,13 @@ import { FormatDate } from "./FormatDate";
 
 afterEach(cleanup);
 
-it("renders a FormatDate", () => {
-  const tree = renderer
-    .create(<FormatDate date={new CivilDate(2020, 2, 26)} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot(`"Feb 26, 2020"`);
+Object.entries({
+  CivilDate: new CivilDate(2020, 2, 26),
+  ISO8601DateString: "2019-03-30T00:45Z",
+  Date: new Date("2019-03-30T00:45Z"),
+}).forEach(([inputType, value]) => {
+  it(`renders a FormatDate from ${inputType}`, () => {
+    const tree = renderer.create(<FormatDate date={value} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/components/src/FormatDate/FormatDate.tsx
+++ b/packages/components/src/FormatDate/FormatDate.tsx
@@ -3,17 +3,29 @@ import { CivilDate } from "@std-proposal/temporal";
 
 interface FormatDateProps {
   /**
-   * Date to be displayed.
+   * Date to be formatted.
+   *
+   * A `string` should be an ISO 8601 format date string.
    */
-  readonly date: CivilDate;
+  readonly date: CivilDate | Date | string;
 }
 
-export function FormatDate(date: FormatDateProps) {
-  return <>{strFormatDate(date.date)}</>;
+export function FormatDate({ date: inputDate }: FormatDateProps) {
+  let dateObject: Date;
+
+  if (inputDate instanceof Date) {
+    dateObject = inputDate;
+  } else if (typeof inputDate === "string") {
+    dateObject = new Date(inputDate);
+  } else {
+    dateObject = new Date(inputDate.year, inputDate.month - 1, inputDate.day);
+  }
+
+  return <>{strFormatDate(dateObject)}</>;
 }
 
-function strFormatDate({ year, month, day }: CivilDate) {
-  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+function strFormatDate(date: Date) {
+  return date.toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",

--- a/packages/components/src/FormatDate/__snapshots__/FormatDate.test.tsx.snap
+++ b/packages/components/src/FormatDate/__snapshots__/FormatDate.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a FormatDate from CivilDate 1`] = `"Feb 26, 2020"`;
+
+exports[`renders a FormatDate from Date 1`] = `"Mar 29, 2019"`;
+
+exports[`renders a FormatDate from ISO8601DateString 1`] = `"Mar 29, 2019"`;

--- a/packages/components/src/FormatDate/__snapshots__/FormatDate.test.tsx.snap
+++ b/packages/components/src/FormatDate/__snapshots__/FormatDate.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`renders a FormatDate from CivilDate 1`] = `"Feb 26, 2020"`;
 
-exports[`renders a FormatDate from Date 1`] = `"Mar 29, 2019"`;
+exports[`renders a FormatDate from Date 1`] = `"Mar 30, 2019"`;
 
-exports[`renders a FormatDate from ISO8601DateString 1`] = `"Mar 29, 2019"`;
+exports[`renders a FormatDate from ISO8601DateString 1`] = `"Mar 30, 2019"`;

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.test.tsx
@@ -14,11 +14,17 @@ it("renders x minutes ago when less than an hour ago", () => {
   testDate.setMinutes(testDate.getMinutes() - 5);
 
   const civilTestDate = getCivilTime(testDate);
+  const isoTestDate = getISOString(testDate);
 
-  const tree = renderer
-    .create(<FormatRelativeDateTime date={civilTestDate} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot(`"5 minutes ago"`);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={civilTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot(`"5 minutes ago"`);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={isoTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot(`"5 minutes ago"`);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={testDate} />).toJSON(),
+  ).toMatchInlineSnapshot(`"5 minutes ago"`);
 });
 
 it("renders 1 minute ago when less than a minute ago", () => {
@@ -26,28 +32,39 @@ it("renders 1 minute ago when less than a minute ago", () => {
   testDate.setSeconds(testDate.getSeconds() - 25);
 
   const civilTestDate = getCivilTime(testDate);
+  const isoTestDate = getISOString(testDate);
 
-  const tree = renderer
-    .create(<FormatRelativeDateTime date={civilTestDate} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot(`"1 minute ago"`);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={civilTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot(`"1 minute ago"`);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={isoTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot(`"1 minute ago"`);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={testDate} />).toJSON(),
+  ).toMatchInlineSnapshot(`"1 minute ago"`);
 });
 
 it("renders the time when less than a day ago", () => {
   const testDate = new Date(Date.now());
   testDate.setHours(testDate.getHours() - 9);
 
-  const civilTestDate = getCivilTime(testDate);
-
   const hours = testDate.getHours();
   const minutes = testDate.getMinutes();
   const expectedStr = hours + ":" + minutes + " AM";
 
-  const tree = renderer
-    .create(<FormatRelativeDateTime date={civilTestDate} />)
-    .toJSON();
+  const civilTestDate = getCivilTime(testDate);
+  const isoTestDate = getISOString(testDate);
 
-  expect(tree).toEqual(expectedStr);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={civilTestDate} />).toJSON(),
+  ).toEqual(expectedStr);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={isoTestDate} />).toJSON(),
+  ).toEqual(expectedStr);
+  expect(
+    renderer.create(<FormatRelativeDateTime date={testDate} />).toJSON(),
+  ).toEqual(expectedStr);
 });
 
 it("renders the day when less than 7 days ago", () => {
@@ -55,11 +72,17 @@ it("renders the day when less than 7 days ago", () => {
   testDate.setDate(testDate.getDate() - 3);
 
   const civilTestDate = getCivilTime(testDate);
+  const isoTestDate = getISOString(testDate);
 
-  const tree = renderer
-    .create(<FormatRelativeDateTime date={civilTestDate} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot('"Mon"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={civilTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Mon"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={isoTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Mon"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={testDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Mon"');
 });
 
 it("renders the month and date when less than 1 year ago", () => {
@@ -67,11 +90,17 @@ it("renders the month and date when less than 1 year ago", () => {
   testDate.setDate(testDate.getDate() - 60);
 
   const civilTestDate = getCivilTime(testDate);
+  const isoTestDate = getISOString(testDate);
 
-  const tree = renderer
-    .create(<FormatRelativeDateTime date={civilTestDate} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot('"Apr 26"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={civilTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Apr 26"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={isoTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Apr 26"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={testDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Apr 26"');
 });
 
 it("renders the month and date when yesterday's date 1 year previous (border case)", () => {
@@ -80,11 +109,17 @@ it("renders the month and date when yesterday's date 1 year previous (border cas
   testDate.setDate(testDate.getDate() + 2); //The +2 vs. +1 is a fudge for leap year
 
   const civilTestDate = getCivilTime(testDate);
+  const isoTestDate = getISOString(testDate);
 
-  const tree = renderer
-    .create(<FormatRelativeDateTime date={civilTestDate} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot('"Jun 27"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={civilTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Jun 27"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={isoTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Jun 27"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={testDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Jun 27"');
 });
 
 it("renders the month day, year when over a year ago", () => {
@@ -92,12 +127,22 @@ it("renders the month day, year when over a year ago", () => {
   testDate.setFullYear(testDate.getFullYear() - 2);
 
   const civilTestDate = getCivilTime(testDate);
+  const isoTestDate = getISOString(testDate);
 
-  const tree = renderer
-    .create(<FormatRelativeDateTime date={civilTestDate} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot('"Jun 25, 2018"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={civilTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Jun 25, 2018"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={isoTestDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Jun 25, 2018"');
+  expect(
+    renderer.create(<FormatRelativeDateTime date={testDate} />).toJSON(),
+  ).toMatchInlineSnapshot('"Jun 25, 2018"');
 });
+
+function getISOString(date: Date) {
+  return date.toISOString();
+}
 
 function getCivilTime(date: Date) {
   const testYear = date.getFullYear();

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -4,16 +4,28 @@ import { CivilDateTime } from "@std-proposal/temporal";
 interface FormatRelativeDateTimeProps {
   /**
    * Date to be displayed.
+   *
+   * A `string` should be an ISO 8601 format date string.
    */
-  readonly date: CivilDateTime;
+  readonly date: CivilDateTime | Date | string;
 }
 
-export function FormatRelativeDateTime(
-  civilDateTime: FormatRelativeDateTimeProps,
-) {
+export function FormatRelativeDateTime({
+  date: inputDate,
+}: FormatRelativeDateTimeProps) {
+  let dateObject: Date;
+
+  if (inputDate instanceof Date) {
+    dateObject = inputDate;
+  } else if (typeof inputDate === "string") {
+    dateObject = new Date(inputDate);
+  } else {
+    dateObject = new Date(inputDate.toJSON());
+  }
+
   const now = Date.now() / 1000; //seconds
-  const inputDate = new Date(civilDateTime.date.toJSON());
-  const delta = now - inputDate.getTime() / 1000; //seconds;
+  const date = dateObject;
+  const delta = now - date.getTime() / 1000; //seconds;
 
   switch (relativeTimeRange(delta)) {
     case "less than an hour":
@@ -21,22 +33,20 @@ export function FormatRelativeDateTime(
     case "less then a day":
       return (
         <>
-          {inputDate.toLocaleTimeString(undefined, {
+          {date.toLocaleTimeString(undefined, {
             hour: "numeric",
             minute: "numeric",
           })}
         </>
       );
     case "less than a week":
-      return <>{strFormatDate(inputDate, { weekday: "short" })}</>;
+      return <>{strFormatDate(date, { weekday: "short" })}</>;
     case "less than a year":
-      return (
-        <>{strFormatDate(inputDate, { month: "short", day: "numeric" })}</>
-      );
+      return <>{strFormatDate(date, { month: "short", day: "numeric" })}</>;
     default:
       return (
         <>
-          {strFormatDate(inputDate, {
+          {strFormatDate(date, {
             month: "short",
             day: "numeric",
             year: "numeric",

--- a/packages/components/src/FormatTime/FormatTime.test.tsx
+++ b/packages/components/src/FormatTime/FormatTime.test.tsx
@@ -6,23 +6,27 @@ import { FormatTime } from "./FormatTime";
 
 afterEach(cleanup);
 
-it("renders a FormatTime", () => {
-  const tree = renderer
-    .create(<FormatTime time={new CivilTime(11, 30)} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot(`"11:30 AM"`);
-});
+Object.entries({
+  CivilDate: new CivilTime(14, 30),
+  ISO8601DateString: "2019-03-30T00:45Z",
+  Date: new Date("2019-03-30T00:45Z"),
+}).forEach(([inputType, value]) => {
+  it(`renders a FormatTime from ${inputType}`, () => {
+    const tree = renderer.create(<FormatTime time={value} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-it("renders a FormatTime using 24 hour clock", () => {
-  const tree = renderer
-    .create(<FormatTime time={new CivilTime(14, 30)} use24HourClock={true} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot(`"14:30"`);
-});
+  it(`renders a FormatTime from ${inputType} using 24 hour clock`, () => {
+    const tree = renderer
+      .create(<FormatTime time={value} use24HourClock={true} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-it("renders a FormatTime using 12 hour clock", () => {
-  const tree = renderer
-    .create(<FormatTime time={new CivilTime(17, 30)} use24HourClock={false} />)
-    .toJSON();
-  expect(tree).toMatchInlineSnapshot(`"5:30 PM"`);
+  it(`renders a FormatTime from ${inputType} using 12 hour clock`, () => {
+    const tree = renderer
+      .create(<FormatTime time={value} use24HourClock={false} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/components/src/FormatTime/FormatTime.test.tsx
+++ b/packages/components/src/FormatTime/FormatTime.test.tsx
@@ -8,8 +8,8 @@ afterEach(cleanup);
 
 Object.entries({
   CivilDate: new CivilTime(14, 30),
-  ISO8601DateString: "2019-03-30T00:45Z",
-  Date: new Date("2019-03-30T00:45Z"),
+  ISO8601DateString: "2019-03-30T14:30",
+  Date: new Date("2019-03-30T14:30"),
 }).forEach(([inputType, value]) => {
   it(`renders a FormatTime from ${inputType}`, () => {
     const tree = renderer.create(<FormatTime time={value} />).toJSON();

--- a/packages/components/src/FormatTime/FormatTime.tsx
+++ b/packages/components/src/FormatTime/FormatTime.tsx
@@ -4,8 +4,10 @@ import { CivilTime } from "@std-proposal/temporal";
 interface FormatTimeProps {
   /**
    * Civil Time of time to be displayed.
+   *
+   * A `string` should be an ISO 8601 format date string.
    */
-  readonly time: CivilTime;
+  readonly time: CivilTime | Date | string;
 
   /**
    * Optionally specify clock format. If `undefined` system format will be respected.
@@ -13,25 +15,36 @@ interface FormatTimeProps {
   readonly use24HourClock?: boolean;
 }
 
-export function FormatTime({ time, use24HourClock }: FormatTimeProps) {
-  return <>{formatCivilTime(time, use24HourClock)}</>;
+export function FormatTime({
+  time: inputTime,
+  use24HourClock,
+}: FormatTimeProps) {
+  let dateObject: Date;
+
+  if (inputTime instanceof Date) {
+    dateObject = inputTime;
+  } else if (typeof inputTime === "string") {
+    dateObject = new Date(inputTime);
+  } else {
+    const currentDate = new Date();
+    const currentYear = currentDate.getFullYear();
+    const currentMonth = currentDate.getMonth();
+    const currentDay = currentDate.getDay();
+    dateObject = new Date(
+      currentYear,
+      currentMonth,
+      currentDay,
+      inputTime.hour,
+      inputTime.minute,
+      inputTime.second,
+      inputTime.millisecond,
+    );
+  }
+
+  return <>{formatCivilTime(dateObject, use24HourClock)}</>;
 }
 
-function formatCivilTime(time: CivilTime, use24HourClock?: boolean) {
-  const currentDate = new Date();
-  const currentYear = currentDate.getFullYear();
-  const currentMonth = currentDate.getMonth();
-  const currentDay = currentDate.getDay();
-  const date = new Date(
-    currentYear,
-    currentMonth,
-    currentDay,
-    time.hour,
-    time.minute,
-    time.second,
-    time.millisecond,
-  );
-
+function formatCivilTime(date: Date, use24HourClock?: boolean) {
   return date.toLocaleTimeString(navigator.language, {
     hour12: typeof use24HourClock === "boolean" ? !use24HourClock : undefined,
     minute: "2-digit",

--- a/packages/components/src/FormatTime/__snapshots__/FormatTime.test.tsx.snap
+++ b/packages/components/src/FormatTime/__snapshots__/FormatTime.test.tsx.snap
@@ -6,14 +6,14 @@ exports[`renders a FormatTime from CivilDate using 12 hour clock 1`] = `"2:30 PM
 
 exports[`renders a FormatTime from CivilDate using 24 hour clock 1`] = `"14:30"`;
 
-exports[`renders a FormatTime from Date 1`] = `"6:45 PM"`;
+exports[`renders a FormatTime from Date 1`] = `"2:30 PM"`;
 
-exports[`renders a FormatTime from Date using 12 hour clock 1`] = `"6:45 PM"`;
+exports[`renders a FormatTime from Date using 12 hour clock 1`] = `"2:30 PM"`;
 
-exports[`renders a FormatTime from Date using 24 hour clock 1`] = `"18:45"`;
+exports[`renders a FormatTime from Date using 24 hour clock 1`] = `"14:30"`;
 
-exports[`renders a FormatTime from ISO8601DateString 1`] = `"6:45 PM"`;
+exports[`renders a FormatTime from ISO8601DateString 1`] = `"2:30 PM"`;
 
-exports[`renders a FormatTime from ISO8601DateString using 12 hour clock 1`] = `"6:45 PM"`;
+exports[`renders a FormatTime from ISO8601DateString using 12 hour clock 1`] = `"2:30 PM"`;
 
-exports[`renders a FormatTime from ISO8601DateString using 24 hour clock 1`] = `"18:45"`;
+exports[`renders a FormatTime from ISO8601DateString using 24 hour clock 1`] = `"14:30"`;

--- a/packages/components/src/FormatTime/__snapshots__/FormatTime.test.tsx.snap
+++ b/packages/components/src/FormatTime/__snapshots__/FormatTime.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a FormatTime from CivilDate 1`] = `"2:30 PM"`;
+
+exports[`renders a FormatTime from CivilDate using 12 hour clock 1`] = `"2:30 PM"`;
+
+exports[`renders a FormatTime from CivilDate using 24 hour clock 1`] = `"14:30"`;
+
+exports[`renders a FormatTime from Date 1`] = `"6:45 PM"`;
+
+exports[`renders a FormatTime from Date using 12 hour clock 1`] = `"6:45 PM"`;
+
+exports[`renders a FormatTime from Date using 24 hour clock 1`] = `"18:45"`;
+
+exports[`renders a FormatTime from ISO8601DateString 1`] = `"6:45 PM"`;
+
+exports[`renders a FormatTime from ISO8601DateString using 12 hour clock 1`] = `"6:45 PM"`;
+
+exports[`renders a FormatTime from ISO8601DateString using 24 hour clock 1`] = `"18:45"`;


### PR DESCRIPTION
…Strings

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- FormatDate now accepts `Date` objects  and ISO Strings
- FormatTime now accepts `Date` objects  and ISO Strings
- FormatRelativeDateTime now accepts `Date` objects  and ISO Strings

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
