### PR TITLE
fix(components): Make Toast variation optional

### DIFF
--- a/packages/components/src/Toast/Toast.test.tsx
+++ b/packages/components/src/Toast/Toast.test.tsx
@@ -16,6 +16,11 @@ afterEach(() => {
   document.body.innerHTML = ``;
 });
 
+const successMessage =
+  "Successful Message that should last the full 5 seconds, it just needs to be 50 characters long";
+const infoMessage = "Bland Toast";
+const errorMessage = "Errorful should last inbetween min-max";
+
 it("creates the placeholder div on showToast call", () => {
   const { getByText } = render(<MockToast />);
   expect(document.querySelector(`#atlantis-toast-element`)).not.toBeInstanceOf(
@@ -33,11 +38,7 @@ it("renders a Slice of Toast when the 'showToast' method is called", () => {
   const { getByText, getByTestId } = render(<MockToast />);
 
   fireEvent.click(getByText("Success"));
-  expect(
-    getByText(
-      "Successful Message that should last the full 5 seconds, it just needs to be 50 charachters long",
-    ),
-  ).toBeInstanceOf(HTMLSpanElement);
+  expect(getByText(successMessage)).toBeInstanceOf(HTMLSpanElement);
   expect(getByTestId("checkmark")).toBeInstanceOf(SVGElement);
 });
 
@@ -69,7 +70,7 @@ it("sets a timer and clears the Slice after a certain amount of time", done => {
 
   fireEvent.click(getByText("No Variation"));
   expect(setTimeout).toHaveBeenCalled();
-  expect(queryAllByText("Bland Toast").length).toBe(1);
+  expect(queryAllByText(infoMessage).length).toBe(1);
 
   act(() => jest.runAllTimers());
 
@@ -117,7 +118,7 @@ const MockToast = ({ mockAction }: MockToastProps) => {
       label: "No Variation",
       onClick: () => {
         showToast({
-          message: "Bland Toast",
+          message: infoMessage,
           variation: "info",
           actionLabel: "Do The Action",
           action: () => mockAction && mockAction(),
@@ -128,8 +129,7 @@ const MockToast = ({ mockAction }: MockToastProps) => {
       label: "Success",
       onClick: () => {
         showToast({
-          message:
-            "Successful Message that should last the full 5 seconds, it just needs to be 50 charachters long",
+          message: successMessage,
         });
       },
     },
@@ -137,7 +137,7 @@ const MockToast = ({ mockAction }: MockToastProps) => {
       label: "Error",
       onClick: () => {
         showToast({
-          message: "Errorful should last inbetween min-max",
+          message: errorMessage,
           variation: "error",
         });
       },

--- a/packages/components/src/Toast/Toast.test.tsx
+++ b/packages/components/src/Toast/Toast.test.tsx
@@ -29,19 +29,23 @@ it("creates the placeholder div on showToast call", () => {
   );
 });
 
-it("renders a Slice of Toast when the 'add' method is called", () => {
-  const { getByText, getByTestId } = render(<MockToast />);
-
-  fireEvent.click(getByText("No Variation"));
-  expect(getByText("Bland Toast")).toBeInstanceOf(HTMLSpanElement);
-  expect(getByTestId("knot")).toBeInstanceOf(SVGElement);
-});
-
-it("renders a successful Slice of Toast when the variation: 'success' is set", () => {
+it("renders a Slice of Toast when the 'showToast' method is called", () => {
   const { getByText, getByTestId } = render(<MockToast />);
 
   fireEvent.click(getByText("Success"));
+  expect(
+    getByText(
+      "Successful Message that should last the full 5 seconds, it just needs to be 50 charachters long",
+    ),
+  ).toBeInstanceOf(HTMLSpanElement);
   expect(getByTestId("checkmark")).toBeInstanceOf(SVGElement);
+});
+
+it("renders an info Slice of Toast when the variation: 'info' is set", () => {
+  const { getByText, getByTestId } = render(<MockToast />);
+
+  fireEvent.click(getByText("No Variation"));
+  expect(getByTestId("knot")).toBeInstanceOf(SVGElement);
 });
 
 it("renders a error Slice of Toast when the variation: 'error' is set", () => {
@@ -114,6 +118,7 @@ const MockToast = ({ mockAction }: MockToastProps) => {
       onClick: () => {
         showToast({
           message: "Bland Toast",
+          variation: "info",
           actionLabel: "Do The Action",
           action: () => mockAction && mockAction(),
         });
@@ -125,7 +130,6 @@ const MockToast = ({ mockAction }: MockToastProps) => {
         showToast({
           message:
             "Successful Message that should last the full 5 seconds, it just needs to be 50 charachters long",
-          variation: "success",
         });
       },
     },

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -7,7 +7,7 @@ import { Button } from "../Button";
 import { Typography } from "../Typography";
 
 interface BaseToastProps {
-  readonly variation: "info" | "success" | "error";
+  readonly variation?: "info" | "success" | "error";
   readonly message: string;
   readonly id?: number;
 }
@@ -31,7 +31,7 @@ interface Icon {
 
 export function Toast({
   message,
-  variation = "info",
+  variation = "success",
   action,
   actionLabel,
 }: ToastPropsInternal) {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The `Toast` should default the variation prop, which means it should be optional. Success is also the most common type of `Toast` so that should be the default.

## Changes

Makes the `variation` prop of toast optional and default to `success`

### Added

- <!-- new features -->

### Changed

- variation default is now `success`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- makes variation prop optional

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
