### PR TITLE
fix(components): autocomplete: update documentation and disable browser autofill

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.mdx
@@ -125,7 +125,6 @@ An autocomplete can provide section headings to break up the options.
     const options = [
       {
         label: "Ships",
-        heading: true,
         options: [
           { value: 1, label: "Sulaco" },
           { value: 2, label: "Nostromo" },
@@ -137,7 +136,6 @@ An autocomplete can provide section headings to break up the options.
       },
       {
         label: "Planets",
-        heading: true,
         options: [
           { value: 7, label: "Endor" },
           { value: 8, label: "Vulcan" },

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -92,6 +92,7 @@ export function Autocomplete({
   return (
     <div className={styles.autocomplete}>
       <InputText
+        autocomplete={false}
         size={size}
         value={inputText}
         onChange={handleInputChange}

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`it should display headers when headers are passed in 1`] = `
       placeholder_name
     </label>
     <input
+      autoComplete="autocomplete-off"
       className="formField"
       id="123e4567-e89b-12d3-a456-426655440012"
       onBlur={[Function]}
@@ -73,6 +74,7 @@ exports[`renders an Autocomplete 1`] = `
       placeholder_name
     </label>
     <input
+      autoComplete="autocomplete-off"
       className="formField"
       id="123e4567-e89b-12d3-a456-426655440001"
       onBlur={[Function]}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We forgot to remove the `heading` prop from one of the examples. This prop was scrapped during the dev process. We also forgot to disable browser autofill in the autocomplete component itself.

## Changes


### Added


### Changed

Browser autocomplete will be disabled in the autocomplete component.

### Deprecated


### Removed


### Fixed


### Security


## Testing

Read the docs and make sure the browser autocomplete doesn't show up!
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
