### PR TITLE
fix(components): Toast show the right icon

### DIFF
--- a/packages/components/src/Toast/Toast.mdx
+++ b/packages/components/src/Toast/Toast.mdx
@@ -68,7 +68,8 @@ appropriatly when using Toast.
           variation="learning"
           onClick={() =>
             showToast({
-              message: "Toast is just crispy bread"
+              message: "Toast is just crispy bread",
+              variation: "info"
             })
           }
         />

--- a/packages/components/src/Toast/Toast.test.tsx
+++ b/packages/components/src/Toast/Toast.test.tsx
@@ -35,23 +35,25 @@ it("creates the placeholder div on showToast call", () => {
 });
 
 it("renders a Slice of Toast when the 'showToast' method is called", () => {
-  const { getByText, getByTestId } = render(<MockToast />);
-
+  const { getByText } = render(<MockToast />);
   fireEvent.click(getByText("Success"));
   expect(getByText(successMessage)).toBeInstanceOf(HTMLSpanElement);
+});
+
+it("shows a the checkmark icon for success toast", () => {
+  const { getByText, getByTestId } = render(<MockToast />);
+  fireEvent.click(getByText("Success"));
   expect(getByTestId("checkmark")).toBeInstanceOf(SVGElement);
 });
 
-it("renders an info Slice of Toast when the variation: 'info' is set", () => {
+it("renders an knot icon variation: 'info' is set", () => {
   const { getByText, getByTestId } = render(<MockToast />);
-
   fireEvent.click(getByText("No Variation"));
   expect(getByTestId("knot")).toBeInstanceOf(SVGElement);
 });
 
-it("renders a error Slice of Toast when the variation: 'error' is set", () => {
+it("renders an alert icon variation: 'error' is set", () => {
   const { getByText, getByTestId } = render(<MockToast />);
-
   fireEvent.click(getByText("Error"));
   expect(getByTestId("alert")).toBeInstanceOf(SVGElement);
 });

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -113,12 +113,12 @@ export function Toast({
 
   function getIcon(): Icon {
     switch (variation) {
-      case "success":
-        return { name: "checkmark", color: "green" };
+      case "info":
+        return { name: "knot", color: "lightBlue" };
       case "error":
         return { name: "alert", color: "red" };
       default:
-        return { name: "knot", color: "lightBlue" };
+        return { name: "checkmark", color: "green" };
     }
   }
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Toast component was showing the wrong icon for the `info` variation. 

## Changes

Makes Toast show the right icons

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Toast component shows the right icon for variations

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
