### PR TITLE
fix(components): Adds unique ids to radio ids

### DIFF
--- a/packages/components/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import renderer from "react-test-renderer";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { RadioGroup, RadioOption } from ".";
@@ -37,3 +37,32 @@ test("it should call the handler with the new value", () => {
   fireEvent.click(getByText(labelOne));
   expect(handleChange).toHaveBeenCalled();
 });
+
+test("it should have unique ids on all radio options", () => {
+  const { container, getAllByLabelText } = render(<MockRadioGroup />);
+  const labels = getAllByLabelText("Two");
+  const radio1 = container.querySelector(`input#${labels[0].id}`);
+  const radio2 = container.querySelector(`input#${labels[1].id}`);
+  expect(radio1.checked).toBeFalsy();
+  expect(radio2.checked).toBeFalsy();
+  fireEvent.click(labels[1]);
+  expect(radio1.checked).toBeFalsy();
+  expect(radio2.checked).toBeTruthy();
+});
+
+function MockRadioGroup() {
+  const [value, setValue] = useState("One");
+  const [valueTwo, setValueTwo] = useState("One");
+  return (
+    <>
+      <RadioGroup onChange={setValue} value={value}>
+        <RadioOption value="one">One</RadioOption>
+        <RadioOption value="two">Two</RadioOption>
+      </RadioGroup>
+      <RadioGroup onChange={setValueTwo} value={valueTwo}>
+        <RadioOption value="one">One</RadioOption>
+        <RadioOption value="two">Two</RadioOption>
+      </RadioGroup>
+    </>
+  );
+}

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -78,7 +78,7 @@ function InternalRadioOption({
   children,
   onChange,
 }: InternalRadioOptionProps) {
-  const inputId = value.toString();
+  const inputId = `${value.toString()}_${uuid()}`;
   return (
     <div>
       <input

--- a/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders a RadioGroup 1`] = `
     <input
       checked={false}
       className="input"
-      id="foo"
+      id="foo_123e4567-e89b-12d3-a456-426655440001"
       name="Foo"
       onChange={[Function]}
       type="radio"
@@ -16,7 +16,7 @@ exports[`renders a RadioGroup 1`] = `
     />
     <label
       className="label"
-      htmlFor="foo"
+      htmlFor="foo_123e4567-e89b-12d3-a456-426655440001"
     >
       Foo
     </label>
@@ -25,7 +25,7 @@ exports[`renders a RadioGroup 1`] = `
     <input
       checked={true}
       className="input"
-      id="bear"
+      id="bear_123e4567-e89b-12d3-a456-426655440002"
       name="Foo"
       onChange={[Function]}
       type="radio"
@@ -33,7 +33,7 @@ exports[`renders a RadioGroup 1`] = `
     />
     <label
       className="label"
-      htmlFor="bear"
+      htmlFor="bear_123e4567-e89b-12d3-a456-426655440002"
     >
       Bear
     </label>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When using multiple `RadioGroup` components on a page, there would be conflict if two of the `RadioOption` components had matching `value`s. 

This PR will add a `uuid` to the `id` of the `RadioOption` component.

## Changes

Adds unique IDs to the `RadioOption` components.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Add`uuid` to `RadioOption` ID.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
