### PR TITLE
feat(components): Disable RadioOption component

### DIFF
--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -1,12 +1,12 @@
+.radioGroup {
+  display: inline-flex;
+  flex-direction: column;
+}
+
 .input {
   /* Hide checkbox on UI but not screen readers and still allow focus state */
   position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(100%);
-  white-space: nowrap;
+  left: -999em;
 }
 
 .label {
@@ -28,13 +28,20 @@
   transition: all 0.2s;
 }
 
+.input:focus + .label:before {
+  box-shadow: 0 0 1px 0.125rem var(--color-outline);
+}
+
 .input:checked + .label::before {
   border-color: var(--color-green--dark);
   background-color: var(--color-green);
-  transition: all 0.2s;
 }
 
-.radioGroup {
-  display: inline-flex;
-  flex-direction: column;
+.input[disabled] + .label {
+  color: var(--color-blue--lighter);
+}
+
+.input[disabled] + .label::before {
+  border-color: var(--color-grey--light);
+  background-color: var(--color-grey--lighter);
 }

--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -6,7 +6,7 @@
 .input {
   /* Hide checkbox on UI but not screen readers and still allow focus state */
   position: absolute;
-  left: -999em;
+  left: -999vw;
 }
 
 .label {

--- a/packages/components/src/RadioGroup/RadioGroup.css.d.ts
+++ b/packages/components/src/RadioGroup/RadioGroup.css.d.ts
@@ -1,3 +1,3 @@
+export const radioGroup: string;
 export const input: string;
 export const label: string;
-export const radioGroup: string;

--- a/packages/components/src/RadioGroup/RadioGroup.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.mdx
@@ -6,8 +6,9 @@ route: /components/radio-group
 
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
-import { RadioGroup } from ".";
-import { RadioOption } from ".";
+import { RadioGroup, RadioOption } from ".";
+import { Content } from "@jobber/components/Content";
+import { Checkbox } from "@jobber/components/Checkbox";
 import { useState } from "react";
 
 # Radio Group
@@ -50,14 +51,27 @@ option will prevent a user from being able to select the option.
 <Playground>
   {() => {
     const [company, setCompany] = useState("apple");
+    const [checked, setChecked] = useState(true);
     return (
-      <RadioGroup onChange={setCompany} value={company}>
-        <RadioOption value="apple">Apple</RadioOption>
-        <RadioOption value="google">Google</RadioOption>
-        <RadioOption value="microsoft" disabled={true}>
-          Microsoft
-        </RadioOption>
-      </RadioGroup>
+      <Content>
+        <Content spacing="large">
+          <RadioGroup onChange={setCompany} value={company}>
+            <RadioOption value="apple">Apple</RadioOption>
+            <RadioOption value="google">Google</RadioOption>
+            <RadioOption value="microsoft" disabled={!checked}>
+              Microsoft
+            </RadioOption>
+            <RadioOption value="amazon" disabled={true}>
+              Amazon
+            </RadioOption>
+          </RadioGroup>
+        </Content>
+        <Checkbox
+          checked={checked}
+          label="Allow Microsoft"
+          onChange={setChecked}
+        />
+      </Content>
     );
   }}
 </Playground>

--- a/packages/components/src/RadioGroup/RadioGroup.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.mdx
@@ -14,7 +14,8 @@ import { useState } from "react";
 
 <ComponentStatus stage="ready" responsive="yes" accessible="yes" />
 
-RadioGroup will allow users to choose from one of a list of provided options.
+RadioGroup will allow users to choose a single selection from one of a list of
+provided options.
 
 ```ts
 import { RadioGroup } from "@jobber/components/RadioGroup";
@@ -33,6 +34,30 @@ import { RadioGroup } from "@jobber/components/RadioGroup";
   }}
 </Playground>
 
-## Props
+## RadioGroup Props
 
 <Props of={RadioGroup} />
+
+## RadioOption Props
+
+<Props of={RadioOption} />
+
+## Disabled Options
+
+`RadioOptions` can be disabled by passing in the disabled prop. Disabling an
+option will prevent a user from being able to select the option.
+
+<Playground>
+  {() => {
+    const [company, setCompany] = useState("apple");
+    return (
+      <RadioGroup onChange={setCompany} value={company}>
+        <RadioOption value="apple">Apple</RadioOption>
+        <RadioOption value="google">Google</RadioOption>
+        <RadioOption value="microsoft" disabled={true}>
+          Microsoft
+        </RadioOption>
+      </RadioGroup>
+    );
+  }}
+</Playground>

--- a/packages/components/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.test.tsx
@@ -38,6 +38,18 @@ test("it should call the handler with the new value", () => {
   expect(handleChange).toHaveBeenCalled();
 });
 
+test("it should be able to disable options", () => {
+  const handleChange = jest.fn();
+  const { container } = render(
+    <RadioGroup name="Foo" value="foo" onChange={handleChange}>
+      <RadioOption value="foo"></RadioOption>
+      <RadioOption value="bear" disabled={true}></RadioOption>
+    </RadioGroup>,
+  );
+
+  expect(container.querySelector(`[value="bear"]`)).toBeDisabled();
+});
+
 test("it should have unique ids on all radio options", () => {
   const { container, getAllByLabelText } = render(<MockRadioGroup />);
   const labels = getAllByLabelText("Two");

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -57,6 +57,7 @@ export function RadioGroup({
 
 interface RadioOptionProps {
   readonly value: string | number;
+  readonly disabled?: boolean;
   readonly children: ReactNode | ReactNode[];
 }
 

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -39,6 +39,7 @@ export function RadioGroup({
           checked={value === option.props.value}
           value={option.props.value}
           name={name}
+          disabled={option.props.disabled}
           onChange={handleChange}
         >
           {option.props.children}
@@ -66,6 +67,7 @@ export function RadioOption({ children }: RadioOptionProps) {
 interface InternalRadioOptionProps {
   readonly value: string | number;
   readonly name: string;
+  readonly disabled: boolean;
   readonly checked: boolean;
   readonly children: ReactNode | ReactNode[];
   onChange(newValue: string | number): void;
@@ -74,6 +76,7 @@ interface InternalRadioOptionProps {
 function InternalRadioOption({
   value,
   name,
+  disabled,
   checked,
   children,
   onChange,
@@ -86,6 +89,7 @@ function InternalRadioOption({
         type="radio"
         name={name}
         value={value}
+        disabled={disabled}
         checked={checked}
         id={inputId}
         className={styles.input}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When using a `RadioGroup` component there may be options that you do not want the user to be able to select. This PR will allow for disabling `RadioOption`

## Changes

Allows for disabling options in `RadioGroup`

### Added

- `disabled` prop to the `RadioOption` component
- adds focus styling to the `RadioOption` component

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
