### PR TITLE
fix(components): autocomplete: use subdued text for description on menu items

### DIFF
--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -72,7 +72,7 @@ export function Menu({
               <div className={styles.label}>
                 <Text>{option.label}</Text>
                 {option.description !== undefined && (
-                  <Text>{option.description}</Text>
+                  <Text variation="subdued">{option.description}</Text>
                 )}
               </div>
               {option.details !== undefined && (


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The visual hierarchy of the menu items of the autocomplete list is not clear, the idea is to make the description subdued to accomplish this.

## Changes

### Added


### Changed

- Added 'subdued' variation on the description text of menu items

### Deprecated


### Removed


### Fixed


### Security


## Testing


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
