### PR TITLE
feat(components): autocomplete: onEnter Prop For AutoComplete

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -69,6 +69,7 @@ interface AutocompleteProps {
   onEnter?(): void;
 }
 
+// eslint-disable-next-line max-statements
 export function Autocomplete({
   initialOptions = [],
   value,
@@ -84,6 +85,7 @@ export function Autocomplete({
   const [options, setOptions] = useState(initialOptions);
   const [menuVisible, setMenuVisible] = useState(false);
   const [inputText, setInputText] = useState((value && value.label) || "");
+  const [isHighlightingOption, setIsHighlightingOption] = useState(false);
 
   const debouncedSetOptions = useRef(debounce(setOptions, 150)).current;
 
@@ -112,6 +114,7 @@ export function Autocomplete({
         options={options}
         selectedOption={value}
         onOptionSelect={handleMenuChange}
+        setIsHighlightingOption={setIsHighlightingOption}
       />
     </div>
   );
@@ -157,7 +160,7 @@ export function Autocomplete({
   }
 
   function handleEnter() {
-    if (onEnter) {
+    if (onEnter && !isHighlightingOption) {
       onEnter();
     }
   }

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -62,6 +62,11 @@ interface AutocompleteProps {
    * Focus behaviour (clicking on the input text)
    */
   onFocus?(): void;
+
+  /**
+   * Enter keypress behaviour (pressing enter while focusing the autocomplete input field)
+   */
+  onEnter?(): void;
 }
 
 export function Autocomplete({
@@ -74,6 +79,7 @@ export function Autocomplete({
   placeholder,
   onBlur,
   onFocus,
+  onEnter,
 }: AutocompleteProps) {
   const [options, setOptions] = useState(initialOptions);
   const [menuVisible, setMenuVisible] = useState(false);
@@ -99,6 +105,7 @@ export function Autocomplete({
         placeholder={placeholder}
         onFocus={handleInputFocus}
         onBlur={handleInputBlur}
+        onEnter={handleEnter}
       />
       <Menu
         visible={menuVisible}
@@ -146,6 +153,12 @@ export function Autocomplete({
     setMenuVisible(true);
     if (onFocus) {
       onFocus();
+    }
+  }
+
+  function handleEnter() {
+    if (onEnter) {
+      onEnter();
     }
   }
 }

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { Dispatch, useEffect, useState } from "react";
 import classnames from "classnames";
 import useEventListener from "@use-it/event-listener";
 import { AnyOption, Option } from "./Option";
@@ -17,18 +17,22 @@ interface MenuProps {
   readonly options: Option[];
   readonly selectedOption?: Option;
   onOptionSelect(chosenOption: Option): void;
+  setIsHighlightingOption: Dispatch<React.SetStateAction<boolean>>;
 }
 
+// eslint-disable-next-line max-statements
 export function Menu({
   visible,
   options,
   selectedOption,
   onOptionSelect,
+  setIsHighlightingOption,
 }: MenuProps) {
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const optionMenuClass = classnames(styles.options, {
     [styles.visible]: visible,
   });
+  setIsHighlightingOption(isCurrentlyHighlighting());
 
   const detectSeparatorCondition = (option: Option) =>
     option.description || option.details;
@@ -127,6 +131,11 @@ export function Menu({
     return requestedIndex && isGroup(requestedIndex)
       ? direction + direction
       : direction;
+  }
+
+  function isCurrentlyHighlighting() {
+    if (visible && options.length > 0 && options[highlightedIndex]) return true;
+    return false;
   }
 }
 

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -110,6 +110,9 @@ export function Menu({
 
     useOnKeyDown("Enter", (event: KeyboardEvent) => {
       if (!visible) return;
+      if (options.length <= 0) {
+        return;
+      }
       if (isGroup(options[highlightedIndex])) return;
 
       event.preventDefault();

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -14,14 +14,14 @@ exports[`it should display headers when headers are passed in 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440012"
+      htmlFor="123e4567-e89b-12d3-a456-426655440013"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440012"
+      id="123e4567-e89b-12d3-a456-426655440013"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Created new prop for onEnter so that we can define custom behaviour for onEnter, specifically preventing default event behaviour on enter press

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

Added a prop for onEnter

## Testing

- [ ] Spin up a docz server and go to the components, specifically the Autocomplete
- [ ] Add a prop in the playground: `onEnter={() => {alert("Enter has been clicked")}}`
- [ ] Click on the input field of the Autocomplete component and press enter
- [ ] Ensure that an alert pops up, saying "Enter has been clicked"

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
