### PR TITLE
feat(components): modify autocomplete to scroll list up and down

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.css
+++ b/packages/components/src/Autocomplete/Autocomplete.css
@@ -18,6 +18,7 @@
   border: var(--border-base) solid var(--color-grey--lighter);
   border-radius: var(--radius-base);
   overflow: auto;
+  scroll-behavior: smooth;
   background-color: var(--color-white);
 }
 

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -29,7 +29,7 @@ export function Menu({
   const optionMenuClass = classnames(styles.options, {
     [styles.visible]: visible,
   });
-  const menuDiv = useRef<HTMLDivElement>();
+  const menuDiv = useRef() as React.MutableRefObject<HTMLDivElement>;
 
   const detectSeparatorCondition = (option: Option) =>
     option.description || option.details;
@@ -45,12 +45,7 @@ export function Menu({
   useEffect(() => setHighlightedIndex(initialHighlight), [options]);
 
   return (
-    <div
-      className={optionMenuClass}
-      ref={element => {
-        menuDiv.current = element as HTMLDivElement;
-      }}
-    >
+    <div className={optionMenuClass} ref={menuDiv}>
       {options.map((option, index) => {
         const optionClass = classnames(styles.option, {
           [styles.active]: index === highlightedIndex,

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -116,17 +116,16 @@ export function Menu({
       direction: "up" | "down",
     ) {
       const itemDiv = menuDivElement.querySelector(
-        `button.${classnames(styles.option)}:nth-child(${highlightedIndex +
-          1})`,
+        `button.${styles.option}:nth-child(${highlightedIndex + 1})`,
       ) as HTMLButtonElement;
-      if (!itemDiv) {
-        return;
-      }
+      if (!itemDiv) return;
       const menuTop = menuDivElement.getBoundingClientRect().top;
-      const itemTop = itemDiv.getBoundingClientRect().top;
-      const itemHeight = itemDiv.getBoundingClientRect().height;
-      const itemTrueBottom =
-        itemDiv.getBoundingClientRect().bottom + itemHeight;
+      const {
+        top: itemTop,
+        height: itemHeight,
+        bottom: itemBottom,
+      } = itemDiv.getBoundingClientRect();
+      const itemTrueBottom = itemBottom + itemHeight;
       const menuBottom = menuDivElement.getBoundingClientRect().bottom;
       if (direction == "up" && itemTop - itemHeight < menuTop) {
         menuDivElement.scrollTop -= itemHeight;

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -51,10 +51,8 @@ export function Menu({
       className={optionMenuClass}
       style={{ scrollBehavior: "smooth" }}
       ref={ref => {
-        if (!menuDiv.current) {
-          const stuff = ref as HTMLDivElement;
-          menuDiv.current = stuff;
-        }
+        const newMenuDiv = ref as HTMLDivElement;
+        menuDiv.current = newMenuDiv;
         return menuDiv.current;
       }}
     >
@@ -79,10 +77,8 @@ export function Menu({
             <div
               className={styles.icon}
               ref={ref => {
-                if (!menuItemRefs.current[index]) {
-                  const newMenuRef = ref as HTMLDivElement;
-                  menuItemRefs.current[index] = newMenuRef;
-                }
+                const newMenuRef = ref as HTMLDivElement;
+                menuItemRefs.current[index] = newMenuRef;
                 return menuItemRefs.current[index];
               }}
             >

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -120,10 +120,10 @@ export function Menu({
       menuDivElement: HTMLDivElement,
       direction: "up" | "down",
     ) {
-      const itemDiv = menuDivElement.querySelectorAll(
+      const itemDiv = menuDivElement.querySelector(
         `button.${classnames(styles.option)}:nth-child(${highlightedIndex +
           1})`,
-      )[0] as HTMLButtonElement;
+      ) as HTMLButtonElement;
       if (!itemDiv) {
         return;
       }

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -49,6 +49,7 @@ export function Menu({
   return (
     <div
       className={optionMenuClass}
+      style={{ scrollBehavior: "smooth" }}
       ref={ref => {
         if (!menuDiv.current) {
           const stuff = ref as HTMLDivElement;

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -49,7 +49,6 @@ export function Menu({
   return (
     <div
       className={optionMenuClass}
-      style={{ scrollBehavior: "smooth" }}
       ref={element => {
         setRef(element, menuDiv);
       }}

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -118,19 +118,20 @@ export function Menu({
 
     function scrollMenuIfItemNotInView(
       menuDivElement: HTMLDivElement,
-      direction: string,
+      direction: "up" | "down",
     ) {
-      const tempDiv = menuDivElement.getElementsByClassName(
-        classnames(styles.option),
-      )[highlightedIndex] as HTMLButtonElement;
-      if (!tempDiv) {
+      const itemDiv = menuDivElement.querySelectorAll(
+        `button.${classnames(styles.option)}:nth-child(${highlightedIndex +
+          1})`,
+      )[0] as HTMLButtonElement;
+      if (!itemDiv) {
         return;
       }
       const menuTop = menuDivElement.getBoundingClientRect().top;
-      const itemTop = tempDiv.getBoundingClientRect().top;
-      const itemHeight = tempDiv.getBoundingClientRect().height;
+      const itemTop = itemDiv.getBoundingClientRect().top;
+      const itemHeight = itemDiv.getBoundingClientRect().height;
       const itemTrueBottom =
-        tempDiv.getBoundingClientRect().bottom + itemHeight;
+        itemDiv.getBoundingClientRect().bottom + itemHeight;
       const menuBottom = menuDivElement.getBoundingClientRect().bottom;
       if (direction == "up" && itemTop - itemHeight < menuTop) {
         menuDivElement.scrollTop -= itemHeight;

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -50,10 +50,8 @@ export function Menu({
     <div
       className={optionMenuClass}
       style={{ scrollBehavior: "smooth" }}
-      ref={ref => {
-        const newMenuDiv = ref as HTMLDivElement;
-        menuDiv.current = newMenuDiv;
-        return menuDiv.current;
+      ref={element => {
+        setRef(element, menuDiv);
       }}
     >
       {options.map((option, index) => {
@@ -76,10 +74,8 @@ export function Menu({
           >
             <div
               className={styles.icon}
-              ref={ref => {
-                const newMenuRef = ref as HTMLDivElement;
-                menuItemRefs.current[index] = newMenuRef;
-                return menuItemRefs.current[index];
+              ref={element => {
+                setRef(element, undefined, menuItemRefs, index);
               }}
             >
               {isOptionSelected(option) && (
@@ -104,6 +100,24 @@ export function Menu({
       })}
     </div>
   );
+
+  function setRef(
+    element: HTMLDivElement | null,
+    ref: React.MutableRefObject<HTMLDivElement | undefined> | undefined,
+    refArray?: React.MutableRefObject<HTMLDivElement[]>,
+    index?: number,
+  ) {
+    const newElement = element as HTMLDivElement;
+    if (index && refArray) {
+      refArray.current[index] = newElement;
+      return refArray.current[index];
+    } else if (ref) {
+      ref.current = newElement;
+      return ref.current;
+    } else {
+      return undefined;
+    }
+  }
 
   function isOptionSelected(option: Option) {
     return selectedOption && selectedOption.value === option.value;

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -19,7 +19,6 @@ interface MenuProps {
   onOptionSelect(chosenOption: Option): void;
 }
 
-// eslint-disable-next-line max-statements
 export function Menu({
   visible,
   options,
@@ -30,7 +29,6 @@ export function Menu({
   const optionMenuClass = classnames(styles.options, {
     [styles.visible]: visible,
   });
-  const menuItemRefs = useRef<HTMLDivElement[]>([]);
   const menuDiv = useRef<HTMLDivElement>();
 
   const detectSeparatorCondition = (option: Option) =>
@@ -50,7 +48,7 @@ export function Menu({
     <div
       className={optionMenuClass}
       ref={element => {
-        setRef(element, menuDiv);
+        menuDiv.current = element as HTMLDivElement;
       }}
     >
       {options.map((option, index) => {
@@ -71,13 +69,8 @@ export function Menu({
             key={option.value}
             onMouseDown={onOptionSelect.bind(undefined, option)}
           >
-            <div
-              className={styles.icon}
-              ref={element => {
-                setRef(element, undefined, menuItemRefs, index);
-              }}
-            >
-              {isOptionSelected(option) && (
+            <div className={styles.icon}>
+              {isOptionSelected(selectedOption, option) && (
                 <Icon name="checkmark" size="small" />
               )}
             </div>
@@ -100,28 +93,6 @@ export function Menu({
     </div>
   );
 
-  function setRef(
-    element: HTMLDivElement | null,
-    ref: React.MutableRefObject<HTMLDivElement | undefined> | undefined,
-    refArray?: React.MutableRefObject<HTMLDivElement[]>,
-    index?: number,
-  ) {
-    const newElement = element as HTMLDivElement;
-    if (index && refArray) {
-      refArray.current[index] = newElement;
-      return refArray.current[index];
-    } else if (ref) {
-      ref.current = newElement;
-      return ref.current;
-    } else {
-      return undefined;
-    }
-  }
-
-  function isOptionSelected(option: Option) {
-    return selectedOption && selectedOption.value === option.value;
-  }
-
   function setupKeyListeners() {
     useOnKeyDown("ArrowDown", (event: KeyboardEvent) => {
       const indexChange = arrowKeyPress(event, IndexChange.Next);
@@ -130,50 +101,41 @@ export function Menu({
           Math.min(options.length - 1, highlightedIndex + indexChange),
         );
       }
-      if (menuDiv.current && menuItemRefs.current[highlightedIndex]) {
-        scrollDownIfTooLow(
-          menuDiv.current,
-          menuItemRefs.current[highlightedIndex],
-        );
+      if (menuDiv.current) {
+        scrollMenuIfItemNotInView(menuDiv.current, "down");
       }
     });
-
-    function scrollDownIfTooLow(
-      menuDivElement: HTMLDivElement,
-      itemDivElement: HTMLDivElement,
-    ) {
-      const tempDiv = itemDivElement.parentElement as HTMLDivElement;
-      const itemHeight = tempDiv.getBoundingClientRect().height;
-      const itemTrueBottom =
-        tempDiv.getBoundingClientRect().bottom + itemHeight;
-      if (itemTrueBottom > menuDivElement.getBoundingClientRect().bottom) {
-        menuDivElement.scrollTop += itemHeight;
-      }
-    }
 
     useOnKeyDown("ArrowUp", (event: KeyboardEvent) => {
       const indexChange = arrowKeyPress(event, IndexChange.Previous);
       if (indexChange) {
         setHighlightedIndex(Math.max(0, highlightedIndex + indexChange));
       }
-      if (menuDiv.current && menuItemRefs.current[highlightedIndex]) {
-        scrollUpIfTooHigh(
-          menuDiv.current,
-          menuItemRefs.current[highlightedIndex],
-        );
+      if (menuDiv.current) {
+        scrollMenuIfItemNotInView(menuDiv.current, "up");
       }
     });
 
-    function scrollUpIfTooHigh(
+    function scrollMenuIfItemNotInView(
       menuDivElement: HTMLDivElement,
-      itemDivElement: HTMLDivElement,
+      direction: string,
     ) {
-      const tempDiv = itemDivElement.parentElement as HTMLDivElement;
+      const tempDiv = menuDivElement.getElementsByClassName(
+        classnames(styles.option),
+      )[highlightedIndex] as HTMLButtonElement;
+      if (!tempDiv) {
+        return;
+      }
       const menuTop = menuDivElement.getBoundingClientRect().top;
       const itemTop = tempDiv.getBoundingClientRect().top;
       const itemHeight = tempDiv.getBoundingClientRect().height;
-      if (itemTop - itemHeight < menuTop) {
+      const itemTrueBottom =
+        tempDiv.getBoundingClientRect().bottom + itemHeight;
+      const menuBottom = menuDivElement.getBoundingClientRect().bottom;
+      if (direction == "up" && itemTop - itemHeight < menuTop) {
         menuDivElement.scrollTop -= itemHeight;
+      } else if (direction == "down" && itemTrueBottom > menuBottom) {
+        menuDivElement.scrollTop += itemHeight;
       }
     }
 
@@ -194,6 +156,10 @@ export function Menu({
       ? direction + direction
       : direction;
   }
+}
+
+function isOptionSelected(selectedOption: Option | undefined, option: Option) {
+  return selectedOption && selectedOption.value === option.value;
 }
 
 // Split this out into a hooks package.

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -32,11 +32,6 @@ exports[`it should display headers when headers are passed in 1`] = `
   </div>
   <div
     className="options"
-    style={
-      Object {
-        "scrollBehavior": "smooth",
-      }
-    }
   >
     <div
       className="heading"
@@ -92,11 +87,6 @@ exports[`renders an Autocomplete 1`] = `
   </div>
   <div
     className="options"
-    style={
-      Object {
-        "scrollBehavior": "smooth",
-      }
-    }
   >
     <button
       className="option active"

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -32,6 +32,11 @@ exports[`it should display headers when headers are passed in 1`] = `
   </div>
   <div
     className="options"
+    style={
+      Object {
+        "scrollBehavior": "smooth",
+      }
+    }
   >
     <div
       className="heading"
@@ -87,6 +92,11 @@ exports[`renders an Autocomplete 1`] = `
   </div>
   <div
     className="options"
+    style={
+      Object {
+        "scrollBehavior": "smooth",
+      }
+    }
   >
     <button
       className="option active"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Autocomplete highlighting behaviour must be changed as highlighted option falls out of view when scrolling too far down or too far up

### Changed

- When list item falls out of view on menu list, the list will scroll to keep that item in view
![autocomplete-scrolling](https://user-images.githubusercontent.com/34727471/93142564-220f1900-f69b-11ea-90c7-bfbcafebdf8b.gif)


## Testing

- [ ] change the `options` in the mdx file for `Autocomplete` to include a bunch of options with labels that start with the same letter
- [ ] In the autocomplete playground, type in that first letter that most of your options begin with
- [ ] Start scrolling down with the arrow keys
- [ ] When you get to the bottom of the list and keep going, ensure that the list scrolls so that the highlighted item never falls out of view
- [ ] Ensure the same for scrolling up

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
