### PR TITLE
 fix(components): fix a border issue on card accent

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -33,7 +33,15 @@
 }
 
 .accent {
+  border-top-width: 0;
+}
+
+.accent::before {
+  content: " ";
+  display: block;
+  margin: 0 calc(-1 * var(--border-base));
   border-top: 0.5rem solid var(--card--accent-color);
+  border-radius: var(--radius-base) var(--radius-base) 0 0;
 }
 
 .clickable {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The current card component has a minor visual issue with the accent. Because the accent and the standard card border are using the same border it creates a visual artifact where the accent angles into the standard border.

I tried exploring the below ideas:
- [x] See if there is a [CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/border) for managing border corners. (There isn't aside from border radius.)
- [x] Try using the CSS `outline` property for the accent. (The outline property can't be used for a single edge)
- [x] Try using the CSS `box-shadow` property. (I can't figure out how to use it for just one edge)
- [x] Try using a `::before` pseudo element. (Works!)


### Fixed

The accent border angles into the side border (3x zoom image).

![image](https://user-images.githubusercontent.com/1479091/93147875-a7042d80-f6af-11ea-9e17-3abda7d90697.png)

I'm using a `::before` pseudo selector to put the border on top of the card and have a clean straight line.

![image](https://user-images.githubusercontent.com/1479091/93147674-1a596f80-f6af-11ea-9c89-432c948542f1.png)
