### PR TITLE
feat(components): Add className param to LightBox

### DIFF
--- a/packages/components/src/LightBox/LightBox.tsx
+++ b/packages/components/src/LightBox/LightBox.tsx
@@ -30,6 +30,10 @@ interface LightBoxProps {
    */
   readonly imageIndex?: number;
   /**
+   * Insert class to the component.
+   */
+  readonly className?: string;
+  /**
    * This function must set open to false in order to close the lightbox. Note there
    * is a 300ms easing animation on lightbox close that occurs before this function
    * is called.
@@ -41,6 +45,7 @@ export function LightBox({
   open,
   images,
   imageIndex = 0,
+  className = "",
   onRequestClose,
 }: LightBoxProps) {
   const [currentImageIndex, setCurrentImageIndex] = useState(imageIndex);
@@ -60,7 +65,7 @@ export function LightBox({
     <>
       {open && (
         <ExternalLightBox
-          wrapperClassName={styles.wrapper}
+          wrapperClassName={`${styles.wrapper} ${className}`}
           mainSrc={images[currentImageIndex].url}
           enableZoom={false}
           nextSrc={nextSrc}

--- a/packages/components/src/LightBox/__snapshots__/LightBoxSnapshots.test.tsx.snap
+++ b/packages/components/src/LightBox/__snapshots__/LightBoxSnapshots.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Images renders an image 1`] = `
     tabIndex="-1"
   >
     <div
-      className="ril-outer ril__outer ril__outerAnimating wrapper "
+      className="ril-outer ril__outer ril__outerAnimating wrapper  "
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       onMouseDown={[Function]}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
 - Chat panel is picking up the click which closes the LightBox, which means one click will close both Light.  Adding `click_ignore` would escape the click.

### Added

 - Added new optional param `className` in LightBox.

## Testing

<!-- How to test your changes. -->
 - Tested in playground.  Checked class added in `className` showed up in debugger.
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
