### PR TITLE
fix(components): Allow the form to not be a form but be a div instead

### DIFF
--- a/packages/components/src/Form/Form.test.tsx
+++ b/packages/components/src/Form/Form.test.tsx
@@ -108,6 +108,16 @@ test("updates state with useFormState to proper state", async () => {
   });
 });
 
+test("wraps the form in a form tag when the onSubmit is set", () => {
+  const { getByTestId } = render(<Form onSubmit={jest.fn()}>Foo</Form>);
+  expect(getByTestId("atlantis-form")).toBeInstanceOf(HTMLFormElement);
+});
+
+test("wraps the form in a div tag when the onSubmit is not set", () => {
+  const { getByTestId } = render(<Form>Foo</Form>);
+  expect(getByTestId("atlantis-form")).toBeInstanceOf(HTMLDivElement);
+});
+
 interface MockFormProps {
   onSubmit(): void;
   onStateChange?(): void;

--- a/packages/components/src/Form/Form.tsx
+++ b/packages/components/src/Form/Form.tsx
@@ -24,9 +24,22 @@ export function Form({ onSubmit, children, onStateChange }: FormProps) {
     isValid,
   ]);
 
+  /**
+   * If an onSubmit is not passed into a form, it will only be used
+   * for validation. For that, we do not need to wrap it in a <form>
+   * tag. This allows the <Form> component to be used in legacy code.
+   */
+  const Wrapper = onSubmit ? "form" : "div";
+
+  const formProps = {
+    onSubmit: onSubmit && handleSubmit(submitHandler),
+  };
+
   return (
     <FormProvider {...methods}>
-      <form onSubmit={handleSubmit(submitHandler)}>{children}</form>
+      <Wrapper {...formProps} data-testid="atlantis-form">
+        {children}
+      </Wrapper>
     </FormProvider>
   );
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

Allows the `<Form>` component to render as a `div` if no `onSubmit` was passed in.

### Added

- <!-- new features -->

### Changed

- Renders the `<Form>` component to as a `div` if no `onSubmit` was passed in.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
