### PR TITLE
docs(components): add related components section to ConfirmationModal

### DIFF
--- a/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
@@ -107,9 +107,10 @@ that presents a confirm modal.
     );
   }}
 </Playground>
-  
+
 ## Related components
-  
-* To present non-blocking, contextual, text-only content, use a [Tooltip](tooltip). 
-* To simply present information for users to view, edit, or for a temporary change of context, use a regular [Modal](modal).
-  
+
+- To present non-blocking, contextual, text-only content, use a
+  [Tooltip](tooltip).
+- To simply present information for users to view, edit, or for a temporary
+  change of context, use a regular [Modal](modal).

--- a/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
@@ -107,3 +107,9 @@ that presents a confirm modal.
     );
   }}
 </Playground>
+  
+  ## Related components
+  
+  * To present non-blocking, contextual, text-only content, use a [Tooltip](tooltip). 
+  * To simply present information for users to view, edit, or for a temporary change of context, use a regular [Modal](modal).
+  

--- a/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
@@ -108,8 +108,8 @@ that presents a confirm modal.
   }}
 </Playground>
   
-  ## Related components
+## Related components
   
-  * To present non-blocking, contextual, text-only content, use a [Tooltip](tooltip). 
-  * To simply present information for users to view, edit, or for a temporary change of context, use a regular [Modal](modal).
+* To present non-blocking, contextual, text-only content, use a [Tooltip](tooltip). 
+* To simply present information for users to view, edit, or for a temporary change of context, use a regular [Modal](modal).
   


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

related components section to ConfirmationModal docs

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
