### PR TITLE
docs(components): add related components section to DescriptionList

### DIFF
--- a/packages/components/src/DescriptionList/DescriptionList.mdx
+++ b/packages/components/src/DescriptionList/DescriptionList.mdx
@@ -49,8 +49,6 @@ You are able to pass a react element in as the second term of the data tuple.
   />
 </Playground>
 
----
-
 ## Related components
 
 * To list more complex collections of related information, consider using a

--- a/packages/components/src/DescriptionList/DescriptionList.mdx
+++ b/packages/components/src/DescriptionList/DescriptionList.mdx
@@ -34,11 +34,6 @@ The Description List is a great solution when you have a small list of
 information with a 1:1 label-to-data relationship. For example, the issued and
 due dates on an invoice, or the job type, billing type and duration of a job.
 
-To list more complex collections of information, you may want to consider the
-[List](https://atlantis.getjobber.com/components/list) component. If you want to
-allow the user to compare data across items, consider using
-[Table](https://atlantis.getjobber.com/components/table).
-
 ---
 
 ## Passing an Element
@@ -53,3 +48,12 @@ You are able to pass a react element in as the second term of the data tuple.
     ]}
   />
 </Playground>
+
+---
+
+## Related components
+
+* To list more complex collections of related information, consider using a
+[List](https://atlantis.getjobber.com/components/list).
+* To display structured data for comparison, consider using a
+[Table](https://atlantis.getjobber.com/components/table).


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

Moved and tweaked some text from design usage and guidelines to related components section

### Added

Added related components section to DescriptionList docs

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
