### PR TITLE
fix(design): embiggen the small Icons

### DIFF
--- a/packages/design/src/icons/Sizes.css
+++ b/packages/design/src/icons/Sizes.css
@@ -1,6 +1,6 @@
 .small {
-  width: calc(var(--base-unit) * 0.875);
-  height: calc(var(--base-unit) * 0.875);
+  width: var(--base-unit);
+  height: var(--base-unit);
 }
 
 .base {


### PR DESCRIPTION
## Motivations

Small Icons were too small (14px)! Now they are just right! (16px)
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Small Icons now render as 16x16px (base-size) instead of 14x14px.

## Testing

This needs to be visually tested in web and mobile, as this package is used by both.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
