### PR TITLE
fix(components): Autocomplete debounce for getOptions

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.mdx
@@ -342,4 +342,5 @@ using either promises or `await` in `getOptions`.
 
 - If you want to present a list of predefined options without text input, use a
   [Select](select) instead.
-- If no suggests are required for the text input, use [InputText](input-text).
+- If autocompleted results are not required for the text input, use
+  [InputText](input-text) instead.

--- a/packages/components/src/Autocomplete/Autocomplete.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.mdx
@@ -46,16 +46,12 @@ import { Autocomplete } from "@jobber/components/Autocomplete";
       />
     );
     function getOptions(text) {
-      alert('hello')
-
       if (text === "") {
         return options;
       }
-
       const filterRegex = new RegExp(text, "i");
       return options.filter(option => option.label.match(filterRegex));
     }
-
 }}
 
 </Playground>

--- a/packages/components/src/Autocomplete/Autocomplete.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.mdx
@@ -46,13 +46,18 @@ import { Autocomplete } from "@jobber/components/Autocomplete";
       />
     );
     function getOptions(text) {
+      alert('hello')
+
       if (text === "") {
         return options;
       }
+
       const filterRegex = new RegExp(text, "i");
       return options.filter(option => option.label.match(filterRegex));
     }
-  }}
+
+}}
+
 </Playground>
 
 ## Props
@@ -338,6 +343,7 @@ using either promises or `await` in `getOptions`.
 </Playground>
 
 ## Related components
-* If you want to present a list of predefined options without text input, use a [Select](select)
-instead. 
-* If no suggests are required for the text input, use [InputText](input-text).
+
+- If you want to present a list of predefined options without text input, use a
+  [Select](select) instead.
+- If no suggests are required for the text input, use [InputText](input-text).

--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { AnyOption, Autocomplete } from ".";
 
 afterEach(cleanup);
@@ -76,12 +76,12 @@ test("it should call the getOptions handler with the new value", async () => {
       placeholder={placeholder}
     />,
   );
-  await act(() => {
+  await waitFor(() => {
     fireEvent.change(getByLabelText(placeholder), {
       target: { value: newValue },
     });
+    expect(changeOptionsHandler).toHaveBeenCalledWith(newValue);
   });
-  expect(changeOptionsHandler).toHaveBeenCalledWith(newValue);
 });
 
 test("it should call the handler when an option is selected", () => {

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -129,7 +129,7 @@ export function Autocomplete({
 
   function updateInput(newText: string) {
     setInputText(newText);
-    if (!newText) {
+    if (newText === "") {
       setOptions(mapToOptions(initialOptions));
     }
   }

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -71,6 +71,10 @@ interface AutocompleteProps {
   onFocus?(): void;
 }
 
+/**
+ * Max statements disabled here to make room for the
+ * debounce functions.
+ */
 // eslint-disable-next-line max-statements
 export function Autocomplete({
   initialOptions = [],

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -87,7 +87,7 @@ export function Autocomplete({
   const [menuVisible, setMenuVisible] = useState(false);
   const [inputText, setInputText] = useState((value && value.label) || "");
 
-  const debouncedSetOptions = useRef(debounce(setOptions, debounceRate))
+  const debouncedGetOptions = useRef(debounce(getOptions, debounceRate))
     .current;
 
   useEffect(() => {
@@ -121,7 +121,7 @@ export function Autocomplete({
   async function updateInput(newText: string) {
     setInputText(newText);
     if (newText) {
-      debouncedSetOptions(mapToOptions(await getOptions(newText)));
+      setOptions(mapToOptions(debouncedGetOptions(newText)));
     } else {
       setOptions(mapToOptions(initialOptions));
     }

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import debounce from "lodash/debounce";
 import { XOR } from "ts-xor";
 import styles from "./Autocomplete.css";
@@ -71,6 +71,7 @@ interface AutocompleteProps {
   onFocus?(): void;
 }
 
+// eslint-disable-next-line max-statements
 export function Autocomplete({
   initialOptions = [],
   value,
@@ -87,8 +88,12 @@ export function Autocomplete({
   const [menuVisible, setMenuVisible] = useState(false);
   const [inputText, setInputText] = useState((value && value.label) || "");
 
-  const debouncedGetOptions = useRef(debounce(getOptions, debounceRate))
-    .current;
+  const delayedSearch = debounce(updateSearch, debounceRate);
+
+  useEffect(() => {
+    delayedSearch();
+    return delayedSearch.cancel;
+  }, [inputText]);
 
   useEffect(() => {
     if (value) {
@@ -118,13 +123,16 @@ export function Autocomplete({
     </div>
   );
 
-  async function updateInput(newText: string) {
+  function updateInput(newText: string) {
     setInputText(newText);
-    if (newText) {
-      setOptions(mapToOptions(debouncedGetOptions(newText)));
-    } else {
+    if (!newText) {
       setOptions(mapToOptions(initialOptions));
     }
+  }
+
+  async function updateSearch() {
+    const opts = await getOptions(inputText);
+    setOptions(mapToOptions(opts));
   }
 
   function handleMenuChange(chosenOption: Option) {

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -14,14 +14,14 @@ exports[`it should display headers when headers are passed in 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440012"
+      htmlFor="123e4567-e89b-12d3-a456-426655440014"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440012"
+      id="123e4567-e89b-12d3-a456-426655440014"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Autocomplete was incorrectly debouncing setOptions instead of getOptions

## Changes

Adds a debounce to `getOptions` prop of the `AutoComplete` component

### Added

- debounce to `getOptions` prop of the `AutoComplete` component

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- debounce on getOptions

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
