### PR TITLE
feat(components): Autocomplete now filters out headers with no options

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -52,7 +52,7 @@ interface AutocompleteProps {
 
   /**
    * Called as the user types in the input. The autocomplete will display what
-   * is retuned from this method to the user as available options.
+   * is returned from this method to the user as available options.
    * @param newInputText
    */
   getOptions(
@@ -135,8 +135,11 @@ export function Autocomplete({
   }
 
   async function updateSearch() {
-    const opts = await getOptions(inputText);
-    setOptions(mapToOptions(opts));
+    const opts: AnyOption[] = await getOptions(inputText);
+    const filteredOpts = opts.filter((o: AnyOption) =>
+      "options" in o && o.options ? o.options.length > 0 : true,
+    );
+    setOptions(mapToOptions(filteredOpts));
   }
 
   function handleMenuChange(chosenOption: Option) {

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -135,11 +135,11 @@ export function Autocomplete({
   }
 
   async function updateSearch() {
-    const opts: AnyOption[] = await getOptions(inputText);
-    const filteredOpts = opts.filter((o: AnyOption) =>
-      "options" in o && o.options ? o.options.length > 0 : true,
+    const updatedOptions: AnyOption[] = await getOptions(inputText);
+    const filteredOptions = updatedOptions.filter((option: AnyOption) =>
+      "options" in option && option.options ? option.options.length > 0 : true,
     );
-    setOptions(mapToOptions(filteredOpts));
+    setOptions(mapToOptions(filteredOptions));
   }
 
   function handleMenuChange(chosenOption: Option) {


### PR DESCRIPTION
## Motivations

Solves issue https://github.com/GetJobber/atlantis/issues/379

## Changes

Added options filtering to updateSearch function (not sure if it should also run on the initial array -- should it?)

### Changed

Autocomplete.updateSearch

### Fixed

fixed typo in a comment

## Testing

type in "Be" in filter at /components/autocomplete#section-headings of docz

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
