### PR TITLE
fix(components): Make modal focus when opened

### DIFF
--- a/packages/components/src/ConfirmationModal/tests/__snapshots__/snapshot-ConfirmationModal.test.tsx.snap
+++ b/packages/components/src/ConfirmationModal/tests/__snapshots__/snapshot-ConfirmationModal.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`renders a simple ConfirmationModal 1`] = `
 <div
   className="container"
+  tabIndex={0}
 >
   <div
     className="overlay"

--- a/packages/components/src/Modal/Modal.test.tsx
+++ b/packages/components/src/Modal/Modal.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { Modal } from ".";
+import styles from "./Modal.css";
 
 afterEach(cleanup);
 
@@ -72,4 +73,23 @@ test("modal fires onRequestClose when pressing the escape key", () => {
 
   fireEvent.keyDown(getByLabelText("Close modal"), { key: "Escape", code: 27 });
   expect(handleClose).toHaveBeenCalledTimes(1);
+});
+
+test("modal gets focused once it opens", () => {
+  const title = "Dis be a title";
+  const content = "Dis be a content 🎉";
+  const handleClose = jest.fn();
+
+  const { baseElement } = render(
+    <>
+      <h1>Some Page</h1>
+      <Modal title={title} open={true} onRequestClose={handleClose}>
+        {content}
+      </Modal>
+      <p>There is some content here.</p>
+    </>,
+  );
+
+  const containerEl = baseElement.querySelector(`.${styles.container}`);
+  expect(containerEl).toHaveFocus();
 });

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect } from "react";
+import React, { ReactNode, RefObject, useEffect, useRef } from "react";
 import ReactDOM from "react-dom";
 import classnames from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
@@ -38,15 +38,22 @@ export function Modal({
   onRequestClose,
 }: ModalProps) {
   const modalClassName = classnames(styles.modal, size && sizes[size]);
+  const modalContainer: RefObject<HTMLDivElement> = useRef(
+    document.createElement("div"),
+  );
 
-  if (open && onRequestClose) {
-    catchKeyboardEvent("Escape", onRequestClose);
-  }
+  useEffect(() => {
+    if (open && modalContainer.current) {
+      modalContainer.current.focus();
+    }
+  });
+
+  catchKeyboardEvent("Escape", open, onRequestClose);
 
   const template = (
     <AnimatePresence>
       {open && (
-        <div className={styles.container}>
+        <div ref={modalContainer} className={styles.container} tabIndex={0}>
           <motion.div
             key={styles.overlay}
             className={styles.overlay}
@@ -90,10 +97,14 @@ export function Modal({
   return ReactDOM.createPortal(template, document.body);
 }
 
-function catchKeyboardEvent(key: string, callback: { (): void }) {
+function catchKeyboardEvent(
+  key: string,
+  isModalOpen: boolean,
+  callback?: { (): void },
+) {
   useEffect(() => {
     const handler = (event: { key: string }) => {
-      if (event.key === key) {
+      if (isModalOpen && callback && event.key === key) {
         callback();
       }
     };

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -42,12 +42,7 @@ export function Modal({
     document.createElement("div"),
   );
 
-  useEffect(() => {
-    if (open && modalContainer.current) {
-      modalContainer.current.focus();
-    }
-  });
-
+  setFocusOnModalOpen(open, modalContainer);
   catchKeyboardEvent("Escape", open, onRequestClose);
 
   const template = (
@@ -97,6 +92,17 @@ export function Modal({
   return ReactDOM.createPortal(template, document.body);
 }
 
+function setFocusOnModalOpen(
+  isModalOpen: boolean,
+  elementRef: RefObject<HTMLDivElement>,
+) {
+  useEffect(() => {
+    if (isModalOpen && elementRef.current) {
+      elementRef.current.focus();
+    }
+  });
+}
+
 function catchKeyboardEvent(
   key: string,
   isModalOpen: boolean,
@@ -114,7 +120,7 @@ function catchKeyboardEvent(
     return () => {
       window.removeEventListener("keydown", handler);
     };
-  }, []);
+  });
 }
 
 interface HeaderProps {

--- a/packages/components/src/Modal/__snapshots__/ModalSnapshots.test.tsx.snap
+++ b/packages/components/src/Modal/__snapshots__/ModalSnapshots.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Button Variations modal shows with primary learning button 1`] = `
 <div
   className="container"
+  tabIndex={0}
 >
   <div
     className="overlay"


### PR DESCRIPTION
## Motivations

Improve component behaviour and contribute to hacktoberfest by providing a fix for https://github.com/GetJobber/atlantis/issues/385

### Fixed

- Fix focus on modal content on mount

### Security

- fixed React vulnerability by making conditional for `catchKeyboardEvent` hook part of the hook itself 

This follows the [Only Call Hooks on Top Level](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level) rule as stated by the React docs.

### Testing

- added unit test for checking focus on open modal
- manual test: open modal in playground (`yarn start` --> http://localhost:3333/components/modal) and press tab key


### Misc

- Please don't forget to add "hacktoberfest" and / or "hacktoberfest-accepted" labels to this pull request to enable [verification](https://hacktoberfest.digitalocean.com/faq). Thank you :) 
