### PR TITLE
feat(hooks): Add useOnKeyDown hook

### DIFF
--- a/packages/hooks/package-lock.json
+++ b/packages/hooks/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@use-it/event-listener": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.5.tgz",
+      "integrity": "sha512-SWbhB0iFcoNL1BEldApGTqfB9aoGpU82iZUVTBtZaTFNrVKAGwuQTF15N9MzRvTgyuOASWf1pCKXbdVtKZgeRg=="
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -13,6 +18,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
+    "ts-xor": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/ts-xor/-/ts-xor-1.0.8.tgz",
+      "integrity": "sha512-0u70/SDLSCaX23UddnwAb2GvZZ2N0Rbjnmemn5pHoR40D32Xcva5KRGWV9SdJOKHCjJUlmctmCTvT0z+2yT8aw=="
     },
     "typescript": {
       "version": "3.8.3",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -16,8 +16,10 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@use-it/event-listener": "^0.1.5",
     "lodash": "^4.17.15",
     "resize-observer-polyfill": "^1.5.1",
+    "ts-xor": "^1.0.8",
     "use-resize-observer": "^6.1.0"
   },
   "peerDependencies": {

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./useResizeObserver";
 export * from "./useFormState";
+export * from "./useOnKeyDown";

--- a/packages/hooks/src/useOnKeyDown/index.ts
+++ b/packages/hooks/src/useOnKeyDown/index.ts
@@ -1,0 +1,1 @@
+export { useOnKeyDown } from "./useOnKeyDown";

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.mdx
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.mdx
@@ -26,7 +26,7 @@ import { useOnKeyDown } from "@jobber/hooks";
     const letterText2 = "Space Enter and Shift + Escape will show here";
     const [ text, setText ] = useState(letterText);
     const [ textTwo, setTextTwo ] = useState(letterText2);
-    useOnKeyDown(() => setText("Deleted. Press Shift + z for undo."), "Delete");
+    useOnKeyDown(() => setText("Deleted. Press Control + z for undo."), "Delete");
     useOnKeyDown(() => setText(letterText), {key: "z", ctrlKey: true});
     useOnKeyDown((e) => {
         if(e.shiftKey) setTextTwo("You pressed Shift and "+e.key);

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.mdx
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.mdx
@@ -1,0 +1,36 @@
+---
+name: useOnKeyDown
+menu: Hooks
+route: /hooks/use-on-key-down
+---
+
+import { Playground } from "docz";
+import { useState } from "react";
+import { useOnKeyDown } from "./useOnKeyDown";
+import { Text } from "@jobber/components/Text";
+
+# UseOnKeyDown
+
+`useOnKeyDown` is an extremly simple hook that can be for adding the keydown event handler when the component is mounted and remove them when it unmount.
+
+`useOnKeyDown` should **only** only by used when making keyboard shortcut in any component.
+
+```tsx
+import { useOnKeyDown } from "@jobber/hooks";
+```
+
+
+<Playground>
+  {()=>{
+    const letterText = "Delete me by pressing Delete key on your keyboard.";
+    const letterText2 = "Space Enter and Shift + Escape will show here";
+    const [ text, setText ] = useState(letterText);
+    const [ textTwo, setTextTwo ] = useState(letterText2);
+    useOnKeyDown(() => setText("Deleted. Press Shift + z for undo."), "Delete");
+    useOnKeyDown(() => setText(letterText), {key: "z", ctrlKey: true});
+    useOnKeyDown((e) => {
+        if(e.shiftKey) setTextTwo("You pressed Shift and "+e.key);
+        else setTextTwo("You pressed '"+e.key+"'");
+    }, [" ", "Enter", {key: "Escape", shiftKey: true} ]);
+    return (<Text>{text}<pre />{textTwo}</Text>);}}
+</Playground>

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.mdx
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.mdx
@@ -13,7 +13,7 @@ import { Text } from "@jobber/components/Text";
 
 `useOnKeyDown` is an extremly simple hook that can be for adding the keydown event handler when the component is mounted and remove them when it unmount.
 
-`useOnKeyDown` should **only** only by used when making keyboard shortcut in any component.
+`useOnKeyDown` should **only** be used when making keyboard shortcut in a component.
 
 ```tsx
 import { useOnKeyDown } from "@jobber/hooks";

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.mdx
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.mdx
@@ -11,7 +11,7 @@ import { Text } from "@jobber/components/Text";
 
 # UseOnKeyDown
 
-`useOnKeyDown` is an extremly simple hook that can be for adding the keydown event handler when the component is mounted and remove them when it unmount.
+`useOnKeyDown` is a simple hook adding the keydown event handler when the component is mounted and removing when unmounted.
 
 `useOnKeyDown` should **only** be used when making keyboard shortcut in a component.
 

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
@@ -18,7 +18,7 @@ export function useOnKeyDown(
   callback: (event: globalThis.KeyboardEvent) => void,
   keys: KeyComparerator[] | KeyComparerator,
 ) {
-  const handler: (event: globalThis.KeyboardEvent) => void = (
+function handler(event: globalThis.KeyboardEvent) {
     event: globalThis.KeyboardEvent,
   ) => {
     const keyboardEvent = (event as unknown) as VerboseKeyComparerator;

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
@@ -1,0 +1,53 @@
+import useEventListener from "@use-it/event-listener";
+import { XOR } from "ts-xor";
+
+type SimpleKeyComparerator = string;
+
+interface VerboseKeyComparerator {
+  readonly key: SimpleKeyComparerator;
+  readonly shiftKey?: boolean;
+  readonly ctrlKey?: boolean;
+  readonly altKey?: boolean;
+  readonly metaKey?: boolean;
+  readonly [index: string]: boolean | string | undefined;
+}
+
+type KeyComparerator = XOR<VerboseKeyComparerator, SimpleKeyComparerator>;
+
+export function useOnKeyDown(
+  keys: KeyComparerator[] | KeyComparerator,
+  callback: () => void,
+) {
+  const handler: (event: globalThis.KeyboardEvent) => void = (
+    event: globalThis.KeyboardEvent,
+  ) => {
+    const keyboardEvent = (event as unknown) as VerboseKeyComparerator;
+    if (typeof keys === "string" && keyboardEvent.key === keys) {
+      return callback();
+    }
+    if (
+      Array.isArray(keys) &&
+      keys.some(item => {
+        if (typeof item === "string") return keyboardEvent.key === item;
+        return Object.keys(item).every(
+          index => keyboardEvent[index] === item[index],
+        );
+      })
+    ) {
+      return callback();
+    }
+    if (
+      !Array.isArray(keys) &&
+      typeof keys !== "string" &&
+      Object.keys(keys).every(index => keyboardEvent[index] === keys[index])
+    ) {
+      return callback();
+    }
+  };
+
+  // Pending: https://github.com/donavon/use-event-listener/pull/12
+  // The types in useEventListener mistakenly require a SyntheticEvent for the passed generic.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  //@ts-ignore
+  useEventListener<KeyboardEvent>("keydown", handler);
+}

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
@@ -1,7 +1,7 @@
 import useEventListener from "@use-it/event-listener";
 import { XOR } from "ts-xor";
 
-type SimpleKeyComparerator = string;
+type SimpleKeyComparerator = globalThis.KeyboardEvent["key"];
 
 interface VerboseKeyComparerator {
   readonly key: SimpleKeyComparerator;
@@ -15,15 +15,15 @@ interface VerboseKeyComparerator {
 type KeyComparerator = XOR<VerboseKeyComparerator, SimpleKeyComparerator>;
 
 export function useOnKeyDown(
+  callback: (event: globalThis.KeyboardEvent) => void,
   keys: KeyComparerator[] | KeyComparerator,
-  callback: () => void,
 ) {
   const handler: (event: globalThis.KeyboardEvent) => void = (
     event: globalThis.KeyboardEvent,
   ) => {
     const keyboardEvent = (event as unknown) as VerboseKeyComparerator;
     if (typeof keys === "string" && keyboardEvent.key === keys) {
-      return callback();
+      callback(event);
     }
     if (
       Array.isArray(keys) &&
@@ -34,14 +34,14 @@ export function useOnKeyDown(
         );
       })
     ) {
-      return callback();
+      callback(event);
     }
     if (
       !Array.isArray(keys) &&
       typeof keys !== "string" &&
       Object.keys(keys).every(index => keyboardEvent[index] === keys[index])
     ) {
-      return callback();
+      callback(event);
     }
   };
 


### PR DESCRIPTION

### Overview 
This is refer to https://github.com/GetJobber/atlantis/pull/394#discussion_r509685744
### Changed

Create new hook called `useOnKeyDown` to create on keydown event listener handler by specific one or multyple key in the same function.
**Thanks**
