### PR TITLE
docs(components): update FormatDate design docs

### DIFF
--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -26,6 +26,14 @@ import { FormatDate } from "@jobber/components/FormatDate";
   <FormatDate date={new CivilDate(2020, 2, 26)} />
 </Playground>
 
+## Design & Usage Guidelines
+
+Use FormatDate to ensure that a date is represented as expected. 
+
+If there are additional text styling concerns, wrap FormatDate in a [Text](https://atlantis.getjobber.com/packages-components-src-text-text) component.
+
+If the formatted date is intended to be part of a heading, wrap FormatDate in a [Heading](https://atlantis.getjobber.com/packages-components-src-heading-heading) component.
+
 ## Props
 
 <Props of={FormatDate} />


### PR DESCRIPTION
Add design guidelines to FormatDate

## Motivations

Making sure our design docs on components are up to date

### Added

- Added design & usage notes to clarify purpose of FormatDate and identify complementary components

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
