### PR TITLE
feat(components): Make switch & description optional on FeatureSwitch

### DIFF
--- a/packages/components/src/FeatureSwitch/FeatureSwitch.test.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.test.tsx
@@ -42,6 +42,27 @@ it("renders a subdued FeatureSwitch content", () => {
   expect(tree).toMatchSnapshot();
 });
 
+test("it should not show description if absent", () => {
+  const tree = renderer
+    .create(<FeatureSwitch enabled={false}>Dis dem content yo</FeatureSwitch>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("it should not show switch if onSwitch is absent", () => {
+  const tree = renderer
+    .create(
+      <FeatureSwitch
+        enabled={false}
+        description="Send a notification to your client following up on an outstanding quote."
+      >
+        Dis dem content yo
+      </FeatureSwitch>,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test("it should call the switch handler with the new value", () => {
   const switchHandler = jest.fn();
   const content = "Send a thing?";

--- a/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.tsx
@@ -17,7 +17,7 @@ interface FeatureSwitchProps {
    * Feature description. This supports basic markdown node types such as
    * `_italic_`, `**bold**`, and `[link name](url)`
    */
-  readonly description: string;
+  readonly description?: string;
 
   /**
    * Determines if the switch is disabled
@@ -92,44 +92,48 @@ export function FeatureSwitch({
         <div className={styles.content}>
           <Content>
             {title && <Heading level={4}>{title}</Heading>}
-            <Text>
-              <Markdown
-                content={description}
-                basicUsage={true}
-                externalLink={externalLink}
-              />
-            </Text>
+            {description && (
+              <Text>
+                <Markdown
+                  content={description}
+                  basicUsage={true}
+                  externalLink={externalLink}
+                />
+              </Text>
+            )}
           </Content>
         </div>
-        <div className={styles.action}>
-          <Switch
-            value={enabled}
-            onChange={handleSwitch}
-            ariaLabel={description}
-            disabled={disabled}
-          />
-          <AnimatePresence>
-            {hasSaveIndicator && savedIndicator && (
-              <motion.div
-                className={styles.savedIndicator}
-                initial={{ y: -4, opacity: 0 }}
-                animate={{ y: 0, opacity: 1 }}
-                exit={{ y: -4, opacity: 0 }}
-                transition={{
-                  delay: 0.2,
-                  type: "spring",
-                  damping: 20,
-                  stiffness: 300,
-                }}
-                onAnimationComplete={handleAnimationComplete}
-              >
-                <Text variation="success">
-                  <Emphasis variation="italic">Saved</Emphasis>
-                </Text>
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
+        {onSwitch && (
+          <div className={styles.action}>
+            <Switch
+              value={enabled}
+              onChange={onSwitch}
+              ariaLabel={description}
+              disabled={disabled}
+            />
+            <AnimatePresence>
+              {hasSaveIndicator && savedIndicator && (
+                <motion.div
+                  className={styles.savedIndicator}
+                  initial={{ y: -4, opacity: 0 }}
+                  animate={{ y: 0, opacity: 1 }}
+                  exit={{ y: -4, opacity: 0 }}
+                  transition={{
+                    delay: 0.2,
+                    type: "spring",
+                    damping: 20,
+                    stiffness: 300,
+                  }}
+                  onAnimationComplete={handleAnimationComplete}
+                >
+                  <Text variation="success">
+                    <Emphasis variation="italic">Saved</Emphasis>
+                  </Text>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        )}
       </div>
 
       {(children || onEdit) && (
@@ -146,10 +150,6 @@ export function FeatureSwitch({
       )}
     </Content>
   );
-
-  function handleSwitch(newValue: boolean) {
-    onSwitch && onSwitch(newValue);
-  }
 
   function shouldShowSavedIndicator() {
     // Check if the component is mounted

--- a/packages/components/src/FeatureSwitch/__snapshots__/FeatureSwitch.test.tsx.snap
+++ b/packages/components/src/FeatureSwitch/__snapshots__/FeatureSwitch.test.tsx.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`it should not show description if absent 1`] = `
+<div
+  className="padded base"
+>
+  <div
+    className="container"
+  >
+    <div
+      className="content"
+    >
+      <div
+        className="padded base"
+      />
+    </div>
+  </div>
+  <div
+    className="container"
+  >
+    <div
+      className="featureContent content"
+    >
+      Dis dem content yo
+    </div>
+  </div>
+</div>
+`;
+
+exports[`it should not show switch if onSwitch is absent 1`] = `
+<div
+  className="padded base"
+>
+  <div
+    className="container"
+  >
+    <div
+      className="content"
+    >
+      <div
+        className="padded base"
+      >
+        <p
+          className="base regular base greyBlueDark"
+        >
+          Send a notification to your client following up on an outstanding quote.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="container"
+  >
+    <div
+      className="featureContent content"
+    >
+      Dis dem content yo
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders a full FeatureSwitch 1`] = `
 <div
   className="padded base"

--- a/packages/components/src/FeatureSwitch/__snapshots__/FeatureSwitch.test.tsx.snap
+++ b/packages/components/src/FeatureSwitch/__snapshots__/FeatureSwitch.test.tsx.snap
@@ -136,49 +136,6 @@ exports[`renders a subdued FeatureSwitch content 1`] = `
         </p>
       </div>
     </div>
-    <div
-      className="action"
-    >
-      <button
-        aria-checked={false}
-        aria-label="Send a notification to your client following up on an outstanding quote."
-        className="track"
-        disabled={false}
-        onClick={[Function]}
-        role="switch"
-        type="button"
-      >
-        <span
-          className="toggle"
-        >
-          <span
-            className="label"
-          >
-            <span
-              className="base bold small uppercase white"
-            >
-              On
-            </span>
-          </span>
-          <span
-            className="pip"
-          />
-          <span
-            className="label"
-          >
-            <span
-              className="base bold small uppercase greyBlue"
-            >
-              Off
-            </span>
-          </span>
-        </span>
-      </button>
-      <input
-        type="hidden"
-        value="false"
-      />
-    </div>
   </div>
   <div
     className="container"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Switch & description are now optional on FeatureSwitch.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
