### PR TITLE
docs(components): add design docs to InputPassword

### DIFF
--- a/packages/components/src/InputPassword/InputPassword.mdx
+++ b/packages/components/src/InputPassword/InputPassword.mdx
@@ -23,6 +23,12 @@ import { InputPassword } from "@jobber/components/InputPassword";
   <InputPassword defaultValue="password" placeholder="Password" />
 </Playground>
 
+## Design & Usage Guidelines
+
+Use InputPassword for authentication flows where the user is required to enter a password. 
+
+If you are building an experience for authentication that does not require character-masking, consider using [InputText](https://atlantis.getjobber.com/components/input-text).
+
 ## Props
 
 <Props of={InputPassword} />


### PR DESCRIPTION
## Motivations

Increase consistency across our components' design documentation.

### Added

- Design & Usage guidelines


[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
