### PR TITLE
docs(components): button docs hierarchy

### DIFF
--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -38,12 +38,18 @@ import { Button } from "@jobber/components/Button";
 
 ---
 
-## Work actions
+## Design & Usage Guidelines
+
+The right button to use depends on:
+- the type of action your user is attempting to complete
+- the hierarchy of the interface the button lives in
+
+### Work actions
 
 Use Work Actions buttons to enable user interactions in the goal of completing
 work in Jobber.
 
-### Primary
+#### Primary
 
 The most important action in a view. Examples include the Save Job button, Log
 In, or the main action in a dialog. There should be one Primary action per view,
@@ -53,7 +59,7 @@ at most.
   <Button label="Do the thing" />
 </Playground>
 
-### Secondary
+#### Secondary
 
 A secondary button should be used when...
 
@@ -64,7 +70,7 @@ A secondary button should be used when...
   <Button label="Do the thing" type="secondary" />
 </Playground>
 
-### Tertiary
+#### Tertiary
 
 A tertiary button should be used to complete actions within the view such as
 editing, revealing details, or navigating within the view.
@@ -73,12 +79,12 @@ editing, revealing details, or navigating within the view.
   <Button label="Do the thing" type="tertiary" />
 </Playground>
 
-## Learning Actions
+### Learning Actions
 
 Use the Learning Actions buttons to enable user interactions in the goal of
 learning about Jobber, whether for marketing or coaching purposes.
 
-### Primary, Secondary, Tertiary
+#### Primary, Secondary, Tertiary
 
 The usage pattern for Learning Actions should follow the same logic as Work
 Actions for all three levels.
@@ -112,18 +118,18 @@ Actions for all three levels.
   />
 </Playground>
 
-## Destructive Actions
+### Destructive Actions
 
 Destructive actions remove something from Jobber.
 
-### Primary
+#### Primary
 
 A Primary destructive action will permanently destroy an object carrying
 signficant data, such as a job, quote, or client. This destructive action should
 be contained in a confirmation dialog triggered by clicking a Secondary
 destructive button.
 
-### Secondary or Tertiary
+#### Secondary or Tertiary
 
 A Secondary or tertiary destructive action will either...
 
@@ -139,7 +145,7 @@ A Secondary or tertiary destructive action will either...
   <Button label="Delete" variation="destructive" type="secondary" />
 </Playground>
 
-## Cancel Actions
+### Cancel Actions
 
 Cancel actions allow the user to opt out of completing an action they have
 triggered, whether that action is Work, Learning, or Destructive.


### PR DESCRIPTION
## Motivations

Cleaning up the hierarchy of the button docs, which were created before our standard "design usage" section was introduced to the component generator template

## Changes

Introduced a "design & usage" header, as well as a brief intro into the purpose of button types and levels


[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
