### PR TITLE
feat(components): add lastIndex argument to onRequestClose function prop of LightBox 

### DIFF
--- a/packages/components/src/LightBox/LightBox.mdx
+++ b/packages/components/src/LightBox/LightBox.mdx
@@ -70,3 +70,42 @@ suited by using a dialogue or alternative method.
 ## Props
 
 <Props of={LightBox} />
+
+### onRequestClose
+
+This function receives the index of the last image the user viewed before
+closing the LightBox component. This might we useful if we need to build some
+analytics on top of this component.
+
+<Playground>
+  {() => {
+    const [open, isOpen] = useState(false);
+    return (
+      <>
+        <Button label="😈 Click me!" onClick={() => isOpen(true)} />
+        <LightBox
+          open={open}
+          images={[
+            {
+              title: "😃 Happy Face",
+              url: "https://i.imgur.com/6Jcfgnp.jpg",
+              caption: "This is a happy face"
+            },
+            {
+              title: "😮",
+              url: "https://i.imgur.com/OsLxYkT.jpg",
+              caption: "Suprised face"
+            },
+            {
+              url: "https://i.imgur.com/uigfzs5.jpg"
+            }
+          ]}
+          onRequestClose={lastIndex => {
+            console.log("The user was saw this image last - ", lastIndex);
+            isOpen(false);
+          }}
+        />
+      </>
+    );
+  }}
+</Playground>

--- a/packages/components/src/LightBox/LightBox.tsx
+++ b/packages/components/src/LightBox/LightBox.tsx
@@ -33,8 +33,9 @@ interface LightBoxProps {
    * This function must set open to false in order to close the lightbox. Note there
    * is a 300ms easing animation on lightbox close that occurs before this function
    * is called.
+   * This function receives the last image position viewed in the LightBox as an argument.
    */
-  onRequestClose(): void;
+  onRequestClose(lastPosition: number): void;
 }
 
 export function LightBox({
@@ -67,7 +68,7 @@ export function LightBox({
           prevSrc={prevSrc}
           imageTitle={images[currentImageIndex].title}
           imageCaption={images[currentImageIndex].caption}
-          onCloseRequest={onRequestClose}
+          onCloseRequest={() => onRequestClose(currentImageIndex)}
           onMovePrevRequest={handleMovePrevious}
           onMoveNextRequest={handleMoveNext}
         />


### PR DESCRIPTION
## Motivations

Passed the last index of the image the user viewed to the onRequestClose function. 
This could be useful if LightBox is used for some onboarding functionality and if we wanted to build some analytics around how much further the user is engaged in the content.

## Changes
Passed the `currentImageIndex` state value to the `onRequestClose` function when LightBox is closed.
