### PR TITLE
feat(components): guard against external anchor element styling

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -35,7 +35,8 @@
   justify-content: center;
 }
 
-.button:focus {
+.button:focus,
+a.button:focus {
   outline-color: var(--color-outline);
 }
 
@@ -47,7 +48,8 @@
   background-color: var(--button--color-work);
 }
 
-.work:hover {
+.work:hover,
+a.work:hover {
   border-color: var(--button--color-work--hover);
   background-color: var(--button--color-work--hover);
 }
@@ -57,7 +59,8 @@
   background-color: var(--button--color-learning);
 }
 
-.learning:hover {
+.learning:hover,
+a.learning:hover {
   border-color: var(--button--color-learning--hover);
   background-color: var(--button--color-learning--hover);
 }
@@ -67,12 +70,13 @@
   background-color: var(--button--color-destructive);
 }
 
-.destructive:hover {
+.destructive:hover,
+a.learning:hover {
   border-color: var(--button--color-destructive--hover);
   background-color: var(--button--color-destructive--hover);
 }
 
-/* Cancel is special because, by defualt, it's styled as a secondary button */
+/* Cancel is special because, by default, it's styled as a secondary button */
 
 .cancel {
   border-color: var(--button--color-cancel);
@@ -80,7 +84,9 @@
 }
 
 .cancel:focus,
-.cancel:hover {
+.cancel:hover,
+a.cancel:focus,
+a.cancel:hover {
   filter: brightness(80%);
 }
 
@@ -95,7 +101,9 @@
 }
 
 .secondary:hover,
-.secondary:focus {
+.secondary:focus,
+a.secondary:hover,
+a.secondary:focus {
   background-color: var(--button--color-secondary);
   filter: brightness(80%);
 }
@@ -106,7 +114,9 @@
 }
 
 .tertiary:hover,
-.tertiary:focus {
+.tertiary:focus,
+a.tertiary:hover,
+a.tertiary:focus {
   border-color: transparent;
   background-color: var(--color-grey--lightest);
 }

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -9,6 +9,8 @@
   --button--color-destructive--hover: var(--color-red--dark);
 
   --button--color-cancel: var(--color-greyBlue);
+  --button--color-cancel--hover: var(--color-grey--lightest);
+
   --button--bg-color-cancel: var(--color-white);
   --button--color-disabled: var(--color-grey--lighter);
   --button--color-secondary: var(--color-white);
@@ -49,7 +51,9 @@ a.button:focus {
 }
 
 .work:hover,
-a.work:hover {
+a.work:hover,
+.work:focus,
+a.work:focus {
   border-color: var(--button--color-work--hover);
   background-color: var(--button--color-work--hover);
 }
@@ -60,7 +64,9 @@ a.work:hover {
 }
 
 .learning:hover,
-a.learning:hover {
+a.learning:hover,
+.learning:focus,
+a.learning:focus {
   border-color: var(--button--color-learning--hover);
   background-color: var(--button--color-learning--hover);
 }
@@ -87,6 +93,7 @@ a.learning:hover {
 .cancel:hover,
 a.cancel:focus,
 a.cancel:hover {
+  background-color: var(--button--color-cancel--hover);
   filter: brightness(80%);
 }
 

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -77,7 +77,9 @@ a.learning:focus {
 }
 
 .destructive:hover,
-a.learning:hover {
+a.destructive:hover,
+.destructive:focus,
+a.destructive:focus {
   border-color: var(--button--color-destructive--hover);
   background-color: var(--button--color-destructive--hover);
 }


### PR DESCRIPTION
## Motivations

We discovered that if pulling Atlantis buttons with a URL (which render as `a` elements) into a product with existing styling for `a` elements, the hover and focus states may end up defined by the `a` element and not our `Button`.

## Changes

Included specific `a` scope on :hover and :focus states.

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
