### PR TITLE
fix(components): Sets AutoComplete to blank if no matches

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -162,3 +162,112 @@ test("it should call the handler skipping headings when an option is selected", 
 
   expect(changeHandler).toHaveBeenCalledWith(headingOptions[1].options[0]);
 });
+
+it("should remove the menu when blurred", async () => {
+  const changeHandler = jest.fn();
+  const { getByRole, getByText, queryByText } = render(
+    <Autocomplete
+      value={undefined}
+      onChange={changeHandler}
+      initialOptions={options}
+      getOptions={returnOptions(options)}
+      placeholder="placeholder_name"
+    />,
+  );
+
+  const input = getByRole("textbox");
+
+  input.focus();
+
+  await waitFor(() => {
+    expect(getByText("option_0")).toBeInstanceOf(HTMLParagraphElement);
+  });
+
+  input.blur();
+
+  await waitFor(() => {
+    expect(queryByText("option_0")).toBeNull();
+  });
+});
+
+it("should call onBlur callback when blurred", async () => {
+  const blurHandler = jest.fn();
+  const { getByRole } = render(
+    <Autocomplete
+      value={undefined}
+      onChange={jest.fn()}
+      initialOptions={options}
+      getOptions={returnOptions(options)}
+      placeholder="placeholder_name"
+      onBlur={blurHandler}
+    />,
+  );
+
+  const input = getByRole("textbox");
+  input.focus();
+  input.blur();
+
+  await waitFor(() => {
+    expect(blurHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("should call onChange with undefined if allowFreeForm is false and not matched", async () => {
+  const changeHandler = jest.fn();
+  const { getByRole } = render(
+    <Autocomplete
+      value={undefined}
+      onChange={changeHandler}
+      initialOptions={options}
+      getOptions={returnOptions(options)}
+      placeholder="placeholder_name"
+      allowFreeForm={false}
+    />,
+  );
+
+  const input = getByRole("textbox");
+
+  input.focus();
+
+  fireEvent.input(input, {
+    target: {
+      value: "opt",
+    },
+  });
+
+  input.blur();
+
+  await waitFor(() => {
+    expect(changeHandler).toHaveBeenCalledWith(undefined);
+  });
+});
+
+it("sets the input value to blank if allowFreeForm is false and not matched", async () => {
+  const changeHandler = jest.fn();
+  const { getByRole } = render(
+    <Autocomplete
+      value={undefined}
+      onChange={changeHandler}
+      initialOptions={options}
+      getOptions={returnOptions(options)}
+      placeholder="placeholder_name"
+      allowFreeForm={false}
+    />,
+  );
+
+  const input = getByRole("textbox") as HTMLInputElement;
+
+  input.focus();
+
+  fireEvent.input(input, {
+    target: {
+      value: "opt",
+    },
+  });
+
+  input.blur();
+
+  await waitFor(() => {
+    expect(input.value).toBe("");
+  });
+});

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -118,12 +118,14 @@ export function Autocomplete({
         onFocus={handleInputFocus}
         onBlur={handleInputBlur}
       />
-      <Menu
-        visible={menuVisible}
-        options={options}
-        selectedOption={value}
-        onOptionSelect={handleMenuChange}
-      />
+      {menuVisible && (
+        <Menu
+          visible={true}
+          options={options}
+          selectedOption={value}
+          onOptionSelect={handleMenuChange}
+        />
+      )}
     </div>
   );
 
@@ -159,11 +161,10 @@ export function Autocomplete({
   function handleInputBlur() {
     setMenuVisible(false);
     if (value == undefined || value.label !== inputText) {
+      setInputText("");
       onChange(undefined);
     }
-    if (onBlur) {
-      onBlur();
-    }
+    onBlur && onBlur();
   }
 
   function handleInputFocus() {

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -30,28 +30,6 @@ exports[`it should display headers when headers are passed in 1`] = `
       value=""
     />
   </div>
-  <div
-    className="options"
-  >
-    <div
-      className="heading"
-    >
-      <h5
-        className="base bold base blue"
-      >
-        first_heading
-      </h5>
-    </div>
-    <div
-      className="heading"
-    >
-      <h5
-        className="base bold base blue"
-      >
-        second_heading
-      </h5>
-    </div>
-  </div>
 </div>
 `;
 
@@ -84,52 +62,6 @@ exports[`renders an Autocomplete 1`] = `
       type="text"
       value=""
     />
-  </div>
-  <div
-    className="options"
-  >
-    <button
-      className="option active"
-      onMouseDown={[Function]}
-    >
-      <div
-        className="icon"
-      />
-      <div
-        className="text"
-      >
-        <div
-          className="label"
-        >
-          <p
-            className="base regular base greyBlueDark"
-          >
-            option_0
-          </p>
-        </div>
-      </div>
-    </button>
-    <button
-      className="option"
-      onMouseDown={[Function]}
-    >
-      <div
-        className="icon"
-      />
-      <div
-        className="text"
-      >
-        <div
-          className="label"
-        >
-          <p
-            className="base regular base greyBlueDark"
-          >
-            option_1
-          </p>
-        </div>
-      </div>
-    </button>
   </div>
 </div>
 `;


### PR DESCRIPTION

## Motivations

When the autocomplete is blurred with `!allowFreeForm` and does not match a result, the `onChange` was correctly being called with undefined, however the input value was not reflecting this change.

This left a confusing user experience as the data returned and the data showed was different.

## Changes

Clears the `input` on `Autocomplete` if `!allowFreeForm` and input does not match a result on blur.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Clears the `input` on `Autocomplete` if `!allowFreeForm` and input does not match a result on blur to that the data and visuals match

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Navigation to `Autocomplete` page on preview.
- add `allowFreeForm={false}` to the first `Playground` example.
- type `Nos` into the input and see that there is one result.
- tab out, value in the input should be cleared

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
