### PR TITLE
feat(components): Add `onUploadComplete` to `InputAvatar`

### DIFF
--- a/packages/components/src/InputAvatar/InputAvatar.test.tsx
+++ b/packages/components/src/InputAvatar/InputAvatar.test.tsx
@@ -33,12 +33,14 @@ it("renders with a provided image", () => {
   expect(container).toMatchSnapshot();
 });
 
-it("should allow an image to be uploaded", async () => {
+it("properly notifies upload callbacks", async () => {
   const changeHandler = jest.fn();
+  const completionHandler = jest.fn();
   const { container } = render(
     <InputAvatar
       getUploadParams={fetchUploadParams}
       onChange={changeHandler}
+      onUploadComplete={completionHandler}
     />,
   );
 
@@ -53,6 +55,16 @@ it("should allow an image to be uploaded", async () => {
       name: "atlantis.png",
       size: expect.any(Number),
       progress: expect.any(Number),
+      src: expect.any(Function),
+      type: "image/png",
+    });
+
+    expect(completionHandler).toHaveBeenCalledTimes(1);
+    expect(completionHandler).toHaveBeenCalledWith({
+      key: "atlantis.png",
+      name: "atlantis.png",
+      size: expect.any(Number),
+      progress: 1,
       src: expect.any(Function),
       type: "image/png",
     });

--- a/packages/components/src/InputAvatar/InputAvatar.tsx
+++ b/packages/components/src/InputAvatar/InputAvatar.tsx
@@ -19,10 +19,16 @@ interface InputAvatarProps extends Omit<AvatarProps, "size"> {
    * Triggered when an image is changed.
    */
   onChange?(file?: FileUpload): void;
+
+  /**
+   * Triggered when an image upload has completed.
+   */
+  onUploadComplete?(file?: FileUpload): void;
 }
 
 export function InputAvatar({
   getUploadParams,
+  onUploadComplete,
   onChange,
   ...avatarProps
 }: InputAvatarProps) {
@@ -52,7 +58,7 @@ export function InputAvatar({
         getUploadParams={getUploadParams}
         onUploadStart={handleChange}
         onUploadProgress={handleUpload}
-        onUploadComplete={handleUpload}
+        onUploadComplete={handleUploadComplete}
       />
       {avatarProps.imageUrl != undefined && progress === 1 && (
         <Button
@@ -68,6 +74,11 @@ export function InputAvatar({
 
   function handleChange(newFile: FileUpload) {
     onChange && onChange(newFile);
+    handleUpload(newFile);
+  }
+
+  function handleUploadComplete(newFile: FileUpload) {
+    onUploadComplete && onUploadComplete(newFile);
     handleUpload(newFile);
   }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Add `onUploadComplete` to `InputAvatar` to allows callbacks to be provided for when the upload has completed.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
