### PR TITLE
feat(components): Add `invalid` to `Autocomplete`

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -271,3 +271,18 @@ it("sets the input value to blank if allowFreeForm is false and not matched", as
     expect(input.value).toBe("");
   });
 });
+
+it("renders correctly when invalid", () => {
+  const tree = renderer
+    .create(
+      <Autocomplete
+        value={undefined}
+        onChange={() => {}}
+        getOptions={returnOptions([])}
+        placeholder="placeholder_name"
+        invalid
+      />,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -38,6 +38,11 @@ interface AutocompleteProps {
   readonly size?: FormFieldProps["size"];
 
   /**
+   * Highlights the field red to indicate an error.
+   */
+  readonly invalid?: FormFieldProps["invalid"];
+
+  /**
    * Debounce in milliseconds for getOptions
    *
    * @default 300
@@ -81,6 +86,7 @@ export function Autocomplete({
   value,
   allowFreeForm = true,
   size = undefined,
+  invalid,
   debounce: debounceRate = 300,
   onChange,
   getOptions,
@@ -112,6 +118,7 @@ export function Autocomplete({
       <InputText
         autocomplete={false}
         size={size}
+        invalid={invalid}
         value={inputText}
         onChange={handleInputChange}
         placeholder={placeholder}

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -65,3 +65,36 @@ exports[`renders an Autocomplete 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders correctly when invalid 1`] = `
+<div
+  className="autocomplete"
+>
+  <div
+    className="wrapper invalid"
+    style={
+      Object {
+        "--formField-maxLength": undefined,
+      }
+    }
+  >
+    <label
+      className="label"
+      htmlFor="123e4567-e89b-12d3-a456-426655440043"
+    >
+      placeholder_name
+    </label>
+    <input
+      autoComplete="autocomplete-off"
+      className="formField"
+      id="123e4567-e89b-12d3-a456-426655440043"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      type="text"
+      value=""
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Add `invalid` to `Autocomplete` to allow highlight field red to indicate an error.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
