### PR TITLE
feat(components): Add label and description to RadioOption

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.css
+++ b/packages/components/src/Checkbox/Checkbox.css
@@ -76,6 +76,6 @@
 }
 
 .description {
-  margin-top: var(--space-smaller);
-  margin-left: var(--space-large);
+  margin-bottom: var(--space-small);
+  padding-left: var(--space-large);
 }

--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -12,6 +12,7 @@
 .label {
   display: inline-flex;
   align-items: center;
+  cursor: pointer;
 }
 
 .input + .label::before {
@@ -20,12 +21,11 @@
   width: var(--space-base);
   height: var(--space-base);
   box-sizing: border-box;
-  margin: 0 var(--space-small);
+  margin: 0 var(--space-small) 0 0;
   border: var(--border-thick) solid var(--color-grey--light);
   border-radius: 100%;
   background-color: var(--color-white);
-  cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--timing-base);
 }
 
 .input:focus + .label:before {
@@ -39,9 +39,15 @@
 
 .input[disabled] + .label {
   color: var(--color-blue--lighter);
+  cursor: not-allowed;
 }
 
 .input[disabled] + .label::before {
   border-color: var(--color-grey--light);
   background-color: var(--color-grey--lighter);
+}
+
+.description {
+  margin-bottom: var(--space-smallest);
+  padding-left: var(--space-large);
 }

--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -48,6 +48,6 @@
 }
 
 .description {
-  margin-bottom: var(--space-smallest);
+  margin-bottom: var(--space-small);
   padding-left: var(--space-large);
 }

--- a/packages/components/src/RadioGroup/RadioGroup.css.d.ts
+++ b/packages/components/src/RadioGroup/RadioGroup.css.d.ts
@@ -1,3 +1,4 @@
 export const radioGroup: string;
 export const input: string;
 export const label: string;
+export const description: string;

--- a/packages/components/src/RadioGroup/RadioGroup.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.mdx
@@ -8,9 +8,10 @@ import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { RadioGroup, RadioOption } from ".";
 import { Content } from "@jobber/components/Content";
+import { Text } from "@jobber/components/Text";
 import { Checkbox } from "@jobber/components/Checkbox";
 import { Divider } from "@jobber/components/Divider";
-import { Icon } from "@jobber/components/Icon";
+import { Avatar } from "@jobber/components/Avatar";
 import { useState } from "react";
 
 # Radio Group
@@ -114,18 +115,33 @@ render the `RadioOptions` with `children`.
 **Note:** When using `children`, `label` and `description` are not allowed due
 to the face that they would collide with the `children` prop.
 
+**Note:** When using `children` it is the responsibility of the child to supply
+the proper accessible labels. If you are using children that do not contain
+text, an `aria-label` should be provided.
+
 <Playground>
   {() => {
-    const [company, setPhoto] = useState("job");
-    const icons = ["job", "quote", "request", "timer", "expense"];
+    const [company, setPhoto] = useState("JBR");
+    const users = [
+      { name: "Jobber", initials: "JBR" },
+      { name: "User 1", initials: "U1" },
+      { name: "User 2", initials: "U2" },
+      { name: "User 3", initials: "U3" },
+      { name: "User 4", initials: "U4" }
+    ];
     return (
-      <RadioGroup onChange={setPhoto} value={company}>
-        {icons.map(icon => (
-          <RadioOption value={icon}>
-            <Icon name={icon} />
-          </RadioOption>
-        ))}
-      </RadioGroup>
+      <>
+        <Content>
+          <Text>Select a user</Text>
+          <RadioGroup onChange={setPhoto} value={company}>
+            {users.map(user => (
+              <RadioOption value={user.name}>
+                <Avatar initials={user.initials} name={user.name} />
+              </RadioOption>
+            ))}
+          </RadioGroup>
+        </Content>
+      </>
     );
   }}
 </Playground>

--- a/packages/components/src/RadioGroup/RadioGroup.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.mdx
@@ -111,7 +111,8 @@ A `description` can be used to further describe the label of the `RadioOption`.
 If the `RadioGroup` is being used to select something other then text, you can
 render the `RadioOptions` with `children`.
 
-**Note:** When using `children`, `label` and `description` are not allowed.
+**Note:** When using `children`, `label` and `description` are not allowed due
+to the face that they would collide with the `children` prop.
 
 <Playground>
   {() => {

--- a/packages/components/src/RadioGroup/RadioGroup.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.mdx
@@ -113,7 +113,7 @@ If the `RadioGroup` is being used to select something other then text, you can
 render the `RadioOptions` with `children`.
 
 **Note:** When using `children`, `label` and `description` are not allowed due
-to the face that they would collide with the `children` prop.
+to the fact that they would collide with the `children` prop.
 
 **Note:** When using `children` it is the responsibility of the child to supply
 the proper accessible labels. If you are using children that do not contain

--- a/packages/components/src/RadioGroup/RadioGroup.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.mdx
@@ -9,6 +9,8 @@ import { ComponentStatus } from "@jobber/docx";
 import { RadioGroup, RadioOption } from ".";
 import { Content } from "@jobber/components/Content";
 import { Checkbox } from "@jobber/components/Checkbox";
+import { Divider } from "@jobber/components/Divider";
+import { Icon } from "@jobber/components/Icon";
 import { useState } from "react";
 
 # Radio Group
@@ -27,9 +29,9 @@ import { RadioGroup } from "@jobber/components/RadioGroup";
     const [company, setCompany] = useState("apple");
     return (
       <RadioGroup onChange={setCompany} value={company}>
-        <RadioOption value="apple">Apple</RadioOption>
-        <RadioOption value="google">Google</RadioOption>
-        <RadioOption value="microsoft">Microsoft</RadioOption>
+        <RadioOption value="apple" label="Apple" />
+        <RadioOption value="google" label="Google" />
+        <RadioOption value="microsoft" label="Microsoft" />
       </RadioGroup>
     );
   }}
@@ -53,25 +55,76 @@ option will prevent a user from being able to select the option.
     const [company, setCompany] = useState("apple");
     const [checked, setChecked] = useState(true);
     return (
-      <Content>
-        <Content spacing="large">
-          <RadioGroup onChange={setCompany} value={company}>
-            <RadioOption value="apple">Apple</RadioOption>
-            <RadioOption value="google">Google</RadioOption>
-            <RadioOption value="microsoft" disabled={!checked}>
-              Microsoft
-            </RadioOption>
-            <RadioOption value="amazon" disabled={true}>
-              Amazon
-            </RadioOption>
-          </RadioGroup>
-        </Content>
+      <Content spacing="large">
+        <RadioGroup onChange={setCompany} value={company}>
+          <RadioOption value="apple" label="Apple" />
+          <RadioOption value="google" label="Google" />
+          <RadioOption value="amazon" label="Amazon" disabled={true} />
+          <RadioOption
+            value="microsoft"
+            label="Microsoft"
+            disabled={!checked}
+          />
+        </RadioGroup>
+        <Divider />
         <Checkbox
           checked={checked}
           label="Allow Microsoft"
           onChange={setChecked}
         />
       </Content>
+    );
+  }}
+</Playground>
+
+## Description
+
+A `description` can be used to further describe the label of the `RadioOption`.
+
+<Playground>
+  {() => {
+    const [company, setCompany] = useState("apple");
+    return (
+      <RadioGroup onChange={setCompany} value={company}>
+        <RadioOption
+          value="apple"
+          label="Apple"
+          description="A delicious fruit that fends off doctors"
+        />
+        <RadioOption
+          value="amazon"
+          label="Amazon"
+          description="The worlds largest rainforest"
+        />
+        <RadioOption
+          value="google"
+          label="Google"
+          description="A search engine"
+        />
+      </RadioGroup>
+    );
+  }}
+</Playground>
+
+## Render RadioOption with Children
+
+If the `RadioGroup` is being used to select something other then text, you can
+render the `RadioOptions` with `children`.
+
+**Note:** When using `children`, `label` and `description` are not allowed.
+
+<Playground>
+  {() => {
+    const [company, setPhoto] = useState("job");
+    const icons = ["job", "quote", "request", "timer", "expense"];
+    return (
+      <RadioGroup onChange={setPhoto} value={company}>
+        {icons.map(icon => (
+          <RadioOption value={icon}>
+            <Icon name={icon} />
+          </RadioOption>
+        ))}
+      </RadioGroup>
     );
   }}
 </Playground>

--- a/packages/components/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.test.tsx
@@ -96,7 +96,7 @@ function MockRadioGroup({ onChange }: MockProps) {
         <RadioOption value="one" label="One" />
         <RadioOption value="two" label="Two" />
       </RadioGroup>
-      <RadioGroup onChange={handleSecondValue} value={valueTwo}>
+      <RadioGroup onChange={handleSecondChange} value={valueTwo}>
         <RadioOption value="one" label="One" />
         <RadioOption value="two" label="Two" />
       </RadioGroup>
@@ -108,7 +108,7 @@ function MockRadioGroup({ onChange }: MockProps) {
     onChange && onChange(val);
   }
 
-  function handleSecondValue(val: string) {
+  function handleSecondChange(val: string) {
     setValueTwo(val);
     onChange && onChange(val);
   }

--- a/packages/components/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.test.tsx
@@ -1,41 +1,28 @@
 import React, { useState } from "react";
-import renderer from "react-test-renderer";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { RadioGroup, RadioOption } from ".";
 
 afterEach(cleanup);
 
 test("renders a RadioGroup", () => {
-  const handleChange = jest.fn();
-  const currentValue = "bear";
-
-  const radioGroup = (
-    <RadioGroup name="Foo" value={currentValue} onChange={handleChange}>
-      <RadioOption value="foo">Foo</RadioOption>
-      <RadioOption value="bear">Bear</RadioOption>
-    </RadioGroup>
-  );
-
-  const tree = renderer.create(radioGroup).toJSON();
-  expect(tree).toMatchSnapshot();
+  const { container } = render(<MockRadioGroup />);
+  expect(container).toMatchSnapshot();
 });
 
 test("it should call the handler with the new value", () => {
-  const labelOne = "Foo1";
-  const labelTwo = "Foo2";
-  const currentValue = "bear";
-
-  const handleChange = jest.fn();
-
-  const { getByText } = render(
-    <RadioGroup name="Foo" value={currentValue} onChange={handleChange}>
-      <RadioOption value="foo">{labelOne}</RadioOption>
-      <RadioOption value="bear">{labelTwo}</RadioOption>
-    </RadioGroup>,
+  const changeHandler = jest.fn();
+  const { getAllByLabelText } = render(
+    <MockRadioGroup onChange={changeHandler} />,
   );
+  fireEvent.click(getAllByLabelText("Two")[0]);
+  expect(changeHandler).toHaveBeenCalledWith("two");
+});
 
-  fireEvent.click(getByText(labelOne));
-  expect(handleChange).toHaveBeenCalled();
+test("it should not call the handler if the value does not change", () => {
+  const changeHandler = jest.fn();
+  const { getAllByText } = render(<MockRadioGroup onChange={changeHandler} />);
+  fireEvent.click(getAllByText("One")[0]);
+  expect(changeHandler).not.toHaveBeenCalled();
 });
 
 test("it should be able to disable options", () => {
@@ -53,8 +40,12 @@ test("it should be able to disable options", () => {
 test("it should have unique ids on all radio options", () => {
   const { container, getAllByLabelText } = render(<MockRadioGroup />);
   const labels = getAllByLabelText("Two");
-  const radio1 = container.querySelector(`input#${labels[0].id}`);
-  const radio2 = container.querySelector(`input#${labels[1].id}`);
+  const radio1 = container.querySelector(
+    `input#${labels[0].id}`,
+  ) as HTMLInputElement;
+  const radio2 = container.querySelector(
+    `input#${labels[1].id}`,
+  ) as HTMLInputElement;
   expect(radio1.checked).toBeFalsy();
   expect(radio2.checked).toBeFalsy();
   fireEvent.click(labels[1]);
@@ -62,19 +53,63 @@ test("it should have unique ids on all radio options", () => {
   expect(radio2.checked).toBeTruthy();
 });
 
-function MockRadioGroup() {
-  const [value, setValue] = useState("One");
-  const [valueTwo, setValueTwo] = useState("One");
+test("it should render an option from `label` prop", () => {
+  const { getByText } = render(
+    <RadioGroup value="" onChange={jest.fn()}>
+      <RadioOption value="foo" label="Radio" />
+    </RadioGroup>,
+  );
+
+  expect(getByText("Radio")).toBeInstanceOf(HTMLLabelElement);
+});
+
+test("it should render an option from `children` prop", () => {
+  const { getByText } = render(
+    <RadioGroup value="" onChange={jest.fn()}>
+      <RadioOption value="foo">Radio</RadioOption>
+    </RadioGroup>,
+  );
+
+  expect(getByText("Radio")).toBeInstanceOf(HTMLLabelElement);
+});
+
+test("it should render a description", () => {
+  const { getByText } = render(
+    <RadioGroup value="" onChange={jest.fn()}>
+      <RadioOption value="foo" description="A sound box" label="Radio" />
+    </RadioGroup>,
+  );
+
+  expect(getByText("A sound box")).toBeInstanceOf(HTMLParagraphElement);
+});
+
+interface MockProps {
+  onChange?(val: string): void;
+}
+
+function MockRadioGroup({ onChange }: MockProps) {
+  const [value, setValue] = useState("one");
+  const [valueTwo, setValueTwo] = useState("one");
   return (
     <>
-      <RadioGroup onChange={setValue} value={value}>
-        <RadioOption value="one">One</RadioOption>
-        <RadioOption value="two">Two</RadioOption>
+      <RadioGroup onChange={handleFirstChange} value={value}>
+        <RadioOption value="one" label="One" />
+        <RadioOption value="two" label="Two" />
       </RadioGroup>
-      <RadioGroup onChange={setValueTwo} value={valueTwo}>
-        <RadioOption value="one">One</RadioOption>
-        <RadioOption value="two">Two</RadioOption>
+      <RadioGroup onChange={handleSecondValue} value={valueTwo}>
+        <RadioOption value="one" label="One" />
+        <RadioOption value="two" label="Two" />
       </RadioGroup>
     </>
   );
+
+  function handleFirstChange(val: string) {
+    setValue(val);
+    onChange && onChange(val);
+  }
+
+  function handleSecondValue(val: string) {
+    setValueTwo(val);
+    onChange && onChange(val);
+  }
 }

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -1,5 +1,6 @@
-import React, { ReactElement, ReactNode } from "react";
+import React, { ReactElement } from "react";
 import uuid from "uuid";
+import { InternalRadioOption } from "./RadioOption";
 import styles from "./RadioGroup.css";
 
 interface RadioGroupProps {
@@ -52,56 +53,5 @@ export function RadioGroup({
     if (newValue !== value) {
       onChange(newValue);
     }
-  }
-}
-
-interface RadioOptionProps {
-  readonly value: string | number;
-  readonly disabled?: boolean;
-  readonly children: ReactNode | ReactNode[];
-}
-
-export function RadioOption({ children }: RadioOptionProps) {
-  return <>{children}</>;
-}
-
-interface InternalRadioOptionProps {
-  readonly value: string | number;
-  readonly name: string;
-  readonly disabled: boolean;
-  readonly checked: boolean;
-  readonly children: ReactNode | ReactNode[];
-  onChange(newValue: string | number): void;
-}
-
-function InternalRadioOption({
-  value,
-  name,
-  disabled,
-  checked,
-  children,
-  onChange,
-}: InternalRadioOptionProps) {
-  const inputId = `${value.toString()}_${uuid()}`;
-  return (
-    <div>
-      <input
-        onChange={handleChange}
-        type="radio"
-        name={name}
-        value={value}
-        disabled={disabled}
-        checked={checked}
-        id={inputId}
-        className={styles.input}
-      />
-      <label className={styles.label} htmlFor={inputId}>
-        {children}
-      </label>
-    </div>
-  );
-
-  function handleChange() {
-    onChange(value);
   }
 }

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -38,10 +38,9 @@ export function RadioGroup({
       {React.Children.map(children, option => (
         <InternalRadioOption
           checked={value === option.props.value}
-          value={option.props.value}
           name={name}
-          disabled={option.props.disabled}
           onChange={handleChange}
+          {...option.props}
         >
           {option.props.children}
         </InternalRadioOption>

--- a/packages/components/src/RadioGroup/RadioOption.tsx
+++ b/packages/components/src/RadioGroup/RadioOption.tsx
@@ -1,25 +1,52 @@
 import React, { PropsWithChildren } from "react";
+import { XOR } from "ts-xor";
 import uuid from "uuid";
 import styles from "./RadioGroup.css";
+import { Text } from "../Text";
 
-interface RadioOptionProps {
+interface BaseRadioOptions {
   readonly value: string | number;
   readonly disabled?: boolean;
 }
+
+interface RadioOptionsWithDescription extends BaseRadioOptions {
+  label: string;
+  /**
+   * Further description of the label
+   */
+  description?: string;
+}
+
+type RadioOptionProps = XOR<
+  RadioOptionsWithDescription,
+  PropsWithChildren<BaseRadioOptions>
+>;
 
 export function RadioOption({ children }: PropsWithChildren<RadioOptionProps>) {
   return <>{children}</>;
 }
 
-interface InternalRadioOptionProps extends RadioOptionProps {
+interface BaseInternalRadioOptions extends BaseRadioOptions {
   readonly name: string;
   readonly checked: boolean;
   onChange(newValue: string | number): void;
 }
 
+interface InternalRadioOptionsWithDescription extends BaseInternalRadioOptions {
+  label: string;
+  description?: string;
+}
+
+type InternalRadioOptionProps = XOR<
+  InternalRadioOptionsWithDescription,
+  PropsWithChildren<BaseInternalRadioOptions>
+>;
+
 export function InternalRadioOption({
   value,
   name,
+  label,
+  description,
   disabled,
   checked,
   children,
@@ -39,8 +66,15 @@ export function InternalRadioOption({
         className={styles.input}
       />
       <label className={styles.label} htmlFor={inputId}>
-        {children}
+        {label ? label : children}
       </label>
+      {description && (
+        <div className={styles.description}>
+          <Text variation="subdued" size="small">
+            {description}
+          </Text>
+        </div>
+      )}
     </div>
   );
 

--- a/packages/components/src/RadioGroup/RadioOption.tsx
+++ b/packages/components/src/RadioGroup/RadioOption.tsx
@@ -1,0 +1,50 @@
+import React, { PropsWithChildren } from "react";
+import uuid from "uuid";
+import styles from "./RadioGroup.css";
+
+interface RadioOptionProps {
+  readonly value: string | number;
+  readonly disabled?: boolean;
+}
+
+export function RadioOption({ children }: PropsWithChildren<RadioOptionProps>) {
+  return <>{children}</>;
+}
+
+interface InternalRadioOptionProps extends RadioOptionProps {
+  readonly name: string;
+  readonly checked: boolean;
+  onChange(newValue: string | number): void;
+}
+
+export function InternalRadioOption({
+  value,
+  name,
+  disabled,
+  checked,
+  children,
+  onChange,
+}: PropsWithChildren<InternalRadioOptionProps>) {
+  const inputId = `${value.toString()}_${uuid()}`;
+  return (
+    <div>
+      <input
+        onChange={handleChange}
+        type="radio"
+        name={name}
+        value={value}
+        disabled={disabled}
+        checked={checked}
+        id={inputId}
+        className={styles.input}
+      />
+      <label className={styles.label} htmlFor={inputId}>
+        {children}
+      </label>
+    </div>
+  );
+
+  function handleChange() {
+    onChange(value);
+  }
+}

--- a/packages/components/src/RadioGroup/RadioOption.tsx
+++ b/packages/components/src/RadioGroup/RadioOption.tsx
@@ -64,12 +64,13 @@ export function InternalRadioOption({
         checked={checked}
         id={inputId}
         className={styles.input}
+        aria-describedby={`${inputId}_description`}
       />
       <label className={styles.label} htmlFor={inputId}>
         {label ? label : children}
       </label>
       {description && (
-        <div className={styles.description}>
+        <div className={styles.description} id={`${inputId}_description`}>
           <Text variation="subdued" size="small">
             {description}
           </Text>

--- a/packages/components/src/RadioGroup/RadioOption.tsx
+++ b/packages/components/src/RadioGroup/RadioOption.tsx
@@ -22,6 +22,10 @@ type RadioOptionProps = XOR<
   PropsWithChildren<BaseRadioOptions>
 >;
 
+/**
+ * For rendering props only. To make updates to
+ * the real RadioOption, look at InternalRadioOption
+ */
 export function RadioOption({ children }: PropsWithChildren<RadioOptionProps>) {
   return <>{children}</>;
 }

--- a/packages/components/src/RadioGroup/RadioOption.tsx
+++ b/packages/components/src/RadioGroup/RadioOption.tsx
@@ -71,7 +71,7 @@ export function InternalRadioOption({
         checked={checked}
         id={inputId}
         className={styles.input}
-        aria-describedby={`${inputId}_description`}
+        aria-describedby={description ? `${inputId}_description` : undefined}
       />
       <label className={styles.label} htmlFor={inputId}>
         {label ? label : children}

--- a/packages/components/src/RadioGroup/RadioOption.tsx
+++ b/packages/components/src/RadioGroup/RadioOption.tsx
@@ -10,9 +10,12 @@ interface BaseRadioOptions {
 }
 
 interface RadioOptionsWithDescription extends BaseRadioOptions {
+  /**
+   * The label to appear beside the radio button.
+   */
   label: string;
   /**
-   * Further description of the label
+   * Further description of the label.
    */
   description?: string;
 }

--- a/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`renders a RadioGroup 1`] = `
   >
     <div>
       <input
-        aria-describedby="one_123e4567-e89b-12d3-a456-426655440002_description"
         checked=""
         class="input"
         id="one_123e4567-e89b-12d3-a456-426655440002"
@@ -24,7 +23,6 @@ exports[`renders a RadioGroup 1`] = `
     </div>
     <div>
       <input
-        aria-describedby="two_123e4567-e89b-12d3-a456-426655440003_description"
         class="input"
         id="two_123e4567-e89b-12d3-a456-426655440003"
         name="123e4567-e89b-12d3-a456-426655440001"
@@ -44,7 +42,6 @@ exports[`renders a RadioGroup 1`] = `
   >
     <div>
       <input
-        aria-describedby="one_123e4567-e89b-12d3-a456-426655440005_description"
         checked=""
         class="input"
         id="one_123e4567-e89b-12d3-a456-426655440005"
@@ -61,7 +58,6 @@ exports[`renders a RadioGroup 1`] = `
     </div>
     <div>
       <input
-        aria-describedby="two_123e4567-e89b-12d3-a456-426655440006_description"
         class="input"
         id="two_123e4567-e89b-12d3-a456-426655440006"
         name="123e4567-e89b-12d3-a456-426655440004"

--- a/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,42 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a RadioGroup 1`] = `
-<div
-  className="radioGroup"
->
-  <div>
-    <input
-      checked={false}
-      className="input"
-      id="foo_123e4567-e89b-12d3-a456-426655440001"
-      name="Foo"
-      onChange={[Function]}
-      type="radio"
-      value="foo"
-    />
-    <label
-      className="label"
-      htmlFor="foo_123e4567-e89b-12d3-a456-426655440001"
-    >
-      Foo
-    </label>
+<div>
+  <div
+    class="radioGroup"
+  >
+    <div>
+      <input
+        checked=""
+        class="input"
+        id="one_123e4567-e89b-12d3-a456-426655440002"
+        name="123e4567-e89b-12d3-a456-426655440001"
+        type="radio"
+        value="one"
+      />
+      <label
+        class="label"
+        for="one_123e4567-e89b-12d3-a456-426655440002"
+      >
+        One
+      </label>
+    </div>
+    <div>
+      <input
+        class="input"
+        id="two_123e4567-e89b-12d3-a456-426655440003"
+        name="123e4567-e89b-12d3-a456-426655440001"
+        type="radio"
+        value="two"
+      />
+      <label
+        class="label"
+        for="two_123e4567-e89b-12d3-a456-426655440003"
+      >
+        Two
+      </label>
+    </div>
   </div>
-  <div>
-    <input
-      checked={true}
-      className="input"
-      id="bear_123e4567-e89b-12d3-a456-426655440002"
-      name="Foo"
-      onChange={[Function]}
-      type="radio"
-      value="bear"
-    />
-    <label
-      className="label"
-      htmlFor="bear_123e4567-e89b-12d3-a456-426655440002"
-    >
-      Bear
-    </label>
+  <div
+    class="radioGroup"
+  >
+    <div>
+      <input
+        checked=""
+        class="input"
+        id="one_123e4567-e89b-12d3-a456-426655440005"
+        name="123e4567-e89b-12d3-a456-426655440004"
+        type="radio"
+        value="one"
+      />
+      <label
+        class="label"
+        for="one_123e4567-e89b-12d3-a456-426655440005"
+      >
+        One
+      </label>
+    </div>
+    <div>
+      <input
+        class="input"
+        id="two_123e4567-e89b-12d3-a456-426655440006"
+        name="123e4567-e89b-12d3-a456-426655440004"
+        type="radio"
+        value="two"
+      />
+      <label
+        class="label"
+        for="two_123e4567-e89b-12d3-a456-426655440006"
+      >
+        Two
+      </label>
+    </div>
   </div>
 </div>
 `;

--- a/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`renders a RadioGroup 1`] = `
   >
     <div>
       <input
+        aria-describedby="one_123e4567-e89b-12d3-a456-426655440002_description"
         checked=""
         class="input"
         id="one_123e4567-e89b-12d3-a456-426655440002"
@@ -23,6 +24,7 @@ exports[`renders a RadioGroup 1`] = `
     </div>
     <div>
       <input
+        aria-describedby="two_123e4567-e89b-12d3-a456-426655440003_description"
         class="input"
         id="two_123e4567-e89b-12d3-a456-426655440003"
         name="123e4567-e89b-12d3-a456-426655440001"
@@ -42,6 +44,7 @@ exports[`renders a RadioGroup 1`] = `
   >
     <div>
       <input
+        aria-describedby="one_123e4567-e89b-12d3-a456-426655440005_description"
         checked=""
         class="input"
         id="one_123e4567-e89b-12d3-a456-426655440005"
@@ -58,6 +61,7 @@ exports[`renders a RadioGroup 1`] = `
     </div>
     <div>
       <input
+        aria-describedby="two_123e4567-e89b-12d3-a456-426655440006_description"
         class="input"
         id="two_123e4567-e89b-12d3-a456-426655440006"
         name="123e4567-e89b-12d3-a456-426655440004"

--- a/packages/components/src/RadioGroup/index.ts
+++ b/packages/components/src/RadioGroup/index.ts
@@ -1,1 +1,2 @@
-export { RadioGroup, RadioOption } from "./RadioGroup";
+export { RadioGroup } from "./RadioGroup";
+export { RadioOption } from "./RadioOption";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

RadioGroup needs to be able to handle a description. The current use case does not allow that to be done very nicely. This PR adds a `label` and `description` prop to `RadioOption` that will allow for a nicer way to add labels and descriptions

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `label` prop to `RadioOption`
- `description` prop to `RadioOption`
- Additional styling to `RadioOption`

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
