### PR TITLE
fix(components): Make sure drawer content is full width

### DIFF
--- a/packages/components/src/Drawer/Drawer.css
+++ b/packages/components/src/Drawer/Drawer.css
@@ -60,6 +60,8 @@
   flex-direction: row;
   overflow-y: auto;
 }
+
 .content {
+  width: 100%;
   padding: var(--drawer--base-padding);
 }


### PR DESCRIPTION
### Fixed

This PR makes sure the content of the drawer fills the available horizontal space.

#### Before 

![image](https://user-images.githubusercontent.com/1479091/100394847-d57d7d80-2ffb-11eb-8a01-88add9b3f317.png)

#### After

![image](https://user-images.githubusercontent.com/1479091/100394810-b7178200-2ffb-11eb-9a0c-12b749333449.png)


