### PR TITLE
feat(components): Reduce width of drawer for medium breakpoint

### DIFF
--- a/packages/components/src/Drawer/Drawer.css
+++ b/packages/components/src/Drawer/Drawer.css
@@ -18,6 +18,10 @@
   @media (--medium-screens), print {
     position: relative;
     z-index: auto;
+    width: 280px;
+  }
+
+  @media (--wide-screens) {
     width: 420px;
   }
 }

--- a/packages/components/src/Drawer/Drawer.css
+++ b/packages/components/src/Drawer/Drawer.css
@@ -1,4 +1,5 @@
 :root {
+  --drawer-width: calc(var(--space-base) * 17.5);
   --drawer--background-color: var(--color-white);
   --drawer--header-background-color: var(--color-grey--lightest);
   --drawer--border-color: var(--color-grey--lighter);
@@ -18,11 +19,11 @@
   @media (--medium-screens), print {
     position: relative;
     z-index: auto;
-    width: 280px;
+    width: var(--drawer-width);
   }
 
   @media (--wide-screens) {
-    width: 420px;
+    --drawer-width: calc(var(--space-base) * 26.25);
   }
 }
 

--- a/packages/components/src/Drawer/DrawerGrid.module.css
+++ b/packages/components/src/Drawer/DrawerGrid.module.css
@@ -1,7 +1,8 @@
 .drawerGrid {
   display: grid;
   width: 100%;
-  grid-template-columns: [main] auto [sidebar] minmax(min-content, max-content);
-  column-gap: var(--space-base);
-  align-items: stretch;
+  height: 100%;
+  overflow: hidden;
+  grid-template-columns: minmax(0, 1fr) minmax(min-content, max-content);
+  grid-template-rows: 1fr;
 }


### PR DESCRIPTION
## Motivations

This PR improved the appearance of the drawer on smaller screens by introducting a medium breakoint. It also fixes some layout issues with the drawerGrid component.

## Changes

The drawer width is too large for screens between 640px and 1024px wide

![image](https://user-images.githubusercontent.com/1479091/100487314-25744700-30c5-11eb-96be-1c22b540be9f.png)

Now the drawer is smaller for this screen size.

![image](https://user-images.githubusercontent.com/1479091/100487292-070e4b80-30c5-11eb-911d-ffcb0b04bf6a.png)
