### PR TITLE
feat(components): add inputNumberRef to inputNumber

### DIFF
--- a/packages/components/src/InputNumber/InputNumber.mdx
+++ b/packages/components/src/InputNumber/InputNumber.mdx
@@ -9,6 +9,8 @@ import { ComponentStatus } from "@jobber/docx";
 import { InputNumber } from ".";
 import { Text } from "../Text";
 import { useState } from "react";
+import { Button } from "../Button";
+import { Content } from "../Content";
 
 # InputNumber
 
@@ -124,6 +126,28 @@ no value to the user by offering an incrementer.
     />
     days
   </Text>
+</Playground>
+
+## Focus & Blur
+
+<Playground>
+  {() => {
+    const inputNumberRef = React.createRef();
+    const focusInput = () => {
+      inputNumberRef.current.focus();
+    };
+    const blurInput = () => {
+      inputNumberRef.current.blur();
+    };
+    return (
+      <Content>
+        <InputNumber value={5} ref={inputNumberRef} />
+        <Button label="Focus input" onClick={focusInput} />
+        <br />
+        <Button label="Blur input" onClick={blurInput} />
+      </Content>
+    );
+  }}
 </Playground>
 
 ## Using onValidation

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -247,3 +247,14 @@ test("it should handle focus", () => {
   inputRef.current.focus();
   expect(document.activeElement).toBe(getByLabelText(placeholder));
 });
+
+test("it should handle blur", () => {
+  const inputRef = React.createRef<InputNumberRef>();
+  const blurHandler = jest.fn();
+
+  render(<InputNumber ref={inputRef} onBlur={blurHandler} />);
+
+  inputRef.current.focus();
+  inputRef.current.blur();
+  expect(blurHandler).toHaveBeenCalledTimes(1);
+});

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
-import { InputNumber } from ".";
+import { InputNumber, InputNumberRef } from ".";
 
 afterEach(cleanup);
 
@@ -233,4 +233,17 @@ test("allows custom validation", async () => {
   await waitFor(() => {
     expect(validationHandler).toHaveBeenCalledWith("only one number");
   });
+});
+
+test("it should handle focus", () => {
+  const placeholder = "Number";
+
+  const inputRef = React.createRef<InputNumberRef>();
+
+  const { getByLabelText } = render(
+    <InputNumber placeholder={placeholder} ref={inputRef} />,
+  );
+
+  inputRef.current.focus();
+  expect(document.activeElement).toBe(getByLabelText(placeholder));
 });

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -236,9 +236,8 @@ test("allows custom validation", async () => {
 });
 
 test("it should handle focus", () => {
-  const placeholder = "Number";
-
   const inputRef = React.createRef<InputNumberRef>();
+  const placeholder = "Number";
 
   const { getByLabelText } = render(
     <InputNumber placeholder={placeholder} ref={inputRef} />,

--- a/packages/components/src/InputNumber/InputNumber.tsx
+++ b/packages/components/src/InputNumber/InputNumber.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Ref, createRef, forwardRef, useImperativeHandle } from "react";
 import { FormField, FormFieldProps } from "../FormField";
 
 /**
@@ -15,11 +15,37 @@ interface InputNumberProps
   value?: number;
 }
 
-export function InputNumber(props: InputNumberProps) {
+export interface InputNumberRef {
+  blur(): void;
+  focus(): void;
+}
+
+function InputNumberInternal(
+  props: InputNumberProps,
+  ref: Ref<InputNumberRef>,
+) {
+  const inputRef = createRef<HTMLTextAreaElement | HTMLInputElement>();
+
+  useImperativeHandle(ref, () => ({
+    blur: () => {
+      const input = inputRef.current;
+      if (input) {
+        input.blur();
+      }
+    },
+    focus: () => {
+      const input = inputRef.current;
+      if (input) {
+        input.focus();
+      }
+    },
+  }));
+
   return (
     <FormField
       {...props}
       type="number"
+      inputRef={inputRef}
       onChange={handleChange}
       validations={{
         ...props.validations,
@@ -51,3 +77,5 @@ export function InputNumber(props: InputNumberProps) {
     return true;
   }
 }
+
+export const InputNumber = forwardRef(InputNumberInternal);

--- a/packages/components/src/InputNumber/index.ts
+++ b/packages/components/src/InputNumber/index.ts
@@ -1,1 +1,1 @@
-export { InputNumber } from "./InputNumber";
+export { InputNumber, InputNumberRef } from "./InputNumber";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Allows focus and blur to be set on inputNumber
<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- InputNumberRef now provide access to focus and blur on InputNumber

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing
Added sample code to InputNumber playground
<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
