### PR TITLE
feat(components): convert `progressBar` to semantic HTML and count step 1

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -80,14 +80,14 @@ exports[`renders correctly when invalid 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440044"
+      htmlFor="123e4567-e89b-12d3-a456-426655440043"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440044"
+      id="123e4567-e89b-12d3-a456-426655440043"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -80,14 +80,14 @@ exports[`renders correctly when invalid 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440043"
+      htmlFor="123e4567-e89b-12d3-a456-426655440044"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440043"
+      id="123e4567-e89b-12d3-a456-426655440044"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -1,17 +1,25 @@
 :root {
   --progress-bar--backgroundColor: var(--color-grey--lightest);
-  --progress-bar--barColor: var(--color-lime);
+  --progress-bar--barColor: var(--color-green);
+  --progress-bar--height: var(--space-base);
 }
 
-.container,
-.content {
+progress[value] {
   width: 100%;
-  height: var(--progress-bar--height);
-  border-radius: calc(var(--progress-bar--height) / 2);
-  background: var(--progress-bar--backgroundColor);
+  /* Reset the default appearance */
+  border: none;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
-.content {
+progress[value]::-webkit-progress-bar {
+  box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.05);
+  border-radius: calc(var(--progress-bar--height) / 2);
+  background-color: var(--progress-bar--backgroundColor);
+}
+
+progress[value]::-webkit-progress-value {
+  border-radius: calc(var(--progress-bar--height) / 2);
   background-color: var(--progress-bar--barColor);
-  transition: width var(--timing-slower) ease-out;
+  transition: all var(--timing-slow) ease-out;
 }

--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -6,19 +6,27 @@
 
 progress[value] {
   width: 100%;
-  /* Reset the default appearance */
   border: none;
-  -webkit-appearance: none;
   appearance: none;
 }
 
+progress[value],
 progress[value]::-webkit-progress-bar {
   box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.05);
   border-radius: calc(var(--progress-bar--height) / 2);
+}
+
+progress[value]::-webkit-progress-bar {
   background-color: var(--progress-bar--backgroundColor);
 }
 
 progress[value]::-webkit-progress-value {
+  border-radius: calc(var(--progress-bar--height) / 2);
+  background-color: var(--progress-bar--barColor);
+  transition: all var(--timing-slow) ease-out;
+}
+
+progress[value]::-moz-progress-bar {
   border-radius: calc(var(--progress-bar--height) / 2);
   background-color: var(--progress-bar--barColor);
   transition: all var(--timing-slow) ease-out;

--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -4,29 +4,30 @@
   --progress-bar--height: var(--space-base);
 }
 
-progress[value] {
+progress.ProgressBar[value] {
   width: 100%;
+  height: var(--progress-bar--height);
   border: none;
   appearance: none;
 }
 
-progress[value],
-progress[value]::-webkit-progress-bar {
+progress.ProgressBar[value],
+progress.ProgressBar[value]::-webkit-progress-bar {
   box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.05);
   border-radius: calc(var(--progress-bar--height) / 2);
 }
 
-progress[value]::-webkit-progress-bar {
+progress.ProgressBar[value]::-webkit-progress-bar {
   background-color: var(--progress-bar--backgroundColor);
 }
 
-progress[value]::-webkit-progress-value {
+progress.ProgressBar[value]::-webkit-progress-value {
   border-radius: calc(var(--progress-bar--height) / 2);
   background-color: var(--progress-bar--barColor);
   transition: all var(--timing-slow) ease-out;
 }
 
-progress[value]::-moz-progress-bar {
+progress.ProgressBar[value]::-moz-progress-bar {
   border-radius: calc(var(--progress-bar--height) / 2);
   background-color: var(--progress-bar--barColor);
   transition: all var(--timing-slow) ease-out;

--- a/packages/components/src/ProgressBar/ProgressBar.css.d.ts
+++ b/packages/components/src/ProgressBar/ProgressBar.css.d.ts
@@ -1,2 +1,0 @@
-export const container: string;
-export const content: string;

--- a/packages/components/src/ProgressBar/ProgressBar.css.d.ts
+++ b/packages/components/src/ProgressBar/ProgressBar.css.d.ts
@@ -1,0 +1,1 @@
+export const ProgressBar: string;

--- a/packages/components/src/ProgressBar/ProgressBar.mdx
+++ b/packages/components/src/ProgressBar/ProgressBar.mdx
@@ -55,7 +55,7 @@ An example where you might be better served using a spinner:
     const totalSteps = 4;
     return (
       <>
-        <button onClick={() => setStep(Math.max(1, step - 1))}>
+        <button onClick={() => setStep(Math.max(0, step - 1))}>
           Step Back
         </button>
         <button onClick={() => setStep(Math.min(totalSteps, step + 1))}>

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -26,11 +26,16 @@ export function ProgressBar({
   totalSteps,
   size = "base",
 }: ProgressBarProps) {
-  const progressBarContentClassName = classnames(styles.content);
+  const percentage = (currentStep / totalSteps) * 100;
+  const progressBarClassName = classnames(styles.ProgressBar, sizes[size]);
 
   return (
-    <progress max={totalSteps} value={currentStep}>
-      {currentStep} of {totalSteps}
+    <progress
+      className={progressBarClassName}
+      max={totalSteps}
+      value={currentStep}
+    >
+      {percentage}%
     </progress>
   );
 }

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -30,7 +30,7 @@ export function ProgressBar({
 
   return (
     <progress max={totalSteps} value={currentStep}>
-      Step {currentStep} of {totalSteps}
+      {currentStep} of {totalSteps}
     </progress>
   );
 }

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -26,20 +26,12 @@ export function ProgressBar({
   totalSteps,
   size = "base",
 }: ProgressBarProps) {
-  const percentage = ((currentStep - 1) / (totalSteps - 1)) * 100;
-  const widthPercent = Math.min(100, Math.max(0, percentage));
-  const progressBarContainerClassName = classnames(
-    styles.container,
-    sizes[size],
-  );
+  const percentage = (currentStep / totalSteps) * 100;
   const progressBarContentClassName = classnames(styles.content);
 
   return (
-    <div className={progressBarContainerClassName}>
-      <div
-        className={progressBarContentClassName}
-        style={{ width: `${widthPercent}%` }}
-      />
-    </div>
+    <progress max={totalSteps} value={currentStep}>
+      {percentage} % complete
+    </progress>
   );
 }

--- a/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -26,12 +26,11 @@ export function ProgressBar({
   totalSteps,
   size = "base",
 }: ProgressBarProps) {
-  const percentage = (currentStep / totalSteps) * 100;
   const progressBarContentClassName = classnames(styles.content);
 
   return (
     <progress max={totalSteps} value={currentStep}>
-      {percentage} % complete
+      Step {currentStep} of {totalSteps}
     </progress>
   );
 }

--- a/packages/components/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/components/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -1,31 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`with props accepts small size 1`] = `
-<div
-  className="container small"
+<progress
+  className="ProgressBar small"
+  max={3}
+  value={2}
 >
-  <div
-    className="content"
-    style={
-      Object {
-        "width": "50%",
-      }
-    }
-  />
-</div>
+  66.66666666666666
+  %
+</progress>
 `;
 
 exports[`with props renders correctly 1`] = `
-<div
-  className="container base"
+<progress
+  className="ProgressBar base"
+  max={10}
+  value={2}
 >
-  <div
-    className="content"
-    style={
-      Object {
-        "width": "11.11111111111111%",
-      }
-    }
-  />
-</div>
+  20
+  %
+</progress>
 `;


### PR DESCRIPTION
## Motivations

Making some improvements to progressBar that @jlelford noticed while working with Atlantis! Also sneaks in an accessibility improvement I've been wanting to make for some time, using `<progress>` instead of divs so that users of assistive tech can know what;s going on!

Also, it makes sense that on step 1 of N, you see your "currentStep" visualized!

## Changes

### Changed

- divs are now `<progress>`, and associated CSS changes
- this cuts out some JS calculations we were doing
- Step 1 is visualized as a step!

## References

https://css-tricks.com/html5-progress-element/
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
