### PR TITLE
feat(components): Add dismissible prop to banner

### DIFF
--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -12,7 +12,9 @@ import { Banner } from ".";
 
 <ComponentStatus stage="ready" responsive="yes" accessible="yes" />
 
-Banners provide information about important changes, persistent conditions, and system errors. They're positioned at the top of the screen or near the content they reference, and are persistent until dismissed or the issue is resolved.
+Banners provide information about important changes, persistent conditions, and
+system errors. They're positioned at the top of the screen or near the content
+they reference, and are persistent until dismissed or the issue is resolved.
 
 ```ts
 import { Banner } from "@jobber/components/Banner";
@@ -67,6 +69,7 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
       label: "Poke Me",
       onClick: () => alert("💥💥SMASH💥💥")
     }}
+    dismissible={false}
   >
     You wouldn't like me when I'm angry.
   </Banner>
@@ -81,7 +84,7 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
   </Banner>
 </Playground>
 
-
 ## Related components
 
-* To provide low priority, temporary feedback on the outcome of a user action, use [Toast](toast) instead.
+- To provide low priority, temporary feedback on the outcome of a user action,
+  use [Toast](toast) instead.

--- a/packages/components/src/Banner/Banner.test.tsx
+++ b/packages/components/src/Banner/Banner.test.tsx
@@ -29,6 +29,17 @@ it("renders a warning banner", () => {
   expect(tree).toMatchSnapshot();
 });
 
+it("renders without close button", () => {
+  const tree = renderer
+    .create(
+      <Banner type="warning" dismissible={false}>
+        Warn
+      </Banner>,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test("it should call the handler with a number value", () => {
   const changeHandler = jest.fn();
 

--- a/packages/components/src/Banner/Banner.test.tsx
+++ b/packages/components/src/Banner/Banner.test.tsx
@@ -30,14 +30,21 @@ it("renders a warning banner", () => {
 });
 
 it("renders without close button", () => {
-  const tree = renderer
-    .create(
-      <Banner type="warning" dismissible={false}>
-        Warn
-      </Banner>,
-    )
-    .toJSON();
-  expect(tree).toMatchSnapshot();
+  const { queryByLabelText } = render(
+    <Banner type="warning" dismissible={false}>
+      Foo
+    </Banner>,
+  );
+  expect(queryByLabelText("Close")).toBeNull();
+});
+
+it("renders with close button", () => {
+  const { queryByLabelText } = render(
+    <Banner type="warning" dismissible={true}>
+      Foo
+    </Banner>,
+  );
+  expect(queryByLabelText("Close")).toBeTruthy();
 });
 
 test("it should call the handler with a number value", () => {

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -15,6 +15,10 @@ interface BannerProps {
    * 'type' is set to 'notice' we change the cta variation to 'learning'
    */
   readonly primaryAction?: ButtonProps;
+  /**
+   * @default true
+   */
+  readonly dismissible?: boolean;
   onDismiss?(): void;
 }
 
@@ -26,6 +30,7 @@ export function Banner({
   children,
   type,
   primaryAction,
+  dismissible = true,
   onDismiss,
 }: BannerProps) {
   const [showFlash, setShowFlash] = useState(true);
@@ -56,13 +61,15 @@ export function Banner({
           <Text>{children}</Text>
           {primaryAction && <Button {...primaryAction} />}
 
-          <button
-            className={styles.closeButton}
-            onClick={handleClose}
-            aria-label="Close"
-          >
-            <Icon name="cross" color={iconColors[type]} />
-          </button>
+          {dismissible && (
+            <button
+              className={styles.closeButton}
+              onClick={handleClose}
+              aria-label="Close"
+            >
+              <Icon name="cross" color={iconColors[type]} />
+            </button>
+          )}
         </div>
       )}
     </>

--- a/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
@@ -195,3 +195,15 @@ exports[`renders an error banner 1`] = `
   </button>
 </div>
 `;
+
+exports[`renders without close button 1`] = `
+<div
+  className="flash warning"
+>
+  <p
+    className="base regular base greyBlueDark"
+  >
+    Warn
+  </p>
+</div>
+`;

--- a/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
@@ -195,15 +195,3 @@ exports[`renders an error banner 1`] = `
   </button>
 </div>
 `;
-
-exports[`renders without close button 1`] = `
-<div
-  className="flash warning"
->
-  <p
-    className="base regular base greyBlueDark"
-  >
-    Warn
-  </p>
-</div>
-`;


### PR DESCRIPTION
## Motivations
 - We do not want the banner reminding SP to setup 2FA phone number to be dismissible. Adding a prop to make non-dismissible banner available.

### Added
- dismissible prop in banner component.
- `dismissible` is true (default)
![image](https://user-images.githubusercontent.com/51678918/100813495-b5372f80-33fc-11eb-812a-a77c76918035.png)

- `dismissible` is false
![image](https://user-images.githubusercontent.com/51678918/100813477-a9e40400-33fc-11eb-97d4-87b81c1bc9d1.png)


## Testing
 - Tested with playground in Atlantis.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
