### PR TITLE
feat: add required column to component proposal template

### DIFF
--- a/docs/proposals/TEMPLATE.md
+++ b/docs/proposals/TEMPLATE.md
@@ -34,6 +34,6 @@ it from another react component? This should consist primarily of code blocks}_
 
 _{Provide a table in the following format of the component's public API}_
 
-| name | type | required | default | description |
-| ---- | ---- | -------- | ------- | ----------- |
-| ...  | ...  | ...      | ...     | ...         |
+| name | type | required? | default | description |
+| ---- | ---- | --------- | ------- | ----------- |
+| ...  | ...  | ...       | ...     | ...         |

--- a/docs/proposals/TEMPLATE.md
+++ b/docs/proposals/TEMPLATE.md
@@ -34,6 +34,6 @@ it from another react component? This should consist primarily of code blocks}_
 
 _{Provide a table in the following format of the component's public API}_
 
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| ...  | ...  | ...     | ...         |
+| name | type | required | default | description |
+| ---- | ---- | -------- | ------- | ----------- |
+| ...  | ...  | ...      | ...     | ...         |


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We noticed in the review process of component proposals that we couldn't figure out if a property was required or not. 

## Changes

Added a `required` column to the prop table in the proposal template.

### Added

Added a `required` column to the prop table in the proposal template.

![image](https://user-images.githubusercontent.com/16542956/100927011-832bd900-34a1-11eb-878e-f013570402e7.png)

