### PR TITLE
fix(components): match colors on radio and checkbox labels and inputs

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -80,14 +80,14 @@ exports[`renders correctly when invalid 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440044"
+      htmlFor="123e4567-e89b-12d3-a456-426655440043"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440044"
+      id="123e4567-e89b-12d3-a456-426655440043"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -80,14 +80,14 @@ exports[`renders correctly when invalid 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440043"
+      htmlFor="123e4567-e89b-12d3-a456-426655440044"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440043"
+      id="123e4567-e89b-12d3-a456-426655440044"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/packages/components/src/Checkbox/Checkbox.css
+++ b/packages/components/src/Checkbox/Checkbox.css
@@ -42,8 +42,11 @@
 }
 
 .disabled .checkBox {
-  border-color: var(--color-grey--light);
-  background-color: var(--color-grey--lightest);
+  border-color: var(--color-grey--lighter);
+}
+
+.disabled p {
+  color: var(--color-grey);
 }
 
 .disabled .checkBox > * {

--- a/packages/components/src/Checkbox/Checkbox.mdx
+++ b/packages/components/src/Checkbox/Checkbox.mdx
@@ -92,7 +92,7 @@ discrete options, such as “fixed price” and “per visit” invoicing option
 ## With a description
 
 If there is more information needed for a `Checkbox`, use the `description` prop
-instead of a longer `label`
+instead of a longer `label`.
 
 <Playground>
   <Checkbox
@@ -121,5 +121,6 @@ that the user has lost control of the interface.
 
 ## Related components
 
-* To let people turn a setting on or off instantly, use a [Switch](switch).
-* To present a set of options where people can only make a single choice, use a [Radio Group](radio-group).
+- To let people turn a setting on or off instantly, use a [Switch](switch).
+- To present a set of options where people can only make a single choice, use a
+  [Radio Group](radio-group).

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -94,7 +94,7 @@ export function Checkbox({
 
         {label != undefined && (
           <span className={styles.label}>
-            <Text variation={disabled ? "subdued" : undefined}>{label}</Text>
+            <Text>{label}</Text>
           </span>
         )}
       </label>

--- a/packages/components/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`renders a disabled Checkbox 1`] = `
       className="label"
     >
       <p
-        className="base regular base greyBlue"
+        className="base regular base greyBlueDark"
       >
         Dont click me
       </p>

--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -22,7 +22,7 @@
   height: var(--space-base);
   box-sizing: border-box;
   margin: 0 var(--space-small) 0 0;
-  border: var(--border-thick) solid var(--color-grey--light);
+  border: var(--border-thick) solid var(--color-green);
   border-radius: 100%;
   background-color: var(--color-white);
   transition: all var(--timing-base);
@@ -33,18 +33,19 @@
 }
 
 .input:checked + .label::before {
+  box-shadow: 0px 0px 0px var(--space-minuscule) var(--color-green--dark);
   border-color: var(--color-green--dark);
+  border-width: var(--border-thicker);
   background-color: var(--color-green);
 }
 
 .input[disabled] + .label {
-  color: var(--color-blue--lighter);
+  color: var(--color-grey);
   cursor: not-allowed;
 }
 
 .input[disabled] + .label::before {
-  border-color: var(--color-grey--light);
-  background-color: var(--color-grey--lighter);
+  border-color: var(--color-grey--lighter);
 }
 
 .description {


### PR DESCRIPTION
## Motivations

Our disabled states on similar UI controls are quite different!
![image](https://user-images.githubusercontent.com/39704901/101068222-aca63c80-3555-11eb-867c-05dc88597790.png)

## Changes

- Uses the disabled "label" color, and same border/fills on the input itself
- Also created a stronger indicator of `selected` on radio options to distinguish a checked+disabled option from unchecked+disabled

This PR is a scoped-down version of what I initially set out to accomplish with [an earlier swing](https://github.com/GetJobber/atlantis/pull/434) that was just all kinds of problematic for the scope of problem this PR actually sets out to solve.

### Changed

- changed colours on checkbox and radio

## Testing

- Go to RadioGroup since there's a checkbox included there!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
