### PR TITLE
feat(components): adjust line-height on largest font sizes and add h6

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -80,14 +80,14 @@ exports[`renders correctly when invalid 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440044"
+      htmlFor="123e4567-e89b-12d3-a456-426655440043"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440044"
+      id="123e4567-e89b-12d3-a456-426655440043"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -80,14 +80,14 @@ exports[`renders correctly when invalid 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440043"
+      htmlFor="123e4567-e89b-12d3-a456-426655440044"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440043"
+      id="123e4567-e89b-12d3-a456-426655440044"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/packages/components/src/Heading/Heading.mdx
+++ b/packages/components/src/Heading/Heading.mdx
@@ -81,6 +81,20 @@ Used to group contents after a [heading 4](#heading-4).
   <Heading level={5}>Receives SMS</Heading>
 </Playground>
 
+### Heading 6
+
+Used to group contents after a [heading 5](#heading-5) or to group small lists
+of content.
+
+<Playground>
+  <Heading level={6}>Business Settings</Heading>
+  ...
+  <Heading level={6}>Organization Settings</Heading>
+  ...
+  <Heading level={6}>Communication Settings</Heading>
+  ...
+</Playground>
+
 ---
 
 ## Props
@@ -91,4 +105,5 @@ Used to group contents after a [heading 4](#heading-4).
 
 ## Related components
 
-* For introductory text after a page title or paragraph text for body copy, use [Text](text).
+- For introductory text after a page title or paragraph text for body copy, use
+  [Text](text).

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -5,7 +5,7 @@ interface HeadingProps {
   /**
    * @default 5
    */
-  readonly level: 1 | 2 | 3 | 4 | 5;
+  readonly level: 1 | 2 | 3 | 4 | 5 | 6;
   readonly children: ReactNode;
 }
 
@@ -44,6 +44,13 @@ export function Heading({ level = 5, children }: HeadingProps) {
     5: {
       element: "h5",
       size: "base",
+      fontWeight: "bold",
+      textColor: "blue",
+    },
+    6: {
+      element: "h6",
+      size: "small",
+      textCase: "uppercase",
       fontWeight: "bold",
       textColor: "blue",
     },

--- a/packages/components/src/Typography/css/FontSizes.css
+++ b/packages/components/src/Typography/css/FontSizes.css
@@ -1,15 +1,16 @@
 .extravagant {
   font-size: var(--typography--fontSize-extravagant);
+  line-height: var(--typography--lineHeight-miniscule);
 }
 
 .jumbo {
   font-size: var(--typography--fontSize-jumbo);
-  line-height: var(--typography--lineHeight-large);
+  line-height: var(--typography--lineHeight-miniscule);
 }
 
 .largest {
   font-size: var(--typography--fontSize-largest);
-  line-height: var(--typography--lineHeight-large);
+  line-height: var(--typography--lineHeight-tightest);
 }
 
 .larger {


### PR DESCRIPTION
## Motivations

While working on [Page updates](https://github.com/GetJobber/atlantis/pull/422), I noticed that our line-heights on h1 (and h2) were quite large. This seems to be following the general principle of scaling the line-heights linearly with the font-size, however with large display typefaces you generally require _less_ line-height as you get into larger sizes, as the user 

a) is less likely to need to read 2+ lines of text
b) requires less space between those lines as the individual characters are larger and more distinguishable

After talking with @eddysims we decided I should do this work in a separate PR. This is that PR. Since I'm in here, I added an h6 to Atlantis because it feels like we should be accounting for a core semantic type element. Styling is based on Jobber's current in-product h6.

## Changes

### Added

- an h6 to Atlantis

### Changed

- reduced the line-height associated with our 3 largest font-sizes 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
