### PR TITLE
fix(components): account for checked disabled state on RadioGroup

### DIFF
--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -48,7 +48,17 @@
   border-color: var(--color-grey--lighter);
 }
 
+.input[disabled]:checked + .label::before {
+  box-shadow: 0px 0px 0px var(--space-minuscule) var(--color-grey);
+  border-color: var(--color-grey);
+  background-color: var(--color-grey--lighter);
+}
+
 .description {
   margin-bottom: var(--space-small);
   padding-left: var(--space-large);
+}
+
+.input[disabled] + .label + .description > p {
+  color: var(--color-grey);
 }


### PR DESCRIPTION
## Motivations

At some point in the process of updating RadioGroup styling, the `[disabled]:checked` state got discarded 😞 . This fixes that and also adds the disabled state to the `.description` when a RadioOption is disabled.

## Changes

### Changed

- Use `grey` for the description and the border of the `[disabled]:checked` input. Use `grey--lighter` for the `[disabled]:checked` input fill.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
