### PR TITLE
docs(design): update color docs layouts

### DIFF
--- a/packages/docx/src/ColorSwatches/ColorSwatch/ColorSwatch.css
+++ b/packages/docx/src/ColorSwatches/ColorSwatch/ColorSwatch.css
@@ -4,8 +4,16 @@
   margin: var(--space-small) 0 var(--space-smaller);
 }
 
+/*  1. There are no borders around the swatches, so this
+    identifies any swatches that are white and gives
+    them a box-shadow so they can be viewed as a swatch
+    against a white background. The swatches are all
+    given their background color via a style tag that
+    the .js generates, so this should be a stable way of
+    tagging this swatch. */
+
 .color[style*="background-color: rgb(255, 255, 255);"] {
-  box-shadow: var(--shadow-base);
+  box-shadow: var(--shadow-base); /* 1 */
 }
 
 .swatch:first-child {

--- a/packages/docx/src/ColorSwatches/ColorSwatch/ColorSwatch.css
+++ b/packages/docx/src/ColorSwatches/ColorSwatch/ColorSwatch.css
@@ -1,23 +1,27 @@
 .swatch {
   display: inline-block;
-  width: calc(100% / 4 - 0.5rem);
-  margin: 0.25rem;
+  width: 25%;
+  margin: var(--space-small) 0 var(--space-smaller);
+}
+
+.color[style*="background-color: rgb(255, 255, 255);"] {
+  box-shadow: var(--shadow-base);
 }
 
 .swatch:first-child {
-  width: calc(100% - 0.5rem);
+  width: 100%;
+  margin-top: var(--space-smaller);
 }
 
 .color {
-  height: 60px;
-  border: solid 1px var(--color-grey--light);
-  border-radius: 0.25rem;
+  height: var(--space-extravagant);
+  margin-bottom: var(--space-smaller);
 }
 
 .name,
 .value {
   width: 100%;
+  color: var(--color-greyBlue--dark);
   font-family: monospace;
-  font-size: 10px;
-  text-align: center;
+  font-size: var(--typography--fontSize-smaller);
 }

--- a/packages/docx/src/ColorSwatches/ColorSwatches.css
+++ b/packages/docx/src/ColorSwatches/ColorSwatches.css
@@ -1,14 +1,14 @@
 .groupTitle {
   position: relative;
-  margin: 30px 0 20px;
-  font-family: "Poppins", sans-serif;
-  font-size: 20px;
-  font-weight: 600;
-  line-height: 1.4em;
-  letter-spacing: -0.02em;
+  margin: var(--space-largest) 0 var(--space-base);
+  color: var(--color-blue);
+  font-family: var(--typography--fontFamily-display);
+  font-size: var(--typography--fontSize-larger);
+  font-weight: 800;
+  line-height: var(--typography--lineHeight-tight);
   text-transform: uppercase;
 }
 
 .swatchGroup {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-base);
 }


### PR DESCRIPTION
## Motivations

Colors is one of the oldest sections of Atlantis, and since that time we've enabled our theme to use Atlantis. This PR puts some of our variables to use, and also makes some layout adjustments for ease of use.

## Changes

Some layout changes, as well as some under-the-hood CSS changes.

### Changed

#### Technical
- convert hard-coded values to variables

#### Visual
- increase font-size for variable name and values
- left-align variables names and values
- remove left/right spacing, borders, and radii from swatches
- increase vertical spacing

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
