### PR TITLE
fix(components): allow Toast to expand on small screens

### DIFF
--- a/packages/components/src/Toast/Toast.css
+++ b/packages/components/src/Toast/Toast.css
@@ -5,20 +5,25 @@
 
 .container {
   display: flex;
+  position: fixed;
+  right: 0;
+  bottom: var(--space-large);
+  left: 0;
+  z-index: var(--elevation-toast);
+  width: 100%;
+  box-sizing: border-box;
   flex-direction: column;
   align-items: center;
-  position: fixed;
-  bottom: var(--space-large);
-  left: 50%;
-  z-index: var(--elevation-toast);
+  padding: 0 var(--space-large);
   color: var(--color-greyBlue--dark);
   font-size: var(--typography--fontSize-large);
-  transform: translateX(-50%);
+  pointer-events: none;
 }
 
 .toast {
   box-shadow: var(--shadow-base);
   overflow: hidden;
+  pointer-events: all;
 }
 
 .toast + .toast {


### PR DESCRIPTION
## Motivations

Toast gets compacted quite a bit on small screens, even when there is sufficient room for it to breathe!
![image](https://user-images.githubusercontent.com/39704901/103926097-b5021200-50d5-11eb-8e94-6e24e71d3cc5.png)

## Changes

Allows the Toast to take up the full width of the screen, minus equivalent spacing on left, right and bottom (uses --space-large on all 3)

### Changed

- Some CSS changes to allow Toast to expand

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
