### PR TITLE
fix(components): reset vertical-align property on `ProgressBar`

### DIFF
--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -8,6 +8,7 @@ progress.ProgressBar[value] {
   width: 100%;
   height: var(--progress-bar--height);
   border: none;
+  vertical-align: initial;
   appearance: none;
 }
 


### PR DESCRIPTION
## Motivations

In switching `ProgressBar` to use the html `<progress>` element, we picked up a user-agent stylesheet `vertical-align` property that causes the `ProgressBar` to sit 0.2em lower than expected.

## Changes

CSS change to reset `vertical-align` to its default value.
 
### Fixed

- baseline alignment issue with `ProgressBar`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
