### PR TITLE
docs: fix image path on product vocabulary

### DIFF
--- a/docs/guides/product-vocabulary.mdx
+++ b/docs/guides/product-vocabulary.mdx
@@ -145,12 +145,12 @@ Use **create new** when a user is generating something from scratch within
 Jobber. Abbreviating to **New [object]** for page or view titles.
 
 Use **add** when a user is adding something to an object in Jobber, even if that
-object is being newly created.<img
-src="/public/assets/images/in-product-words/addvscreate.png" style={{
-maxWidth:
-"100%"
-}} />
+object is being newly created.
 
+<img
+  src="/public/assets/images/product-vocabulary/addvscreate.png"
+  style={{ maxWidth: "100%" }}
+/>
 <br />
 
 ### back / continue / next / previous


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Changes

image path is broken.



[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
