### PR TITLE
feat(components): Spinner

### DIFF
--- a/packages/components/src/Spinner/Spinner.css
+++ b/packages/components/src/Spinner/Spinner.css
@@ -1,0 +1,44 @@
+.spinner {
+  width: var(--space-larger);
+  height: var(--space-larger);
+  box-shadow: var(--shadow-dark);
+  border: solid var(--color-blue--light);
+  border-top-color: var(--color-white);
+  border-width: calc(var(--space-small) * 0.75);
+  border-radius: 50%;
+  vertical-align: middle;
+  background-color: var(--color-blue--lightest);
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-name: animation-spin;
+  animation-timing-function: linear;
+  will-change: transform;
+}
+
+@keyframes animation-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(359deg);
+  }
+}
+
+/* -------------------------------------------------------------------------
+   Small Spinner
+   ------------------------------------------------------------------------- */
+
+.small {
+  width: var(--space-base);
+  height: var(--space-base);
+  border-width: var(--space-smaller);
+}
+
+/* -------------------------------------------------------------------------
+   Inline Spinner
+   ------------------------------------------------------------------------- */
+
+.inline {
+  display: inline-block;
+}

--- a/packages/components/src/Spinner/Spinner.css.d.ts
+++ b/packages/components/src/Spinner/Spinner.css.d.ts
@@ -1,0 +1,3 @@
+export const spinner: string;
+export const small: string;
+export const inline: string;

--- a/packages/components/src/Spinner/Spinner.mdx
+++ b/packages/components/src/Spinner/Spinner.mdx
@@ -1,0 +1,53 @@
+---
+name: Spinner
+menu: Components
+route: /components/spinner
+---
+
+import { Playground, Props } from "docz";
+import { ComponentStatus } from "@jobber/docx";
+import { Spinner } from ".";
+import { Text } from "../Text";
+
+# Spinner
+
+<ComponentStatus stage="pre" responsive="no" accessible="yes" />
+
+Spinners are used to visualize an undetermined load time for a section of a page
+and prevent double clicking of a UI element by overlaying it while its action is
+processing.
+
+The default spinner should be used to indicate loading of a view
+
+```ts
+import { Spinner } from "@jobber/components/Spinner";
+```
+
+<Playground>
+  <Spinner />
+</Playground>
+
+## Props
+
+<Props of={Spinner} />
+
+---
+
+## Small
+
+The `small` spinner should be used on individual element of an interface (ie.
+button or card contents) or when inline with content
+
+<Playground>
+  <Spinner size="small" />
+</Playground>
+
+## Inline
+
+Use `inline` to render the spinner inline with content.
+
+<Playground>
+  <Text>
+    Uploading... <Spinner size="small" inline={true} />
+  </Text>
+</Playground>

--- a/packages/components/src/Spinner/Spinner.test.tsx
+++ b/packages/components/src/Spinner/Spinner.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { Spinner } from ".";
+
+it("renders the spinner", () => {
+  const tree = renderer.create(<Spinner />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders the small spinner", () => {
+  const tree = renderer.create(<Spinner size="small" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders the inline spinner", () => {
+  const tree = renderer.create(<Spinner inline={true} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders a small inline spinner", () => {
+  const tree = renderer.create(<Spinner inline={true} size="small" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import classnames from "classnames";
+import styles from "./Spinner.css";
+
+interface SpinnerProps {
+  /**
+   * Specifies the size of the spinner
+   *
+   * @default "base"
+   */
+  readonly size?: "small" | "base";
+
+  /**
+   * Spinner becomes an inline element when true,
+   * otherwise it is a block element
+   */
+  readonly inline?: boolean;
+}
+
+export function Spinner({ size = "base", inline }: SpinnerProps) {
+  const spinnerStyles = classnames(styles.spinner, {
+    [styles.small]: size === "small",
+    [styles.inline]: inline,
+  });
+
+  return (
+    <div
+      className={spinnerStyles}
+      role="alert"
+      aria-busy={true}
+      aria-label="loading"
+    />
+  );
+}

--- a/packages/components/src/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/components/src/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a small inline spinner 1`] = `
+<div
+  aria-busy={true}
+  aria-label="loading"
+  className="spinner small inline"
+  role="alert"
+/>
+`;
+
+exports[`renders the inline spinner 1`] = `
+<div
+  aria-busy={true}
+  aria-label="loading"
+  className="spinner inline"
+  role="alert"
+/>
+`;
+
+exports[`renders the small spinner 1`] = `
+<div
+  aria-busy={true}
+  aria-label="loading"
+  className="spinner small"
+  role="alert"
+/>
+`;
+
+exports[`renders the spinner 1`] = `
+<div
+  aria-busy={true}
+  aria-label="loading"
+  className="spinner"
+  role="alert"
+/>
+`;

--- a/packages/components/src/Spinner/index.ts
+++ b/packages/components/src/Spinner/index.ts
@@ -1,0 +1,1 @@
+export { Spinner } from "./Spinner";

--- a/packages/design/src/shadows.css
+++ b/packages/design/src/shadows.css
@@ -2,4 +2,5 @@
   --shadow-base: 0px 1px 4px 0px rgba(0, 0, 0, 0.0980392),
     0px 4px 12px 0px rgba(0, 0, 0, 0.0470588);
   --shadow-focus: 0px 0px 4px 2px var(--color-outline);
+  --shadow-dark: 0px 0px 4px 2px var(--color-blue--lightest);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Continues the work of https://github.com/GetJobber/atlantis/pull/177 to add a spinner component to indicate loading states

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

Spinner component

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
