### PR TITLE
fix(components): allow button to remain its' own height when Banner content gets long

### DIFF
--- a/packages/components/src/Banner/Banner.css
+++ b/packages/components/src/Banner/Banner.css
@@ -22,6 +22,7 @@
   flex: 1 1 auto;
   flex-wrap: wrap;
   justify-content: space-between;
+  align-items: flex-start;
 }
 
 .dismissibleSpacing {


### PR DESCRIPTION
## Motivations

When Banner content runs past 1 line, the actions container was flexing to full height, making the button taller than needed.

## Changes

- CSS flex changes to align banner content to the top of the container.

### Fixed

- Button no longer expands taller than its' own content

## Testing

Add a long string of text to a banner with an action

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
