### PR TITLE
fix(components): Make page subtitle and intro optional

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,17 +8,6 @@ menu: Changelog
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [2.23.0](https://github.com/GetJobber/atlantis/compare/@jobber/components@2.22.2...@jobber/components@2.23.0) (2021-01-26)
-
-
-### Features
-
-* **components:** Add subtitle to Page component ([#457](https://github.com/GetJobber/atlantis/issues/457)) ([1c6d11f](https://github.com/GetJobber/atlantis/commit/1c6d11fd520e0f08b0cb752837cbbb33aef5ec35))
-
-
-
-
-
 ## [2.22.2](https://github.com/GetJobber/atlantis/compare/@jobber/components@2.22.1...@jobber/components@2.22.2) (2021-01-19)
 
 **Note:** Version bump only for package @jobber/components

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jobber/components",
-	"version": "2.23.0",
+	"version": "2.22.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/components",
-  "version": "2.23.0",
+  "version": "2.22.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -17,7 +17,7 @@ export interface PageProps {
    * Content of the page. This supports basic markdown node types such as
    * `_italic_`, `**bold**`, and `[link name](url)`
    */
-  readonly intro: string;
+  readonly intro?: string;
 
   /**
    * Title of the page.

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -27,7 +27,7 @@ export interface PageProps {
   /**
    * Subtitle of the page.
    */
-  readonly subtitle: string;
+  readonly subtitle?: string;
 
   /**
    * Determines the width of the page.

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -140,9 +140,11 @@ export function Page({
               </div>
             )}
           </div>
-          <Text size="large">
-            <Markdown content={intro} basicUsage={true} />
-          </Text>
+          {intro && (
+            <Text size="large">
+              <Markdown content={intro} basicUsage={true} />
+            </Text>
+          )}
         </Content>
         <Content>{children}</Content>
       </Content>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Make subtitle and intro on Page optional

### Changed

* From `readonly subtitle: string;` to `readonly subtitle?: string;`
* From `readonly intro: string;` to `readonly intro?: string;`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
