### PR TITLE
feat(components): spinner loading state on input text

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -80,14 +80,14 @@ exports[`renders correctly when invalid 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440044"
+      htmlFor="123e4567-e89b-12d3-a456-426655440043"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440044"
+      id="123e4567-e89b-12d3-a456-426655440043"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -80,14 +80,14 @@ exports[`renders correctly when invalid 1`] = `
   >
     <label
       className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440043"
+      htmlFor="123e4567-e89b-12d3-a456-426655440044"
     >
       placeholder_name
     </label>
     <input
       autoComplete="autocomplete-off"
       className="formField"
-      id="123e4567-e89b-12d3-a456-426655440043"
+      id="123e4567-e89b-12d3-a456-426655440044"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -201,7 +201,7 @@ select.formField {
   );
 }
 
-.icon {
+.postfix {
   position: absolute;
   top: 50%;
   right: var(--field--padding-right);

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -371,9 +371,8 @@ test("it should render the spinner when loading is true", () => {
     <FormField placeholder="foo" type="text" loading={true} />,
   );
   const spinner = getByLabelText("loading");
-  const classNames = spinner.getAttribute("class");
 
-  expect(classNames).toContain("spinner small");
+  expect(spinner).toBeInstanceOf(HTMLElement);
 });
 
 it("it should set the autocomplete value with one-time-code", () => {

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -366,6 +366,16 @@ test("it should set the inputMode when the keyboard prop is set", () => {
   expect(name).toContain(keyboardMode);
 });
 
+test("it should render the spinner when loading is true", () => {
+  const { getByLabelText } = render(
+    <FormField placeholder="foo" type="text" loading={true} />,
+  );
+  const spinner = getByLabelText("loading");
+  const classNames = spinner.getAttribute("class");
+
+  expect(classNames).toContain("spinner small");
+});
+
 it("it should set the autocomplete value with one-time-code", () => {
   const { getByLabelText } = render(
     <FormField placeholder="foo" autocomplete={"one-time-code"} />,

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -260,12 +260,12 @@ export function FormField({
       </label>
       {fieldElement()}
       {type === "text" && loading && (
-        <span className={styles.icon}>
+        <span className={styles.postfix}>
           <Spinner size="small" />
         </span>
       )}
       {type === "select" && (
-        <span className={styles.icon}>
+        <span className={styles.postfix}>
           <Icon name="arrowDown" />
         </span>
       )}

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -12,6 +12,7 @@ import { ValidationRules, useForm, useFormContext } from "react-hook-form";
 import styles from "./FormField.css";
 import { Icon } from "../Icon";
 import { InputValidation } from "../InputValidation";
+import { Spinner } from "../Spinner";
 
 export interface FormFieldProps {
   /**
@@ -122,6 +123,11 @@ export interface FormFieldProps {
   readonly value?: string | number;
 
   /**
+   * Show a spinner to indicate loading
+   */
+  showSpinner?: boolean;
+
+  /**
    * Simplified onChange handler that only provides the new value.
    * @param newValue
    */
@@ -182,6 +188,7 @@ export function FormField({
   onChange,
   onEnter,
   onValidation,
+  showSpinner,
   placeholder,
   readonly,
   rows,
@@ -252,6 +259,11 @@ export function FormField({
         {placeholder || " "}
       </label>
       {fieldElement()}
+      {type === "text" && showSpinner && (
+        <span className={styles.icon}>
+          <Spinner size="small" />
+        </span>
+      )}
       {type === "select" && (
         <span className={styles.icon}>
           <Icon name="arrowDown" />

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -125,7 +125,7 @@ export interface FormFieldProps {
   /**
    * Show a spinner to indicate loading
    */
-  showSpinner?: boolean;
+  loading?: boolean;
 
   /**
    * Simplified onChange handler that only provides the new value.
@@ -188,7 +188,7 @@ export function FormField({
   onChange,
   onEnter,
   onValidation,
-  showSpinner,
+  loading,
   placeholder,
   readonly,
   rows,
@@ -259,7 +259,7 @@ export function FormField({
         {placeholder || " "}
       </label>
       {fieldElement()}
-      {type === "text" && showSpinner && (
+      {type === "text" && loading && (
         <span className={styles.icon}>
           <Spinner size="small" />
         </span>

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -229,7 +229,7 @@ Determine what default keyboard appears on mobile web.
   />
 </Playground>
 
-## Spinner
+## Loading
 
 Add a loading state to content.
 
@@ -237,7 +237,7 @@ Add a loading state to content.
   <InputText
     placeholder="Checking phone number"
     name="phoneNumber"
-    showSpinner={true}
+    loading={true}
     keyboard="numeric"
   />
 </Playground>

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -229,6 +229,19 @@ Determine what default keyboard appears on mobile web.
   />
 </Playground>
 
+## Spinner
+
+Add a loading state to content.
+
+<Playground>
+  <InputText
+    placeholder="Checking phone number"
+    name="phoneNumber"
+    showSpinner={true}
+    keyboard="numeric"
+  />
+</Playground>
+
 ## Using onValidation
 
 If you need to capture the error message and render it outside of the component.

--- a/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`renders a Select with many options 1`] = `
     </option>
   </select>
   <span
-    className="icon"
+    className="postfix"
   >
     <svg
       className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -72,7 +72,7 @@ exports[`renders a Select with no options 1`] = `
     onChange={[Function]}
   />
   <span
-    className="icon"
+    className="postfix"
   >
     <svg
       className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -114,7 +114,7 @@ exports[`renders a Select with one option 1`] = `
     </option>
   </select>
   <span
-    className="icon"
+    className="postfix"
   >
     <svg
       className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -156,7 +156,7 @@ exports[`renders correctly as large 1`] = `
     </option>
   </select>
   <span
-    className="icon"
+    className="postfix"
   >
     <svg
       className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -198,7 +198,7 @@ exports[`renders correctly as small 1`] = `
     </option>
   </select>
   <span
-    className="icon"
+    className="postfix"
   >
     <svg
       className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -241,7 +241,7 @@ exports[`renders correctly when disabled 1`] = `
     </option>
   </select>
   <span
-    className="icon"
+    className="postfix"
   >
     <svg
       className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -283,7 +283,7 @@ exports[`renders correctly when invalid 1`] = `
     </option>
   </select>
   <span
-    className="icon"
+    className="postfix"
   >
     <svg
       className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This feature adds the ability to incorporate a spinner into the text input field. This would be used when a component is making a call to validate the contents of the field or doing some other long running task with the contents of the field.

## Changes

The spinner component now is used in the form field generic component.
### Added

- a boolean `showSpinner` has been added to the form field component, however it will only work with text input components.
### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

The mdx has a section that includes the spinner. 
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
