### PR TITLE
docs(components): Add content guidelines to Banner

### DIFF
--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -33,8 +33,13 @@ import { Banner } from "@jobber/components/Banner";
 
 ## Notice message
 
-**Use notice banners to provide information about new functionality, background
-operations, or general non-blocking advice.**
+Use notice banners to provide information about:
+
+<ul>
+  <li>new functionality</li>
+  <li>background operations</li>
+  <li>general non-blocking advice</li>
+</ul>
 
 Notices should get to the point and inform the user about why the functionality
 or change is important if context is not provided elsewhere.
@@ -47,8 +52,14 @@ or change is important if context is not provided elsewhere.
 
 ## Success message
 
-**Use [toasts](toast) as the default for success messages. Success banners are
-appropriate when success feedback had a call to action or is delayed.**
+Success banners are appropriate when:
+
+<ul>
+  <li>success feedback had a call to action</li>
+  <li>success feeback is delayed</li>
+</ul>
+
+Otherwise, use [toasts](toast) as the default for success messages.
 
 <Playground>
   <Banner
@@ -65,8 +76,12 @@ appropriate when success feedback had a call to action or is delayed.**
 
 ## Warning message
 
-**Use warning banners when something requires when an action could have unseen
-consequences or additional action has to be taken.**
+Use warning banners when:
+
+<ul>
+  <li>an action could have unseen consequences</li>
+  <li>additional action has to be taken by the user</li>
+</ul>
 
 Warning messages should be one to two short sentences which clearly describe the
 possibly unknown impact a user’s changes or actions will have. They should not
@@ -82,12 +97,19 @@ workflow.
 
 ## Error message
 
-**Use error banners when something requires immediate attention and blocks the
-user.**
+Use error banners when:
+
+<ul>
+  <li>something requires immediate attention</li>
+  <li>blocks the user</li>
+</ul>
 
 Errors should explain what happened, and summarize how many issues need to be
 addressed in a concise manner. Detailed information about each error is the role
 of the [input validation](input-validation) component.
+
+For more guidance on wording, check out the
+[Product Vocabulary](../guides/product-vocabulary).
 
 <Playground>
   <Banner type="error">
@@ -121,7 +143,7 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
       type="notice"
       primaryAction={{
         label: "View Plans",
-        onClick: () => alert("💥💥SMASH💥💥")
+        onClick: () => alert("Plans")
       }}
       dismissible={false}
     >
@@ -131,7 +153,7 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
       type="error"
       primaryAction={{
         label: "Refresh",
-        onClick: () => alert("😡😡😡")
+        onClick: () => alert("Refreshing")
       }}
     >
       Network is unavailable. Please check your internet connection.

--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -22,7 +22,7 @@ import { Banner } from "@jobber/components/Banner";
 ```
 
 <Playground>
-  <Banner type="success">You've successfully Hulked out</Banner>
+  <Banner type="notice">Your visits are being scheduled</Banner>
 </Playground>
 
 ## Props
@@ -33,28 +33,80 @@ import { Banner } from "@jobber/components/Banner";
 
 ## Notice message
 
+**Use notice banners to provide information about new functionality, background
+operations, or general non-blocking advice.**
+
+Notices should get to the point and inform the user about why the functionality
+or change is important if context is not provided elsewhere.
+
 <Playground>
   <Banner type="notice">
-    Getting angry would result in a great amount of smashing
+    Your import is in progress. Feel free to leave this page while it continues.
   </Banner>
 </Playground>
 
 ## Success message
 
+**Use [toasts](toast) as the default for success messages. Success banners are
+appropriate when success feedback had a call to action or is delayed.**
+
 <Playground>
-  <Banner type="success">You've successfully Hulked out</Banner>
+  <Banner
+    type="success"
+    primaryAction={{
+      label: "View clients",
+      onClick: () => alert("🎉 Woo hoo")
+    }}
+    dismissible={false}
+  >
+    Your client import is complete
+  </Banner>
 </Playground>
 
 ## Warning message
 
+**Use warning banners when something requires when an action could have unseen
+consequences or additional action has to be taken.**
+
+Warning messages should be one to two short sentences which clearly describe the
+possibly unknown impact a user’s changes or actions will have. They should not
+begin with "Warning:" and should not be used as a way to block or redirect a
+workflow.
+
 <Playground>
-  <Banner type="warning">Smashing would result in a log of rubble</Banner>
+  <Banner type="warning">
+    Editing this schedule will replace all incomplete visits with the updated
+    information for this job
+  </Banner>
 </Playground>
 
 ## Error message
 
+**Use error banners when something requires immediate attention and blocks the
+user.**
+
+Errors should explain what happened, and summarize how many issues need to be
+addressed in a concise manner. Detailed information about each error is the role
+of the [input validation](input-validation) component.
+
 <Playground>
-  <Banner type="error">Hulk smash has been unsuccessful</Banner>
+  <Banner type="error">
+    Client cannot be saved. 1 change needs to be made:
+    <ul>
+      <li>Email address</li>
+    </ul>
+  </Banner>
+</Playground>
+
+<br />
+
+System errors should avoid technical or intimidating language, and provide ways
+to resolve or troubleshoot the issue if possible.
+
+<Playground>
+  <Banner type="error">
+    Something went wrong. Please try again in a few minutes.
+  </Banner>
 </Playground>
 
 ## Actions in Banners
@@ -66,23 +118,23 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
 <Playground>
   <Content>
     <Banner
-      type="success"
+      type="notice"
       primaryAction={{
-        label: "Poke Me",
+        label: "View Plans",
         onClick: () => alert("💥💥SMASH💥💥")
       }}
       dismissible={false}
     >
-      You wouldn't like me when I'm angry.
+      Your trial has been extended!
     </Banner>
     <Banner
-      type="notice"
+      type="error"
       primaryAction={{
-        label: "I'm always angry",
+        label: "Refresh",
         onClick: () => alert("😡😡😡")
       }}
     >
-      That's my secret Captain
+      Network is unavailable. Please check your internet connection.
     </Banner>
   </Content>
 </Playground>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

https://jobber.atlassian.net/browse/JOB-27849

## Changes

Added content guidelines for how to use banner types, and clarification of when to use banners (notably reducing the usage of success banners as we want to use toasts in lieu of them for feedback in both Jobber online and mobile when appropriate)

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
