### PR TITLE
fix(components): exports date formatting as a string

### DIFF
--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -1,9 +1,12 @@
 ---
-
-name: FormatDate menu: Components route: /components/date-formatter ---import {
-Playground, Props } from "docz"; import { ComponentStatus } from "@jobber/docx";
-import { CivilDate } from "@std-proposal/temporal"; import { FormatDate,
-strFormatDate } from "."; import { Text } from "../Text";
+name: FormatDate
+menu: Components
+route: /components/date-formatter
+---import { Playground, Props } from "docz";
+import { ComponentStatus } from "@jobber/docx";
+import { CivilDate } from "@std-proposal/temporal";
+import { FormatDate, strFormatDate } from ".";
+import { Text } from "../Text";
 
 # FormatDate
 

--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -1,13 +1,14 @@
----
-name: FormatDate
-menu: Components
-route: /components/date-formatter
+## import {Text} from "../Text";
+
+name: FormatDate menu: Components route: /components/date-formatter
+
 ---
 
 import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { CivilDate } from "@std-proposal/temporal";
-import { FormatDate } from ".";
+import { FormatDate, strFormatDate } from ".";
+import { Text } from "../Text";
 
 # FormatDate
 
@@ -26,6 +27,16 @@ import { FormatDate } from "@jobber/components/FormatDate";
   <FormatDate date={new CivilDate(2020, 2, 26)} />
 </Playground>
 
+## Getting a string version
+
+```ts
+import { strFormatDate } from "@jobber/components/FormatDate";
+```
+
+<Playground>
+  <Text>{strFormatDate(new Date())}</Text>
+</Playground>
+
 ## Design & Usage Guidelines
 
 Use FormatDate to ensure that a date is represented as expected.
@@ -37,6 +48,8 @@ component.
 If the formatted date is intended to be part of a heading, wrap FormatDate in a
 [Heading](https://atlantis.getjobber.com/packages-components-src-heading-heading)
 component.
+
+If you require a string instead of a component use strFormatDate.
 
 ## Props
 

--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -2,7 +2,9 @@
 name: FormatDate
 menu: Components
 route: /components/date-formatter
----import { Playground, Props } from "docz";
+---
+
+import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { CivilDate } from "@std-proposal/temporal";
 import { FormatDate, strFormatDate } from ".";

--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -1,12 +1,9 @@
 ---
-name: FormatDate
-menu: Components
-route: /components/date-formatter
----import { Playground, Props } from "docz";
-import { ComponentStatus } from "@jobber/docx";
-import { CivilDate } from "@std-proposal/temporal";
-import { FormatDate, strFormatDate } from ".";
-import { Text } from "../Text";
+
+name: FormatDate menu: Components route: /components/date-formatter ---import {
+Playground, Props } from "docz"; import { ComponentStatus } from "@jobber/docx";
+import { CivilDate } from "@std-proposal/temporal"; import { FormatDate,
+strFormatDate } from "."; import { Text } from "../Text";
 
 # FormatDate
 
@@ -26,6 +23,9 @@ import { FormatDate } from "@jobber/components/FormatDate";
 </Playground>
 
 ## Getting a string version
+
+Use strFormateDate if you need your formatted date as a string so it can be
+passed as an attribute that doesn't allow for a component.
 
 ```ts
 import { strFormatDate } from "@jobber/components/FormatDate";

--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -1,10 +1,8 @@
-## import {Text} from "../Text";
-
-name: FormatDate menu: Components route: /components/date-formatter
-
 ---
-
-import { Playground, Props } from "docz";
+name: FormatDate
+menu: Components
+route: /components/date-formatter
+---import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { CivilDate } from "@std-proposal/temporal";
 import { FormatDate, strFormatDate } from ".";

--- a/packages/components/src/FormatDate/FormatDate.tsx
+++ b/packages/components/src/FormatDate/FormatDate.tsx
@@ -24,7 +24,7 @@ export function FormatDate({ date: inputDate }: FormatDateProps) {
   return <>{strFormatDate(dateObject)}</>;
 }
 
-function strFormatDate(date: Date) {
+export function strFormatDate(date: Date) {
   return date.toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",

--- a/packages/components/src/FormatDate/index.ts
+++ b/packages/components/src/FormatDate/index.ts
@@ -1,1 +1,1 @@
-export { FormatDate } from "./FormatDate";
+export { strFormatDate, FormatDate } from "./FormatDate";


### PR DESCRIPTION
## Motivations
We needed to export formatDate as a string so the resulting date can be passed as an attribute to other components.
Allowing the returned formatted date to be a string offers more flexibility on the places it can be used.

## Changes
Exported the strFormateDate (the method used by FormatDate).

## Testing
I'm now able to import `strFormatDate` and use it.

---

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
