### PR TITLE
fix(design): Make company icon colour default to teal

### DIFF
--- a/packages/design/src/icons/Icon.css
+++ b/packages/design/src/icons/Icon.css
@@ -18,6 +18,7 @@
 
 .person,
 .clients,
+.company,
 .property {
   fill: var(--color-teal);
 }

--- a/packages/design/src/icons/getIcon.ts
+++ b/packages/design/src/icons/getIcon.ts
@@ -96,6 +96,7 @@ function getPathClassNames(name: string, color?: IconColorNames) {
   return classnames(color && colors[color], {
     [styles.person]: name === "person",
     [styles.clients]: name === "clients",
+    [styles.company]: name === "company",
     [styles.property]: name === "property",
     [styles.userUnassigned]: name === "userUnassigned",
     [styles.job]: name === "job",


### PR DESCRIPTION
## Motivations

Backward compatibility of SG-1 to match `.company` Icon to teal.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Change `.company` icon default to `teal`.

### Security

- <!-- in case of vulnerabilities -->

## Testing
Check the Icon Component page: https://deploy-preview-470--jobber-atlantis.netlify.app/components/icon
 The Icon for company should be teal. 

![Pasted_Image_2021-02-11__4_54_PM](https://user-images.githubusercontent.com/6612596/107714118-edbf7900-6c89-11eb-9a33-f4deea005da3.jpg)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
