### PR TITLE
fix(design): add in CSS types missing from last build

### DIFF
--- a/packages/design/src/icons/Icon.css.d.ts
+++ b/packages/design/src/icons/Icon.css.d.ts
@@ -4,6 +4,7 @@ export const longArrowDown: string;
 export const thumbsDown: string;
 export const person: string;
 export const clients: string;
+export const company: string;
 export const property: string;
 export const job: string;
 export const jobOnHold: string;


### PR DESCRIPTION
## Motivations

Missing type files for the last PR (#470) released are breaking the build of Atlantis master. 
This add them back in. 

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Include missing type files required for build.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
