### PR TITLE
feat: moves the null loader to the root gatsby-node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,7 +2,7 @@
 /* eslint-env node */
 const path = require("path");
 
-exports.onCreateWebpackConfig = ({ actions, stage, getConfig }) => {
+exports.onCreateWebpackConfig = ({ loaders, actions, stage, getConfig }) => {
   const config = getConfig();
 
   /**
@@ -43,7 +43,13 @@ exports.onCreateWebpackConfig = ({ actions, stage, getConfig }) => {
     ],
   });
 
+  // Situationally disable serverside rendering.
   if (stage.includes("html")) {
+    config.module.rules.push({
+      test: /(?:packages|docs)\/.*\.(?:js|jsx|ts|tsx)$/,
+      use: loaders.null(),
+    });
+
     config.module.rules.push({
       test: /.*\.(?:md|mdx)$/,
       use: path.resolve("../null-markdown-loader.js"),

--- a/packages/docz-tools/gatsby-node.js
+++ b/packages/docz-tools/gatsby-node.js
@@ -5,13 +5,7 @@ const path = require("path");
 const { USE_ATLANTIS_ALIASES } = process.env;
 const useAtlantisAliases = USE_ATLANTIS_ALIASES === "true";
 
-exports.onCreateWebpackConfig = ({
-  stage,
-  rules,
-  actions,
-  loaders,
-  getConfig,
-}) => {
+exports.onCreateWebpackConfig = ({ rules, actions, getConfig }) => {
   const config = getConfig();
 
   /**
@@ -51,14 +45,6 @@ exports.onCreateWebpackConfig = ({
       "@jobber/components": path.resolve(__dirname, "../components/src"),
       "@jobber/hooks": path.resolve(__dirname, "../hooks"),
     };
-  }
-
-  // Situationally disable serverside rendering.
-  if (stage.includes("html")) {
-    config.module.rules.push({
-      test: /(?:packages|docs)\/.*\.(?:js|jsx|ts|tsx)$/,
-      use: loaders.null(),
-    });
   }
 
   actions.replaceWebpackConfig(config);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When using the `@jobber/docz-tools` package in another instance of `docz` there were some issues with the `gatsby-node` where if there was not a `js|jsx|ts|tsx` file in a specific directory, the `loaders.null()` would fail.

This PR moves that check from the `@jobber/docz-tools` package to the root of `🔱Atlantis`

## Changes

Moves the null loader to the root of Atlantis

### Added

- <!-- new features -->

### Changed

- Moves the null loader to the root of Atlantis

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
