### PR TITLE
fix(docz-tools): update styling for code to prevent breaking paragraphs [29104]

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/theme/styles.ts
+++ b/packages/docz-tools/src/gatsby-theme-docz/theme/styles.ts
@@ -50,14 +50,10 @@ export const styles = {
   inlineCode: {
     display: "inline-block",
     borderRadius: "base",
-    fontSize: "small",
+    fontSize: "base",
     fontFamily: "monospace",
     bg: "greyLightest",
     color: "greyBlueDark",
-    paddingY: "smaller",
-    paddingX: "small",
-    marginBottom: "smallest",
-    border: "1px solid",
-    borderColor: "greyLighter",
+    paddingX: "smaller",
   },
 };


### PR DESCRIPTION
## Motivations

We were seeing hard-to-read paragraphs in cases where `code` was used, as the padding and margins impacted the leading (line-height) of the text.

## Changes

Removed vertical padding, increased font-size, and removed margin from `code`.

### Added

- n/a

### Changed

- some js styling for `code` to prevent it from taking up additional space in a layout.

### Deprecated

- n/a

### Removed

- n/a

### Fixed

- bug with broken leading in paragraphs


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
