### PR TITLE
docs(components): Add accessibility notes to Spinner

### DIFF
--- a/packages/components/src/Spinner/Spinner.mdx
+++ b/packages/components/src/Spinner/Spinner.mdx
@@ -26,13 +26,7 @@ import { Spinner } from "@jobber/components/Spinner";
 Use Spinner to indicate loading of content where the actual amount of loading
 time or progress is unknown.
 
-## Props
-
-<Props of={Spinner} />
-
----
-
-## Small
+### Small
 
 The `small` spinner should be used on individual element of an interface (ie.
 button or card contents) or when inline with content
@@ -41,15 +35,32 @@ button or card contents) or when inline with content
   <Spinner size="small" />
 </Playground>
 
-## Inline
+### Inline
 
-Use `inline` to render the spinner inline with content.
+Use `inline` to render the spinner inline with content, such as when it has a leading
+piece of text content that adds context to what loading is happening.
 
 <Playground>
   <Text>
     Uploading... <Spinner size="small" inline={true} />
   </Text>
 </Playground>
+
+## Accessibility
+
+The `Spinner` should announce itself to users of assistive technology such as screenreaders.
+
+The following built-in properties help `Spinner` convey its' role effectively:
+
+- `role="alert"` allows the `Spinner` to be announced as an alert feedback element
+- `aria-busy={true}` informs the user that the view is busy, setting the expectation that they cannot interact for the time being
+- `aria-label="loading"` reads out "Loading" to assistive teach, adding context as to _why_ the view is busy
+
+## Props
+
+<Props of={Spinner} />
+
+---
 
 ## Related Components
 

--- a/packages/components/src/Spinner/Spinner.mdx
+++ b/packages/components/src/Spinner/Spinner.mdx
@@ -21,6 +21,12 @@ import { Spinner } from "@jobber/components/Spinner";
   <Spinner />
 </Playground>
 
+## Props
+
+<Props of={Spinner} />
+
+---
+
 ## Design & Usage Guidelines
 
 Use Spinner to indicate loading of content where the actual amount of loading
@@ -45,12 +51,6 @@ piece of text content that adds context to what loading is happening.
     Uploading... <Spinner size="small" inline={true} />
   </Text>
 </Playground>
-
-## Props
-
-<Props of={Spinner} />
-
----
 
 ## Accessibility
 

--- a/packages/components/src/Spinner/Spinner.mdx
+++ b/packages/components/src/Spinner/Spinner.mdx
@@ -46,6 +46,12 @@ piece of text content that adds context to what loading is happening.
   </Text>
 </Playground>
 
+## Props
+
+<Props of={Spinner} />
+
+---
+
 ## Accessibility
 
 The `Spinner` should announce itself to users of assistive technology such as screenreaders.
@@ -56,11 +62,7 @@ The following built-in properties help `Spinner` convey its' role effectively:
 - `aria-busy={true}` informs the user that the view is busy, setting the expectation that they cannot interact for the time being
 - `aria-label="loading"` reads out "Loading" to assistive teach, adding context as to _why_ the view is busy
 
-## Props
-
-<Props of={Spinner} />
-
----
+___
 
 ## Related Components
 


### PR DESCRIPTION
## Motivations

@rebecca-li asked a good question about accessibility relating to loading states and I didn't have any of our own documentation on this to share 😭 

## Changes

Added accessibility section to Spinner

### Added

- accessibility section to Spinner

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
