### PR TITLE
feat(docz-tools): added theme configuration options for hiding actions, logo and fixed sidebar 

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -31,10 +31,6 @@ export default {
     "./public",
     ...privateComponents,
   ],
-  themeConfig: {
-    hasActions: true,
-    hasLogo: true,
-  },
 };
 
 function getPackagesToDocument() {

--- a/doczrc.js
+++ b/doczrc.js
@@ -31,6 +31,10 @@ export default {
     "./public",
     ...privateComponents,
   ],
+  themeConfig: {
+    hasActions: true,
+    hasLogo: true,
+  },
 };
 
 function getPackagesToDocument() {

--- a/packages/docz-tools/README.md
+++ b/packages/docz-tools/README.md
@@ -72,6 +72,23 @@ export default {
 }
 ```
 
+### Sidebar Offset
+
+The sidebar offset can be adjusted if you have a wrapping component at the top,
+such as a primary navigation bar. By default, it is `0` and represents
+`pixels / px`
+
+```
+// doczrc.js
+export default {
+  ...,
+  themeConfig: {
+    ...,
+    sidebarOffset: 100
+  }
+}
+```
+
 ### Container Width
 
 The container width can be adjusted. This will adjust the width that the content
@@ -85,5 +102,34 @@ export default {
     ...,
     containerWidth: 768
   }
+}
+```
+
+### Hide / Show Actions
+
+The actions in the top right can be hidden if required by adjusting `hasActions`
+to false. By default it is `true`
+
+```
+// doczrc.js
+export default {
+  ...,
+  themeConfig: {
+    ...,
+    hasActions: false
+  }
+}
+```
+
+### Hide / Show Logo
+
+The logo within the sidebar can be hidden if required by providing an
+`undefined` value to `title`.
+
+```
+// doczrc.js
+export default {
+  ...,
+  title: undefined
 }
 ```

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/index.tsx
@@ -11,7 +11,7 @@ import "@jobber/design/foundation.css";
 
 export function Layout({ children }: PropsWithChildren<{}>) {
   const {
-    themeConfig: { sideBarWidth, containerWidth, hideActions },
+    themeConfig: { sideBarWidth, containerWidth, hasActions },
   } = useConfig();
 
   return (
@@ -20,7 +20,7 @@ export function Layout({ children }: PropsWithChildren<{}>) {
         <Box sx={styles.sidebar(sideBarWidth)}>
           <Sidebar />
         </Box>
-        {!hideActions && <Actions />}
+        {hasActions && <Actions />}
         <Box sx={styles.content}>
           <Box sx={styles.container(containerWidth)}>{children}</Box>
         </Box>

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/index.tsx
@@ -11,7 +11,7 @@ import "@jobber/design/foundation.css";
 
 export function Layout({ children }: PropsWithChildren<{}>) {
   const {
-    themeConfig: { sideBarWidth, containerWidth },
+    themeConfig: { sideBarWidth, containerWidth, hideActions },
   } = useConfig();
 
   return (
@@ -20,7 +20,7 @@ export function Layout({ children }: PropsWithChildren<{}>) {
         <Box sx={styles.sidebar(sideBarWidth)}>
           <Sidebar />
         </Box>
-        <Actions />
+        {!hideActions && <Actions />}
         <Box sx={styles.content}>
           <Box sx={styles.container(containerWidth)}>{children}</Box>
         </Box>

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/index.tsx
@@ -11,7 +11,7 @@ import "@jobber/design/foundation.css";
 
 export function Layout({ children }: PropsWithChildren<{}>) {
   const {
-    themeConfig: { sideBarWidth, containerWidth, hasActions },
+    themeConfig: { sideBarWidth, containerWidth, hasActions = true },
   } = useConfig();
 
   return (

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Logo/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Logo/index.tsx
@@ -1,10 +1,19 @@
 /** @jsx jsx */
+import { Fragment } from "react";
 import { Box, Image, jsx } from "theme-ui";
 import { Link, useConfig, useCurrentDoc } from "docz";
 import * as styles from "./styles";
 
 export function Logo() {
   const { route } = useCurrentDoc();
+  const {
+    themeConfig: { logoUrl },
+    title,
+  } = useConfig();
+
+  if (!logoUrl && !title) {
+    return <Fragment></Fragment>;
+  }
 
   if (route === "/") {
     return (

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
@@ -11,7 +11,7 @@ import { DeferRender } from "../DeferRender";
 export function Sidebar() {
   const [query, setQuery] = useState("");
   const {
-    themeConfig: { sideBarWidth, hasLogo, sidebarOffset = 0 },
+    themeConfig: { sideBarWidth, hasLogo = true, sidebarOffset = 0 },
   } = useConfig();
   const sidebarRef = createRef<HTMLDivElement>();
 

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
@@ -11,12 +11,12 @@ import { DeferRender } from "../DeferRender";
 export function Sidebar() {
   const [query, setQuery] = useState("");
   const {
-    themeConfig: { sideBarWidth, hideLogo },
+    themeConfig: { sideBarWidth, hideLogo, isFixedHeight },
   } = useConfig();
   const sidebarRef = createRef<HTMLDivElement>();
 
   return (
-    <Box sx={styles.sidebar(sideBarWidth)} ref={sidebarRef}>
+    <Box sx={styles.sidebar(sideBarWidth, isFixedHeight)} ref={sidebarRef}>
       {!hideLogo && <Logo />}
       <Box sx={styles.search}>
         <DeferRender>

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
@@ -11,13 +11,13 @@ import { DeferRender } from "../DeferRender";
 export function Sidebar() {
   const [query, setQuery] = useState("");
   const {
-    themeConfig: { sideBarWidth, hasLogo = true, sidebarOffset = 0 },
+    themeConfig: { sideBarWidth, sidebarOffset = 0 },
   } = useConfig();
   const sidebarRef = createRef<HTMLDivElement>();
 
   return (
     <Box sx={styles.sidebar(sideBarWidth, sidebarOffset)} ref={sidebarRef}>
-      {hasLogo && <Logo />}
+      <Logo />
       <Box sx={styles.search}>
         <DeferRender>
           <Icon name="search" color="greyBlue" />

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
@@ -11,13 +11,13 @@ import { DeferRender } from "../DeferRender";
 export function Sidebar() {
   const [query, setQuery] = useState("");
   const {
-    themeConfig: { sideBarWidth },
+    themeConfig: { sideBarWidth, hideLogo },
   } = useConfig();
   const sidebarRef = createRef<HTMLDivElement>();
 
   return (
     <Box sx={styles.sidebar(sideBarWidth)} ref={sidebarRef}>
-      <Logo />
+      {!hideLogo && <Logo />}
       <Box sx={styles.search}>
         <DeferRender>
           <Icon name="search" color="greyBlue" />

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
@@ -11,13 +11,13 @@ import { DeferRender } from "../DeferRender";
 export function Sidebar() {
   const [query, setQuery] = useState("");
   const {
-    themeConfig: { sideBarWidth, hideLogo, isFixedHeight },
+    themeConfig: { sideBarWidth, hasLogo, sidebarOffset = 0 },
   } = useConfig();
   const sidebarRef = createRef<HTMLDivElement>();
 
   return (
-    <Box sx={styles.sidebar(sideBarWidth, isFixedHeight)} ref={sidebarRef}>
-      {!hideLogo && <Logo />}
+    <Box sx={styles.sidebar(sideBarWidth, sidebarOffset)} ref={sidebarRef}>
+      {hasLogo && <Logo />}
       <Box sx={styles.search}>
         <DeferRender>
           <Icon name="search" color="greyBlue" />

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
@@ -1,8 +1,12 @@
 export const sidebar = (width: number, isFixedHeight: boolean) =>
   ({
     bg: "greyBlueDark",
-    height: isFixedHeight ? "100vh" : "100%",
-    position: isFixedHeight ? "fixed" : "relative",
+    height:
+      isFixedHeight || typeof isFixedHeight === undefined ? "100vh" : "100%",
+    position:
+      isFixedHeight || typeof isFixedHeight === undefined
+        ? "fixed"
+        : "relative",
     top: 0,
     width: width,
     overflowY: "scroll",

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
@@ -1,8 +1,8 @@
-export const sidebar = (width: number) =>
+export const sidebar = (width: number, isFixedHeight: boolean) =>
   ({
     bg: "greyBlueDark",
-    height: "100vh",
-    position: "fixed",
+    height: isFixedHeight ? "100vh" : "100%",
+    position: isFixedHeight ? "fixed" : "relative",
     top: 0,
     width: width,
     overflowY: "scroll",

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
@@ -1,4 +1,4 @@
-export const sidebar = (width: number, sidebarOffset: boolean) =>
+export const sidebar = (width: number, sidebarOffset: number) =>
   ({
     bg: "greyBlueDark",
     height: `calc(100vh - ${sidebarOffset}px)`,

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
@@ -1,13 +1,9 @@
-export const sidebar = (width: number, isFixedHeight: boolean) =>
+export const sidebar = (width: number, sidebarOffset: boolean) =>
   ({
     bg: "greyBlueDark",
-    height:
-      isFixedHeight || typeof isFixedHeight === undefined ? "100vh" : "100%",
-    position:
-      isFixedHeight || typeof isFixedHeight === undefined
-        ? "fixed"
-        : "relative",
-    top: 0,
+    height: `calc(100vh - ${sidebarOffset}px)`,
+    position: "fixed",
+    top: sidebarOffset,
     width: width,
     overflowY: "scroll",
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Added theme configuration options so that when using `@jobber/docz-tools` in the Developer Center project, we can hide actions and update formatting so it doesn't cause overlap issues.

![overlapping seen with wrapper component](https://user-images.githubusercontent.com/80279872/111388349-b66f2e00-8674-11eb-8ec9-81548acd7876.png)
Overlapping seen with wrapper component and on a docs page.

![wrapper component seen on non docs page](https://user-images.githubusercontent.com/80279872/111388406-d272cf80-8674-11eb-968b-1a5fa3aa9c25.png)
Wrapper component seen on a non docs page.


Added theme configuration options so that the actions (GitHub link+logo & Edit Page) & logo can be conditionally hidden. As well the sidebar can be positioned relatively instead of fixed, which causes overlapping issues when wrapping with other components.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
- added configuration options for the `@jobber/docz-tools` package to hide actions, logo and update sidebar relativeness

### Added

- added `isFixedHeight` theme configuration option which when set to false, sidebar will be relatively positioned and height will be 100% instead of vh
- added `hideActions` theme configuration option which when set to true, actions will be hidden
- added `hideLogo` theme configuration option which when set to true, logo will be hidden

## Testing

<!-- How to test your changes. -->
Add any of the three theme options to `doczrc.js` in `themeConfig`. If `themeConfig` is not present in `doczrc.js`, add it to the root of the default exported object.
```
  themeConfig: {
    isFixedHeight: false,
    hideActions: true,
    hideLogo: true,
  }
```
Run the docz development site: `npm run start`


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
