### PR TITLE
fix(components): use correct html for DescriptionList 

### DIFF
--- a/packages/components/src/DescriptionList/DescriptionList.tsx
+++ b/packages/components/src/DescriptionList/DescriptionList.tsx
@@ -15,11 +15,11 @@ export function DescriptionList({ data }: DescriptionListProps) {
     <dl className={styles.descriptionList}>
       {data.map(([term, description]) => (
         <div key={term} className={styles.termGroup}>
-          <Typography element="dd" textColor="blue" size="base">
+          <Typography element="dt" textColor="blue" size="base">
             {term}
           </Typography>
 
-          <Typography element="dt" textColor="greyBlueDark" size="base">
+          <Typography element="dd" textColor="greyBlueDark" size="base">
             {description}
           </Typography>
         </div>

--- a/packages/components/src/DescriptionList/__snapshots__/DescriptionList.test.tsx.snap
+++ b/packages/components/src/DescriptionList/__snapshots__/DescriptionList.test.tsx.snap
@@ -7,30 +7,30 @@ exports[`renders an object as a list of key value pairs 1`] = `
   <div
     className="termGroup"
   >
-    <dd
+    <dt
       className="base regular base blue"
     >
       Issued
-    </dd>
-    <dt
+    </dt>
+    <dd
       className="base regular base greyBlueDark"
     >
       2018-12-08
-    </dt>
+    </dd>
   </div>
   <div
     className="termGroup"
   >
-    <dd
+    <dt
       className="base regular base blue"
     >
       Due
-    </dd>
-    <dt
+    </dt>
+    <dd
       className="base regular base greyBlueDark"
     >
       2019-01-06
-    </dt>
+    </dd>
   </div>
 </dl>
 `;
@@ -42,30 +42,30 @@ exports[`renders an object as a list of key value pairs with an element 1`] = `
   <div
     className="termGroup"
   >
-    <dd
+    <dt
       className="base regular base blue"
     >
       Foo
-    </dd>
-    <dt
+    </dt>
+    <dd
       className="base regular base greyBlueDark"
     >
       Foo
-    </dt>
+    </dd>
   </div>
   <div
     className="termGroup"
   >
-    <dd
+    <dt
       className="base regular base blue"
     >
       Bar
-    </dd>
-    <dt
+    </dt>
+    <dd
       className="base regular base greyBlueDark"
     >
       Bar
-    </dt>
+    </dd>
   </div>
 </dl>
 `;


### PR DESCRIPTION
## Motivations

Addresses a minor HTML discrepancy identified by the accessibility guild's audit

## Changes

Uses correct order of term `dt` and description `dd` elements in the `DescriptionList` component

### Changed

- Swapped order of dt and dd

### Fixed

- html presents in the expected sequence

## Testing

- hit cmd+f5 to activate VoiceOver, using `control+option+rightArrow` to navigate the DescriptionList, content should read as expected

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
