### PR TITLE
fix(components): allow screen-readers to skip Divider

### DIFF
--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -16,5 +16,5 @@ export function Divider({ size = "base" }: DividerProps) {
     [styles.large]: size === "large",
   });
 
-  return <hr className={className} />;
+  return <hr className={className} role="none" />;
 }

--- a/packages/components/src/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/packages/components/src/Divider/__snapshots__/Divider.test.tsx.snap
@@ -3,11 +3,13 @@
 exports[`renders a Divider 1`] = `
 <hr
   className="divider"
+  role="none"
 />
 `;
 
 exports[`renders a large Divider 1`] = `
 <hr
   className="divider large"
+  role="none"
 />
 `;


### PR DESCRIPTION
## Motivations

While our `Divider` uses an HTML element (hr) that comes out of the box with semantic meaning, we actually used Divider for strictly decorative purposes, rather than the spec of:

> a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section

As we use Divider strictly for visual aid, it does not need to be announced to screen-readers or other assistive technology, and in doing so actually adds unhelpful noise to the experience.

## Changes

### Changed

- Divider now has a `role="none"` attribute so that assistive tech skips it

## Testing

Use VoiceOver, ChromeVox, or another screen-reader and see that Divider is no longer announced to assistive tech.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
