### PR TITLE
feat(components): add 'disabled' props to Tab component

### DIFF
--- a/packages/components/src/Tabs/Tabs.css
+++ b/packages/components/src/Tabs/Tabs.css
@@ -61,6 +61,17 @@
   background-color: var(--color-yellow--lightest);
 }
 
+.tab.disabled {
+  border-color: var(--button--color-disabled);
+  background-color: var(--button--color-disabled);
+  cursor: not-allowed;
+}
+
+.tab.disabled:hover,
+.tab.disabled:focus {
+  user-select: none;
+}
+
 .selected {
   border-top-color: var(--tab--border-color--selected);
   border-bottom-color: var(--color-white);

--- a/packages/components/src/Tabs/Tabs.css.d.ts
+++ b/packages/components/src/Tabs/Tabs.css.d.ts
@@ -4,5 +4,6 @@ export const overflowRight: string;
 export const overflowLeft: string;
 export const tabRow: string;
 export const tab: string;
+export const disabled: string;
 export const selected: string;
 export const tabContent: string;

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -18,6 +18,18 @@ const omelet = (
   </Tabs>
 );
 
+const omeletNoCheese = (
+  <Tabs>
+    <Tab label="Eggs">
+      <p>🍳</p>
+      <p>Eggs</p>
+    </Tab>
+    <Tab disabled={true} label="Cheese" onClick={() => count++}>
+      <p>🧀</p>
+    </Tab>
+  </Tabs>
+);
+
 it("renders Tabs", () => {
   const tree = renderer.create(omelet).toJSON();
   expect(tree).toMatchSnapshot();
@@ -46,4 +58,25 @@ test("it should handle tab onClick", () => {
   expect(count).toBe(1);
   fireEvent.click(getByText("Cheese"));
   expect(count).toBe(2);
+});
+
+test("it should not switch tabs when `disabled` props is set", () => {
+  const { getByText, queryByText } = render(omeletNoCheese);
+
+  expect(queryByText("🍳")).toBeTruthy();
+  expect(queryByText("🧀")).toBeFalsy();
+
+  fireEvent.click(getByText("Cheese"));
+  expect(queryByText("🍳")).toBeTruthy();
+  expect(queryByText("🧀")).toBeFalsy();
+});
+
+test("it should not handle tab onClick when `disabled` props is set", () => {
+  const { getByText } = render(omeletNoCheese);
+  count = 0;
+
+  fireEvent.click(getByText("Cheese"));
+  expect(count).toBe(0);
+  fireEvent.click(getByText("Cheese"));
+  expect(count).toBe(0);
 });

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -61,6 +61,7 @@ export function Tabs({ children }: TabsProps) {
         <div className={styles.tabRow} ref={tabRow}>
           {React.Children.map(children, (tab, index) => (
             <InternalTab
+              disabled={tab.props.disabled}
               label={tab.props.label}
               selected={activeTab === index}
               activateTab={activateTab(index)}
@@ -82,6 +83,7 @@ export function Tabs({ children }: TabsProps) {
 interface TabProps {
   readonly label: string;
   readonly children: ReactNode | ReactNode[];
+  disabled?: boolean;
   onClick?(): void;
 }
 
@@ -90,6 +92,7 @@ export function Tab({ label }: TabProps) {
 }
 
 interface InternalTabProps {
+  disabled?: boolean;
   readonly label: string;
   readonly selected: boolean;
   activateTab(): void;
@@ -97,6 +100,7 @@ interface InternalTabProps {
 }
 
 export function InternalTab({
+  disabled,
   label,
   selected,
   activateTab,
@@ -104,14 +108,19 @@ export function InternalTab({
     return;
   },
 }: InternalTabProps) {
-  const className = classnames(styles.tab, { [styles.selected]: selected });
+  const className = disabled
+    ? classnames(styles.tab, styles.disabled)
+    : classnames(styles.tab, { [styles.selected]: selected });
   const color = selected ? "green" : undefined;
   return (
     <button
       type="button"
       role="tab"
       className={className}
+      disabled={disabled}
       onClick={() => {
+        if (disabled) return;
+
         activateTab();
         onClick();
       }}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- There is a need for disabling tabs switching, let's say when the user has engaged partly into a workflow that is wrapped with `<Tabs>`.
- Or when the user is awaiting for confirmation with contents from a specific `<Tab>`, we want to disallow tab switching until their committed action has reached a conclusion (such as transmitting / sending form information)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `disabled` prop is added to `<Tab>` and `<InternalTab>`
- `.tab.disabled` css styling added, following similar approach with button disabled stylings

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

1. Simply load up this PR and head over to `/components/tabs`
1. Enter the disabled value (eg: `disabled={true}`)
1. Observe the disabled UI and blocked interactions

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
