### PR TITLE
docs(generators): Update component documentation template

### DIFF
--- a/packages/generators/templates/component/{{name}}.{{mdx}}
+++ b/packages/generators/templates/component/{{name}}.{{mdx}}
@@ -21,7 +21,7 @@ import { {{ name }} } from "@jobber/components/{{ name }}";
 
 ## Usage Guidelines
 
-The <{{name}}> component will... {Add a brief description of the component}
+The <{{name}}> will... {Add a brief description of the component}
 
 <!--
   What is the design purpose of this component? How do its responsibilities
@@ -39,9 +39,9 @@ The <{{name}}> component will... {Add a brief description of the component}
   What type of content does this component present (documents, text, images, other components)?
   What is the recommended, or expected, amount of content? What is the components’ behaviour when
   the provided content diverges from what is expected (image aspect ratio, amount of text, video
-  vs audio, filesize)? Are there any important references to the Product Vocabulary that should
-  be made regarding this component? What happens when content is unavailable or unreliable (poor
-  connection, empty states, flaky GPS data?)
+  vs audio, filesize)? Are there any important references to the [Product Vocabulary](https://atlantis.getjobber.com/guides/product-vocabulary)
+  that should be made regarding this component? What happens when content is unavailable or unreliable
+  (poor connection, empty states, flaky GPS data?)
 -->
 
 ## Accessibility
@@ -55,16 +55,18 @@ The <{{name}}> component will... {Add a brief description of the component}
 
 <!--
   How should the component behave on an iPhone 8? An iPad? A 1920x1080 monitor? How does the
-  component appear when the component itself is less than 375px wide? Less than 640px wide? Less than 1200px wide? Greater than 1200px? Does it change when the device DPI is higher
+  component appear when the component itself is less than 375px wide? Less than 640px wide?
+  Less than 1200px wide? Greater than 1200px? Does it change when the device DPI is higher
   or lower?
 -->
 
 ## Mockup
 
 <!--
-  Insert a Figma mockup from the Design System Contribution template that conveys the visual
-  design of the component, with variants and state accounted for. Consider progressive enhancement;
-  might this rely on newer browser features that aren’t widely supported yet?
+  Insert a Figma mockup from the [Design System Contribution template](https://www.figma.com/file/3BXCXXD9glMtj8RAHjXiQC/Design-System-Contribution-TEMPLATE?node-id=26%3A2)
+  that conveys the visual design of the component, with variants and state accounted for.
+  Consider progressive enhancement; might this rely on newer browser features that aren’t
+  widely supported yet?
 -->
 
 ## Interface

--- a/packages/generators/templates/component/{{name}}.{{mdx}}
+++ b/packages/generators/templates/component/{{name}}.{{mdx}}
@@ -40,7 +40,7 @@ import { {{ name }} } from "@jobber/components/{{ name }}";
 
 ## Usage Guidelines
 
-The <{{name}}> will... {Add a brief description of the component}
+The `<{{name}}>` will... _Add a brief description of the component_
 
 <!--
   What is the design purpose of this component? How do its responsibilities

--- a/packages/generators/templates/component/{{name}}.{{mdx}}
+++ b/packages/generators/templates/component/{{name}}.{{mdx}}
@@ -62,6 +62,14 @@ The <{{name}}> will... {Add a brief description of the component}
 
 ## Mockup
 
+<iframe
+  style="border: 1px solid rgba(0, 0, 0, 0.1);"
+  width="800"
+  height="450"
+  src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F3BXCXXD9glMtj8RAHjXiQC%2FDesign-System-Contribution-TEMPLATE%3Fnode-id%3D332%253A5526"
+  allowfullscreen>
+</iframe>
+
 <!--
   Insert a Figma mockup from the [Design System Contribution template](https://www.figma.com/file/3BXCXXD9glMtj8RAHjXiQC/Design-System-Contribution-TEMPLATE?node-id=26%3A2)
   that conveys the visual design of the component, with variants and state accounted for.

--- a/packages/generators/templates/component/{{name}}.{{mdx}}
+++ b/packages/generators/templates/component/{{name}}.{{mdx}}
@@ -19,6 +19,14 @@ import { {{ name }} } from "@jobber/components/{{ name }}";
   <{{ name }} text="Bob" />
 </Playground>
 
+<!--
+  INTERFACE:
+  Provide an example of what the component looks like in code. How would you use
+  it from another React component? This should consist primarily of code blocks.
+  This section can be deleted once the component is built, when the Playground
+  will demonstrate this at a higher fidelity.
+-->
+
 ## Props
 
 <Props of={ {{ name }} } />
@@ -86,13 +94,6 @@ The <{{name}}> will... {Add a brief description of the component}
   that conveys the visual design of the component, with variants and state accounted for.
   Consider progressive enhancement; might this rely on newer browser features that aren’t
   widely supported yet?
--->
-
-## Interface
-
-<!--
-  Provide an example of what the component looks like in code. How would you use it from another
-  React component? This should consist primarily of code blocks
 -->
 
 ## Notes

--- a/packages/generators/templates/component/{{name}}.{{mdx}}
+++ b/packages/generators/templates/component/{{name}}.{{mdx}}
@@ -11,10 +11,6 @@ import { {{name}} } from ".";
 
 # {{ titleCase name }}
 
-<ComponentStatus stage="pre" responsive="no" accessible="no" />
-
-Write a description about what {{ name }} component is trying to achieve.
-
 ```ts
 import { {{ name }} } from "@jobber/components/{{ name }}";
 ```
@@ -23,18 +19,60 @@ import { {{ name }} } from "@jobber/components/{{ name }}";
   <{{ name }} text="Bob" />
 </Playground>
 
+## Usage Guidelines
+
+The <{{name}}> component will... {Add a brief description of the component}
+
 <!--
-  It is not necessary to include Design & Usage Guidlelines. Use this section
-  to answer common questions and considerations about component usage.
+  What is the design purpose of this component? How do its responsibilities
+  relate to other components? What should this component not be used for? What
+  are some related components in Atlantis? Try to describe this component not
+  in terms of what it looks like or what elements make it up, but what function
+  it performs or how it enables a user to perform tasks (e.g. “Buttons allow users
+  to initiate, complete, and reverse actions.” vs “Buttons are rectangular elements
+  that have a green background and white text”).
 -->
 
-## Design & Usage Guidelines
+## Content Guidelines
 
-When contributing to, or consuming the {{ name }} component, consider the following:
+<!--
+  What type of content does this component present (documents, text, images, other components)?
+  What is the recommended, or expected, amount of content? What is the components’ behaviour when
+  the provided content diverges from what is expected (image aspect ratio, amount of text, video
+  vs audio, filesize)? Are there any important references to the Product Vocabulary that should
+  be made regarding this component? What happens when content is unavailable or unreliable (poor
+  connection, empty states, flaky GPS data?)
+-->
 
-- When using the {{ name }} component always consider the volume you would like it to
-  be displayed at.
-- The {{ name }} component should never be used inside another component.
+## Accessibility
+
+<!--
+  Describe the accessibility concerns for the component. How does it handle touch vs cursor vs
+  keyboard events? Should it capture input? What should a screen reader see when it's focuse?
+-->
+
+## Responsiveness
+
+<!--
+  How should the component behave on an iPhone 8? An iPad? A 1920x1080 monitor? How does the
+  component appear when the component itself is less than 375px wide? Less than 640px wide? Less than 1200px wide? Greater than 1200px? Does it change when the device DPI is higher
+  or lower?
+-->
+
+## Mockup
+
+<!--
+  Insert a Figma mockup from the Design System Contribution template that conveys the visual
+  design of the component, with variants and state accounted for. Consider progressive enhancement;
+  might this rely on newer browser features that aren’t widely supported yet?
+-->
+
+## Interface
+
+<!--
+  Provide an example of what the component looks like in code. How would you use it from another
+  React component? This should consist primarily of code blocks
+-->
 
 ## Props
 
@@ -47,10 +85,11 @@ When contributing to, or consuming the {{ name }} component, consider the follow
   See `Button.mdx` for a good example of this.
 -->
 
-## Loud
+## Notes
 
-Use `loud` to indicate that a component is yelling.
-
-<Playground>
-  <{{ name }} text="Fred" loud={true} />
-</Playground>
+<!--
+  What decisions worth remembering have gone into this component? Did we consider any potentially valuable
+  functionality that we’re not implementing right now for scope purposes? Are there any design decisions
+  that might need explaining beyond the usage guidelines? This will help consumers understand this component
+  more fully.
+-->

--- a/packages/generators/templates/component/{{name}}.{{mdx}}
+++ b/packages/generators/templates/component/{{name}}.{{mdx}}
@@ -19,6 +19,17 @@ import { {{ name }} } from "@jobber/components/{{ name }}";
   <{{ name }} text="Bob" />
 </Playground>
 
+## Props
+
+<Props of={ {{ name }} } />
+
+<!--
+  It is not necessary to provide an example of each prop. Use usage examples to
+  highlight key features of a component or particular considerations.
+
+  See `Button.mdx` for a good example of this.
+-->
+
 ## Usage Guidelines
 
 The <{{name}}> will... {Add a brief description of the component}
@@ -82,17 +93,6 @@ The <{{name}}> will... {Add a brief description of the component}
 <!--
   Provide an example of what the component looks like in code. How would you use it from another
   React component? This should consist primarily of code blocks
--->
-
-## Props
-
-<Props of={ {{ name }} } />
-
-<!--
-  It is not necessary to provide an example of each prop. Use usage examples to
-  highlight key features of a component or particular considerations.
-
-  See `Button.mdx` for a good example of this.
 -->
 
 ## Notes

--- a/packages/generators/templates/component/{{name}}.{{mdx}}
+++ b/packages/generators/templates/component/{{name}}.{{mdx}}
@@ -6,7 +6,6 @@ showDirectoryLink: true
 ---
 
 import { Playground, Props } from "docz";
-import { ComponentStatus } from "@jobber/docx";
 import { {{name}} } from ".";
 
 # {{ titleCase name }}
@@ -20,7 +19,8 @@ import { {{ name }} } from "@jobber/components/{{ name }}";
 </Playground>
 
 <!--
-  INTERFACE:
+  INTERFACE: This is for the proposal stage of the component
+
   Provide an example of what the component looks like in code. How would you use
   it from another React component? This should consist primarily of code blocks.
   This section can be deleted once the component is built, when the Playground


### PR DESCRIPTION
## Motivations

As we're tweaking the way we handle design system contributions for Atlantis, one of the changes will be to our component documentation templates.

## Changes

Update the component documentation template

### Added

- Accessibility section to provide more clarity on a component's a11y requirements and outcomes
- Notes to provide future consumers of a component with any necessary context
- Usage guidelines are now required
- iframe for Figma embedding
- Interface stub until component is built (Playground would then fill this role)
- Content guidelines for both contributors and consumers to consider

### Removed

- "Sample" component documentation (loud, volume, etc)
- "status" indicators as these have only provided confusion 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
