### PR TITLE
docs(design): Docs With Borders (write docs for Borders)

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -2,7 +2,7 @@
   --card--background-color: var(--color-white);
   --card--header-background-color: var(--color-grey--lightest);
   --card--content-background-color: var(--color-white);
-  --card--border-color: var(--color-grey--lighter);
+  --card--border-color: var(--color-border);
   --card--accent-color: var(--color-grey);
   --card--base-padding: var(--space-base);
 }

--- a/packages/components/src/Drawer/Drawer.css
+++ b/packages/components/src/Drawer/Drawer.css
@@ -2,7 +2,7 @@
   --drawer-width: calc(var(--space-base) * 17.5);
   --drawer--background-color: var(--color-white);
   --drawer--header-background-color: var(--color-grey--lightest);
-  --drawer--border-color: var(--color-grey--lighter);
+  --drawer--border-color: var(--color-border);
   --drawer--base-padding: var(--space-base);
 }
 

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -3,7 +3,7 @@
   --field--textAlign: left;
   --field--placeholder-color: var(--color-greyBlue--light);
   --field--border-width: var(--border-base);
-  --field--border-color: var(--color-grey--lighter);
+  --field--border-color: var(--color-border);
   --field--background-color: var(--color-white);
 
   --field--padding-top: calc(var(--space-base) - var(--space-smallest));

--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -3,7 +3,7 @@
   --file-card--background-color: var(--color-white);
   --file-card--header-background-color: var(--color-greyBlue--lighter);
   --file-card--content-background-color: var(--color-white);
-  --file-card--border-color: var(--color-grey--lighter);
+  --file-card--border-color: var(--color-border);
   --file-card--accent-color: var(--color-grey);
   --file-card--base-padding: var(--space-small);
 }

--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -1,5 +1,5 @@
 :root {
-  --border-color: var(--color-blue--lightest);
+  --border-color: var(--color-border);
   --border-active-color: var(--color-outline);
 }
 

--- a/packages/components/src/List/List.css
+++ b/packages/components/src/List/List.css
@@ -5,7 +5,7 @@
 }
 
 .item:not(:last-child) {
-  border-bottom: var(--border-base) solid var(--color-grey--lighter);
+  border-bottom: var(--border-base) solid var(--color-border);
 }
 
 .section {

--- a/packages/components/src/List/SectionHeader.css
+++ b/packages/components/src/List/SectionHeader.css
@@ -2,7 +2,7 @@
   position: sticky;
   top: 0;
   padding: var(--space-small) var(--space-base);
-  border-bottom: 1px solid var(--color-blue);
+  border-bottom: 1px solid var(--color-border--section);
   background-color: var(--color-white);
 }
 

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -1,7 +1,7 @@
 :root {
   --modal--width: calc(var(--base-unit) * 37.5);
   --modal--padding: var(--space-base);
-  --modal--border-color: var(--color-grey--lighter);
+  --modal--border-color: var(--color-border);
 }
 
 @media (--medium-screens) {

--- a/packages/components/src/Table/Table.css
+++ b/packages/components/src/Table/Table.css
@@ -1,6 +1,6 @@
 .table {
-  --border-color: var(--color-grey--lighter);
-  --header-border-color: var(--color-blue);
+  --border-color: var(--color-border);
+  --header-border-color: var(--color-border--section);
   --horizontal-inset: var(--space-base);
   position: relative;
   width: 100%;

--- a/packages/components/src/Tabs/Tabs.css
+++ b/packages/components/src/Tabs/Tabs.css
@@ -1,5 +1,5 @@
 :root {
-  --tab--border-color: var(--color-grey--lighter);
+  --tab--border-color: var(--color-border);
   --tab--border-color--selected: var(--color-green);
   --tab--height: calc(var(--space-larger) + var(--space-small));
   --tab--inset: var(--space-base);

--- a/packages/design/src/Borders.mdx
+++ b/packages/design/src/Borders.mdx
@@ -1,7 +1,7 @@
 ---
 name: Dividing Content
 menu: Design
-route: /borders-and-dividers
+route: /borders
 ---
 
 # Borders and Dividers
@@ -12,8 +12,14 @@ platforms: borders and dividers.
 
 ## Borders
 
-To add a border to an element, use the border variables in the component's
+### Border Widths
+
+To add a border to an element, use the border-width variables in the component's
 styling to ensure consistent border thickness throughout Jobber.
+
+Border style should be `solid` unless a specific use case calls for some other
+format, such as indicating a dropzone on the
+[`InputFile` component](https://atlantis.getjobber.com/components/input-file).
 
 export function Example({ of: size }) {
   const style = {
@@ -32,10 +38,12 @@ export function Example({ of: size }) {
 | `--border-thick`   | <Example of="thick" />   |
 | `--border-thicker` | <Example of="thicker" /> |
 
-The `base` border width should be used for most use cases. Examples where you
-may want to consider thicker borders are when the border conveys an opening or
+The `base` border width should be used for most use cases (see
+[`Card`](https://atlantis.getjobber.com/components/card) and
+[`List` items](https://atlantis.getjobber.com/components/list) for in-context
+examples). You may want to consider thicker borders when the border conveys a
 closing of already-divided sections, such as a
-[`Table` footer](https://atlantis.getjobber.com/components/table)
+[`Table` footer](https://atlantis.getjobber.com/components/table).
 
 ### Border Colors
 
@@ -50,5 +58,7 @@ For accessibility reasons, ensure that color usage is not the only way to
 
 ## Dividers
 
-The [`Divider`](https://atlantis.getjobber.com/components/divider) will help you
-do so without writing additional styling.
+The [`Divider` component](https://atlantis.getjobber.com/components/divider)
+will help you segment sections of content without writing additional styling.
+This component will render a horizontal rule that takes up the full available
+width.

--- a/packages/design/src/Borders.mdx
+++ b/packages/design/src/Borders.mdx
@@ -1,0 +1,54 @@
+---
+name: Dividing Content
+menu: Design
+route: /borders-and-dividers
+---
+
+# Borders and Dividers
+
+You may find that a visual indicator is helpful to segment elements in an
+interface. We have elements to help you do so in a consistent way across
+platforms: borders and dividers.
+
+## Borders
+
+To add a border to an element, use the border variables in the component's
+styling to ensure consistent border thickness throughout Jobber.
+
+export function Example({ of: size }) {
+  const style = {
+    width: "100%",
+    height: "var(--space-miniscule)",
+    borderBottomStyle: "solid",
+    borderBottomWidth: `var(--border-${size})`,
+    borderBottomColor: "var(--color-grey--lighter)",
+  };
+  return <div style={style} />;
+}
+
+| Width              | Visual                   |
+| :----------------- | :----------------------- |
+| `--border-base`    | <Example of="base" />    |
+| `--border-thick`   | <Example of="thick" />   |
+| `--border-thicker` | <Example of="thicker" /> |
+
+The `base` border width should be used for most use cases. Examples where you
+may want to consider thicker borders are when the border conveys an opening or
+closing of already-divided sections, such as a
+[`Table` footer](https://atlantis.getjobber.com/components/table)
+
+### Border Colors
+
+Borders should use `var(--color-grey--lighter)` for most use cases.
+[`List` sections](https://atlantis.getjobber.com/components/list#sectioned-list-items),
+[`Table` headers](https://atlantis.getjobber.com/components/table) and other
+scenarios where other bordered content is being further subsectioned should use
+`var(--color-blue)`.
+
+For accessibility reasons, ensure that color usage is not the only way to
+[convey meaning](https://webaim.org/articles/contrast/#sc141) in an interface.
+
+## Dividers
+
+The [`Divider`](https://atlantis.getjobber.com/components/divider) will help you
+do so without writing additional styling.

--- a/packages/design/src/Borders.mdx
+++ b/packages/design/src/Borders.mdx
@@ -1,5 +1,5 @@
 ---
-name: Dividing Content
+name: Borders
 menu: Design
 route: /borders
 ---
@@ -47,11 +47,11 @@ closing of already-divided sections, such as a
 
 ### Border Colors
 
-Borders should use `var(--color-grey--lighter)` for most use cases.
+Borders should use `--color-border)` for most use cases.
 [`List` sections](https://atlantis.getjobber.com/components/list#sectioned-list-items),
 [`Table` headers](https://atlantis.getjobber.com/components/table) and other
 scenarios where other bordered content is being further subsectioned should use
-`var(--color-blue)`.
+`--color-border--section)`.
 
 For accessibility reasons, ensure that color usage is not the only way to
 [convey meaning](https://webaim.org/articles/contrast/#sc141) in an interface.

--- a/packages/design/src/borders.css
+++ b/packages/design/src/borders.css
@@ -2,4 +2,6 @@
   --border-base: var(--space-minuscule);
   --border-thick: var(--space-smallest);
   --border-thicker: var(--space-smaller);
+  --color-border: var(--color-grey--lighter);
+  --color-border--section: var(--color-blue);
 }


### PR DESCRIPTION
## Motivations

Sean said this on a PR:
![image](https://user-images.githubusercontent.com/39704901/113639404-5564c580-9636-11eb-941b-ad5bd5009d05.png)

And I thought
![image](https://user-images.githubusercontent.com/39704901/113639440-6b728600-9636-11eb-8889-b2a786fb2172.png)

## Changes

Add docs for our Borders foundation elements

### Added

- docs for borders
- reference in that to Divider

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
