### PR TITLE
fix(docz-tools): change configuration option for hiding logo to resolve undefined page titles 

### DIFF
--- a/packages/docz-tools/README.md
+++ b/packages/docz-tools/README.md
@@ -131,7 +131,8 @@ false. By default it is `true`
 export default {
   ...,
   themeConfig: {
-  hasLogo: false
+    ...,
+    hasLogo: false
   }
 }
 ```

--- a/packages/docz-tools/README.md
+++ b/packages/docz-tools/README.md
@@ -123,14 +123,16 @@ export default {
 
 ### Hide / Show Logo
 
-The logo within the sidebar can be hidden if required by providing an
-`undefined` value to `title`.
+The logo within the sidebar can be hidden if required by adjusting `hasLogo` to
+false. By default it is `true`
 
 ```
 // doczrc.js
 export default {
   ...,
-  title: undefined
+  themeConfig: {
+  hasLogo: false
+  }
 }
 ```
 

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
@@ -11,13 +11,14 @@ import { DeferRender } from "../DeferRender";
 export function Sidebar() {
   const [query, setQuery] = useState("");
   const {
-    themeConfig: { sideBarWidth, sidebarOffset = 0 },
+    themeConfig: { sideBarWidth, sidebarOffset = 0, hasLogo = true },
   } = useConfig();
   const sidebarRef = createRef<HTMLDivElement>();
+  console.log(hasLogo);
 
   return (
     <Box sx={styles.sidebar(sideBarWidth, sidebarOffset)} ref={sidebarRef}>
-      <Logo />
+      {hasLogo && <Logo />}
       <Box sx={styles.search}>
         <DeferRender>
           <Icon name="search" color="greyBlue" />

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/index.tsx
@@ -14,7 +14,6 @@ export function Sidebar() {
     themeConfig: { sideBarWidth, sidebarOffset = 0, hasLogo = true },
   } = useConfig();
   const sidebarRef = createRef<HTMLDivElement>();
-  console.log(hasLogo);
 
   return (
     <Box sx={styles.sidebar(sideBarWidth, sidebarOffset)} ref={sidebarRef}>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
In #487, I had requested/suggested there be options to hide the logo, actions and change some layout options. I have noticed that there is an issue with hiding the logo when `title` is `undefined`.

The page's title when using `title: undefined` in `doczrc.js`
![image](https://user-images.githubusercontent.com/80279872/113947308-9e984f00-97c7-11eb-9f46-1e8a3fe60110.png)


Docz is expecting title to have a value to set page titles using a template. I am recommending a different configuration option which fixes this issue and has more flexibility as some may want a title but not a logo. I am considering this a fix - as it's not changing expected behaviour, it's simply accomplishing it differently than implemented before.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Changed conditional logo display to use hasLogo instead of undefined title

## Testing

- Add `hasLogo` to `doczrc.js`'s theme configuration object as follows:
```
// doczrc.js
export default {
  ...,
  themeConfig: {
  hasLogo: false
  }
}
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
