### PR TITLE
docs(components): Tweak some verbiage and order of the Popover docs

### DIFF
--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -25,7 +25,7 @@
   width: 100%;
   max-width: var(--popover--width);
   box-shadow: var(--shadow-base);
-  border: var(--border-base) solid var(--color-grey--light);
+  border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
   font-size: var(--base-unit);
   line-height: normal;

--- a/packages/components/src/Popover/Popover.mdx
+++ b/packages/components/src/Popover/Popover.mdx
@@ -9,6 +9,7 @@ import { Playground, Props } from "docz";
 import { Content } from "../Content";
 import { Heading } from "../Heading";
 import { Text } from "../Text";
+import { Banner } from "../Banner";
 import { Button } from "../Button";
 import { Checkbox } from "../Checkbox";
 import { useState, useRef } from "react";
@@ -58,12 +59,6 @@ import { Popover } from "@jobber/components/Popover";
 
 Some scenarios for Popover include the following:
 
-### Functional
-
-Reveal a list of available actions to the user. For example, if the user clicks
-on an element and there are four potential actions they might take, Popover is a
-great way to present those actions.
-
 ### Informational
 
 Introducing the user to a new experience, whether their first time using a
@@ -111,7 +106,23 @@ understand the change, use a `learning`
   }}
 </Playground>
 
+### Functional
+
+Reveal a list of available actions to the user. For example, if the user clicks
+on an element and there are four potential actions they might take, Popover is a
+great way to present those actions. If you're looking to provide a menu of
+actions that comes complete with a trigger button,
+[Menu](https://atlantis.getjobber.com/components/menu) has that bundle ready to
+go.
+
+<Banner type="warning" dismissible={false}>
+  A "functional" Popover hasn't been implemented in a componentized fashion yet.
+</Banner>
+
 ### Related Components
+
+To add a menu button that presents multiple actions to the user, use
+[Menu](https://atlantis.getjobber.com/components/menu).
 
 To add a hint about a UI element's function in a permanent fashion (ie revealing
 a Button's label on hover), use
@@ -222,6 +233,9 @@ You have 5 `preferredPlacement` options you can use:
 
 ## Notes
 
+- There is no componentized way to pass in actions for a "functional" Popover
+  yet, but we have a good idea of what that would look like. We believe there
+  may be some opportunity to share elements of Popover with Menu and vice-versa.
 - There is no built-in focus management in Popover, as the specific
   implementation should drive those considerations
 - Popover uses a plugin called [Popper](https://popper.js.org/react-popper/v2/)

--- a/packages/components/src/Popover/Popover.mdx
+++ b/packages/components/src/Popover/Popover.mdx
@@ -134,8 +134,8 @@ your use case.
 
 ## Content Guidelines
 
-- Popover text content should not exceed three lines, and should be concise and
-  clear
+- Popover text content should be concise and clear. Try not to go over three
+  lines so the user can get back to what they were doing!
 - In "informational" usage, Popper may have a CTA that allows the user to
   "acknowledge" and dismiss the Popover; this does not replace the need for the
   dismiss button

--- a/packages/components/src/Popover/Popover.mdx
+++ b/packages/components/src/Popover/Popover.mdx
@@ -6,7 +6,6 @@ showDirectoryLink: true
 ---
 
 import { Playground, Props } from "docz";
-import { ComponentStatus } from "@jobber/docx";
 import { Content } from "../Content";
 import { Heading } from "../Heading";
 import { Button } from "../Button";
@@ -16,9 +15,9 @@ import { Popover } from ".";
 
 # Popover
 
-<ComponentStatus stage="pre" responsive="no" accessible="no" />
-
-Write a description about what Popover component is trying to achieve.
+A Popover displays floating informative and actionable content positioned in
+relation to a target. The Popover can contain content, media, or other
+components.
 
 ```ts
 import { Popover } from "@jobber/components/Popover";
@@ -43,63 +42,74 @@ import { Popover } from "@jobber/components/Popover";
           preferredPlacement="right"
           onRequestClose={() => setShowPopover(false)}
         >
-          <Content>Here is your first popover</Content>
+          <Content>Here is your first Popover</Content>
         </Popover>
       </>
     );
   }}
 </Playground>
 
-<!--
-  It is not necessary to include Design & Usage Guidlelines. Use this section
-  to answer common questions and considerations about component usage.
--->
-
-## Design & Usage Guidelines
-
-When contributing to, or consuming the Popover component, consider the
-following:
-
-### Usage
-
-The popover component displays floating informative and actionable content in
-relation to a target. The popover can contain content, media, or other
-components.
-
-Some scenarios for popover include the following:
-
-- Show available related actions
-- First time experience
-- To call out product features or changes
-
-There are also some outstanding questions:
-
-- Can our current tooltips can be a real tooltip?
-
-### Content
-
-- Popover text content should not exceed 3 lines and can consist of an optional
-  "dismiss" CTA
-
-### Reference Docs
-
-- Documentation on the popper plugin that was used to build the popover
-  component https://popper.js.org/react-popper/v2/
-
 ## Props
 
 <Props of={Popover} />
 
-<!--
-  It is not necessary to provide an example of each prop. Use usage examples to
-  highlight key features of a component or particular considerations.
+## Usage Guidelines
 
-  See `Button.mdx` for a good example of this.
--->
+Some scenarios for Popover include the following:
+
+### Functional
+
+Reveal a list of available actions to the user. For example, if the user clicks
+on an element and there are four potential actions they might take, Popover is a
+great way to present those actions.
+
+### Informational
+
+Introducing the user to a new experience, whether their first time using a
+product or to introduce a new or updated functionality in an existing
+experience, Popover can be an excellent choice to highlight a specific piece of
+the experience.
+
+If there is an "acknowledgement" CTA for the user to confirm that they
+understand the change, use a `learning`
+[Button](https://atlantis.getjobber.com/components/button).
+
+### Related Components
+
+To add a hint about a UI element's function in a permanent fashion (ie revealing
+a Button's label on hover), use
+[Tooltip](https://atlantis.getjobber.com/components/tooltip).
+
+To add an inline informational element that the user can dismiss, consider if
+[Banner](https://atlantis.getjobber.com/components/banner) is the right fit for
+your use case.
+
+## Content Guidelines
+
+- Popover text content should not exceed three lines, and should be concise and
+  clear
+- In "informational" usage, Popper may have a CTA that allows the user to
+  "acknowledge" and dismiss the Popover; this does not replace the need for the
+  dismiss button
+
+## Accessibility
+
+Popover has a role of `dialog` as it is an element that the user will be "in
+dialogue" with, whether selecting an action, confirming acknowledgement, or
+dismissing the Popover.
+
+Depending on your use case, you may need to add focus management to your usage
+of Popover; for example, if selecting a Button opens a Popover, you will want to
+then set focus to the Popover, and if the user dismisses the Popover, return
+focus to the button that opened the Popover.
+
+If your element is effectively acting as an inline DOM element that the user
+would otherwise encounter when traversing the page, this focus management may
+not be necessary.
 
 ## preferredPlacement options
 
-You have 5 preferredPlacement options you can use
+You have 5 `preferredPlacement` options you can use:
 
 - `right`
 - `top`
@@ -172,3 +182,10 @@ You have 5 preferredPlacement options you can use
     );
   }}
 </Playground>
+
+## Notes
+
+- There is no built-in focus management in Popover, as the specific
+  implementation should drive those considerations
+- Popover uses a plugin called [Popper](https://popper.js.org/react-popper/v2/)
+  to power its' positioning

--- a/packages/components/src/Popover/Popover.mdx
+++ b/packages/components/src/Popover/Popover.mdx
@@ -77,7 +77,7 @@ understand the change, use a `learning`
 
 <Playground>
   {() => {
-    const divRef = useRef();
+    const newFeatureButton = useRef();
     const [showPopover, setShowPopover] = useState(false);
     return (
       <>
@@ -95,14 +95,15 @@ understand the change, use a `learning`
         >
           <Content>
             <Heading>New feature!</Heading>
-            <Text>You can now press a button that you couldn't before.</Text>
-            <div style="display:flex;align-items:flex-end;">
-              <Button
-                label="Got it"
-                variation="learning"
-                onClick={() => setShowPopover(!showPopover)}
-              />
-            </div>
+            <Text>
+              You can now press a button that you couldn't before. This is
+              important!
+            </Text>
+            <Button
+              label="Got it"
+              variation="learning"
+              onClick={() => setShowPopover(!showPopover)}
+            />
           </Content>
         </Popover>
       </>

--- a/packages/components/src/Popover/Popover.mdx
+++ b/packages/components/src/Popover/Popover.mdx
@@ -8,6 +8,7 @@ showDirectoryLink: true
 import { Playground, Props } from "docz";
 import { Content } from "../Content";
 import { Heading } from "../Heading";
+import { Text } from "../Text";
 import { Button } from "../Button";
 import { Checkbox } from "../Checkbox";
 import { useState, useRef } from "react";
@@ -73,6 +74,41 @@ the experience.
 If there is an "acknowledgement" CTA for the user to confirm that they
 understand the change, use a `learning`
 [Button](https://atlantis.getjobber.com/components/button).
+
+<Playground>
+  {() => {
+    const divRef = useRef();
+    const [showPopover, setShowPopover] = useState(false);
+    return (
+      <>
+        <span ref={newFeatureButton}>
+          <Button
+            label="New Feature"
+            onClick={() => setShowPopover(!showPopover)}
+          />
+        </span>
+        <Popover
+          attachTo={newFeatureButton}
+          open={showPopover}
+          preferredPlacement="right"
+          onRequestClose={() => setShowPopover(false)}
+        >
+          <Content>
+            <Heading>New feature!</Heading>
+            <Text>You can now press a button that you couldn't before.</Text>
+            <div style="display:flex;align-items:flex-end;">
+              <Button
+                label="Got it"
+                variation="learning"
+                onClick={() => setShowPopover(!showPopover)}
+              />
+            </div>
+          </Content>
+        </Popover>
+      </>
+    );
+  }}
+</Playground>
 
 ### Related Components
 

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -5,28 +5,28 @@ import { ButtonDismiss } from "../ButtonDismiss";
 
 export interface PopoverProps {
   /**
-   * Element the popover will attach to and point at. A `useRef` must be attached to an html element
-   * and passed as an attachTo prop in order for the popover to function properly
+   * Element the Popover will attach to and point at. A `useRef` must be attached to an html element
+   * and passed as an attachTo prop in order for the Popover to function properly
    */
   readonly attachTo: Element | React.RefObject<Element | null>;
 
   /**
-   * Pop-over content.
+   * Popover content.
    */
   readonly children: React.ReactNode;
 
   /**
-   * Control popover viability.
+   * Control Popover visibility.
    */
   readonly open: boolean;
 
   /**
-   * Callback executed when the user wants to close/dismiss the popover
+   * Callback executed when the user wants to close/dismiss the Popover
    */
   readonly onRequestClose?: () => void;
 
   /**
-   * Describes the preferred placement of the popper.
+   * Describes the preferred placement of the Popover.
    * @default 'auto'
    */
   readonly preferredPlacement?: "top" | "bottom" | "left" | "right" | "auto";


### PR DESCRIPTION
## Motivations

Gave the Popover docs a quick re-read after release, just some cleanups and design clarifications.

Also pulled in the border variable I'd introduced alongside the build of this component, which is available now!

## Changes

### Added

- add a11y notes
- add related components

### Changed

- use title-case when referencing component names
- flesh out design use cases
- use `color-border` design variable

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
