### PR TITLE
fix(components): Allow input validation to be easily read by assistive tech

### DIFF
--- a/packages/components/src/InputValidation/InputValidation.css
+++ b/packages/components/src/InputValidation/InputValidation.css
@@ -12,3 +12,8 @@
 .message > svg {
   margin-right: var(--space-smaller);
 }
+
+.message:focus {
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}

--- a/packages/components/src/InputValidation/InputValidation.test.tsx
+++ b/packages/components/src/InputValidation/InputValidation.test.tsx
@@ -20,6 +20,7 @@ it("renders the input validation messages", () => {
         }
       >
         <div
+          aria-live="assertive"
           className="message"
         >
           <p

--- a/packages/components/src/InputValidation/InputValidation.test.tsx
+++ b/packages/components/src/InputValidation/InputValidation.test.tsx
@@ -22,6 +22,8 @@ it("renders the input validation messages", () => {
         <div
           aria-live="assertive"
           className="message"
+          role="alert"
+          tabIndex={0}
         >
           <p
             className="base regular base red"

--- a/packages/components/src/InputValidation/InputValidation.tsx
+++ b/packages/components/src/InputValidation/InputValidation.tsx
@@ -31,7 +31,7 @@ export function InputValidation({ message }: InputValidationProps) {
                 exit="slideOut"
                 transition={{ duration: 0.2 }}
               >
-                <div className={styles.message}>
+                <div className={styles.message} aria-live="assertive">
                   <Text variation="error">{msg}</Text>
                 </div>
               </motion.div>

--- a/packages/components/src/InputValidation/InputValidation.tsx
+++ b/packages/components/src/InputValidation/InputValidation.tsx
@@ -31,7 +31,12 @@ export function InputValidation({ message }: InputValidationProps) {
                 exit="slideOut"
                 transition={{ duration: 0.2 }}
               >
-                <div className={styles.message} aria-live="assertive">
+                <div
+                  className={styles.message}
+                  aria-live="assertive"
+                  role="alert"
+                  tabIndex={0}
+                >
                   <Text variation="error">{msg}</Text>
                 </div>
               </motion.div>


### PR DESCRIPTION
## Motivations

While our error messages do print text elements to the DOM that _could_ be read by assistive technologies, the pattern is un-intuitive and more likely than not would be missed, leading to further errors when a user attempts to submit their form.

Users navigating a form will more likely than not be operating via the `tab` key, as this is a familiar pattern for moving between inputs in forms.

`p` elements are not tab-operable by default, and in addition we sometimes render these errors _above_ the input in the DOM; in either case, the user would need to `control+option+left/right arrow` to engage, and this action does not trigger the `onBlur` event of `tab`-ing, meaning the message will not be read out.

Solution follows the pattern recommended by the [W3C group](https://www.w3.org/WAI/tutorials/forms/notifications/#on-focus-change). 

**Notes**

It is possible that we may want to move to a pattern where validation is consumed by, or exists alongside, "assistive text", which would include elements like the `description` text on [Checkbox](https://atlantis.getjobber.com/components/checkbox#with-a-description) and [RadioGroup](https://atlantis.getjobber.com/components/radio-group#description). I do not believe that this immediate fix prevents us from rolling out either of those.

## Changes

Error message wrapper now have an `aria-live` attribute that announces the error message to the user upon the validation event.

### Added

- `aria-live="assertive"` attribute to the `div` that wraps `InputValidation` error messages.

### Changed

- if there is an error, the error message is now read aloud to the user.

### Fixed

- Users are able to hear error messages more easily.

## Testing

Go to InputText "with validation"...

- [on production](https://atlantis.getjobber.com//components/input-text/#validation-message)
- [locally](http://localhost:3333/components/input-text/#validation-message)

1. Turn on [VoiceOver](https://support.apple.com/en-ca/guide/mac-help/mh40578/mac#:~:text=On%20your%20Mac%2C%20use%20the,click%20Accessibility%2C%20then%20click%20VoiceOver.&text=Turn%20VoiceOver%20on%20or%20off.)
2. Go to the Input in the Validation Message example
3. Trigger the following errors (`tab` or `shift+tab` to blur the input and trigger validation):
- Without typing, blur the input
- Enter the text "123"
- Enter the text "vientisiete"
4. Notice that on production, you do not hear any error message, while on this branch, you should hear respectively...
- "You have to tell us your age"
- "Type your age in words please."
- "That seems too old."

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
