### PR TITLE
feat(design): Update timing variables and docs

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -15,6 +15,8 @@
   --button--color-disabled: var(--color-grey--lighter);
   --button--color-secondary: var(--color-white);
   --button--color-tertiary: var(--color-white);
+
+  --button--duration-loading: 2s;
 }
 
 .button {
@@ -210,7 +212,7 @@ a.tertiary:focus {
   background-size: var(--space-larger) var(--space-larger);
   pointer-events: none;
   cursor: not-allowed;
-  animation-duration: var(--timing-slowest);
+  animation-duration: var(--button--duration-loading);
   animation-iteration-count: infinite;
   animation-name: animateStripes;
   animation-timing-function: linear;

--- a/packages/design/src/animation.mdx
+++ b/packages/design/src/animation.mdx
@@ -33,20 +33,20 @@ Delighters can be used occasionally to create surprise and delight, and can give
 personality to our brand. These can be used to reinforce success in an important
 milestones in a user's journey.
 
-## Durations
+## Timing
 
-Use judgement when determining the appropriate durations for animations. This
-will depend on the size of the element and the distance it covers. Animations
-for larger elements or longer distances should be longer than smaller elements
-or shorter distances.
+Use judgement when determining the appropriate timing durations for animations.
+This will depend on the size of the element and the distance it covers.
+Animations for larger elements or longer distances should be longer than smaller
+elements or shorter distances.
 
-| Name                 | Value | Examples of use                                         |
-| :------------------- | :---- | :------------------------------------------------------ |
-| `--duration-fastest` | 100ms | smaller elements exiting, small elements, state changes |
-| `--duration-fast`    | 200ms | larger elements exiting, small elements, state changes  |
-| `--duration-normal`  | 300ms | modals, side panels                                     |
-| `--duration-slow`    | 400ms | large elements traversing across large area             |
-| `--duration-slowest` | 500ms | page transitions                                        |
+| Name               | Value | Examples of use                                         |
+| :----------------- | :---- | :------------------------------------------------------ |
+| `--timing-quick`   | 100ms | smaller elements exiting, small elements, state changes |
+| `--timing-base`    | 200ms | larger elements exiting, small elements, state changes  |
+| `--timing-slow`    | 300ms | modals, side panels                                     |
+| `--timing-slower`  | 400ms | large elements traversing across large area             |
+| `--timing-slowest` | 500ms | page transitions                                        |
 
 ## Easing
 

--- a/packages/design/src/timings.css
+++ b/packages/design/src/timings.css
@@ -1,7 +1,7 @@
 :root {
   --timing-quick: 100ms;
   --timing-base: 200ms;
-  --timing-slow: 500ms;
-  --timing-slower: 1s;
-  --timing-slowest: 2s;
+  --timing-slow: 300ms;
+  --timing-slower: 400ms;
+  --timing-slowest: 500ms;
 }


### PR DESCRIPTION
## Motivations

@rebecca-li wrote some great guidelines on how to use animations in Atlantis, including guides on how to incorporate our timing variables. However, those were not actually reflected!

I did change the verbiage around the `timings` in documentation from `duration` to `timing` to get those to match, but the values themselves have been updated.

## Changes

Change description of animation-duration variables to `timing` and update docs, change underlying timing values, add a new variable for Button as I think that's more of a one-off tied to a specific state of that component.

### Changed

- changed timing variables to match Rebecca's guidelines
- changed Button loading animation from a global variable to one specific to Button
- updated docs to match names of concept and variables

## Testing

- Go to animation docs, look at Button with `loading` state, look at hover state on Card, bar-filling on ProgressBar, etc and make sure they still have working transitions

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
