### PR TITLE
docs: add installation notes to Atlantis home

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ The primary packages in here are:
   - `docx/`
     - Any components internal to the documention viewer itself.
 
-When installing dependancies be sure to install them relative to the appropriate
+When installing dependencies be sure to install them relative to the appropriate
 sub package. For example if you want to use package `foo` in a component you
 would run `npm install foo` from within the `components` directory.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,18 +49,18 @@ has installation links for each package:
 
 These are the core packages you'll need to build with Atlantis:
 
-- [Components](https://atlantis.getjobber.com/packages/components#installation)
-- [Design foundations](https://atlantis.getjobber.com/packages/design#installation)
-- [Hooks](https://atlantis.getjobber.com/packages/hooks#installing)
+- [Components](/packages/components)
+- [Design foundations](/packages/design)
+- [Hooks](/packages/hooks)
 
 #### Tooling and configuration
 
 If you're looking to build documentation and tooling using Atlantis' development standards,
 these packages will be useful:
 
-- [Docz tools](https://atlantis.getjobber.com/packages/docz-tools#usage)
-- [EsLint configuration](https://atlantis.getjobber.com/packages/eslint-config)
-- [StyleLint configuration](https://atlantis.getjobber.com/packages/stylelint-config#installing)
+- [Docz tools](/packages/docz-tools)
+- [EsLint configuration](/packages/eslint-config)
+- [StyleLint configuration](/packages/stylelint-config)
 
 ## Generating a Component
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ developers to quickly build beautiful and consistent interfaces for our users.
 
 ## Development
 
-##### Prerequisites
+### Prerequisites
 
 - `node@10` or higher
 - `npm@6` or higher
@@ -39,6 +39,28 @@ To start the [docz](https://www.docz.site/) development server:
 ```sh
 npm start
 ```
+
+### Installing packages
+
+Atlantis are installed and updated using [npm](https://www.npmjs.com/). This following list
+has installation links for each package:
+
+#### Design system
+
+These are the core packages you'll need to build with Atlantis:
+
+- [Components](https://atlantis.getjobber.com/packages/components#installation)
+- [Design foundations](https://atlantis.getjobber.com/packages/design#installation)
+- [Hooks](https://atlantis.getjobber.com/packages/hooks#installing)
+
+#### Tooling and configuration
+
+If you're looking to build documentation and tooling using Atlantis' development standards,
+these packages will be useful:
+
+- [Docz tools](https://atlantis.getjobber.com/packages/docz-tools#usage)
+- [EsLint configuration](https://atlantis.getjobber.com/packages/eslint-config)
+- [StyleLint configuration](https://atlantis.getjobber.com/packages/stylelint-config#installing)
 
 ## Generating a Component
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ npm start
 
 ### Installing packages
 
-Atlantis are installed and updated using [npm](https://www.npmjs.com/). This following list
+Atlantis packages are installed and updated using [npm](https://www.npmjs.com/). This following list
 has installation links for each package:
 
 #### Design system


### PR DESCRIPTION
## Motivations

Our installation instructions are buried pretty deep in our IA - using Atlantis should be a key piece of info for contributors!

## Changes

Added packages overview and links to installation

### Added

- Added packages overview and links to installation

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
