### PR TITLE
docs: Add note on requesting review

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -157,6 +157,10 @@ follow the following format.
 Want help with your pull request title? We have a
 [tool to help](/pull-request-name-generator).
 
+##### Requesting review
+
+To request a review from Atlantis maintainers, use [Github's review tool](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review) and request from review from `GetJobber/McWeb`.
+
 ## Guiding Principles
 
 ### Documentation first


### PR DESCRIPTION
## Motivations

Clarify how contributors should request reviews in more places, so that it's easier for a new contributor to follow our workflow.

## Changes

Add notes on review requests

### Added

- link to Github's review process docs

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
