### PR TITLE
fix(components): update popover return type and examples

### DIFF
--- a/packages/components/src/Popover/Popover.mdx
+++ b/packages/components/src/Popover/Popover.mdx
@@ -40,7 +40,6 @@ import { Popover } from "@jobber/components/Popover";
         <Popover
           attachTo={divRef}
           open={showPopover}
-          dismissible={true}
           preferredPlacement="right"
           onRequestClose={() => setShowPopover(false)}
         >
@@ -179,12 +178,7 @@ You have 5 `preferredPlacement` options you can use:
             <Button label="Top Reference" />
           </span>
         </Content>
-        <Popover
-          attachTo={topRef}
-          open={showPopover}
-          dismissible={true}
-          preferredPlacement="top"
-        >
+        <Popover attachTo={topRef} open={showPopover} preferredPlacement="top">
           <Content>Top Popover</Content>
         </Popover>
         <Content>
@@ -195,7 +189,6 @@ You have 5 `preferredPlacement` options you can use:
         <Popover
           attachTo={leftRef}
           open={showPopover}
-          dismissible={true}
           preferredPlacement="left"
         >
           <Content>Left Popover</Content>
@@ -208,7 +201,6 @@ You have 5 `preferredPlacement` options you can use:
         <Popover
           attachTo={rightRef}
           open={showPopover}
-          dismissible={true}
           preferredPlacement="right"
         >
           <Content>Right Popover</Content>
@@ -221,7 +213,6 @@ You have 5 `preferredPlacement` options you can use:
         <Popover
           attachTo={bottomRef}
           open={showPopover}
-          dismissible={true}
           preferredPlacement="bottom"
         >
           <Content>Bottom Popover</Content>

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -50,26 +50,26 @@ export function Popover({
     },
   );
 
-  return (
-    open && (
-      <div
-        role="dialog"
-        ref={setPopperElement}
-        style={popperStyles.popper}
-        className={classes.popover}
-        {...attributes.popper}
-      >
-        <div className={classes.dismissButton}>
-          <ButtonDismiss onClick={onRequestClose} ariaLabel="Close dialog" />
-        </div>
-        {children}
-        <div
-          ref={setArrowElement}
-          className={classes.arrow}
-          style={popperStyles.arrow}
-        />
+  return open ? (
+    <div
+      role="dialog"
+      ref={setPopperElement}
+      style={popperStyles.popper}
+      className={classes.popover}
+      {...attributes.popper}
+    >
+      <div className={classes.dismissButton}>
+        <ButtonDismiss onClick={onRequestClose} ariaLabel="Close dialog" />
       </div>
-    )
+      {children}
+      <div
+        ref={setArrowElement}
+        className={classes.arrow}
+        style={popperStyles.arrow}
+      />
+    </div>
+  ) : (
+    <></>
   );
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
- upon using popover, I was receiving invalid jsx element
![image](https://user-images.githubusercontent.com/54861184/115570563-38620080-a28c-11eb-9366-7968a1a52b1d.png)
- this is due to popover returning false if `open=false` and the popover component otherwise

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- added a ternary operator to return either the component or a jsx fragment depending on the `open` condition.

### Removed

- removed `dismissible` from the mdx examples

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
