### PR TITLE
docs(design): More detail on semantic color usage

### DIFF
--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -68,7 +68,9 @@ Use to signify that an interactive element is disabled.
 
 ##### Disabled--Secondary
 
-Use when a disabled element needs more than one shade.
+Use when a disabled element needs more than one color to be readable in a
+disabled state; for example, a button's background and label colors must be
+different.
 
 #### Focus
 

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -33,7 +33,7 @@ readability.
 
 #### Heading
 
-Headings have a bold, dark color to cement their hierarchy.
+Headings have a bold, high-contrast color to cement their hierarchy.
 
 #### Text
 
@@ -110,8 +110,8 @@ Surfaces are the background-colors of almost every element in Jobber.
 
 #### Surface
 
-Most elements in Jobber have a white surface; if clickable, they have a light
-hover color.
+Most elements in Jobber have a light surface to indicate their nearness to the
+user; if clickable, they have a hover color.
 
 #### Surface--Background
 

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -18,138 +18,141 @@ Atlantis is built with a
 overtop of a base palette. Use the semantic color values whenever possible to
 ensure you are using colors for their intended purpose.
 
-## Typography
-
-Typographic elements in Jobber should use consistent colors to ensure readability.
-
-### Heading
-
-Headings have a bold, dark color to cement their hierarchy.
-
-### Text
-
-A slightly softer color is used for body text for greater readability.
-
-#### Text--Supporting
-
-Text that is relevant but less important can be lower-contrast to suggest its’ reduced importance.
-
-## Interactive
-
-Use these colors in buttons and form  controls to communicate the presence and meaning of interaction.
-
-### Interactive
-
-The default color used for interactive elements.
-
-### Destructive
-
-Use to signfify that an interaction will destroy something in the users’ account or workflow.
-
-### Cancel
-
-Use to signify that an interaction will cancel or exit a workflow
-
-### Disabled
-
-Use to signify that an interactive element is disabled.
-
-#### Disabled--Secondary
-
-Use when a disabled element needs more than one shade.
-
-### Focus
-
-Use to indicate that an element has been focused.
-
-## Status
-
-Use these colors in labels, icons, filters, alerts, and other elements where color can add meaning to the state of the system or an item in the system.
-
-### Critical
-
-Action required; user must see this status to be unblocked.
-
-### Warning
-
-Action _may_ be required as a consequence of current state.
-
-### Success
-
-No action required; an action has completed successfully.
-
-### Informative
-
-No action required; but helpful to know about.
-
-### Inactive
-
-No action required; not part of an active workflow.
-
-## Surfaces
-
-Surfaces are the background-colors of almost every element in Jobber.
-
-### Surface
-
-Most elements in Jobber have a white surface; if clickable, they have a light hover color.
-
-### Surface--Background
-
-A slightly darker surface gives a receded appearance relative to main surfaces.
-
-### Surface--Reverse
-
-When a strong constrast is needed with the rest of the application, a reversed surface can be used.
-
-#### Status Surfaces
-
-Elements that convey status have surface colors to help signify their meaning.
-
-##### Surface--Error
-
-Follow guidelines for Status/Critical.
-
-##### Surface--Warning
-
-Follow guidelines for Status/Warning.
-
-##### Surface--Success
-
-Follow guidelines for Status/Success.
-
-##### Surface--Notice
-
-Follow guidelines for Status/Informative.
-
-## Borders
-
-Defining the edges of elements on the same elevation plane, border colors are the subtle maintainers of layout structure.
-
-### Border
-
-Most of our borders should use this color for subtle definition.
-
-### Border--Section
-
-Use where other bordered content is being further sectioned, such as table headers or list sections.
-
-## Brand
-
-Use these colors to represent the Jobber brand visual language.
-
-### Brand
-
-The primary color associated with our brand, from website to ads to product; AKA “Jobber Green”.
-
-### Brand--Highlight
-
-Use to highlight an element in a way that aligns with our website. Use with caution, it’s _bright!_
-
 <Banner type="warning" dismissible={false}>
-  Color should never be the _single_ means of conveying information in an
+  Color should never be the single means of conveying information in an
   interface. Use labels, iconography, or hints for assistive technology
   alongside color to ensure your content can be understood by everyone.
 </Banner>
+
+## Usage Guidelines
+
+### Typography
+
+Typographic elements in Jobber should use consistent colors to ensure
+readability.
+
+#### Heading
+
+Headings have a bold, dark color to cement their hierarchy.
+
+#### Text
+
+A slightly softer color is used for body text for greater readability.
+
+##### Text--Supporting
+
+Text that is relevant but less important can be lower-contrast to suggest its’
+reduced importance.
+
+### Interactive
+
+Use these colors in buttons and form controls to communicate the presence and
+meaning of interaction.
+
+#### Interactive
+
+The default color used for interactive elements.
+
+#### Destructive
+
+Use to signfify that an interaction will destroy something in the users’ account
+or workflow.
+
+#### Cancel
+
+Use to signify that an interaction will cancel or exit a workflow
+
+#### Disabled
+
+Use to signify that an interactive element is disabled.
+
+##### Disabled--Secondary
+
+Use when a disabled element needs more than one shade.
+
+#### Focus
+
+Use to indicate that an element has been focused.
+
+### Status
+
+Use these colors in labels, icons, filters, alerts, and other elements where
+color can add meaning to the state of the system or an item in the system.
+
+All status colors have a main color, a surface color, and an on-surface color.
+The on-surface color should be used for an element when it sits inside of an
+element with the status' surface color to maintain a cohesive tone and ensure
+sufficient color contrast.
+
+#### Critical
+
+Action required; user must see this status to be unblocked.
+
+#### Warning
+
+Action _may_ be required as a consequence of current state.
+
+#### Success
+
+No action required; an action has completed successfully.
+
+#### Informative
+
+No action required; but helpful to know about.
+
+#### Inactive
+
+No action required; not part of an active workflow.
+
+### Surfaces
+
+Surfaces are the background-colors of almost every element in Jobber.
+
+#### Surface
+
+Most elements in Jobber have a white surface; if clickable, they have a light
+hover color.
+
+#### Surface--Background
+
+A slightly darker surface gives a receded appearance relative to main surfaces.
+
+#### Surface--Reverse
+
+When a strong constrast is needed with the rest of the application, a reversed
+surface can be used.
+
+### Borders
+
+Defining the edges of elements on the same elevation plane, border colors are
+the subtle maintainers of layout structure.
+
+#### Border
+
+Most of our borders should use this color for subtle definition.
+
+#### Border--Section
+
+Use where other bordered content is being further sectioned, such as table
+headers or list sections.
+
+### Brand
+
+Use these colors to represent the Jobber brand visual language.
+
+#### Brand
+
+The primary color associated with our brand, from website to ads to product; AKA
+“Jobber Green”.
+
+#### Brand--Highlight
+
+Use to highlight an element in a way that aligns with our website. Use with
+caution, it’s _bright!_
+
+<br />
+<br />
+
+## Swatches
 
 <ColorSwatches colors={colors.customProperties} />

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -18,8 +18,136 @@ Atlantis is built with a
 overtop of a base palette. Use the semantic color values whenever possible to
 ensure you are using colors for their intended purpose.
 
+## Typography
+
+Typographic elements in Jobber should use consistent colors to ensure readability.
+
+### Heading
+
+Headings have a bold, dark color to cement their hierarchy.
+
+### Text
+
+A slightly softer color is used for body text for greater readability.
+
+#### Text--Supporting
+
+Text that is relevant but less important can be lower-contrast to suggest its’ reduced importance.
+
+## Interactive
+
+Use these colors in buttons and form  controls to communicate the presence and meaning of interaction.
+
+### Interactive
+
+The default color used for interactive elements.
+
+### Destructive
+
+Use to signfify that an interaction will destroy something in the users’ account or workflow.
+
+### Cancel
+
+Use to signify that an interaction will cancel or exit a workflow
+
+### Disabled
+
+Use to signify that an interactive element is disabled.
+
+#### Disabled--Secondary
+
+Use when a disabled element needs more than one shade.
+
+### Focus
+
+Use to indicate that an element has been focused.
+
+## Status
+
+Use these colors in labels, icons, filters, alerts, and other elements where color can add meaning to the state of the system or an item in the system.
+
+### Critical
+
+Action required; user must see this status to be unblocked.
+
+### Warning
+
+Action _may_ be required as a consequence of current state.
+
+### Success
+
+No action required; an action has completed successfully.
+
+### Informative
+
+No action required; but helpful to know about.
+
+### Inactive
+
+No action required; not part of an active workflow.
+
+## Surfaces
+
+Surfaces are the background-colors of almost every element in Jobber.
+
+### Surface
+
+Most elements in Jobber have a white surface; if clickable, they have a light hover color.
+
+### Surface--Background
+
+A slightly darker surface gives a receded appearance relative to main surfaces.
+
+### Surface--Reverse
+
+When a strong constrast is needed with the rest of the application, a reversed surface can be used.
+
+#### Status Surfaces
+
+Elements that convey status have surface colors to help signify their meaning.
+
+##### Surface--Error
+
+Follow guidelines for Status/Critical.
+
+##### Surface--Warning
+
+Follow guidelines for Status/Warning.
+
+##### Surface--Success
+
+Follow guidelines for Status/Success.
+
+##### Surface--Notice
+
+Follow guidelines for Status/Informative.
+
+## Borders
+
+Defining the edges of elements on the same elevation plane, border colors are the subtle maintainers of layout structure.
+
+### Border
+
+Most of our borders should use this color for subtle definition.
+
+### Border--Section
+
+Use where other bordered content is being further sectioned, such as table headers or list sections.
+
+## Brand
+
+Use these colors to represent the Jobber brand visual language.
+
+### Brand
+
+The primary color associated with our brand, from website to ads to product; AKA “Jobber Green”.
+
+### Brand--Highlight
+
+Use to highlight an element in a way that aligns with our website. Use with caution, it’s _bright!_
+
 <Banner type="warning" dismissible={false}>
-  Color should never be the single means of conveying information in an
+  Color should never be the _single_ means of conveying information in an
   interface. Use labels, iconography, or hints for assistive technology
   alongside color to ensure your content can be understood by everyone.
 </Banner>

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -17,24 +17,24 @@
   /* Status Colours */
 
   --color-critical: var(--color-red);
-  --color-critical--light: var(--color-red--lightest);
-  --color-critical--dark: var(--color-red--dark);
+  --color-critical--surface: var(--color-red--lightest);
+  --color-critical--onSurface: var(--color-red--dark);
 
   --color-warning: var(--color-yellow);
-  --color-warning--light: var(--color-yellow--lightest);
-  --color-warning--dark: var(--color-yellow--dark);
+  --color-warning--surface: var(--color-yellow--lightest);
+  --color-warning--onSurface: var(--color-yellow--dark);
 
   --color-success: var(--color-green);
-  --color-success--light: var(--color-green--lightest);
-  --color-success--dark: var(--color-green--dark);
+  --color-success--surface: var(--color-green--lightest);
+  --color-success--onSurface: var(--color-green--dark);
 
   --color-informative: var(--color-lightBlue);
-  --color-informative--light: var(--color-lightBlue--lightest);
-  --color-informative--dark: var(--color-lightBlue--dark);
+  --color-informative--surface: var(--color-lightBlue--lightest);
+  --color-informative--onSurface: var(--color-lightBlue--dark);
 
   --color-inactive: var(--color-blue--light);
-  --color-inactive--light: var(--color-blue--lightest);
-  --color-inactive--dark: var(--color-blue--dark);
+  --color-inactive--surface: var(--color-blue--lightest);
+  --color-inactive--onSurface: var(--color-blue--dark);
 
   /* Typography */
   --color-heading: var(--color-blue);
@@ -46,10 +46,6 @@
   --color-surface--hover: var(--color-yellow--lightest);
   --color-surface--background: var(--color-grey--lightest);
   --color-surface--reverse: var(--color-greyBlue--dark);
-  --color-surface--success: var(--color-green--lighter);
-  --color-surface--error: var(--color-red--lighter);
-  --color-surface--warning: var(--color-yellow--lighter);
-  --color-surface--notice: var(--color-lightBlue--lightest);
 
   --color-border: var(--color-grey--lighter);
   --color-border--section: var(--color-blue);


### PR DESCRIPTION
## Motivations

In adding semantic colors to Atlantis, we should help people know how to use them.

Content references [this Figma.](https://www.figma.com/file/PNo7p9G0OxygCOjgm4rpngav/Product-Colors?node-id=450%3A124)

While writing the docs, I had one of those "as you write it, you feel like the system is bad if you need to write too much" moments. As such, there are also some adjustments to the colors.css design package as well, to clarify the intent of the light and dark shades of the status colors and eliminate redundancy with extraneous "surface status" colors. 

## Changes

### Added

- Added guidelines for how to use semantic colors

### Changed

- Renamed some of the "Status" variables and removed the `surface--{status}` colors

## Testing

Go to the colors page in Atlantis and take a look!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).