### PR TITLE
feat(components): use semantic colors in Switch

### DIFF
--- a/packages/components/src/Switch/Switch.css
+++ b/packages/components/src/Switch/Switch.css
@@ -1,5 +1,5 @@
 :root {
-  --switch--pipSize: calc(var(--space-base) * 1.875); /* equivalent to 30px */
+  --switch--pipSize: calc(var(--space-base) * 1.875);
   --switch--labelWidth: calc(var(--switch--pipSize) * 1.3);
   --switch--borderOffset: calc(var(--border-base) * 2);
 }

--- a/packages/components/src/Switch/Switch.css
+++ b/packages/components/src/Switch/Switch.css
@@ -1,5 +1,5 @@
 :root {
-  --switch--pipSize: 30px;
+  --switch--pipSize: calc(var(--space-base) * 1.875); /* equivalent to 30px */
   --switch--labelWidth: calc(var(--switch--pipSize) * 1.3);
   --switch--borderOffset: calc(var(--border-base) * 2);
 }
@@ -14,23 +14,23 @@
   display: inline-flex;
   width: calc(var(--switch--labelWidth) + var(--switch--pipSize));
   padding: 0;
-  border: var(--border-base) solid var(--color-grey--lighter);
+  border: var(--border-base) solid var(--color-border);
   border-radius: var(--switch--pipSize);
   overflow: hidden;
   line-height: normal;
-  background-color: var(--color-grey--lightest);
+  background-color: var(--color-surface--background);
   cursor: pointer;
   appearance: none;
 }
 
 .track:focus {
-  box-shadow: 0 0 4px 1px var(--color-yellow--light);
+  box-shadow: var(--shadow-focus);
   outline: none;
 }
 
 .isChecked {
-  border-color: var(--color-green);
-  background-color: var(--color-green);
+  border-color: var(--color-interactive);
+  background-color: var(--color-interactive);
 }
 
 .toggle {
@@ -68,9 +68,9 @@
   flex: 0 0 auto;
   width: var(--switch--pipSize);
   height: var(--switch--pipSize);
-  border: var(--border-base) solid var(--color-grey);
-  border-radius: var(--switch--pipSize);
-  background-color: var(--color-white);
+  border: var(--border-base) solid var(--color-border);
+  border-radius: var(--radius-circle);
+  background-color: var(--color-surface);
 }
 
 .isChecked .pip {
@@ -78,11 +78,11 @@
 }
 
 .disabled {
-  border-color: var(--color-grey--lighter);
-  background-color: var(--color-grey--lightest);
+  border-color: var(--color-disabled--secondary);
+  background-color: var(--color-surface--background);
   cursor: not-allowed;
 }
 
 .disabled .pip {
-  border-color: var(--color-grey--lighter);
+  border-color: var(--color-disabled--secondary);
 }


### PR DESCRIPTION
## Motivations

We have semantic colors in Atlantis now, we should use them to get the full benefit!

## Changes

### Changed

- a bunch of CSS in Switch; mostly replacing internal custom CSS properties from that component to leverage the Atlantis system properties

### Removed

- Old component-specific properties where relevant

## Testing

Go to the component page and test focus, disabled, etc

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
