### PR TITLE
feat(components): use semantic colors in Checkbox

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.css
+++ b/packages/components/src/Checkbox/Checkbox.css
@@ -33,20 +33,20 @@
   width: var(--space-base);
   height: var(--space-base);
   box-sizing: border-box;
-  border: var(--border-thick) solid var(--color-green);
+  border: var(--border-thick) solid var(--color-interactive);
   border-radius: var(--radius-base);
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
   transition: all 200ms;
   justify-content: center;
   align-items: center;
 }
 
 .disabled .checkBox {
-  border-color: var(--color-grey--lighter);
+  border-color: var(--color-disabled--secondary);
 }
 
 .disabled p {
-  color: var(--color-grey);
+  color: var(--color-disabled);
 }
 
 .disabled .checkBox > * {
@@ -55,8 +55,8 @@
 
 .input.indeterminate + .checkBox,
 .input:checked + .checkBox {
-  border-color: var(--color-green);
-  background-color: var(--color-green);
+  border-color: var(--color-interactive);
+  background-color: var(--color-interactive);
 }
 
 .input:focus + .checkBox {
@@ -65,8 +65,8 @@
 
 .disabled .input.indeterminate + .checkBox,
 .disabled .input:checked + .checkBox {
-  border-color: var(--color-grey--lighter);
-  background-color: var(--color-grey--lighter);
+  border-color: var(--color-disabled--secondary);
+  background-color: var(--color-disabled--secondary);
 }
 
 .disabled .input.indeterminate + .checkBox > *,


### PR DESCRIPTION
## Motivations

We have semantic colors in Atlantis now, we should use them to get the full benefit!

## Changes

### Changed

- a bunch of CSS in Checkbox; mostly replacing descriptive CSS properties from that component to leverage the Atlantis system semantic properties

### Removed

- Old component-specific properties where relevant

## Testing

Go to the component page and test focus, disabled, etc

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
