### PR TITLE
feat(components): Use semantic colors in card, modal and drawer

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -1,8 +1,4 @@
 :root {
-  --card--background-color: var(--color-white);
-  --card--header-background-color: var(--color-grey--lightest);
-  --card--content-background-color: var(--color-white);
-  --card--border-color: var(--color-border);
   --card--accent-color: var(--color-grey);
   --card--base-padding: var(--space-base);
 }
@@ -10,10 +6,10 @@
 .card {
   display: block;
   width: 100%;
-  border: var(--border-base) solid var(--card--border-color);
+  border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
   outline-color: var(--color-focus);
-  background-color: var(--card--background-color);
+  background-color: var(--color-surface);
 }
 
 /* Adjust `Content` components public padding to match the cards */
@@ -45,7 +41,7 @@
 }
 
 .clickable {
-  --card--border-color: transparent;
+  --color-border: transparent;
 
   box-shadow: var(--shadow-base);
   color: inherit;
@@ -56,10 +52,10 @@
 
 .clickable:hover,
 .clickable:focus {
-  background-color: var(--color-yellow--lightest);
+  background-color: var(--color-surface--hover);
 }
 
 .header {
   padding: var(--card--base-padding);
-  background-color: var(--card--header-background-color);
+  background-color: var(--color-surface--background);
 }

--- a/packages/components/src/Drawer/Drawer.css
+++ b/packages/components/src/Drawer/Drawer.css
@@ -1,8 +1,5 @@
 :root {
   --drawer-width: calc(var(--space-base) * 17.5);
-  --drawer--background-color: var(--color-white);
-  --drawer--header-background-color: var(--color-grey--lightest);
-  --drawer--border-color: var(--color-border);
   --drawer--base-padding: var(--space-base);
 }
 
@@ -33,8 +30,8 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  border: var(--border-base) solid var(--drawer--border-color);
-  background-color: var(--drawer--background-color);
+  border: var(--border-base) solid var(--color-border);
+  background-color: var(--color-surface);
   flex-direction: column;
 }
 
@@ -45,7 +42,7 @@
 .header {
   display: flex;
   padding: var(--drawer--base-padding);
-  background-color: var(--drawer--header-background-color);
+  background-color: var(--color-surface--background);
   justify-content: space-between;
   align-items: center;
 }

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -1,7 +1,6 @@
 :root {
   --modal--width: calc(var(--base-unit) * 37.5);
   --modal--padding: var(--space-base);
-  --modal--border-color: var(--color-border);
 }
 
 @media (--medium-screens) {
@@ -40,10 +39,10 @@
   width: 100%;
   max-width: var(--modal--width);
   margin: auto;
-  border: var(--border-base) solid var(--modal--border-color);
+  border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
   outline-color: var(--color-focus);
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
 }
 
 /* Adjust `Content` components public padding to match the modal */
@@ -63,7 +62,7 @@
   justify-content: space-between;
   align-items: center;
   padding: var(--modal--padding);
-  background-color: var(--color-grey--lightest);
+  background-color: var(--color-surface--background);
 }
 
 .closeButton {


### PR DESCRIPTION
We have semantic colors in Atlantis now, we should use them to get the full benefit!

I changed all three of these components in one PR as the changes are _extremely_ similar, and I think easier to review in this format.

## Changes

### Changed

- some CSS properties in each component; mostly replacing descriptive CSS properties from that component to leverage the Atlantis system semantic properties

### Removed

- Old component-specific properties where relevant

## Testing

Go to the component page and test focus, disabled, etc

---

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
