### PR TITLE
feat(components): use semantic colors in FormField and Inputs

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -4,7 +4,7 @@
   --field--placeholder-color: var(--color-greyBlue--light);
   --field--border-width: var(--border-base);
   --field--border-color: var(--color-border);
-  --field--background-color: var(--color-white);
+  --field--background-color: var(--color-surface);
 
   --field--padding-top: calc(var(--space-base) - var(--space-smallest));
   --field--padding-bottom: calc(var(--space-base) - var(--space-smallest));
@@ -148,14 +148,14 @@ select.formField {
 
 .invalid,
 .invalid .formField:focus {
-  --field--border-color: var(--color-red);
+  --field--border-color: var(--color-critical);
   --field--wrapper-elevation: var(--elevation-base);
 }
 
 .disabled {
-  --field--placeholder-color: var(--color-grey);
-  --field--background-color: var(--color-grey--lightest);
-  --field--border-color: var(--color-grey--lighter);
+  --field--placeholder-color: var(--color-disabled);
+  --field--background-color: var(--color-surface--background);
+  --field--border-color: var(--color-disabled--secondary);
 
   opacity: 0.6;
 }
@@ -180,7 +180,7 @@ select.formField {
   z-index: var(--elevation-base);
 
   height: auto;
-  color: var(--color-greyBlue);
+  color: var(--color-text--secondary);
   font-size: calc(var(--base-unit) * 0.875);
 }
 
@@ -200,7 +200,7 @@ select.formField {
 }
 
 .miniLabel.textareaLabel .label {
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
 }
 
 /**
@@ -218,7 +218,7 @@ select.formField {
   position: absolute;
   top: 50%;
   right: var(--field--padding-right);
-  color: var(--color-greyBlue);
+  color: var(--color-text--secondary);
   pointer-events: none;
   transform: translateY(-50%);
 }

--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -1,8 +1,3 @@
-:root {
-  --border-color: var(--color-border);
-  --border-active-color: var(--color-focus);
-}
-
 .dropZoneBase {
   font-size: 0;
   line-height: 0;
@@ -12,12 +7,12 @@
 
 .dropZone {
   padding: var(--space-base);
-  border: var(--border-color) dashed var(--border-thick);
+  border: var(--color-border) dashed var(--border-thick);
   border-radius: var(--radius-larger);
   text-align: center;
 }
 
 .dropZone.active {
-  border-color: var(--border-active-color);
-  background-color: var(--color-yellow--lightest);
+  border-color: var(--color--focus);
+  background-color: var(--color-surface--hover);
 }

--- a/packages/components/src/Select/Select.css
+++ b/packages/components/src/Select/Select.css
@@ -6,7 +6,7 @@
   height: var(--space-largest);
   margin-bottom: var(--space-base);
   border-radius: var(--radius-base);
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
 }
 
 .select {
@@ -15,7 +15,7 @@
   height: inherit;
   padding-left: var(--inset);
   padding-right: var(--inset);
-  border: var(--border-base) solid var(--color-grey--lighter);
+  border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
   color: var(--color-blue);
   font-size: 14px;
@@ -66,7 +66,7 @@
 }
 
 .select:disabled {
-  background-color: var(--color-grey--lightest);
+  background-color: var(--color-surface--background);
   opacity: 0.6;
 }
 
@@ -92,5 +92,5 @@
 /* Invalid State */
 
 .invalid .select {
-  border-color: var(--color-red);
+  border-color: var(--color-critical);
 }


### PR DESCRIPTION
We have semantic colors in Atlantis now, we should use them to get the full benefit!

I changed all of these components in one PR as the changes are _extremely_ similar, in many cases fairly entwined with each other, and I think easier to review in this format.

## Changes

### Changed

- some CSS properties in each component; mostly replacing descriptive CSS properties from that component to leverage the Atlantis system semantic properties
- note that in FormField we are actually leveraging a component-specific custom property that in turn leverages our semantic colors, so I actually did _not_ remove that one!

### Removed

- Old component-specific or descriptive properties where relevant

## Testing

Go to the component pages, test out focus, hover, error, as relevant ❤️ 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
