### PR TITLE
feat(components): update remaining Atlantis components to use semantics

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.css
+++ b/packages/components/src/Autocomplete/Autocomplete.css
@@ -15,16 +15,16 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  border: var(--border-base) solid var(--color-grey--lighter);
+  border: var(--border-base) solid var(--color-color-border);
   border-radius: var(--radius-base);
   overflow: auto;
   scroll-behavior: smooth;
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
 }
 
 .options h5 {
   padding: var(--space-small) 0 var(--space-smaller) var(--space-small);
-  border-bottom: var(--border-base) solid var(--color-blue--dark);
+  border-bottom: var(--border-base) solid var(--color-border--section);
 }
 
 .options.visible {
@@ -56,12 +56,12 @@
 .option:hover,
 .option:focus,
 .option.active {
-  background-color: var(--color-yellow--lightest);
+  background-color: var(--color-surface--hover);
   outline-color: var(--color-focus);
 }
 
 .option.separator:not(:last-child) {
-  border-bottom: var(--border-base) solid var(--color-grey--lighter);
+  border-bottom: var(--border-base) solid var(--color-color-border);
 }
 
 .options:hover .option.active:not(:hover) {

--- a/packages/components/src/Autocomplete/Autocomplete.css
+++ b/packages/components/src/Autocomplete/Autocomplete.css
@@ -61,7 +61,7 @@
 }
 
 .option.separator:not(:last-child) {
-  border-bottom: var(--border-base) solid var(--color-color-border);
+  border-bottom: var(--border-base) solid var(--color-border);
 }
 
 .options:hover .option.active:not(:hover) {

--- a/packages/components/src/Banner/notificationTypes.css
+++ b/packages/components/src/Banner/notificationTypes.css
@@ -1,19 +1,17 @@
 .notice {
-  border-color: var(--color-lightBlue);
-  background-color: var(--color-lightBlue--lightest);
+  background-color: var(--color-informative--surface);
 }
 
+/* Our Banner "surface" colors should be lighter than they are so we're leaving the following alone for now */
+
 .success {
-  border-color: var(--color-green);
   background-color: var(--color-green--lighter);
 }
 
 .warning {
-  border-color: var(--color-yellow);
   background-color: var(--color-yellow--lighter);
 }
 
 .error {
-  border-color: var(--color-red);
   background-color: var(--color-red--lighter);
 }

--- a/packages/components/src/DescriptionList/DescriptionList.css
+++ b/packages/components/src/DescriptionList/DescriptionList.css
@@ -1,7 +1,3 @@
-:root {
-  --descriptionList--divider-color: var(--color-grey--lighter);
-}
-
 .descriptionList {
   margin: 0;
 }
@@ -10,7 +6,7 @@
   display: flex;
   flex-wrap: wrap;
   padding: var(--space-small) 0;
-  border-bottom: var(--border-base) solid var(--descriptionList--divider-color);
+  border-bottom: var(--border-base) solid var(--color-border);
 }
 
 .termGroup:first-child {

--- a/packages/components/src/Disclosure/Disclosure.css
+++ b/packages/components/src/Disclosure/Disclosure.css
@@ -23,7 +23,7 @@
 
 .summary:hover,
 .summary:focus {
-  background: var(--color-yellow--lightest);
+  background: var(--color-surface--hover);
 }
 
 .summary:focus,

--- a/packages/components/src/Divider/Divider.css
+++ b/packages/components/src/Divider/Divider.css
@@ -2,7 +2,7 @@
   height: var(--space-minuscule);
   margin: 0;
   border: none;
-  border-bottom: var(--border-base) solid var(--color-grey--lighter);
+  border-bottom: var(--border-base) solid var(--color-border);
 }
 
 .large {

--- a/packages/components/src/List/ListItem.css
+++ b/packages/components/src/List/ListItem.css
@@ -23,7 +23,7 @@
 .hoverable:hover,
 .hoverable:focus {
   outline: none;
-  background-color: var(--color-yellow--lightest);
+  background-color: var(--color-surface--hover);
 }
 
 .icon {

--- a/packages/components/src/List/SectionHeader.css
+++ b/packages/components/src/List/SectionHeader.css
@@ -3,7 +3,7 @@
   top: 0;
   padding: var(--space-small) var(--space-base);
   border-bottom: 1px solid var(--color-border--section);
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
 }
 
 .greyBlue {

--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -19,7 +19,7 @@
   border-radius: var(--radius-base) var(--radius-base) 0 0;
   -webkit-overflow-scrolling: touch;
   overflow-y: scroll;
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
 
   @media (--medium-screens) {
     position: absolute;
@@ -27,7 +27,7 @@
     width: calc(var(--base-unit) * 12.5);
     box-shadow: var(--shadow-base);
     padding: var(--space-small);
-    border: var(--border-base) solid var(--color-grey--lighter);
+    border: var(--border-base) solid var(--color-border);
     border-radius: var(--radius-base);
     overflow: auto;
   }
@@ -64,7 +64,7 @@
 
 .section {
   padding: var(--space-small) 0;
-  border-bottom: var(--border-base) dotted var(--color-grey);
+  border-bottom: var(--border-base) dotted var(--color-border);
 }
 
 .section:first-of-type {
@@ -93,7 +93,7 @@
 
 .action:hover,
 .action:focus {
-  background-color: var(--color-yellow--lightest);
+  background-color: var(--color-surface--hover);
   outline-color: var(--color-focus);
 }
 

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -223,7 +223,7 @@ function Action({ label, icon, onClick }: ActionProps) {
           <Icon name={icon} />
         </span>
       )}
-      <Typography element="span" size="base" textColor="greyBlueDark">
+      <Typography element="span" size="base" textColor="text">
         {label}
       </Typography>
     </button>

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -223,7 +223,7 @@ function Action({ label, icon, onClick }: ActionProps) {
           <Icon name={icon} />
         </span>
       )}
-      <Typography element="span" size="base" textColor="greyBlue">
+      <Typography element="span" size="base" textColor="greyBlueDark">
         {label}
       </Typography>
     </button>

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -223,7 +223,7 @@ function Action({ label, icon, onClick }: ActionProps) {
           <Icon name={icon} />
         </span>
       )}
-      <Typography element="span" size="base" textColor="text">
+      <Typography element="span" size="base" textColor="greyBlue">
         {label}
       </Typography>
     </button>

--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -1,5 +1,4 @@
 :root {
-  --card--background-color: var(--color-white);
   --card--base-padding: var(--space-base);
   --popover--padding: var(--space-base);
   --popover--width: calc(var(--base-unit) * 21.875);
@@ -29,7 +28,7 @@
   border-radius: var(--radius-base);
   font-size: var(--base-unit);
   line-height: normal;
-  background: var(--color-white);
+  background: var(--color-surface);
 }
 
 .popover > * {
@@ -51,7 +50,7 @@
 .arrow::before {
   content: "";
   visibility: visible;
-  border: var(--border-base) solid var(--color-grey--light);
+  border: var(--border-base) solid var(--color-border);
   transform: rotate(45deg);
   transform-origin: center;
   clip-path: polygon(-4px -4px, 15.3px 0, 0 15.3px);

--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -1,6 +1,4 @@
 :root {
-  --progress-bar--backgroundColor: var(--color-grey--lightest);
-  --progress-bar--barColor: var(--color-green);
   --progress-bar--height: var(--space-base);
 }
 
@@ -19,17 +17,17 @@ progress.ProgressBar[value]::-webkit-progress-bar {
 }
 
 progress.ProgressBar[value]::-webkit-progress-bar {
-  background-color: var(--progress-bar--backgroundColor);
+  background-color: var(--color-surface--background);
 }
 
 progress.ProgressBar[value]::-webkit-progress-value {
   border-radius: calc(var(--progress-bar--height) / 2);
-  background-color: var(--progress-bar--barColor);
+  background-color: var(--color-interactive);
   transition: all var(--timing-slow) ease-out;
 }
 
 progress.ProgressBar[value]::-moz-progress-bar {
   border-radius: calc(var(--progress-bar--height) / 2);
-  background-color: var(--progress-bar--barColor);
+  background-color: var(--color-interactive);
   transition: all var(--timing-slow) ease-out;
 }

--- a/packages/components/src/Tabs/Tabs.css
+++ b/packages/components/src/Tabs/Tabs.css
@@ -1,6 +1,4 @@
 :root {
-  --tab--border-color: var(--color-border);
-  --tab--border-color--selected: var(--color-green);
   --tab--height: calc(var(--space-larger) + var(--space-small));
   --tab--inset: var(--space-base);
   --public-tab--inset: var(--tab--inset);
@@ -13,7 +11,7 @@
 
 .overflow {
   position: relative;
-  border-bottom: solid var(--border-base) var(--tab--border-color);
+  border-bottom: solid var(--border-base) var(--color-border);
 }
 
 .overflowRight:after,
@@ -48,7 +46,7 @@
   margin: 0;
   padding-left: var(--public-tab--inset);
   padding-right: var(--public-tab--inset);
-  border: solid var(--border-base) var(--tab--border-color);
+  border: solid var(--border-base) var(--color-border);
   border-left-width: 0;
   outline: none;
   background: transparent;
@@ -58,12 +56,12 @@
 
 .tab:hover,
 .tab:focus {
-  background-color: var(--color-yellow--lightest);
+  background-color: var(--color-surface--hover);
 }
 
 .selected {
-  border-top-color: var(--tab--border-color--selected);
-  border-bottom-color: var(--color-white);
+  border-top-color: var(--color-interactive);
+  border-bottom-color: var(--color-surface);
 }
 
 .selected:focus {

--- a/packages/components/src/Toast/Toast.css
+++ b/packages/components/src/Toast/Toast.css
@@ -15,7 +15,7 @@
   flex-direction: column;
   align-items: center;
   padding: 0 var(--space-large);
-  color: var(--color-greyBlue--dark);
+  color: var(--color-text);
   font-size: var(--typography--fontSize-large);
   pointer-events: none;
 }
@@ -35,7 +35,7 @@
   align-items: center;
   padding: calc(var(--space-small) / 1.25) var(--space-base);
   border-radius: var(--radius-base);
-  background: var(--color-white);
+  background: var(--color-surface);
 }
 
 .icon {

--- a/packages/components/src/Tooltip/Tooltip.css
+++ b/packages/components/src/Tooltip/Tooltip.css
@@ -1,5 +1,4 @@
 :root {
-  --tooltip--border-color: var(--color-lightBlue);
   --tooltip--arrow-size: var(--space-small);
   --tooltip--offset: calc(-1 * calc(var(--space-smaller) + 1px));
 }
@@ -19,9 +18,9 @@
   position: relative;
   max-width: calc(var(--base-unit) * 15);
   padding: var(--space-small);
-  border: var(--border-base) solid var(--tooltip--border-color);
+  border: var(--border-base) solid var(--color-informative);
   border-radius: var(--radius-base);
-  background-color: var(--color-lightBlue--lightest);
+  background-color: var(--color-informative--surface);
 }
 
 .tooltip .arrow,
@@ -35,7 +34,7 @@
   content: "";
   display: block;
   position: absolute;
-  border: var(--border-base) solid var(--tooltip--border-color);
+  border: var(--border-base) solid var(--color-informative);
   transform: rotate(45deg);
 }
 


### PR DESCRIPTION
## Motivations

To get the full value out of our new semantic color palette, we should use it as broadly as possible.

I know this is a whole pile of components, but they have very similar changes across the board and should be fairly easy to verify in QA.

## Changes

### Changed

Replaced base colors with semantic colors in...
- Autocomplete/Autocomplete.css
- Banner/notificationTypes.css
- DescriptionList/DescriptionList.css
- Disclosure/Disclosure.css
- Divider/Divider.css
- List/ListItem.css
- List/SectionHeader.css
- Menu/Menu.css
- Popover/Popover.css
- ProgressBar/ProgressBar.css
- Tabs/Tabs.css
- Toast/Toast.css
- Tooltip.css

Almost entirely "surface" and "border" colors, with a few "interactive" and "text" along the way.

### Removed

- some component-specific CSS properties
- border-color values from Banner's "notificationTypes" as Banner does not have a border anymore

## Testing

Take a look at the components and make sure they look like they did before - this is an "under the hood" change.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
