### PR TITLE
feat(components): Add ability to open Page intro links in a new tab 

### DIFF
--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -90,6 +90,7 @@ export type PageProps = PagePropsWithIntro | PagePropsNoIntro;
 export function Page({
   title,
   intro,
+  externalIntroLinks,
   subtitle,
   children,
   width = "standard",
@@ -169,7 +170,11 @@ export function Page({
           </div>
           {intro && (
             <Text size="large">
-              <Markdown content={intro} basicUsage={true} />
+              <Markdown
+                content={intro}
+                basicUsage={true}
+                externalLink={externalIntroLinks}
+              />
             </Text>
           )}
         </Content>

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -75,8 +75,8 @@ interface PagePropsWithIntro extends BasePageProps {
 interface PagePropsNoIntro extends BasePageProps {
   // No descriptions are necessary here, since they are already covered
   // inside of the PagePropsWithIntro interface.
-  readonly intro: undefined;
-  readonly externalIntroLinks: never;
+  readonly intro?: undefined;
+  readonly externalIntroLinks?: never;
 }
 
 /**

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -54,15 +54,36 @@ interface BasePageProps {
 }
 
 interface PagePropsWithIntro extends BasePageProps {
+  /**
+   * Content of the page. This supports basic markdown node types
+   * such as `_italic_`, `**bold**`, and `[link name](url)`.
+   *
+   * The `externalIntroLinks` prop can only be used if the
+   * `intro` prop is specified.
+   */
   readonly intro: string;
+
+  /**
+   * Causes any markdown links in the `intro` prop to open in a new
+   * tab, i.e. with `target="_blank"`.
+   *
+   * Defaults to `false`.
+   */
   readonly externalIntroLinks?: boolean;
 }
 
 interface PagePropsNoIntro extends BasePageProps {
+  // No descriptions are necessary here, since they are already covered
+  // inside of the PagePropsWithIntro interface.
   readonly intro: undefined;
   readonly externalIntroLinks: never;
 }
 
+/**
+ * We have a discriminated union here to ensure usage
+ * of externalIntroLinks is only valid if intro is
+ * also specified.
+ */
 export type PageProps = PagePropsWithIntro | PagePropsNoIntro;
 
 // eslint-disable-next-line max-statements

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -10,14 +10,8 @@ import { Button, ButtonProps } from "../Button";
 import { Menu, SectionProps } from "../Menu";
 import { Emphasis } from "../Emphasis";
 
-export interface PageProps {
+interface BasePageProps {
   readonly children: ReactNode | ReactNode[];
-
-  /**
-   * Content of the page. This supports basic markdown node types such as
-   * `_italic_`, `**bold**`, and `[link name](url)`
-   */
-  readonly intro?: string;
 
   /**
    * Title of the page.
@@ -58,6 +52,18 @@ export interface PageProps {
    */
   readonly moreActionsMenu?: SectionProps[];
 }
+
+interface PagePropsWithIntro extends BasePageProps {
+  readonly intro: string;
+  readonly externalIntroLinks?: boolean;
+}
+
+interface PagePropsNoIntro extends BasePageProps {
+  readonly intro: undefined;
+  readonly externalIntroLinks: never;
+}
+
+export type PageProps = PagePropsWithIntro | PagePropsNoIntro;
 
 // eslint-disable-next-line max-statements
 export function Page({


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
I was adding links to Jobber's help docs from a settings page (see the change [here](https://github.com/GetJobber/Jobber/pull/25164/files#diff-a1ec27a51bee40e7da882fbf2063446086ae0652ee3b1d3e8d89c82303cdbf9aR54)), and I couldn't get links open in a new tab when they were in the `intro` of the `Page` component.

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Add `externalIntroLinks` prop (boolean) to the `Page` component
  - Typescript error if `externalIntroLinks` is used without also specifyinig an `intro` prop
  - Defaults to `false` so this is a backwards-compatible change



## Testing

<!-- How to test your changes. -->

- Go to the Atlantis Page component docs locally ([localhost link](http://localhost:3333/components/page)), scroll to the bottom example with the Help Center link in the intro
- (control) verify the Help Center link opens in the same tab
- Add a new `externalIntroLinks={true}` and verify Help Center link opens in a new tab
- Change to `externalIntroLinks={false}` and verify Help Center link opens in the same tab

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
