### PR TITLE
docs(design): create radius docs

### DIFF
--- a/packages/design/src/Radii.mdx
+++ b/packages/design/src/Radii.mdx
@@ -1,10 +1,10 @@
 ---
 name: Radius
 menu: Design
-route: /radius
+route: /border-radius
 ---
 
-# Radius
+# Border Radius
 
 We favour a subtle rounding of corners wherever possible as a nod to the blunt
 visual style of our marketing properties to afford a smoother transition from

--- a/packages/design/src/Radii.mdx
+++ b/packages/design/src/Radii.mdx
@@ -1,0 +1,40 @@
+---
+name: Radius
+menu: Design
+route: /radius
+---
+
+# Radius
+
+We favour a subtle rounding of corners wherever possible as a nod to the blunt
+visual style of our marketing properties to afford a smoother transition from
+the signup flow into the product. To achieve this appearance, use
+`--radius-base`.
+
+This base radius can be found in almost all of our components that have a
+defined "edge": [Button](/components/button), [Card](/components/Card),
+[InputText](/components/input-text), and [Menu](/components/menu) are all
+examples of this in practice.
+
+Larger rounded corners should be used sparingly, but are available for cases
+where the user may expect a smoother corner, such as
+[ProgressBar](/components/progress-bar). `--radius-circle` can be used for
+circular elements like [Radio](/components/radio-group) options or the "pip" in
+[Switch](/components/switch).
+
+export function Example({ of: radius }) {
+  const style = {
+    width: "var(--space-large)",
+    height: "var(--space-large)",
+    backgroundColor: "var(--color-indigo)",
+    borderRadius: `var(--radius-${radius})`,
+  };
+  return <div style={style} />;
+}
+
+| Radius            | Visual                  |
+| :---------------- | :---------------------- |
+| `--radius-base`   | <Example of="base" />   |
+| `--radius-large`  | <Example of="large" />  |
+| `--radius-larger` | <Example of="larger" /> |
+| `--radius-circle` | <Example of="circle" /> |


### PR DESCRIPTION
## Motivations

Got a question about our border radius today and realized we don't have docs on them 😓 

## Changes

New raddi docs in Design!

### Added

- An MDX file for radii, including example table based off Borders

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
