### PR TITLE
docs: remove the "gold" in sidenav and increase contrast of pageLabel

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/components/Logo/styles.ts
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Logo/styles.ts
@@ -6,12 +6,9 @@ export const logo = {
 };
 
 export const text = {
-  background: `-webkit-linear-gradient(var(--color-yellow--lighter),var(--color-yellow))`,
-  WebkitBackgroundClip: "text",
-  WebkitTextFillColor: "transparent",
-  textTransform: "uppercase",
+  WebkitTextFillColor: "white",
   fontFamily: "heading",
-  letterSpacing: "0.05em",
+  letterSpacing: "0.0125em",
   fontSize: "larger",
   padding: 0,
 };

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
@@ -58,7 +58,6 @@
 .level2 .pageLabel {
   display: block;
   padding: var(--space-smaller) 0;
-  color: var(--color-greyBlue--light);
   font-size: calc(var(--base-unit) * 0.875);
   text-transform: none;
 }

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
@@ -58,7 +58,8 @@
 .level2 .pageLabel {
   display: block;
   padding: var(--space-smaller) 0;
-  font-size: calc(var(--base-unit) * 0.875);
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: normal;
   text-transform: none;
 }
 
@@ -67,7 +68,7 @@
   display: inline-block;
   width: var(--space-small);
   height: var(--space-small);
-  margin-right: var(--space-small);
+  margin-right: var(--space-base);
   border: var(--border-base) solid var(--color-greyBlue--light);
   border-radius: var(--radius-circle);
   background: none;


### PR DESCRIPTION
## Motivations

The "gold" styling we applied to make the text in "Atlantis" look like the 🔱 emoji isn't necessary, and doesn't make any sense when used outside of Atlantis.

Also, the initial `greyBlue-light` color we were setting on level 2 pageLabel did add more distinction between levels 1 and 2, but was harder to read (and failed WCAG AA). By leaving it as `greyBlue-lighter` we get better contrast, and the indentation/bullets still do enough heavy lifting on level-separation.

## Changes

Adjusted text color of page labels and removed gold styling from title of the site.

### Changed

#### Before
![image](https://user-images.githubusercontent.com/39704901/120384462-71f24680-c2e3-11eb-887f-97ee968ee0a9.png)
![image](https://user-images.githubusercontent.com/39704901/120384388-51c28780-c2e3-11eb-9920-4b3a23b523aa.png)

#### After
![image](https://user-images.githubusercontent.com/39704901/120384502-7e769f00-c2e3-11eb-8ef0-7349c6d45c0a.png)
![image](https://user-images.githubusercontent.com/39704901/120384421-5dae4980-c2e3-11eb-9c7c-841149566161.png)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
