### PR TITLE
docs: keep newlines of pageLabel aligned

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
@@ -56,7 +56,9 @@
 }
 
 .level2 .pageLabel {
-  display: block;
+  display: flex;
+  justify-content: flex-start;
+  align-items: baseline;
   padding: var(--space-smaller) 0;
   font-family: "Source Sans Pro", sans-serif;
   font-weight: normal;
@@ -66,6 +68,7 @@
 .level2 .pageLabel::before {
   content: "";
   display: inline-block;
+  flex-shrink: 0;
   width: var(--space-small);
   height: var(--space-small);
   margin-right: var(--space-base);


### PR DESCRIPTION
## Motivations

The "level 2" elements in the Atlantis navigation module do not handle long titles very well. This isn't an issue in Atlantis, but in other places we use this module (ie internal Jobber docs) it's problematic.

**Before**
![image](https://user-images.githubusercontent.com/39704901/121397660-c6b04580-c911-11eb-955b-6ac152dbf030.png)

**After**
![image](https://user-images.githubusercontent.com/39704901/121397167-586b8300-c911-11eb-8ffd-360d7c7c1874.png)

## Changes

Modified navigation CS to better reflow newlines in level 2 pagelabels.

### Changed

- newlines in pageLabel re-flow to align with the other pageLabels, instead of wrapping

## Testing

In the DOM or in code, change the labels of the sidenav elements and see that they wrap correctly

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
