### PR TITLE
feat(hooks): add useCollectionQuery and useIsMounted [JOB-32207]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,35 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollo/client": {
+      "version": "3.3.20",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz",
+      "integrity": "sha512-hS7UmBwJweudw/J3M0RAcusMHNiRuGqkRH6g91PM2ev8cXScIMdXr/++9jo7wD1nAITMCMF4HQQ3LFaw/Or0Bw==",
+      "dev": true,
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.12.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.0",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.7.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+          "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+          "dev": true
+        }
+      }
+    },
     "@ardatan/aggregate-error": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
@@ -2106,6 +2135,12 @@
         }
       }
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "dev": true
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -2690,9 +2725,9 @@
       "version": "file:packages/components",
       "dev": true,
       "requires": {
-        "@jobber/design": "^0.9.5",
+        "@jobber/design": "^0.13.1",
         "@jobber/formatters": "^0.1.0",
-        "@jobber/hooks": "^1.1.1",
+        "@jobber/hooks": "^1.2.0",
         "@popperjs/core": "^2.0.6",
         "@std-proposal/temporal": "0.0.1",
         "@types/color": "^3.0.1",
@@ -2710,6 +2745,7 @@
         "react-hook-form": "^6.7.2",
         "react-image-lightbox": "^5.1.1",
         "react-markdown": "^4.1.0",
+        "react-popper": "^2.2.5",
         "react-router-dom": "^5.2.0",
         "time-input-polyfill": "^1.0.7",
         "ts-xor": "^1.0.8",
@@ -12279,9 +12315,15 @@
       "dev": true,
       "requires": {
         "@emotion/react": "^11.1.4",
-        "@jobber/components": "^2.26.5",
-        "@jobber/design": "^0.9.5",
+        "@jobber/components": "^2.36.1",
+        "@jobber/design": "^0.13.1",
+        "classnames": "^2.3.1",
         "deepmerge": "^4.2.2",
+        "framer-motion": "^1.11.1",
+        "postcss": "^7.0.17",
+        "postcss-loader": "^3.0.0",
+        "postcss-preset-env": "^6.7.0",
+        "react-helmet": "^6.1.0",
         "ts-xor": "^1.0.8"
       },
       "dependencies": {
@@ -12413,9 +12455,9 @@
           }
         },
         "classnames": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-          "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+          "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
           "dev": true
         },
         "csstype": {
@@ -12485,7 +12527,7 @@
         "eslint-plugin-no-null": "^1.0.2",
         "eslint-plugin-prettier": "^3.0.1",
         "eslint-plugin-react": "^7.14.3",
-        "prettier": "^1.18.2"
+        "prettier": "^2.2.1"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -18381,6 +18423,12 @@
       "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
       "dev": true
     },
+    "@types/zen-observable": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+      "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.34.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
@@ -18622,6 +18670,57 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@wry/context": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@wry/equality": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
+      "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -28241,6 +28340,23 @@
         "iterall": "^1.2.1"
       }
     },
+    "graphql-tag": {
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz",
+      "integrity": "sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
     "graphql-type-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
@@ -35109,6 +35225,16 @@
         }
       }
     },
+    "optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "dev": true,
+      "requires": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
+      }
+    },
     "optimize-css-assets-webpack-plugin": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz",
@@ -38027,6 +38153,18 @@
       "integrity": "sha512-4PurhctiqnmC1F5prPZ+LdsalH7pZ3SFA5xoc0HBe8mSHctdLLt4Cr2WXfXOoajHBYq/yiipp9zOgx+vy8GiEA==",
       "dev": true
     },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      }
+    },
     "react-helmet-async": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.7.tgz",
@@ -38213,6 +38351,16 @@
         "warning": "^4.0.3"
       }
     },
+    "react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "dev": true,
+      "requires": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      }
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -38281,6 +38429,12 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "dev": true
     },
     "react-simple-code-editor": {
       "version": "0.10.0",
@@ -42417,6 +42571,23 @@
       "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==",
       "dev": true
     },
+    "ts-invariant": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+      "integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
     "ts-node": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
@@ -45550,6 +45721,12 @@
         "read": "^1.0.7",
         "strip-ansi": "^5.2.0"
       }
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "dev": true
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/GetJobber/atlantis#readme",
   "devDependencies": {
+    "@apollo/client": "^3.3.16",
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",

--- a/packages/hooks/package-lock.json
+++ b/packages/hooks/package-lock.json
@@ -101,6 +101,16 @@
         "@testing-library/dom": "^7.22.3"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.7.0.tgz",
+      "integrity": "sha512-TwfbY6BWtWIHitjT05sbllyLIProcysC0dF0q1bbDa7OHLC6A6rJOYJwZ13hzfz3O4RtOuInmprBozJRyyo7/g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/testing-library__react-hooks": "^3.4.0"
+      }
+    },
     "@types/aria-query": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
@@ -136,6 +146,47 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
       "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
       "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.14.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.8.tgz",
+      "integrity": "sha512-QN0/Qhmx+l4moe7WJuTxNiTsjBwlBGHqKGvInSQCBdo7Qio0VtOqwsC0Wq7q3PbJlB0cR4Y4CVo1OOe6BOsOmA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "16.9.5",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.5.tgz",
+      "integrity": "sha512-C4cN7C2uSSGOYelp2XfdtJb5TsCP+QiZ+0Bm4U3ZfUswN8oN9O/l86XO/OvBSFCmWY7w75fzsQvZ50eGkFN34A==",
+      "dev": true,
+      "requires": {
+        "@types/react": "^16"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
+      "dev": true
+    },
+    "@types/testing-library__react-hooks": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz",
+      "integrity": "sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==",
+      "dev": true,
+      "requires": {
+        "@types/react-test-renderer": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.11",
@@ -254,6 +305,12 @@
       "integrity": "sha512-fRjhg3NeouotRoIV0L1FdchA6CK7ZD+lyINyMoz19SyV+ROpC4noS1xItWHFtwZdlqfMfVPJEyEGdfri2bD1pA==",
       "dev": true
     },
+    "csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "dev": true
+    },
     "dom-accessibility-api": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
@@ -283,10 +340,25 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "pretty-format": {
@@ -327,11 +399,50 @@
         }
       }
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
+      }
+    },
     "react-is": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
       "dev": true
+    },
+    "react-test-renderer": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.19.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
+      }
     },
     "regenerator-runtime": {
       "version": "0.13.7",
@@ -343,6 +454,16 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
+    "scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/packages/hooks/package-lock.json
+++ b/packages/hooks/package-lock.json
@@ -4,6 +4,44 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollo/client": {
+      "version": "3.3.20",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz",
+      "integrity": "sha512-hS7UmBwJweudw/J3M0RAcusMHNiRuGqkRH6g91PM2ev8cXScIMdXr/++9jo7wD1nAITMCMF4HQQ3LFaw/Or0Bw==",
+      "dev": true,
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.12.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.0",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.7.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@apollo/react-testing": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-4.0.0.tgz",
+      "integrity": "sha512-P7Z/flUHpRRZYc3FkIqxZH9XD3FuP2Sgks1IXqGq2Zb7qI0aaTfVeRsLYmZNUcFOh2pTHxs0NXgPnH1VfYOpig==",
+      "dev": true,
+      "requires": {
+        "@apollo/client": "^3.3.20"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -61,6 +99,12 @@
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
       }
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "dev": true
     },
     "@jest/types": {
       "version": "26.6.2",
@@ -188,6 +232,12 @@
         "@types/react-test-renderer": "*"
       }
     },
+    "@types/uuid": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
+      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "15.0.11",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
@@ -203,10 +253,43 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
+    "@types/zen-observable": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+      "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==",
+      "dev": true
+    },
     "@use-it/event-listener": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.6.tgz",
       "integrity": "sha512-e6V7vbU8xpuqy4GZkTLExHffOFgxmGHo3kNWnlhzM/zcX2v+idbD/HaJ9sKdQMgTh+L7MIhdRDXGX3SdAViZzA=="
+    },
+    "@wry/context": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
+      "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -323,11 +406,43 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "graphql-tag": {
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz",
+      "integrity": "sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -360,6 +475,16 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "dev": true,
+      "requires": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
+      }
     },
     "pretty-format": {
       "version": "26.6.2",
@@ -474,10 +599,31 @@
         "has-flag": "^3.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "dev": true
+    },
+    "ts-invariant": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+      "integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "ts-xor": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/ts-xor/-/ts-xor-1.0.8.tgz",
       "integrity": "sha512-0u70/SDLSCaX23UddnwAb2GvZZ2N0Rbjnmemn5pHoR40D32Xcva5KRGWV9SdJOKHCjJUlmctmCTvT0z+2yT8aw=="
+    },
+    "tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
     },
     "typescript": {
       "version": "3.8.3",
@@ -492,6 +638,18 @@
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
       }
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "dev": true
     }
   }
 }

--- a/packages/hooks/package-lock.json
+++ b/packages/hooks/package-lock.json
@@ -620,29 +620,6 @@
         }
       }
     },
-    "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      }
-    },
     "react-is": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",

--- a/packages/hooks/package-lock.json
+++ b/packages/hooks/package-lock.json
@@ -185,6 +185,22 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.170",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
+      "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.14.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
@@ -208,6 +224,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-dom": {
+      "version": "16.9.13",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.13.tgz",
+      "integrity": "sha512-34Hr3XnmUSJbUVDxIw/e7dhQn2BJZhJmlAaPyPwfTQyuVS9mV/CeyghFcXyvkJXxI7notQJz8mF8FeCVvloJrA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "^16"
+      }
+    },
     "@types/react-test-renderer": {
       "version": "16.9.5",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.5.tgz",
@@ -215,6 +240,19 @@
       "dev": true,
       "requires": {
         "@types/react": "^16"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "16.14.8",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.8.tgz",
+          "integrity": "sha512-QN0/Qhmx+l4moe7WJuTxNiTsjBwlBGHqKGvInSQCBdo7Qio0VtOqwsC0Wq7q3PbJlB0cR4Y4CVo1OOe6BOsOmA==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        }
       }
     },
     "@types/scheduler": {
@@ -394,6 +432,12 @@
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
       "dev": true
     },
+    "diff-sequences": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+      "dev": true
+    },
     "dom-accessibility-api": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
@@ -411,6 +455,15 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "graphql": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "dev": true,
+      "requires": {
+        "iterall": "^1.2.2"
+      }
     },
     "graphql-tag": {
       "version": "2.12.4",
@@ -444,6 +497,30 @@
         }
       }
     },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "dev": true
+    },
+    "jest-diff": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      }
+    },
+    "jest-get-type": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -451,9 +528,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -541,6 +618,29 @@
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
           "dev": true
         }
+      }
+    },
+    "react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
       }
     },
     "react-is": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.js",
   "scripts": {
-    "build": "tsc --project .",
+    "build": "",
     "clean": "rm -rf dist/* tsconfig.tsbuildinfo",
     "prepare": "npm run clean; npm run build"
   },
@@ -13,10 +13,14 @@
     "dist/*"
   ],
   "devDependencies": {
-    "@testing-library/react-hooks": "^3.2.1",
-    "react-test-renderer": "^16.9.0",
+    "@apollo/react-testing": "^4.0.0",
     "@testing-library/react": "^10.2.1",
-    "typescript": "^3.8.3"
+    "@testing-library/react-hooks": "^3.2.1",
+    "@types/uuid": "^3.4.5",
+    "graphql-tag": "^2.10.3",
+    "react-test-renderer": "^16.9.0",
+    "typescript": "^3.8.3",
+    "uuid": "^3.3.2"
   },
   "dependencies": {
     "@use-it/event-listener": "^0.1.6",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -13,6 +13,8 @@
     "dist/*"
   ],
   "devDependencies": {
+    "@testing-library/react-hooks": "^3.2.1",
+    "react-test-renderer": "^16.9.0",
     "@testing-library/react": "^10.2.1",
     "typescript": "^3.8.3"
   },

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -24,6 +24,7 @@
     "use-resize-observer": "^6.1.0"
   },
   "peerDependencies": {
+    "@apollo/client": "^3.3.16",
     "react": "^16.8.6"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -24,8 +24,6 @@
     "@types/uuid": "^3.4.5",
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.3",
-    "react": "^16.8.6",
-    "react-dom": "^16.9.0",
     "react-test-renderer": "^16.9.0",
     "typescript": "^3.8.3",
     "uuid": "^3.3.2"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -13,18 +13,26 @@
     "dist/*"
   ],
   "devDependencies": {
+    "@apollo/client": "^3.3.16",
     "@apollo/react-testing": "^4.0.0",
     "@testing-library/react": "^10.2.1",
     "@testing-library/react-hooks": "^3.2.1",
+    "@types/jest": "^26.0.23",
+    "@types/lodash": "^4.14.136",
+    "@types/react": "^16.9.43",
+    "@types/react-dom": "^16.9.2",
     "@types/uuid": "^3.4.5",
+    "graphql": "^14.6.0",
     "graphql-tag": "^2.10.3",
+    "react": "^16.8.6",
+    "react-dom": "^16.9.0",
     "react-test-renderer": "^16.9.0",
     "typescript": "^3.8.3",
     "uuid": "^3.3.2"
   },
   "dependencies": {
     "@use-it/event-listener": "^0.1.6",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "resize-observer-polyfill": "^1.5.1",
     "ts-xor": "^1.0.8",
     "use-resize-observer": "^6.1.0"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.js",
   "scripts": {
-    "build": "",
+    "build": "tsc --project .",
     "clean": "rm -rf dist/* tsconfig.tsbuildinfo",
     "prepare": "npm run clean; npm run build"
   },

--- a/packages/hooks/src/configure.test.ts
+++ b/packages/hooks/src/configure.test.ts
@@ -1,0 +1,19 @@
+import { Configuration, configure } from "./configure";
+
+describe("configure", () => {
+  const originalNotifier = Configuration.errorNotifier;
+  afterEach(() => {
+    configure({
+      errorNotifier: originalNotifier,
+    });
+  });
+
+  it("should set the errorNotifier to the passed in configuration option", () => {
+    const myNotifier = jest.fn();
+    configure({
+      errorNotifier: myNotifier,
+    });
+
+    expect(Configuration.errorNotifier).toBe(myNotifier);
+  });
+});

--- a/packages/hooks/src/configure.ts
+++ b/packages/hooks/src/configure.ts
@@ -1,0 +1,15 @@
+export type ErrorNotifierFunction = (message: string, error: unknown) => void;
+
+export interface ConfigurationOptions {
+  errorNotifier: ErrorNotifierFunction;
+}
+
+export const Configuration: ConfigurationOptions = {
+  errorNotifier(message, error) {
+    console.error(message, error);
+  },
+};
+
+export function configure(options: ConfigurationOptions) {
+  Object.assign(Configuration, options);
+}

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./configure";
 export * from "./useResizeObserver";
 export * from "./useFormState";
 export * from "./useOnKeyDown";
+export * from "./useCollectionQuery";

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -3,3 +3,4 @@ export * from "./useResizeObserver";
 export * from "./useFormState";
 export * from "./useOnKeyDown";
 export * from "./useCollectionQuery";
+export * from "./useIsMounted";

--- a/packages/hooks/src/useCollectionQuery/__mocks__/index.ts
+++ b/packages/hooks/src/useCollectionQuery/__mocks__/index.ts
@@ -1,0 +1,3 @@
+export * from "./queries";
+export * from "./utils";
+export * from "./mocks";

--- a/packages/hooks/src/useCollectionQuery/__mocks__/mocks.tsx
+++ b/packages/hooks/src/useCollectionQuery/__mocks__/mocks.tsx
@@ -1,0 +1,103 @@
+import { MockedProvider, MockedResponse } from "@apollo/react-testing";
+import React from "react";
+import uuid from "uuid";
+import { LIST_QUERY, SUBSCRIPTION_QUERY } from "./queries";
+
+export function wrapper(mocks: MockedResponse[]) {
+  function ApolloMockedProvider({
+    children,
+  }: {
+    children: React.ReactElement;
+  }) {
+    return (
+      <MockedProvider addTypename={true} mocks={mocks}>
+        {children}
+      </MockedProvider>
+    );
+  }
+
+  return ApolloMockedProvider as React.FunctionComponent;
+}
+
+let listQueryHasNextPage = true;
+export const listQueryResponseMock = jest.fn(id => {
+  return {
+    data: {
+      conversation: {
+        __typename: "Conversation",
+        smsMessages: {
+          __typename: "SMSMessageConnection",
+          edges: [
+            {
+              __typename: "SMSMessageEdge",
+              node: {
+                __typename: "SMSMessage",
+                id: id || uuid.v1(),
+              },
+            },
+          ],
+          nodes: [
+            {
+              __typename: "SMSMessage",
+              id: id || uuid.v1(),
+            },
+          ],
+          pageInfo: {
+            __typename: "PageInfo",
+            endCursor: "MZ",
+            hasNextPage: listQueryHasNextPage,
+          },
+          totalCount: 42,
+        },
+      },
+    },
+  };
+});
+
+export const subscriptionQueryMock = jest.fn(id => {
+  return {
+    data: {
+      conversationMessage: {
+        __typename: "conversationMessage",
+        id: "other stuff",
+        smsMessage: {
+          __typename: "SMSMessageData",
+          id: id,
+        },
+      },
+    },
+  };
+});
+
+export function buildListRequestMock(id?: string | undefined) {
+  return {
+    request: {
+      query: LIST_QUERY,
+    },
+    result: () => listQueryResponseMock(id),
+  };
+}
+
+export function buildSubscriptionRequestMock(id?: string | undefined) {
+  return {
+    request: {
+      query: SUBSCRIPTION_QUERY,
+    },
+    result: () => subscriptionQueryMock(id),
+    delay: 100,
+  };
+}
+
+export function buildListRequestMockForNextPage(id?: string | undefined) {
+  return {
+    request: {
+      query: LIST_QUERY,
+      variables: { cursor: "MZ" },
+    },
+    result: () => listQueryResponseMock(id),
+  };
+}
+
+export function setListQueryMockHasNextPage(hasNextPage: boolean) {
+  listQueryHasNextPage = hasNextPage;
+}

--- a/packages/hooks/src/useCollectionQuery/__mocks__/queries.ts
+++ b/packages/hooks/src/useCollectionQuery/__mocks__/queries.ts
@@ -1,0 +1,72 @@
+import gql from "graphql-tag";
+
+export const LIST_QUERY = gql`
+  query ConversationMessages($cursor: string) {
+    conversation(id: "MQ==") {
+      smsMessages(first: 1, after: $cursor) {
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+        nodes {
+          __typename
+          id
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        totalCount
+      }
+    }
+  }
+`;
+
+export interface ListQueryType {
+  __typename?: "Query";
+  conversation?: {
+    __typename?: "Conversation";
+    smsMessages: {
+      edges: Array<{
+        __typename?: "SMSMessageConnection";
+        node: {
+          __typename?: "SMSMessage";
+          id: string;
+        };
+        cursor: string;
+      }>;
+      nodes: Array<{
+        __typename?: "SMSMessage";
+        id: string;
+      }>;
+      pageInfo: {
+        endCursor: string;
+        hasNextPage: boolean;
+      };
+      totalCount: number;
+    };
+  };
+}
+
+export const SUBSCRIPTION_QUERY = gql`
+  subscription ConversationMessage($conversationId: EncodedId!) {
+    conversationMessage(conversationId: $conversationId) {
+      smsMessage {
+        __typename
+        id
+      }
+    }
+  }
+`;
+
+export interface SubscriptionQueryType {
+  __typename?: "Subscription";
+  conversationMessage?: {
+    smsMessage: {
+      __typename?: "SMSMessage";
+      id: string;
+    };
+  };
+}

--- a/packages/hooks/src/useCollectionQuery/__mocks__/utils.ts
+++ b/packages/hooks/src/useCollectionQuery/__mocks__/utils.ts
@@ -1,0 +1,3 @@
+export async function wait(milliseconds = 0) {
+  await new Promise(resolve => setTimeout(resolve, milliseconds));
+}

--- a/packages/hooks/src/useCollectionQuery/index.ts
+++ b/packages/hooks/src/useCollectionQuery/index.ts
@@ -1,0 +1,1 @@
+export { useCollectionQuery } from "./useCollectionQuery";

--- a/packages/hooks/src/useCollectionQuery/uniqueEdges.tsx
+++ b/packages/hooks/src/useCollectionQuery/uniqueEdges.tsx
@@ -1,0 +1,26 @@
+import { Node } from "./uniqueNodes";
+
+export interface Edge {
+  __typename?: unknown;
+  node: Node;
+  cursor: string;
+}
+
+export function createEdge(node: Node): Edge {
+  return {
+    node: node,
+    cursor: "",
+    __typename: `${node.__typename}Edge`,
+  };
+}
+
+export function uniqueEdges(edges: Edge[]): Edge[] {
+  const result = new Map<string, Edge>();
+  edges.forEach(edge => {
+    result.set(
+      `${edge.__typename}-${edge.node.__typename}-${edge.node.id}`,
+      edge,
+    );
+  });
+  return Array.from(result.values());
+}

--- a/packages/hooks/src/useCollectionQuery/uniqueNodes.tsx
+++ b/packages/hooks/src/useCollectionQuery/uniqueNodes.tsx
@@ -1,0 +1,12 @@
+export interface Node {
+  id: unknown;
+  __typename?: unknown;
+}
+
+export function uniqueNodes(nodes: Node[]): Node[] {
+  const result = new Map<string, Node>();
+  nodes.forEach(node => {
+    result.set(`${node.__typename}-${node.id}`, node);
+  });
+  return Array.from(result.values());
+}

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.mdx
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.mdx
@@ -1,0 +1,7 @@
+---
+name: useCollectionQuery
+menu: Hooks
+route: /hooks/use-collection-query
+---
+
+# ToDo

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
@@ -1,0 +1,44 @@
+import { isAlreadyUpdated } from "./useCollectionQuery";
+
+const existingNode = {
+  id: "123",
+  __typename: "Conversation",
+};
+
+const newNode = {
+  id: "124",
+  __typename: "Conversation",
+};
+
+const collection = {
+  conversations: {
+    totalCount: 2,
+    edges: [
+      {
+        node: existingNode,
+        cursor: "MQ",
+      },
+    ],
+    pageInfo: {
+      endCursor: "MM",
+      startCursor: "MQ",
+      hasNextPage: true,
+    },
+  },
+};
+
+describe("#isAlreadyUpdated", () => {
+  describe("when hook receives update from item not in collection", () => {
+    it("it should add new item to collection", async () => {
+      const result = isAlreadyUpdated(collection.conversations, existingNode);
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe("when hook receives update from item already in collection", () => {
+    it("it should return the existing collection", async () => {
+      const result = isAlreadyUpdated(collection.conversations, newNode);
+      expect(result).toBeFalsy();
+    });
+  });
+});

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
@@ -1,44 +1,345 @@
-import { isAlreadyUpdated } from "./useCollectionQuery";
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useCollectionQuery } from "./useCollectionQuery";
+import {
+  LIST_QUERY,
+  ListQueryType,
+  SUBSCRIPTION_QUERY,
+  SubscriptionQueryType,
+  buildListRequestMock,
+  buildListRequestMockForNextPage,
+  buildSubscriptionRequestMock,
+  listQueryResponseMock,
+  setListQueryMockHasNextPage,
+  subscriptionQueryMock,
+  wait,
+  wrapper,
+} from "./__mocks__";
 
-const existingNode = {
-  id: "123",
-  __typename: "Conversation",
-};
+beforeEach(() => {
+  setListQueryMockHasNextPage(true);
+  listQueryResponseMock.mockClear();
+  subscriptionQueryMock.mockClear();
+});
 
-const newNode = {
-  id: "124",
-  __typename: "Conversation",
-};
-
-const collection = {
-  conversations: {
-    totalCount: 2,
-    edges: [
-      {
-        node: existingNode,
-        cursor: "MQ",
-      },
-    ],
-    pageInfo: {
-      endCursor: "MM",
-      startCursor: "MQ",
-      hasNextPage: true,
+function useCollectionQueryHook() {
+  return useCollectionQuery<ListQueryType>({
+    query: LIST_QUERY,
+    getCollectionByPath(data) {
+      return data?.conversation?.smsMessages;
     },
-  },
-};
+  });
+}
 
-describe("#isAlreadyUpdated", () => {
-  describe("when hook receives update from item not in collection", () => {
-    it("it should add new item to collection", async () => {
-      const result = isAlreadyUpdated(collection.conversations, existingNode);
-      expect(result).toBeTruthy();
+function useCollectionQueryHookWithSubscription() {
+  return useCollectionQuery<ListQueryType, SubscriptionQueryType>({
+    query: LIST_QUERY,
+    getCollectionByPath(data) {
+      return data?.conversation?.smsMessages;
+    },
+    subscription: {
+      document: SUBSCRIPTION_QUERY,
+      getNodeByPath(conversationData) {
+        return conversationData?.conversationMessage?.smsMessage;
+      },
+    },
+  });
+}
+
+describe("when useCollectionQuery is first called", () => {
+  describe("when nextPage is called while it's still loading initial content", () => {
+    it("should not trigger a the next page to be fetched", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([
+          buildListRequestMock(),
+          buildListRequestMockForNextPage(),
+        ]),
+      });
+
+      act(() => {
+        result.current.nextPage();
+      });
+
+      await act(wait);
+      expect(listQueryResponseMock).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe("when hook receives update from item already in collection", () => {
+  describe("when refresh is called while it's still loading initial content", () => {
+    it("should not trigger a refresh", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([buildListRequestMock(), buildListRequestMock()]),
+      });
+
+      act(() => {
+        result.current.refresh();
+      });
+
+      await act(wait);
+      expect(listQueryResponseMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when there is no error", () => {
+    it("should update data", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([buildListRequestMock()]),
+      });
+
+      await act(wait);
+
+      expect(
+        result.current.data?.conversation?.smsMessages?.edges?.length,
+      ).toBe(1);
+    });
+
+    it("should set initialLoading while loading data", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([buildListRequestMock()]),
+      });
+
+      expect(result.current.loadingInitialContent).toBe(true);
+
+      await act(wait);
+    });
+  });
+});
+
+describe("#nextPage", () => {
+  describe("when nextPage is called while it's still loadingNextPage", () => {
+    it("should not trigger a nextPage", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([
+          buildListRequestMock(),
+          buildListRequestMockForNextPage(),
+          buildListRequestMockForNextPage(),
+        ]),
+      });
+
+      await act(wait);
+      act(() => {
+        result.current.nextPage();
+      });
+
+      act(() => {
+        result.current.nextPage();
+      });
+
+      await act(wait);
+
+      expect(
+        result.current.data?.conversation?.smsMessages?.edges?.length,
+      ).toBe(2);
+    });
+  });
+
+  describe("when refresh is called while it's still loadingNextPage", () => {
+    it("should trigger a refresh", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([
+          buildListRequestMock(),
+          buildListRequestMock(),
+          buildListRequestMockForNextPage(),
+        ]),
+      });
+
+      await act(wait);
+
+      act(() => {
+        result.current.nextPage();
+      });
+
+      act(() => {
+        result.current.refresh();
+      });
+
+      expect(result.current.loadingRefresh).toBe(true);
+
+      await act(wait);
+    });
+  });
+
+  describe("when there is no more data to fetch", () => {
+    it("should not fetch more data", async () => {
+      setListQueryMockHasNextPage(false);
+
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([
+          buildListRequestMock(),
+          buildListRequestMockForNextPage(),
+        ]),
+      });
+
+      await act(wait);
+      act(() => {
+        result.current.nextPage();
+      });
+
+      await act(wait);
+
+      expect(listQueryResponseMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when there is no error", () => {
+    it("should update data", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([
+          buildListRequestMock(),
+          buildListRequestMockForNextPage(),
+        ]),
+      });
+
+      await act(wait);
+      act(() => {
+        result.current.nextPage();
+      });
+
+      await act(wait);
+
+      expect(
+        result.current.data?.conversation?.smsMessages?.edges?.length,
+      ).toBe(2);
+    });
+
+    it("should set loadingNextPage while loading data", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([
+          buildListRequestMock(),
+          buildListRequestMockForNextPage(),
+        ]),
+      });
+
+      await act(wait);
+
+      act(() => {
+        result.current.nextPage();
+      });
+
+      expect(result.current.loadingNextPage).toBe(true);
+
+      await act(wait);
+    });
+  });
+});
+
+describe("#refresh", () => {
+  describe("when refresh is called while it's still loadingRefresh", () => {
+    it("should not trigger a refresh", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([
+          buildListRequestMock(),
+          buildListRequestMock(),
+          buildListRequestMock(),
+        ]),
+      });
+
+      await act(wait);
+
+      act(() => {
+        result.current.refresh();
+      });
+
+      act(() => {
+        result.current.refresh();
+      });
+
+      await act(wait);
+
+      expect(listQueryResponseMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("when nextPage is called while it's still loadingRefresh", () => {
+    it("should not trigger a nextPage", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([
+          buildListRequestMock(),
+          buildListRequestMock(),
+          buildListRequestMockForNextPage(),
+        ]),
+      });
+
+      await act(wait);
+
+      act(() => {
+        result.current.refresh();
+      });
+
+      act(() => {
+        result.current.nextPage();
+      });
+
+      expect(result.current.loadingNextPage).toBe(false);
+
+      await act(wait);
+    });
+  });
+
+  describe("when there is no error", () => {
+    it("should set loadingRefresh while loading data", async () => {
+      const { result } = renderHook(() => useCollectionQueryHook(), {
+        wrapper: wrapper([buildListRequestMock(), buildListRequestMock()]),
+      });
+
+      await act(wait);
+
+      act(() => {
+        result.current.refresh();
+      });
+
+      expect(result.current.loadingRefresh).toBe(true);
+
+      await act(wait);
+    });
+  });
+});
+
+describe("#subscribeToMore", () => {
+  describe("when hook receives update from item not in collection", () => {
+    it("it should add new item to collection", async () => {
+      const { result, waitForNextUpdate } = renderHook(
+        () => useCollectionQueryHookWithSubscription(),
+        {
+          wrapper: wrapper([
+            buildListRequestMock("1"),
+            buildSubscriptionRequestMock("2"),
+          ]),
+        },
+      );
+
+      // Wait for initial load
+      await act(waitForNextUpdate);
+
+      // Wait for subscription
+      await act(waitForNextUpdate);
+
+      expect(
+        result?.current?.data?.conversation?.smsMessages?.edges?.length,
+      ).toBe(2);
+    });
+  });
+
+  describe("when hook receives upate from item already in collection", () => {
     it("it should return the existing collection", async () => {
-      const result = isAlreadyUpdated(collection.conversations, newNode);
-      expect(result).toBeFalsy();
+      const { result, waitForNextUpdate } = renderHook(
+        () => useCollectionQueryHookWithSubscription(),
+        {
+          wrapper: wrapper([
+            buildListRequestMock("1"),
+            buildSubscriptionRequestMock("1"),
+          ]),
+        },
+      );
+
+      // Wait for initial load
+      await act(waitForNextUpdate);
+
+      // Wait for subscription
+      await act(() => wait(200));
+
+      expect(
+        result?.current?.data?.conversation?.smsMessages?.edges?.length,
+      ).toBe(1);
     });
   });
 });

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -1,0 +1,341 @@
+import {
+  ApolloError,
+  QueryHookOptions,
+  SubscribeToMoreOptions,
+  useQuery,
+} from "@apollo/client";
+import { DocumentNode } from "graphql";
+import { cloneDeep } from "lodash";
+import { useCallback, useEffect, useState } from "react";
+import { PageInfo, Scalars } from "utilities/API/graphql";
+import { Rollbar } from "utilities/errors/Rollbar";
+import { useIsMounted } from "packages/hooks/src/useIsMounted";
+import { Node, uniqueNodes } from "./uniqueNodes";
+import { Edge, createEdge, uniqueEdges } from "./uniqueEdges";
+
+interface UseCollectionQueryArguments<TQuery, TSubscription> {
+  /**
+   * The graphQL query that fetches the collection
+   */
+  query: DocumentNode;
+
+  /**
+   * A list of options for us to pass into the apollo `useQuery` hook
+   */
+  queryOptions?: QueryHookOptions<TQuery>;
+
+  /**
+   * A function that returns the location where the {@link Collection} is located.
+   *
+   * The collection is the part of the result that needs to be paginated.
+   */
+  getCollectionByPath: GetCollectionByPathFunction<TQuery>;
+
+  /**
+   *  A list of subscription options if you want to create a GraphQL
+   *  subscription to listen for more content.
+   */
+  subscription?: ListSubscription<TSubscription>;
+}
+
+interface ListSubscription<TSubscription> {
+  /**
+   * The graphQL subscription that listens for more data. This query should
+   * return a single Node that matches the data structure in
+   * `getCollectionByPath<TQuery>(...).edges.node` and
+   * `getCollectionByPath<TQuery>(...).nodes
+   */
+  document: DocumentNode;
+
+  /**
+   * A list of variables to pass into the apollo `subscribeToMore` function.
+   */
+  options?: Pick<SubscribeToMoreOptions<TSubscription>, "variables">;
+
+  /**
+   * A function that returns the location where the `Node` is located on the
+   * `TSubscription` object.
+   *
+   * It should return a single Node that matches the data structure in
+   * `getCollectionByPath<TQuery>(...).edges.node` and
+   * `getCollectionByPath<TQuery>(...).nodes
+   */
+  getNodeByPath: GetNodeByPath<TSubscription>;
+}
+
+interface Collection {
+  edges?: Edge[];
+  nodes?: Node[];
+  pageInfo: Pick<PageInfo, "endCursor" | "hasNextPage">;
+  totalCount: Scalars["Int"];
+  [otherProperties: string]: unknown;
+}
+
+interface CollectionQueryResult<TQuery> {
+  data: TQuery | undefined;
+  error: ApolloError | undefined;
+  loadingRefresh: boolean;
+  loadingNextPage: boolean;
+  loadingInitialContent: boolean;
+  refresh(): void;
+  nextPage(): void;
+}
+
+type GetCollectionByPathFunction<TQuery> = (
+  data: TQuery | undefined,
+) => Collection | undefined;
+
+type GetNodeByPath<TSubscription> = (
+  data: TSubscription | undefined,
+) => Node | undefined;
+
+export function useCollectionQuery<TQuery, TSubscription = undefined>({
+  query,
+  queryOptions,
+  getCollectionByPath,
+  subscription,
+}: UseCollectionQueryArguments<
+  TQuery,
+  TSubscription
+>): CollectionQueryResult<TQuery> {
+  const {
+    data,
+    loading,
+    refetch,
+    error,
+    fetchMore,
+    subscribeToMore,
+  } = useQuery<TQuery>(query, queryOptions);
+
+  const isMounted = useIsMounted();
+  const [loadingRefresh, setLoadingRefresh] = useState<boolean>(false);
+  const [loadingNextPage, setLoadingNextPage] = useState<boolean>(false);
+  const [loadingInitialContent, setLoadingInitialContent] = useState<boolean>(
+    loading,
+  );
+
+  useEffect(() => {
+    setLoadingInitialContent(loading && !loadingRefresh && !loadingNextPage);
+  }, [loading, loadingRefresh, loadingNextPage]);
+
+  const refresh = useCallback(() => {
+    if (loadingInitialContent || loadingRefresh) {
+      return;
+    }
+
+    setLoadingRefresh(true);
+    // tslint:disable-next-line:no-floating-promises
+    refetch()
+      // tslint:disable-next-line:no-unsafe-any
+      .catch(err => Rollbar.EXECUTE("Refetch Error", err))
+      .finally(() => {
+        if (isMounted.current) {
+          setLoadingRefresh(false);
+        }
+      });
+  }, [
+    loadingInitialContent,
+    loadingRefresh,
+    setLoadingRefresh,
+    refetch,
+    isMounted,
+  ]);
+
+  const nextPage = useCallback(() => {
+    if (loadingInitialContent || loadingRefresh || loadingNextPage) {
+      return;
+    }
+
+    const pageInfo = getCollectionByPath(data)?.pageInfo;
+
+    if (!pageInfo || !pageInfo.hasNextPage) {
+      return;
+    }
+
+    setLoadingNextPage(true);
+    // tslint:disable-next-line:no-floating-promises
+    fetchMore({
+      variables: {
+        cursor: pageInfo.endCursor,
+      },
+      updateQuery: (prev, { fetchMoreResult }) =>
+        fetchMoreUpdateQueryHandler(prev, fetchMoreResult, getCollectionByPath),
+    })
+      // tslint:disable-next-line:no-unsafe-any
+      .catch(err => Rollbar.EXECUTE("FetchMore Error", err))
+      .finally(() => {
+        if (isMounted.current) {
+          setLoadingNextPage(false);
+        }
+      });
+  }, [
+    data,
+    loadingInitialContent,
+    loadingRefresh,
+    fetchMore,
+    loadingNextPage,
+    setLoadingNextPage,
+    getCollectionByPath,
+    isMounted,
+  ]);
+
+  useEffect(
+    () => {
+      if (subscription == undefined) return;
+
+      const subscriptionOptions = subscription.options || {};
+
+      return subscribeToMore<TSubscription>({
+        ...subscriptionOptions,
+        document: subscription.document,
+        updateQuery: (prev, { subscriptionData }) =>
+          subscribeToMoreHandler(
+            prev,
+            getCollectionByPath,
+            subscriptionData?.data,
+            subscription.getNodeByPath,
+          ),
+        onError: err => Rollbar.EXECUTE("Subscribe to More Error", err),
+      });
+    },
+    // Disabling this linter so we can force this only run once. If we didn't
+    // do this we would need to ensure subscription, subscribeToMore, and getNodeByPath
+    // all use useCallback.
+    [],
+  );
+
+  return {
+    data,
+    error,
+    refresh,
+    loadingRefresh,
+    nextPage,
+    loadingNextPage,
+    loadingInitialContent,
+  };
+}
+
+/**
+ * The following method uses an `output` variable, and indirectly modifies it through the `outputCollection` variable.
+ * This type of indirect modification is prone to bugs, but I couldn't think of a better way to write this code.
+ *
+ * Here's what I was balancing:
+ * 1. We need to copy the structure of prev to ensure that when we're combining two objects, we're not losing properties
+ * 2. We need to extract a key from an unknown path that's given to us by getCollectionByPath and then we need to modify
+ *    that, and ensure that it's properly set on the cloned output object.
+ * 3. We want to keep the interface to this hook as simple and easy to use as possible
+ *
+ * The alternative approaches that were rejected:
+ * 1. We replace the getCollectionByPath with a keyPath string. (Eg. "data.conversation.message") and then we use lodash
+ *    `get` and `set` which should remove all the object manipulation. But, this approach loses us the type safety that
+ *    getCollectionByPath gives us
+ * 2. We could add a setCollection function to the list of arguments for this hook. This leaves us with type safety but
+ *    makes the `useCollectionQuery` interface more complicated by adding arguments
+ */
+function fetchMoreUpdateQueryHandler<TQuery>(
+  prev: TQuery,
+  fetchMoreResult: TQuery | undefined,
+  getCollectionByPath: GetCollectionByPathFunction<TQuery>,
+): TQuery {
+  const nextCollection = getCollectionByPath(fetchMoreResult);
+  const output = cloneDeep(prev);
+  const outputCollection = getCollectionByPath(output);
+
+  if (outputCollection === undefined || nextCollection === undefined) {
+    return output;
+  }
+
+  if (outputCollection.nodes && nextCollection.nodes) {
+    outputCollection.nodes = getUpdatedNodes(
+      outputCollection.nodes,
+      nextCollection.nodes,
+    );
+  }
+  if (outputCollection.edges && nextCollection.edges) {
+    outputCollection.edges = getUpdatedEdges(
+      outputCollection.edges,
+      nextCollection.edges,
+    );
+  }
+
+  Object.assign(outputCollection, {
+    pageInfo: cloneDeep(nextCollection.pageInfo),
+    totalCount: nextCollection.totalCount,
+  });
+
+  return output;
+}
+
+function subscribeToMoreHandler<TQuery, TSubscription>(
+  prev: TQuery,
+  getCollectionByPath: GetCollectionByPathFunction<TQuery>,
+  subscriptionData: TSubscription | undefined,
+  getNodeByPath: GetNodeByPath<TSubscription>,
+): TQuery {
+  const node = getNodeByPath(subscriptionData);
+  const output = cloneDeep(prev);
+  const outputCollection = getCollectionByPath(output);
+
+  if (outputCollection == undefined || node == undefined) return output;
+
+  if (isAlreadyUpdated(outputCollection, node)) {
+    return prev;
+  }
+
+  if (outputCollection.nodes) {
+    outputCollection.nodes = getUpdatedNodes(
+      outputCollection.nodes,
+      [node],
+      false,
+    );
+  }
+  if (outputCollection.edges) {
+    outputCollection.edges = getUpdatedEdges(
+      outputCollection.edges,
+      [createEdge(node)],
+      false,
+    );
+  }
+
+  Object.assign(outputCollection, {
+    pageInfo: cloneDeep(outputCollection.pageInfo),
+    totalCount: outputCollection.totalCount + 1,
+  });
+
+  return output;
+}
+
+export function isAlreadyUpdated(outputCollection: Collection, newNode: Node) {
+  if (outputCollection.edges) {
+    return outputCollection.edges.some(edge => {
+      return edge.node.id === newNode.id;
+    });
+  }
+  if (outputCollection.nodes) {
+    return outputCollection.nodes.some(node => {
+      return node.id === newNode.id;
+    });
+  }
+}
+
+function getUpdatedEdges(
+  prevEdges: Edge[],
+  nextEdges: Edge[],
+  appendToEnd = true,
+) {
+  const newEdges = appendToEnd
+    ? [...prevEdges, ...nextEdges]
+    : [...nextEdges, ...prevEdges];
+  return uniqueEdges(newEdges);
+}
+
+function getUpdatedNodes(
+  prevNodes: Node[],
+  nextNodes: Node[],
+  appendToEnd = true,
+) {
+  const newNodes = appendToEnd
+    ? [...prevNodes, ...nextNodes]
+    : [...nextNodes, ...prevNodes];
+  return uniqueNodes(newNodes);
+}

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -296,19 +296,22 @@ function subscribeToMoreHandler<TQuery, TSubscription>(
 }
 
 export function isAlreadyUpdated(outputCollection: Collection, newNode: Node) {
+  let edgesAlreadyUpdated = true;
+  let nodesAlreadyUpdated = true;
+
   if (outputCollection.edges) {
-    return outputCollection.edges.some(edge => {
+    edgesAlreadyUpdated = outputCollection.edges.some(edge => {
       return edge.node.id === newNode.id;
     });
   }
 
   if (outputCollection.nodes) {
-    return outputCollection.nodes.some(node => {
+    nodesAlreadyUpdated = outputCollection.nodes.some(node => {
       return node.id === newNode.id;
     });
   }
 
-  return false;
+  return edgesAlreadyUpdated && nodesAlreadyUpdated;
 }
 
 function getUpdatedEdges(

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -101,14 +101,8 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
   TQuery,
   TSubscription
 >): CollectionQueryResult<TQuery> {
-  const {
-    data,
-    loading,
-    refetch,
-    error,
-    fetchMore,
-    subscribeToMore,
-  } = useQuery<TQuery>(query, queryOptions);
+  const { data, loading, refetch, error, fetchMore, subscribeToMore } =
+    useQuery<TQuery>(query, queryOptions);
 
   const isMounted = useIsMounted();
   const [loadingRefresh, setLoadingRefresh] = useState<boolean>(false);

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -101,8 +101,14 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
   TQuery,
   TSubscription
 >): CollectionQueryResult<TQuery> {
-  const { data, loading, refetch, error, fetchMore, subscribeToMore } =
-    useQuery<TQuery>(query, queryOptions);
+  const {
+    data,
+    loading,
+    refetch,
+    error,
+    fetchMore,
+    subscribeToMore,
+  } = useQuery<TQuery>(query, queryOptions);
 
   const isMounted = useIsMounted();
   const [loadingRefresh, setLoadingRefresh] = useState<boolean>(false);

--- a/packages/hooks/src/useIsMounted/index.ts
+++ b/packages/hooks/src/useIsMounted/index.ts
@@ -1,0 +1,1 @@
+export { useIsMounted } from "./useIsMounted";

--- a/packages/hooks/src/useIsMounted/useIsMounted.mdx
+++ b/packages/hooks/src/useIsMounted/useIsMounted.mdx
@@ -1,0 +1,7 @@
+---
+name: useIsMounted
+menu: Hooks
+route: /hooks/use-is-mounted
+---
+
+# ToDo

--- a/packages/hooks/src/useIsMounted/useIsMounted.test.tsx
+++ b/packages/hooks/src/useIsMounted/useIsMounted.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useIsMounted } from "./useIsMounted";
+
+it("should return true when the component is currently mounted", () => {
+  const { result } = renderHook(() => useIsMounted());
+  const isMounted = result.current;
+
+  expect(isMounted.current).toBe(true);
+});
+
+it("should return false when the component is unmounted", () => {
+  const { result, unmount } = renderHook(() => useIsMounted());
+  const isMounted = result.current;
+
+  unmount();
+
+  expect(isMounted.current).toBe(false);
+});

--- a/packages/hooks/src/useIsMounted/useIsMounted.ts
+++ b/packages/hooks/src/useIsMounted/useIsMounted.ts
@@ -1,0 +1,30 @@
+import { useLayoutEffect, useRef } from "react";
+
+/**
+ * Why does this work?
+ *
+ * The following is from the react docs:
+ *    [The return function from `useLayoutEffect`] is the optional cleanup mechanism for effects.
+ *    Every effect may return a function that cleans up after it.
+ *
+ *    When exactly does React clean up an effect? React performs the cleanup when the component unmounts.
+ *    The cleanup for useLayoutEffect is called after component unmounts and before before browser painting
+ *    the screen
+ *
+ * What does that mean for us? When this hook is initially loaded, we then trigger a `useLayoutEffect` that
+ * sets the isMounted to true right after the component is mounted.
+ * When the component unmounts, it calls the cleanup function that sets `isMounted` to false.
+ * This `useLayoutEffect` hook will only be run once.
+ */
+export function useIsMounted(): { current: boolean } {
+  const isMounted = useRef(false);
+
+  useLayoutEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return isMounted;
+}

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "typeRoots": ["./node_modules/@types"],
+    "jsx": "react",
     "declaration": true,
     "rootDir": "src",
     "outDir": "dist"


### PR DESCRIPTION
## Motivations

Both Jobber Online and Jobber Mobile use useCollectionQuery for 2WSMS. The version in Jobber Online, however did not have tests as it was implemented in Jobber Online during a big bug fix. It was always the intention to move useCollectionQuery to Atlantis, no time like now.

## Changes

To make useCollectionQuery work, we needed to also move over useIsMounted.
Tests have been written.

### Added

Both hooks can now be updated from a shared component in Atlantis

### Changed

The functionality should not change.

### Deprecated

NA

### Removed

NA

### Fixed

NA

### Security

NA

## Testing

Tests should work. Integrations with Jobber Online and Mobile should be tested completely.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
