### PR TITLE
fix: Text / Typography don't always respect maxLines [JOB-32400]

### DIFF
--- a/packages/components/src/Typography/Typography.test.tsx
+++ b/packages/components/src/Typography/Typography.test.tsx
@@ -205,6 +205,7 @@ it("should add textTruncate class when numberOfLines property is passed", () => 
       className="base regular textTruncate"
       style={
         Object {
+          "WebkitBoxOrient": "vertical",
           "WebkitLineClamp": 3,
         }
       }

--- a/packages/components/src/Typography/Typography.tsx
+++ b/packages/components/src/Typography/Typography.tsx
@@ -70,6 +70,7 @@ export function Typography({
   if (shouldTruncateText) {
     truncateLines = {
       WebkitLineClamp: numberOfLines,
+      WebkitBoxOrient: "vertical",
     };
   }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
In certain cases - it appears that the `maxLines` prop on `<Text/>` or `<Typography/>` was ignored.
See following from [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp):
```
The -webkit-line-clamp CSS property allows limiting of the contents of a block container to the specified number of lines.

It only works in combination with the display property set to -webkit-box or -webkit-inline-box and the -webkit-box-orient property set to vertical.
```

The `-webkit-box-orient: "Vertical"` was missing, and has been added.


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Fixed the `maxLines` prop on Text & Typography to be slightly more consistent with popular browsers.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
