### PR TITLE
fix(components): add "radiogroup" role to RadioGroup

### DIFF
--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -34,7 +34,7 @@ export function RadioGroup({
   name = uuid.v1(),
 }: RadioGroupProps) {
   return (
-    <div className={styles.radioGroup}>
+    <div role="radiogroup" className={styles.radioGroup}>
       {React.Children.map(children, option => (
         <InternalRadioOption
           checked={value === option.props.value}

--- a/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders a RadioGroup 1`] = `
 <div>
   <div
     class="radioGroup"
+    role="radiogroup"
   >
     <div>
       <input
@@ -39,6 +40,7 @@ exports[`renders a RadioGroup 1`] = `
   </div>
   <div
     class="radioGroup"
+    role="radiogroup"
   >
     <div>
       <input


### PR DESCRIPTION
## Motivations

Add role of "radiogroup" to the div that has that responsibility in the RadioGroup component so that assistive technology has a better idea of what that div is responsible for.

## Changes

### Added

- role of `radiogroup` to the div with the classname "RadioGroup"

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
