### PR TITLE
fix(hooks): fix refreshing expected behaviour until apollo fix lands 

### DIFF
--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -122,7 +122,15 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
     }
 
     setLoadingRefresh(true);
-    refetch()
+
+    fetchMore({
+      // a workaround fix for the error described in this post
+      // https://github.com/apollographql/apollo-client/issues/7491#issuecomment-767985363
+      // These changes can be reverted once we can update to version 3.4
+      // (the current release candidate)
+      variables: {},
+      updateQuery: (prev, { fetchMoreResult }) => fetchMoreResult || prev,
+    })
       .catch(err => config.errorNotifier("Refetch Error", err))
       .finally(() => {
         if (isMounted.current) {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Communiverse has run into an Apollo cache invalidation issue that is described [here](https://github.com/apollographql/apollo-client/issues/7491#issuecomment-767985363)

What we saw:
If you have a list, and use fetchMore to get a new page, and then call refetch it will refresh the first page of data only, and if that data has not changed, it will not remove the following pages, and the cached data will all be returned. However, if the first page is different than it was before, the following pages will be cleared out.
The result is that you can't actually "refetch" all data on your machine if the first page hasn't changed.
This is resolved in the Apollo 3.4.0 RC so we'd like to get onto that version once it's released. In the mean time we have this workaround for the issue

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- NA

### Changed

- Instead of refresh, call fetchMore with no cursor to retrieve the first items.

### Deprecated

- NA

### Removed

- NA

### Fixed

- Fixes refresh behaviour of returning the first original query result.

### Security

- NA

## Testing

1. navigate to the useCollectionQuery Docs
2. Hit the Fetch More button
3. Hit the Refresh button: 
Before: would display all fetch more items
Expected: display only first items (set to first 4 items)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
