### PR TITLE
docs: Add skipnav to `Layout`

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
@@ -73,6 +73,7 @@
   transition: all 0.2s ease;
 
   @media (--wide-screens) {
+    width: calc(100% - var(--table-of-contents-width) - var(--space-base));
     box-shadow: var(--shadow-focus);
   }
 }

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
@@ -58,3 +58,31 @@
   margin: 0 auto;
   padding: 0 var(--space-large);
 }
+
+.skipNav {
+  position: absolute;
+  top: calc(-1 * var(--space-large));
+  left: var(--space-small);
+  z-index: 3;
+  width: calc(100% - var(--space-base));
+  padding: var(--space-base) 0;
+  border-radius: var(--radius-base);
+  text-align: center;
+  background: var(--color-surface);
+  opacity: 0;
+  transition: all 0.2s ease;
+
+  @media (--wide-screens) {
+    box-shadow: var(--shadow-focus);
+  }
+}
+
+.skipNav:focus-within {
+  top: var(--space-small);
+  opacity: 1;
+}
+
+.skipNav a:visited,
+.skipNav a:focus {
+  color: var(--color-interactive);
+}

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
@@ -82,7 +82,11 @@
   opacity: 1;
 }
 
-.skipNav a:visited,
-.skipNav a:focus {
+a.skipNav:hover {
+  background: var(--color-surface--hover);
+}
+
+a.skipNav:visited,
+a.skipNav:focus {
   color: var(--color-interactive);
 }

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
@@ -72,7 +72,7 @@
   opacity: 0;
   transition: all 0.2s ease;
 
-  @media (--wide-screens) {
+  @media (min-width: 1300px) {
     width: calc(100% - var(--table-of-contents-width) - var(--space-base));
     box-shadow: var(--shadow-focus);
   }

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css.d.ts
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css.d.ts
@@ -5,3 +5,4 @@ export const overlay: string;
 export const sidebar: string;
 export const content: string;
 export const container: string;
+export const skipNav: string;

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.tsx
@@ -39,11 +39,13 @@ export function Layout({ children }: PropsWithChildren<unknown>) {
           />
         </div>
         <div className={styles.sidebar} style={sidebarStyles}>
-          <div className={styles.skipNav}>
-            <a href="#mainContent" onClick={toggleMenu}>
-              Skip to Content
-            </a>
-          </div>
+          <a
+            href="#mainContent"
+            className={styles.skipNav}
+            onClick={toggleMenu}
+          >
+            Skip to content
+          </a>
           <Sidebar />
         </div>
         <div id="mainContent" className={styles.content}>

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.tsx
@@ -39,9 +39,14 @@ export function Layout({ children }: PropsWithChildren<unknown>) {
           />
         </div>
         <div className={styles.sidebar} style={sidebarStyles}>
+          <div className={styles.skipNav}>
+            <a href="#mainContent" onClick={toggleMenu}>
+              Skip to Content
+            </a>
+          </div>
           <Sidebar />
         </div>
-        <div className={styles.content}>
+        <div id="mainContent" className={styles.content}>
           <div
             className={styles.container}
             style={{ maxWidth: containerWidth }}


### PR DESCRIPTION
## Motivations

It's a Bad Time™ to use your keyboard to make your way through Atlantis, if you have to tab through all of the sidenav items. As a general accessibility practice, it's important to allow keyboard users to skip main navigation in favour of the main content.

This adds a skipnav link in keeping with [WebAIM guidance.](https://webaim.org/techniques/skipnav/)

## Changes

Added a skipnav link to the Layout module.

### Added

- There's now a link that jumps the user to the main content of a page in Atlantis
- If you are on a less-than-wide screen, the link will also close the menu
- if you are on a wide+ screen, the link does not close the menu (because the menu should not ever close on wide screens)

### Changed

- The `content` div in Layout now has an id of `mainContent` to act as a target for the skipnav link

## Testing

Use the `tab` key on pageload in Atlantis - the skipnav link should appear before any other elements receive focus (other than the `close menu` button on smaller screens)

On wide screens, the skipnav link should be full-width to ensure that it is immediately noticeable.

On screens where the menu has an overlay, the skipnav link should be constrained to the sidenav "logo" area. 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
