### PR TITLE
feat(design): introduce web shadow variations, document and add to Toast

### DIFF
--- a/packages/components/src/Toast/Toast.css
+++ b/packages/components/src/Toast/Toast.css
@@ -21,7 +21,7 @@
 }
 
 .toast {
-  box-shadow: var(--shadow-base);
+  box-shadow: var(--shadow-high);
   overflow: hidden;
   pointer-events: all;
 }

--- a/packages/components/src/Toast/Toast.mdx
+++ b/packages/components/src/Toast/Toast.mdx
@@ -21,7 +21,7 @@ performed. They provide visual feedback on the outcome of an action, and require
 minimal user interacction.
 
 Toast, unlike common React components is not a component that will be added to
-your view. Instead, toast is used by importing and calling the `showToast()`
+your view. Instead, Toast is used by importing and calling the `showToast()`
 function.
 
 ```ts
@@ -41,26 +41,30 @@ import { showToast } from "@jobber/components/Toast";
 
 ## Design & Usage Guidelines
 
-When contributing to, or consuming the Toast component, consider the following:
+When contributing to or consuming the Toast component, consider the following:
 
 - Keep text labels as short as possible. They should be clear and concise, and
   should not take up more than one line.
 - Use the pattern: noun + verb.
-  - Examples: `Job created`, `Quote approved`, `Client archived`.
+  - Examples: `Job saved`, `Quote approved`, `Client archived`.
 - No need to use "Successfully", should be implicit in the toast.
 - Don't use `Dismiss` or `Cancel` as an action label.
   - Examples of action labels: `Undo`, `View`, `Refresh`.
-  
-### Errors
-  
-Only use Toast for errors if there is some other mechanism alerting the user of the problem (such as [InputValidation](input-validation))
-so that they can recover from the error.
 
-In most cases, use [Banner](banner) so the user can appropriately assess and recover from the error.
-  
+### Errors
+
+Only use Toast for errors if there is some other mechanism alerting the user of
+the problem (such as [InputValidation](input-validation)) so that they can
+recover from the error.
+
+In most cases, use [Banner](banner) so the user can appropriately assess and
+recover from the error.
+
 ## Related Components
-  
-For more persistent feedback, or for feedback that has a longer reading length or CTA, use [Banner.](banner)
+
+For more persistent feedback (such as displaying errors), communicating a
+background process that is ongoing, or for feedback that has a longer reading
+length or CTA, use [Banner.](banner)
 
 ## Props
 
@@ -69,7 +73,9 @@ For more persistent feedback, or for feedback that has a longer reading length o
 ## Variations
 
 Toasts have 3 variations, `info`, `success`, and `error`. Each should be used
-appropriatly when using Toast.
+appropriately when using Toast.
+
+The primary use case for Toast is success messages.
 
 <Playground>
   {() => {
@@ -80,7 +86,7 @@ appropriatly when using Toast.
           variation="learning"
           onClick={() =>
             showToast({
-              message: "Toast is just crispy bread",
+              message: "Toast is crispy bread",
               variation: "info",
             })
           }
@@ -89,7 +95,7 @@ appropriatly when using Toast.
           label="Success Toast"
           onClick={() =>
             showToast({
-              message: "Toast is great",
+              message: "Toast is ready",
               variation: "success",
             })
           }

--- a/packages/design/src/Elevations.mdx
+++ b/packages/design/src/Elevations.mdx
@@ -24,30 +24,31 @@ directly into the screen.
 
 ### Low
 
+<Example of="low" />
+
 A low element may have a slight elevation, but is not necessarily something that
 will glide across the surface. A card that holds interactive controls within
 itself, but that does not have any interactions itself, may be useful to
 indicate as "low".
 
-<Example of="low" />
-
 ### Base
-
-This shadow should be used for most instances of shadows, as it conveys an
-elevation that is noticeable but not aggressively close to the user. An element
-with a base elevation is likely interactive, and this level can indicate and
-invite the use of gesture controls in a mobile app.
 
 <Example of="base" />
 
+This shadow should be used for most instances of shadows to convey that an
+element is floating overtop related elements, such as in
+[Menu](/components/menu) or [Popover](/components/popover). An element with a
+base elevation is likely interactive, and this level can indicate and invite the
+use of gesture controls in a mobile app.
+
 ### High
 
-High elements should be elements that float overtop the entire interface, likely
-with a fixed position. The "high" elevation indicates that the element has
-broken the plane of the view. A good example for web would be
-[Toast](/components/toast).
-
 <Example of="high" />
+
+High elements should be elements that float overtop the entire interface,
+typically with a fixed position. The "high" elevation indicates that the element
+has broken the plane of the view. A good example for web would be
+[Toast](/components/toast).
 
 ## Web
 
@@ -59,7 +60,11 @@ export function Value({ of: type }) {
 
 ### Z-index elevation
 
-The following table lists all elements that have a z-index specified.
+The following table lists Atlantis components that have a z-index specified.
+
+These values can be referenced when you are building a view so that you can
+ensure the elements you are using do not unintentionally overlap, if you end up
+using z-index on non-Atlantis components.
 
 | Component        | Value                  |
 | :--------------- | :--------------------- |
@@ -71,7 +76,7 @@ The following table lists all elements that have a z-index specified.
 
 export function Example({ of: shadow }) {
   const style = {
-    width: "var(--space-largest)",
+    width: "100%",
     height: "var(--space-largest)",
     backgroundColor: "var(--color-white)",
     boxShadow: `var(--shadow-${shadow})`,

--- a/packages/design/src/Elevations.mdx
+++ b/packages/design/src/Elevations.mdx
@@ -27,9 +27,8 @@ directly into the screen.
 <Example of="low" />
 
 A low element may have a slight elevation, but is not necessarily something that
-will glide across the surface. A card that holds interactive controls within
-itself, but that does not have any interactions itself, may be useful to
-indicate as "low".
+will glide across the surface. A basic card on mobile that is not tappable would
+be represented as having a "low" elevation.
 
 ### Base
 

--- a/packages/design/src/Elevations.mdx
+++ b/packages/design/src/Elevations.mdx
@@ -103,6 +103,5 @@ they map to our low/base/high pattern.
 ## Mobile
 
 For mobile designs, the concept of elevation applies to both shadows and
-hierarchy of the element along the z-index. The technical implementation differs
-slightly between iOS and Android, as Android accepts a single "depth" value,
-while iOS offers more customizable configuration similar to CSS.
+hierarchy of the element along the z-index. Android accepts a single "elevation"
+value, while iOS accepts more granular shadow values similar to CSS.

--- a/packages/design/src/Elevations.mdx
+++ b/packages/design/src/Elevations.mdx
@@ -13,10 +13,6 @@ In Atlantis, our web components use elevation to specify position on the z-axis,
 with shadows separately responsible for conveying that depth. Our mobile
 components combine these two concepts in keeping with Android and iOS patterns.
 
-> Our web implementation was built first and didn't consider these shared
-> concerns at the time but we may reconcile web and mobile concepts in the
-> future.
-
 Generally speaking, the "higher" an element sits in the z-axis, the broader its'
 shadow should spread, to reflect diffusion in the distance between the element
 and the ground. As an element gets nearer to the ground, or "lower", the
@@ -26,29 +22,6 @@ We also include a _slight_ y-axis offset of elevation shadows to imply that the
 light source is coming from an angle slightly over the head of a user looking
 directly into the screen.
 
-## Web
-
-The following table lists all elements that has a z-index specified on it.
-
-export function Value({ of: type }) {
-  const styles = getComputedStyle(document.documentElement);
-  const getValue = styles.getPropertyValue(`--elevation-${type}`);
-  return <React.Fragment>{getValue}</React.Fragment>;
-}
-
-| Component        | Value                  |
-| :--------------- | :--------------------- |
-| Form field label | <Value of="base" />    |
-| Menu             | <Value of="menu" />    |
-| Modal            | <Value of="modal" />   |
-| Tooltip          | <Value of="tooltip" /> |
-
-## Mobile
-
-For mobile designs, the concept of elevation applies to both shadows and
-hierarchy of the element along the z-index. Currently we have 3 defined levels
-of elevation:
-
 ### Low
 
 A low element may have a slight elevation, but is not necessarily something that
@@ -56,15 +29,76 @@ will glide across the surface. A card that holds interactive controls within
 itself, but that does not have any interactions itself, may be useful to
 indicate as "low".
 
+<Example of="low" />
+
 ### Base
 
 This shadow should be used for most instances of shadows, as it conveys an
 elevation that is noticeable but not aggressively close to the user. An element
 with a base elevation is likely interactive, and this level can indicate and
-invite the use of gesture controls.
+invite the use of gesture controls in a mobile app.
+
+<Example of="base" />
 
 ### High
 
 High elements should be elements that float overtop the entire interface, likely
 with a fixed position. The "high" elevation indicates that the element has
-broken the plane of the view.
+broken the plane of the view. A good example for web would be
+[Toast](/components/toast).
+
+<Example of="high" />
+
+## Web
+
+export function Value({ of: type }) {
+  const styles = getComputedStyle(document.documentElement);
+  const getValue = styles.getPropertyValue(`--elevation-${type}`);
+  return <React.Fragment>{getValue}</React.Fragment>;
+}
+
+### Z-index elevation
+
+The following table lists all elements that have a z-index specified.
+
+| Component        | Value                  |
+| :--------------- | :--------------------- |
+| Form field label | <Value of="base" />    |
+| Menu             | <Value of="menu" />    |
+| Modal            | <Value of="modal" />   |
+| Tooltip          | <Value of="tooltip" /> |
+| Toast            | <Value of="toast" />   |
+
+export function Example({ of: shadow }) {
+  const style = {
+    width: "var(--space-largest)",
+    height: "var(--space-largest)",
+    backgroundColor: "var(--color-white)",
+    boxShadow: `var(--shadow-${shadow})`,
+  };
+  return <div style={style} />;
+}
+
+export function Elevation({ of: shadow }) {
+  const element = document.createElement("div");
+  element.style.boxShadow = `var(--shadow-${shadow})`;
+  document.body.appendChild(element);
+}
+
+### Shadow elevation
+
+These are the box-shadows rendered to signify elevation on given UI elements;
+they map to our low/base/high pattern.
+
+| Name            | Visual                |
+| :-------------- | :-------------------- |
+| `--shadow-low`  | <Example of="low" />  |
+| `--shadow-base` | <Example of="base" /> |
+| `--shadow-high` | <Example of="high" /> |
+
+## Mobile
+
+For mobile designs, the concept of elevation applies to both shadows and
+hierarchy of the element along the z-index. The technical implementation differs
+slightly between iOS and Android, as Android accepts a single "depth" value,
+while iOS offers more customizable configuration similar to CSS.

--- a/packages/design/src/shadows.css
+++ b/packages/design/src/shadows.css
@@ -1,5 +1,8 @@
 :root {
-  --shadow-base: 0px 1px 4px 0px rgba(0, 0, 0, 0.0980392),
-    0px 4px 12px 0px rgba(0, 0, 0, 0.0470588);
+  --shadow-low: 0px 1px 4px rgba(0, 0, 0, 0.08);
+  --shadow-base: 0px 1px 4px 0px rgba(0, 0, 0, 0.1),
+    0px 4px 12px 0px rgba(0, 0, 0, 0.05);
+  --shadow-high: 0px 16px 16px 0px rgba(0, 0, 0, 0.16),
+    0px 0px 8px 0px rgba(0, 0, 0, 0.12);
   --shadow-focus: 0px 0px 4px 2px var(--color-focus);
 }

--- a/packages/design/src/shadows.css
+++ b/packages/design/src/shadows.css
@@ -1,8 +1,13 @@
 :root {
-  --shadow-low: 0px 1px 4px rgba(0, 0, 0, 0.08);
-  --shadow-base: 0px 1px 4px 0px rgba(0, 0, 0, 0.1),
-    0px 4px 12px 0px rgba(0, 0, 0, 0.05);
-  --shadow-high: 0px 16px 16px 0px rgba(0, 0, 0, 0.16),
-    0px 0px 8px 0px rgba(0, 0, 0, 0.12);
-  --shadow-focus: 0px 0px 4px 2px var(--color-focus);
+  --shadow-low: 0px var(--space-minuscule) var(--space-smallest)
+      rgba(0, 0, 0, 0.25),
+    0px 0px var(--space-smallest) rgba(0, 0, 0, 0.1);
+  --shadow-base: 0px var(--space-minuscule) var(--space-smaller) 0px
+      rgba(0, 0, 0, 0.1),
+    0px var(--space-smaller) 12px 0px rgba(0, 0, 0, 0.05);
+  --shadow-high: 0px var(--space-base) var(--space-base) 0px
+      rgba(0, 0, 0, 0.075),
+    0px 0px var(--space-small) 0px rgba(0, 0, 0, 0.05);
+  --shadow-focus: 0px 0px var(--space-smaller) var(--space-smallest)
+    var(--color-focus);
 }


### PR DESCRIPTION
## Motivations

Toast is too subtle in part because it was built using the one and only shadow token we have in our design foundations! Also looks different in Figma as the Figma reflects the intended design @rebecca-li created, causing a conflict.

## Changes

Add web shadow variations and apply them to Toast

### Added

- Shadow Low and Shadow High

### Changed

- Toast shadow from Base to High

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
