### PR TITLE
feat(hooks): Update useCollectionQuery to handle search terms [32867]

### DIFF
--- a/lerna-debug.log
+++ b/lerna-debug.log
@@ -1,0 +1,9 @@
+0 silly argv { _: [ 'bootstrap' ],
+0 silly argv   lernaVersion: '3.22.1',
+0 silly argv   '$0': '/Users/tylersantos/atlantis/node_modules/.bin/lerna' }
+1 notice cli v3.22.1
+2 verbose rootPath /Users/tylersantos/atlantis
+3 info versioning independent
+4 error JSONError: Unexpected token < in JSON at position 407 while parsing near '...testing": "^4.0.0",<<<<<<< HEAD    "@j...' in packages/hooks/package.json
+4 error     at module.exports (/Users/tylersantos/atlantis/node_modules/@lerna/project/node_modules/parse-json/index.js:26:19)
+4 error     at parse (/Users/tylersantos/atlantis/node_modules/@lerna/project/node_modules/load-json-file/index.js:15:9)

--- a/lerna-debug.log
+++ b/lerna-debug.log
@@ -1,9 +1,0 @@
-0 silly argv { _: [ 'bootstrap' ],
-0 silly argv   lernaVersion: '3.22.1',
-0 silly argv   '$0': '/Users/tylersantos/atlantis/node_modules/.bin/lerna' }
-1 notice cli v3.22.1
-2 verbose rootPath /Users/tylersantos/atlantis
-3 info versioning independent
-4 error JSONError: Unexpected token < in JSON at position 407 while parsing near '...testing": "^4.0.0",<<<<<<< HEAD    "@j...' in packages/hooks/package.json
-4 error     at module.exports (/Users/tylersantos/atlantis/node_modules/@lerna/project/node_modules/parse-json/index.js:26:19)
-4 error     at parse (/Users/tylersantos/atlantis/node_modules/@lerna/project/node_modules/load-json-file/index.js:15:9)

--- a/packages/hooks/src/useCollectionQuery/test-utilities/mocks.tsx
+++ b/packages/hooks/src/useCollectionQuery/test-utilities/mocks.tsx
@@ -69,10 +69,14 @@ export const subscriptionQueryMock = jest.fn(id => {
   };
 });
 
-export function buildListRequestMock(id?: string | undefined) {
+export function buildListRequestMock(
+  id?: string | undefined,
+  searchTerm?: string | undefined,
+) {
   return {
     request: {
       query: LIST_QUERY,
+      variables: { searchTerm: searchTerm },
     },
     result: () => listQueryResponseMock(id),
   };

--- a/packages/hooks/src/useCollectionQuery/test-utilities/queries.ts
+++ b/packages/hooks/src/useCollectionQuery/test-utilities/queries.ts
@@ -1,9 +1,9 @@
 import { gql } from "@apollo/client";
 
 export const LIST_QUERY = gql`
-  query ConversationMessages($cursor: string) {
+  query ConversationMessages($cursor: string, $searchTerm: string) {
     conversation(id: "MQ==") {
-      smsMessages(first: 1, after: $cursor) {
+      smsMessages(first: 1, after: $cursor, searchTerm: $searchTerm) {
         edges {
           node {
             __typename

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
@@ -382,7 +382,6 @@ describe("#subscribeToMore", () => {
       // Wait for subscription
       await act(() => wait(200));
 
-      console.log(result?.current);
       expect(
         result?.current?.data?.conversation?.smsMessages?.edges?.length,
       ).toBe(1);

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -114,6 +114,7 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
   const [loadingRefresh, setLoadingRefresh] = useState<boolean>(false);
   const [loadingNextPage, setLoadingNextPage] = useState<boolean>(false);
   const loadingInitialContent = loading && !loadingRefresh && !loadingNextPage;
+  const isSearching = !!queryOptions?.variables?.searchTerm;
 
   const refresh = useCallback(() => {
     if (loadingInitialContent || loadingRefresh) {
@@ -184,6 +185,7 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
         document: subscription.document,
         updateQuery: (prev, { subscriptionData }) =>
           subscribeToMoreHandler(
+            isSearching,
             prev,
             getCollectionByPath,
             subscriptionData?.data,
@@ -195,7 +197,7 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
     // Disabling this linter so we can force this only run once. If we didn't
     // do this we would need to ensure subscription, subscribeToMore, and getNodeByPath
     // all use useCallback.
-    [],
+    [queryOptions?.variables?.searchTerm],
   );
 
   return {
@@ -261,6 +263,7 @@ function fetchMoreUpdateQueryHandler<TQuery>(
 }
 
 function subscribeToMoreHandler<TQuery, TSubscription>(
+  isSearching: boolean,
   prev: TQuery,
   getCollectionByPath: GetCollectionByPathFunction<TQuery>,
   subscriptionData: TSubscription | undefined,
@@ -272,7 +275,7 @@ function subscribeToMoreHandler<TQuery, TSubscription>(
 
   if (outputCollection == undefined || node == undefined) return output;
 
-  if (isAlreadyUpdated(outputCollection, node)) {
+  if (isAlreadyUpdated(outputCollection, node) || isSearching) {
     return prev;
   }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- We want to be able to use useCollectionQuery with search and a subscription, if someone is searching for something, we don't want new subscription data to come in and mess up those results. This fixes that problem. 

## Changes


### Changed

- Changed useCollectionQuery so that it does not pull in new data when a user is searching for content

## Testing
- Specs were written to specifically test this situation.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
