### PR TITLE
feat(design): add active surface and dimmed overlay colors

### DIFF
--- a/packages/components/src/List/ListItem.css
+++ b/packages/components/src/List/ListItem.css
@@ -48,7 +48,7 @@
 /* States */
 
 .isActive {
-  background-color: var(--color-green--lightest);
+  background-color: var(--color-surface--active);
 }
 
 /* TODO: Move truncate in typography */

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -86,7 +86,7 @@ The default color used for interactive elements.
   background-color:var(--color-destructive)"
 ></div>
 
-Use to signfify that an interaction will destroy something in the users’ account
+Use to signify that an interaction will destroy something in the users’ account
 or workflow.
 
 #### Cancel
@@ -326,7 +326,7 @@ A slightly darker surface gives a receded appearance relative to main surfaces.
   background-color:var(--color-surface--reverse);"
 ></div>
 
-When a strong constrast is needed with the rest of the application, a reversed
+When a strong contrast is needed with the rest of the application, a reversed
 surface can be used.
 
 #### Overlay
@@ -338,7 +338,8 @@ surface can be used.
 ></div>
 
 Use to mask an area of the interface to promote focus to a foreground action,
-such as a [Modal](/components/modal)’s appearance.
+such as a [Modal](/components/modal)’s appearance. Overlay includes built-in
+opacity values.
 
 #### Overlay--Dimmed
 
@@ -350,7 +351,8 @@ such as a [Modal](/components/modal)’s appearance.
 ></div>
 
 A transparent version of [Surface](#surface), this masks an area of the nterface
-to indicate inactivity (i.e. waiting for updates)
+to indicate inactivity (i.e. waiting for updates). Overlay--Dimmed includes
+built-in opacity values.
 
 ### Borders
 
@@ -367,7 +369,7 @@ the subtle maintainers of layout structure. Learn more about borders in our
   border: var(--border-base) solid var(--color-border)"
 ></div>
 
-Most of our borders should use this color for subtle definition.
+Most borders should use `--color-border` for subtle definition.
 
 #### Border--Section
 
@@ -378,8 +380,8 @@ Most of our borders should use this color for subtle definition.
   border: var(--border-base) solid var(--color-border--section)"
 ></div>
 
-Use where other bordered content is being further sectioned, such as table
-headers or list sections.
+Use `--color-border--section` where other bordered content is being further
+sectioned, such as table headers or list sections.
 
 ### Brand
 

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -349,8 +349,8 @@ such as a [Modal](/components/modal)’s appearance.
   box-shadow: var(--shadow-base);"
 ></div>
 
-A transparent version of [Surface](#surface), this masks an area of the
-interface to indicate inactivity (i.e. waiting for updates)
+A transparent version of [Surface](#surface), this masks an area of the nterface
+to indicate inactivity (i.e. waiting for updates)
 
 ### Borders
 
@@ -410,6 +410,6 @@ caution, it’s _bright!_
 <br />
 <br />
 
-## Swatches
+## Swatch List
 
 <ColorSwatches colors={colors.customProperties} />

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -66,7 +66,12 @@ text content already present.
 ### Interactive
 
 Use these colors in buttons and form controls to communicate the presence and
-meaning of interaction.
+meaning of interaction. In cases such as [Buttons](/components/button) where the
+interactive color is functioning as a background color or the text color, the
+alternative color should be `--color-white`\*.
+
+_\*This is a known contrast issue in the case of Interactive/White, as we have
+currently tied our interactive color to our brand color._
 
 #### Interactive
 

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -6,7 +6,6 @@ route: /colors
 
 import { ColorSwatches } from "@jobber/docx";
 import colors from "../colors";
-import { Banner } from "@jobber/components/Banner";
 
 # Colors
 
@@ -15,14 +14,15 @@ interface.
 
 Atlantis is built with a
 [semantic layer](https://dev.to/ynab/a-semantic-color-system-the-theory-hk7)
-overtop of a base palette. Use the semantic color values whenever possible to
-ensure you are using colors for their intended purpose.
+overtop of a base palette. Use the semantic color values defined in the usage
+guidelines whenever possible to ensure you are using colors for their intended
+purpose.
 
-<Banner type="warning" dismissible={false}>
-  Color should never be the single means of conveying information in an
-  interface. Use labels, iconography, or hints for assistive technology
-  alongside color to ensure your content can be understood by everyone.
-</Banner>
+## Accessibility
+
+Color should never be the single means of conveying information in an interface.
+Use labels, iconography, or hints for assistive technology alongside color to
+ensure your content can be understood by everyone.
 
 ## Usage Guidelines
 

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -33,16 +33,35 @@ readability.
 
 #### Heading
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-heading)"
+></div>
+
 Headings have a bold, high-contrast color to cement their hierarchy.
 
 #### Text
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-text)"
+></div>
+
 A slightly softer color is used for body text for greater readability.
 
-##### Text--Supporting
+##### Text--Secondary
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-text--secondary)"
+></div>
 
 Text that is relevant but less important can be lower-contrast to suggest its’
-reduced importance.
+reduced importance. This color should only be used when there is more important
+text content already present.
 
 ### Interactive
 
@@ -51,22 +70,52 @@ meaning of interaction.
 
 #### Interactive
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-interactive)"
+></div>
+
 The default color used for interactive elements.
 
 #### Destructive
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-destructive)"
+></div>
 
 Use to signfify that an interaction will destroy something in the users’ account
 or workflow.
 
 #### Cancel
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-cancel)"
+></div>
+
 Use to signify that an interaction will cancel or exit a workflow
 
 #### Disabled
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-disabled)"
+></div>
+
 Use to signify that an interactive element is disabled.
 
 ##### Disabled--Secondary
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-disabled--secondary)"
+></div>
 
 Use when a disabled element needs more than one color to be readable in a
 disabled state; for example, a button's background and label colors must be
@@ -74,7 +123,15 @@ different.
 
 #### Focus
 
-Use to indicate that an element has been focused.
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-surface);
+  box-shadow:var(--shadow-focus);"
+></div>
+
+Use to indicate that an element has been focused (ideally using the
+`--shadow-focus` property).
 
 ### Status
 
@@ -88,52 +145,238 @@ sufficient color contrast.
 
 #### Critical
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  display:flex;"
+>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-critical)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-critical--surface)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-critical--onSurface)"
+  ></div>
+</div>
+
 Action required; user must see this status to be unblocked.
 
 #### Warning
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  display:flex;"
+>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-warning)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-warning--surface)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-warning--onSurface)"
+  ></div>
+</div>
 
 Action _may_ be required as a consequence of current state.
 
 #### Success
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  display:flex;"
+>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-success)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-success--surface)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-success--onSurface)"
+  ></div>
+</div>
+
 No action required; an action has completed successfully.
 
 #### Informative
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  display:flex;"
+>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-informative)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-informative--surface)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-informative--onSurface)"
+  ></div>
+</div>
 
 No action required; but helpful to know about.
 
 #### Inactive
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  display:flex;"
+>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-inactive)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-inactive--surface)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-inactive--onSurface)"
+  ></div>
+</div>
+
 No action required; not part of an active workflow.
 
 ### Surfaces
 
-Surfaces are the background-colors of almost every element in Jobber.
+Surfaces are the background-colors of almost every element in Jobber. Overlays
+act as supplementary surfaces that mask areas of the interface to adjust visual
+focus.
 
 #### Surface
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  display:flex;
+  box-shadow: var(--shadow-base)"
+>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-surface)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-surface--hover)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-surface--active)"
+  ></div>
+</div>
+
 Most elements in Jobber have a light surface to indicate their nearness to the
-user; if clickable, they have a hover color.
+user; if interactive, they have a hover color and an active color to indicate
+state.
 
 #### Surface--Background
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-surface--background);"
+></div>
 
 A slightly darker surface gives a receded appearance relative to main surfaces.
 
 #### Surface--Reverse
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-surface--reverse);"
+></div>
+
 When a strong constrast is needed with the rest of the application, a reversed
 surface can be used.
+
+#### Overlay
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-overlay);"
+></div>
+
+Use to mask an area of the interface to promote focus to a foreground action,
+such as a [Modal](/components/modal)’s appearance.
+
+#### Overlay--Dimmed
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-overlay--dimmed);
+  box-shadow: var(--shadow-base);"
+></div>
+
+A transparent version of [Surface](#surface), this masks an area of the
+interface to indicate inactivity (i.e. waiting for updates)
 
 ### Borders
 
 Defining the edges of elements on the same elevation plane, border colors are
-the subtle maintainers of layout structure.
+the subtle maintainers of layout structure. Learn more about borders in our
+[Borders guide.](/borders)
 
 #### Border
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-surface);
+  border: var(--border-base) solid var(--color-border)"
+></div>
 
 Most of our borders should use this color for subtle definition.
 
 #### Border--Section
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-surface);
+  border: var(--border-base) solid var(--color-border--section)"
+></div>
 
 Use where other bordered content is being further sectioned, such as table
 headers or list sections.
@@ -144,10 +387,22 @@ Use these colors to represent the Jobber brand visual language.
 
 #### Brand
 
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-brand);"
+></div>
+
 The primary color associated with our brand, from website to ads to product; AKA
 “Jobber Green”.
 
 #### Brand--Highlight
+
+<div
+  style="width:100%;
+  height:var(--space-extravagant);
+  background-color:var(--color-brand--highlight);"
+></div>
 
 Use to highlight an element in a way that aligns with our website. Use with
 caution, it’s _bright!_

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -52,7 +52,7 @@
   --color-border--section: var(--color-blue);
 
   --color-overlay: rgba(var(--color--greyBlue--rgb), 0.8);
-  --color-overlay--dimmed: rgba(var(--color--white--rgb), 0.4);
+  --color-overlay--dimmed: rgba(var(--color--white--rgb), 0.6);
 
   /* Brand */
   --color-brand: var(--color-green);
@@ -165,6 +165,6 @@
   --color-indigo--lightest: rgb(230, 233, 247);
   --color-indigo--dark: rgb(55, 69, 132);
 
-  --color--white--rgb: 255, 255, 255;
+  --color-white--rgb: 255, 255, 255;
   --color-white: rgba(var(--color--white--rgb));
 }

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -44,6 +44,7 @@
   /* Surfaces and Borders */
   --color-surface: var(--color-white);
   --color-surface--hover: var(--color-yellow--lightest);
+  --color-surface--active: var(--color-green--lightest);
   --color-surface--background: var(--color-grey--lightest);
   --color-surface--reverse: var(--color-greyBlue--dark);
 
@@ -51,6 +52,7 @@
   --color-border--section: var(--color-blue);
 
   --color-overlay: rgba(var(--color--greyBlue--rgb), 0.8);
+  --color-overlay--dimmed: rgba(var(--color--white--rgb), 0.4);
 
   /* Brand */
   --color-brand: var(--color-green);
@@ -163,5 +165,6 @@
   --color-indigo--lightest: rgb(230, 233, 247);
   --color-indigo--dark: rgb(55, 69, 132);
 
-  --color-white: rgb(255, 255, 255);
+  --color--white--rgb: 255, 255, 255;
+  --color-white: rgba(var(--color--white--rgb));
 }

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -166,5 +166,5 @@
   --color-indigo--dark: rgb(55, 69, 132);
 
   --color-white--rgb: 255, 255, 255;
-  --color-white: rgba(var(--color--white--rgb));
+  --color-white: rgba(var(--color-white--rgb));
 }

--- a/packages/docx/src/ColorSwatches/ColorSwatch/ColorSwatch.css
+++ b/packages/docx/src/ColorSwatches/ColorSwatch/ColorSwatch.css
@@ -13,7 +13,8 @@
     tagging this swatch. */
 
 .color[style*="background-color: rgb(255, 255, 255);"],
-.color[style="background-color: var(--color-white);"] {
+.color[style*="background-color: var(--color-white);"],
+.color[style*="background-color: var(--color-white-rgb);"] {
   box-shadow: var(--shadow-base); /* 1 */
 }
 


### PR DESCRIPTION
## Motivations

Reflecting some more common surface and overlay patterns that I picked up on when rolling semantic colours out across Jobber. Also updates the docs to have color swatches associated with the usage guidelines, albeit in a rough fashion that could potentially be componentized in the future.

## Changes

Some new colours! Some new swatches in the docs!

### Added

- color-surface--active extends the surface--hover pattern
- color-overlay--dimmed extends the overlay pattern, but for "dimming" temporarily-non-interactive (but not disabled) UI

### Changed

- color-white now consumes an rgb value a la color-greyBlue for use in color-overlay
- components using surface--active now use them
- color docs have HTML-based color swatches
- split out accessibility in docs as its' own section, vs as a Banner

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
