### PR TITLE
fix: Null Reference variable for form-field component [JOB-33267]

### DIFF
--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -133,22 +133,22 @@ export function FormField(props: FormFieldProps) {
               case "textarea":
                 return (
                   <textarea
+                    {...textFieldProps}
                     rows={rows}
                     ref={inputRef as MutableRefObject<HTMLTextAreaElement>}
-                    {...textFieldProps}
                   />
                 );
               default:
                 return (
                   <>
                     <input
+                      {...textFieldProps}
                       autoComplete={setAutocomplete(autocomplete)}
                       type={type}
                       maxLength={maxLength}
                       max={max}
                       min={min}
                       ref={inputRef as MutableRefObject<HTMLInputElement>}
-                      {...textFieldProps}
                     />
                     {loading && <FormSpinner />}
                   </>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
The latest version of the Form field component is breaking. The reference variable is being overwritten by null reference.
<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->


### Changed
Changed the sequence of props in destructuring.


#
### Fixed

Null object reference

<!-- How to test your changes. -->

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
