### PR TITLE
fix(design): clean up --rgb tokens

### DIFF
--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -51,8 +51,8 @@
   --color-border: var(--color-grey--lighter);
   --color-border--section: var(--color-blue);
 
-  --color-overlay: rgba(var(--color--greyBlue--rgb), 0.8);
-  --color-overlay--dimmed: rgba(var(--color--white--rgb), 0.6);
+  --color-overlay: rgba(var(--color-greyBlue--rgb), 0.8);
+  --color-overlay--dimmed: rgba(var(--color-white--rgb), 0.6);
 
   /* Brand */
   --color-brand: var(--color-green);
@@ -110,8 +110,8 @@
   --color-grey--lightest: rgb(244, 244, 244);
   --color-grey--dark: rgb(118, 118, 118);
 
-  --color--greyBlue--rgb: 101, 120, 132;
-  --color-greyBlue: rgb(var(--color--greyBlue--rgb));
+  --color-greyBlue--rgb: 101, 120, 132;
+  --color-greyBlue: rgb(var(--color-greyBlue--rgb));
   --color-greyBlue--light: rgb(147, 161, 169);
   --color-greyBlue--lighter: rgb(193, 201, 206);
   --color-greyBlue--lightest: rgb(232, 235, 237);


### PR DESCRIPTION
## Motivations

While reviewing [a subsequent PR](https://github.com/GetJobber/atlantis/pull/580/files) I realized that the reason the `color-overlay--dimmed` value was not working was because I used an inconsistent hyphenation practice in the initial implementation.

This led to the color being interpreted as `rgba(0,0,0,0)` which is equivalent to... no color at all (transparent).

## Changes

RGB token values now use naming consistent with other color values.

`--color-{colorName}--{modifier}`

### Changed

- Hyphenation in `--color-overlay` and `--color-overlay--dimmed`

### Fixed

- `--color-overlay--dimmed` works!

## Testing

You can merge this branch into the PR above, or change the color of some other element in Atlantis to use the `overlay--dimmed` color and inspect it to see that it's a 60% opacity of white.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
