### PR TITLE
fix(components): Focus the first error on Form submission

### DIFF
--- a/packages/components/src/Form/Form.test.tsx
+++ b/packages/components/src/Form/Form.test.tsx
@@ -14,7 +14,9 @@ test("calls the submit handler if the form is valid", async () => {
   );
 
   const input = getByLabelText("test form");
+  const inputTwo = getByLabelText("test input");
   fireEvent.change(input, { target: { value: "hello" } });
+  fireEvent.change(inputTwo, { target: { value: "hello" } });
   fireEvent.click(getByText("submit"));
 
   await waitFor(() => expect(submitHandler).toHaveBeenCalledTimes(1));
@@ -128,7 +130,7 @@ test("submit method can be used to successfully submit the form", async () => {
   fireEvent.change(input, { target: { value: "Bo" } });
   fireEvent.click(getByText("submit"));
 
-  waitFor(() => {
+  await waitFor(() => {
     expect(submitHandler).toHaveBeenCalledTimes(1);
   });
 });
@@ -139,9 +141,30 @@ test("submit method can be used to trigger validation from outside the form", as
 
   fireEvent.click(getByText("submit"));
 
-  waitFor(() => {
+  await waitFor(() => {
     expect(getByText("validation error")).not.toBeNull();
-    expect(getByText("validation error")).toBeInstanceOf(HTMLDivElement);
+    expect(getByText("validation error")).toBeInstanceOf(HTMLParagraphElement);
+  });
+});
+
+it("should focus on the first errored field", async () => {
+  const { getByLabelText, getByText } = render(
+    <MockForm onSubmit={jest.fn()} />,
+  );
+
+  const input = getByLabelText("test form");
+  const inputTwo = getByLabelText("test input");
+  fireEvent.click(getByText("submit"));
+
+  await waitFor(() => {
+    expect(input).toHaveFocus();
+  });
+
+  fireEvent.change(input, { target: { value: "hello" } });
+  fireEvent.click(getByText("submit"));
+
+  await waitFor(() => {
+    expect(inputTwo).toHaveFocus();
   });
 });
 
@@ -190,6 +213,20 @@ function MockForm({ onSubmit, onStateChange }: MockFormProps) {
           minLength: {
             value: 3,
             message: "short.",
+          },
+        }}
+      />
+      <InputText
+        placeholder="test input"
+        name="testInput"
+        validations={{
+          required: {
+            value: true,
+            message: "validation error when required",
+          },
+          minLength: {
+            value: 3,
+            message: "two short.",
           },
         }}
       />

--- a/packages/components/src/Form/Form.tsx
+++ b/packages/components/src/Form/Form.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useImperativeHandle,
 } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { ErrorOption, FormProvider, useForm } from "react-hook-form";
 
 export interface FormRef {
   submit(): void;
@@ -28,6 +28,7 @@ export const Form = forwardRef(function InternalForm(
 ) {
   const methods = useForm({ mode: "onTouched" });
   const {
+    errors,
     trigger,
     handleSubmit,
     formState: { isDirty, isValid },
@@ -52,6 +53,7 @@ export const Form = forwardRef(function InternalForm(
         submitHandler();
       } else {
         trigger();
+        errorHandler(errors);
       }
     },
   }));
@@ -64,7 +66,7 @@ export const Form = forwardRef(function InternalForm(
   const Wrapper = onSubmit ? "form" : "div";
 
   const formProps = {
-    onSubmit: onSubmit && handleSubmit(submitHandler),
+    onSubmit: onSubmit && handleSubmit(submitHandler, errorHandler),
   };
 
   return (
@@ -77,5 +79,16 @@ export const Form = forwardRef(function InternalForm(
 
   function submitHandler() {
     onSubmit && onSubmit();
+  }
+
+  function errorHandler(errs: ErrorOption) {
+    const firstErrName = Object.keys(errs)[0];
+    const element = document.querySelector(
+      `[name="${firstErrName}"]`,
+    ) as HTMLElement;
+
+    if (typeof element != undefined) {
+      element?.focus();
+    }
   }
 });


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When forms were being submitted, they were not focusing on the invalid fields. This was causing users to have to scroll to find their invalid feidls.

## Changes

Adds an `errorHandler` to the `Form` component that will focus on the first invalid field

### Added

- `errorHandler` to the `Form` component that will focus on the first invalid field

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
