### PR TITLE
feat(components): Add more values to autocomplete attribute

### DIFF
--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -378,6 +378,24 @@ it("it should set the autocomplete value with one-time-code", () => {
   expect(autocomplete).toContain("one-time-code");
 });
 
+it("it should set the autocomplete value with address-line1", () => {
+  const { getByLabelText } = render(
+    <FormField placeholder="foo" autocomplete={"address-line1"} />,
+  );
+  const input = getByLabelText("foo");
+  const autocomplete = input.getAttribute("autocomplete");
+  expect(autocomplete).toContain("address-line1");
+});
+
+it("it should set the autocomplete value with address-line2", () => {
+  const { getByLabelText } = render(
+    <FormField placeholder="foo" autocomplete={"address-line2"} />,
+  );
+  const input = getByLabelText("foo");
+  const autocomplete = input.getAttribute("autocomplete");
+  expect(autocomplete).toContain("address-line2");
+});
+
 it("it should set the autocomplete value to off", () => {
   const { getByLabelText } = render(
     <FormField placeholder="foo" autocomplete={false} />,

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -11,7 +11,7 @@ import classnames from "classnames";
 import uuid from "uuid";
 import { Controller, useForm, useFormContext } from "react-hook-form";
 import styles from "./FormField.css";
-import { AutocompleteTypes, FormFieldProps } from "./FormFieldTypes";
+import { FormFieldProps } from "./FormFieldTypes";
 import { FormLabel } from "./FormLabel";
 import { FieldWrapper } from "./FieldWrapper";
 import { FormSpinner } from "./FormSpinner";
@@ -199,7 +199,7 @@ export function FormField(props: FormFieldProps) {
           }
 
           function setAutocomplete(
-            autocompleteSetting: boolean | AutocompleteTypes,
+            autocompleteSetting: boolean | FormFieldProps["autocomplete"],
           ) {
             if (autocompleteSetting === true) {
               return undefined;

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -11,7 +11,7 @@ import classnames from "classnames";
 import uuid from "uuid";
 import { Controller, useForm, useFormContext } from "react-hook-form";
 import styles from "./FormField.css";
-import { FormFieldProps } from "./FormFieldTypes";
+import { AutocompleteTypes, FormFieldProps } from "./FormFieldTypes";
 import { FormLabel } from "./FormLabel";
 import { FieldWrapper } from "./FieldWrapper";
 import { FormSpinner } from "./FormSpinner";
@@ -198,12 +198,16 @@ export function FormField(props: FormFieldProps) {
             onControllerBlur();
           }
 
-          function setAutocomplete(autocompleteSetting: boolean | string) {
-            if (autocompleteSetting === "one-time-code") {
-              return "one-time-code";
+          function setAutocomplete(
+            autocompleteSetting: boolean | AutocompleteTypes,
+          ) {
+            if (autocompleteSetting === true) {
+              return undefined;
+            } else if (autocompleteSetting === false) {
+              return "autocomplete-off";
             }
 
-            return autocompleteSetting ? undefined : "autocomplete-off";
+            return autocompleteSetting;
           }
         }}
       />

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -12,9 +12,7 @@ export type FormFieldTypes =
 export type AutocompleteTypes =
   | "one-time-code"
   | "address-line1"
-  | "address-line2"
-  | "postal-code"
-  | "cc-name";
+  | "address-line2";
 
 export interface FieldActionsRef {
   setValue(value: string | number): void;
@@ -29,7 +27,8 @@ export interface FormFieldProps {
   /**
    * Determines if browser form autocomplete is enabled.
    * Note that "one-time-code" is experimental and should not be used without
-   * consultation.
+   * consultation. "address-line1" and "address-line2" are
+   * used for billing address information.
    */
   readonly autocomplete?: boolean | AutocompleteTypes;
 

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -13,6 +13,7 @@ export type AutocompleteTypes =
   | "one-time-code"
   | "address-line1"
   | "address-line2"
+  | "postal-code"
   | "cc-name";
 
 export interface FieldActionsRef {

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -9,6 +9,12 @@ export type FormFieldTypes =
   | "textarea"
   | "select";
 
+export type AutocompleteTypes =
+  | "one-time-code"
+  | "address-line1"
+  | "address-line2"
+  | "cc-name";
+
 export interface FieldActionsRef {
   setValue(value: string | number): void;
 }
@@ -24,7 +30,7 @@ export interface FormFieldProps {
    * Note that "one-time-code" is experimental and should not be used without
    * consultation.
    */
-  readonly autocomplete?: boolean | "one-time-code";
+  readonly autocomplete?: boolean | AutocompleteTypes;
 
   /**
    * If you need to pass in a children. For example, `<options>` inside


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We want to support more options for autocomplete attribute

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- added 4 new values: address-line1, address-line2, postal-code, cc-name

### Changed

- changed `setAutocomplete` function


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
