### PR TITLE
fix(design): Fix parsing of colors.css to support rgb and rgba [JOB-34356]

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -6,6 +6,8 @@ const customPropertiesObject = require("./src/foundation.js");
 const regexExpressions = {
   cssVars: /var\((.*)\)/,
   calculations: /calc\((.*)\)/,
+  rgbVars: /rgb\(var\((.*)\)\)/,
+  rgbaVars: /rgba\(var\((.*)\),?(.*)\)/,
   removeAllNonNumerals: /[^0-9.+\-/*]/gi,
   extractAllVarGroups: /var\(.*?\)/g,
 };
@@ -49,24 +51,46 @@ function jobberStyle(styling) {
 
   //varRegexResult returns --base-unit from var(--base-unit)
   const varRegexResult = regexExpressions.cssVars.exec(styleValue);
+  //rgbVarRegexResult returns --base-unit from rgb(var(--base-unit))
+  const rgbVarRegexResult = regexExpressions.rgbVars.exec(styleValue);
+  //rgbaVarRegexResult returns --base-unit and alpha (if exists) from rgba(var(--base-unit), alpha)
+  const rgbaVarRegexResult = regexExpressions.rgbaVars.exec(styleValue);
 
   //calcRegexResult returns var(--base-unit) / 16 from calc(var(--base-unit) / 16)
   const calcRegexResult = regexExpressions.calculations.exec(styleValue);
   if (calcRegexResult) {
-    const finalExpression = handleExpressionsInCalc(calcRegexResult);
-    // eslint-disable-next-line no-new-func
-    const calculatedValue = new Function(
-      "return " +
-        finalExpression.replace(regexExpressions.removeAllNonNumerals, ""),
-    )();
-    return isSpacingValue(calculatedValue)
-      ? parseFloat(calculatedValue)
-      : calculatedValue;
+    return handleCalc(calcRegexResult);
+  } else if (rgbVarRegexResult) {
+    return jobberStyle(rgbVarRegexResult[1]);
+  } else if (rgbaVarRegexResult) {
+    return handleRbga(rgbaVarRegexResult);
   } else if (varRegexResult) {
     return jobberStyle(varRegexResult[1]);
   } else {
     return isSpacingValue(styleValue) ? parseFloat(styleValue) : styleValue;
   }
+}
+
+function handleCalc(calcRegexResult) {
+  const finalExpression = handleExpressionsInCalc(calcRegexResult);
+  // eslint-disable-next-line no-new-func
+  const calculatedValue = new Function(
+    "return " +
+      finalExpression.replace(regexExpressions.removeAllNonNumerals, ""),
+  )();
+  return isSpacingValue(calculatedValue)
+    ? parseFloat(calculatedValue)
+    : calculatedValue;
+}
+
+function handleRbga(rgbaVarRegexResult) {
+  let resolved = "rgba(" + jobberStyle(rgbaVarRegexResult[1]);
+  if (rgbaVarRegexResult[2]) {
+    resolved += "," + rgbaVarRegexResult[2];
+  }
+  resolved += ")";
+
+  return resolved;
 }
 
 function handleExpressionsInCalc(calcRegexResult) {

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -51,8 +51,8 @@
   --color-border: var(--color-grey--lighter);
   --color-border--section: var(--color-blue);
 
-  --color-overlay: rgba(101, 120, 132, 0.8);
-  --color-overlay--dimmed: rgba(255, 255, 255, 0.6);
+  --color-overlay: rgba(var(--color-greyBlue--rgb), 0.8);
+  --color-overlay--dimmed: rgba(var(--color-white--rgb), 0.6);
 
   /* Brand */
   --color-brand: var(--color-green);
@@ -110,10 +110,8 @@
   --color-grey--lightest: rgb(244, 244, 244);
   --color-grey--dark: rgb(118, 118, 118);
 
-  /* TODO: Reintroduce RGB once the issue with JobberStyle is fixed */
-  /* --color-greyBlue--rgb: 101, 120, 132; */
-  /* --color-greyBlue: rgb(var(--color-greyBlue--rgb)); */
-  --color-greyBlue: rgb(101, 120, 132);
+  --color-greyBlue--rgb: 101, 120, 132;
+  --color-greyBlue: rgb(var(--color-greyBlue--rgb));
   --color-greyBlue--light: rgb(147, 161, 169);
   --color-greyBlue--lighter: rgb(193, 201, 206);
   --color-greyBlue--lightest: rgb(232, 235, 237);
@@ -167,8 +165,6 @@
   --color-indigo--lightest: rgb(230, 233, 247);
   --color-indigo--dark: rgb(55, 69, 132);
 
-  /* TODO: Reintroduce RGB once the issue with JobberStyle is fixed */
-  /* --color-white--rgb: 255, 255, 255; */
-  /* --color-white: rgba(var(--color-white--rgb)); */
-  --color-white: rgb(255, 255, 255);
+  --color-white--rgb: 255, 255, 255;
+  --color-white: rgba(var(--color-white--rgb));
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We currently do not properly parse values like rgb(var(--color-greyBlue--rgb)) and rgba(var(--color-greyBlue--rgb), 0.8) in colors.css

## Changes

Update jobberStyle.js to support the above.

### Added

- Support rgb and rgba

### Changed

- none

### Deprecated

- none

### Removed

- none

### Fixed

- JOB-34356 - Can not parse rgb in colors.css

### Security

- none

## Testing

- Build foundation.js and confirm that values in colors.css like the above appear in foundation.js
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
