### PR TITLE
docs: add prop naming conventions to styleguide

### DIFF
--- a/docs/guides/frontent-style.mdx
+++ b/docs/guides/frontent-style.mdx
@@ -15,6 +15,35 @@ we can. To that end this guide serves to document conventions that we can't (or
 haven't yet been able to) automate. Automation is always preferred to adding a
 guidance here.
 
+---
+
+## Property naming conventions
+
+Consider common terminology across components and design foundations when naming properties.
+As Atlantis is a system, end users should expect similar-behaving properties to have similar 
+names across the system. For example...
+
+### Base vs "Default" or "Medium" for setting the default option in a range
+
+We use `base` as our default whenever possible when a property has a set range of outcomes. This can be seen in.. 
+
+  - the `size` properties of [Button](/components/Button), [Avatar](/components/avatar), [InputText](/components/input-text), [Text](/packages-components-src-text-text), ]ProgressBar](/components/progress-bar), [Spinner](/components/spinner), etc;
+  - `maxLines` of [Text](/packages-components-src-text-text)
+  - values of [Shadow](/elevation), [Spacing](/space), [Border Radius](/border-radius) design tokens
+
+This allows us to set an expectation of the base (or most common) use case when a prop is
+in action.
+
+---
+
+### Open and closed states
+
+If a component has `open` and `closed` states, use a boolean property named `open`.
+
+This can be seen in [Modal](/components/modal), [Drawer](/components/drawer), and [Popover](/components/popover).
+
+---
+
 ## Typescript
 
 ### Linter Exceptions


### PR DESCRIPTION
## Motivations

Unblock opening Atlantis to McFriends by adding reference to common naming convention PR reviews

## Changes

New rules in styleguide

### Added

- Open/close
- Base

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
