### PR TITLE
feat(components): Allow inline labels to be dismissible

### DIFF
--- a/packages/components/src/ButtonDismiss/ButtonDismiss.tsx
+++ b/packages/components/src/ButtonDismiss/ButtonDismiss.tsx
@@ -1,18 +1,23 @@
 import React from "react";
 import styles from "./ButtonDismiss.css";
-import { Button } from "../Button";
+import { Button, ButtonProps } from "../Button";
 
-interface ButtonDismissProps {
+interface ButtonDismissProps extends Pick<ButtonProps, "size"> {
   onClick?(): void;
   ariaLabel: string;
 }
 
-export function ButtonDismiss({ onClick, ariaLabel }: ButtonDismissProps) {
+export function ButtonDismiss({
+  onClick,
+  ariaLabel,
+  size,
+}: ButtonDismissProps) {
   return (
     <div className={styles.closeButtonWrapper}>
       <Button
         ariaLabel={ariaLabel}
         icon="remove"
+        size={size}
         onClick={onClick}
         type="tertiary"
         variation="cancel"

--- a/packages/components/src/InlineLabel/InlineLabel.css
+++ b/packages/components/src/InlineLabel/InlineLabel.css
@@ -1,7 +1,7 @@
 .inlineLabel {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-smallest);
+  gap: var(--space-smaller);
   border-radius: var(--radius-large);
 }
 

--- a/packages/components/src/InlineLabel/InlineLabel.css
+++ b/packages/components/src/InlineLabel/InlineLabel.css
@@ -1,5 +1,7 @@
 .inlineLabel {
   display: inline-flex;
+  align-items: center;
+  gap: var(--space-smallest);
   border-radius: var(--radius-large);
 }
 

--- a/packages/components/src/InlineLabel/InlineLabel.mdx
+++ b/packages/components/src/InlineLabel/InlineLabel.mdx
@@ -46,6 +46,18 @@ descriptive label can help the user understand the meaning of an item's status.
 
 ---
 
+## Dismissable
+
+<Playground>
+  <InlineLabel
+    dismissable={true}
+    dismissAriaLabel="Remove Label"
+    onDismiss={() => alert("🗑 item dismissed!")}
+  >
+    Beta
+  </InlineLabel>
+</Playground>
+
 ## Sizes
 
 ### Large

--- a/packages/components/src/InlineLabel/InlineLabel.mdx
+++ b/packages/components/src/InlineLabel/InlineLabel.mdx
@@ -50,7 +50,6 @@ descriptive label can help the user understand the meaning of an item's status.
 
 <Playground>
   <InlineLabel
-    dismissable={true}
     dismissAriaLabel="Remove Label"
     onDismiss={() => alert("🗑 item dismissed!")}
   >

--- a/packages/components/src/InlineLabel/InlineLabel.test.tsx
+++ b/packages/components/src/InlineLabel/InlineLabel.test.tsx
@@ -1,18 +1,42 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { InlineLabel } from ".";
 
-it("renders correctly", () => {
-  const tree = renderer.create(<InlineLabel>My Label</InlineLabel>).toJSON();
-  expect(tree).toMatchInlineSnapshot(`
-    <span
-      className="inlineLabel base greyBlue"
-    >
-      <span
-        className="base regular small uppercase"
+afterEach(cleanup);
+
+describe("Basic InlineLabel", () => {
+  it("renders correctly", () => {
+    const { container } = render(<InlineLabel>My Label</InlineLabel>);
+    expect(container).toMatchSnapshot();
+  });
+});
+
+describe("Dismissable InlineLabel", () => {
+  it("renders correctly", () => {
+    const { container } = render(
+      <InlineLabel
+        dismissable
+        dismissAriaLabel="Remove Label"
+        onDismiss={jest.fn()}
       >
         My Label
-      </span>
-    </span>
-  `);
+      </InlineLabel>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it("triggers onDismiss", () => {
+    const onDismissFn = jest.fn();
+    const { getByLabelText } = render(
+      <InlineLabel
+        dismissable
+        dismissAriaLabel="Remove Label"
+        onDismiss={onDismissFn}
+      >
+        My Label
+      </InlineLabel>,
+    );
+    fireEvent.click(getByLabelText("Remove Label"));
+    expect(onDismissFn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/components/src/InlineLabel/InlineLabel.test.tsx
+++ b/packages/components/src/InlineLabel/InlineLabel.test.tsx
@@ -14,11 +14,7 @@ describe("Basic InlineLabel", () => {
 describe("Dismissable InlineLabel", () => {
   it("renders correctly", () => {
     const { container } = render(
-      <InlineLabel
-        dismissable
-        dismissAriaLabel="Remove Label"
-        onDismiss={jest.fn()}
-      >
+      <InlineLabel dismissAriaLabel="Remove Label" onDismiss={jest.fn()}>
         My Label
       </InlineLabel>,
     );
@@ -28,11 +24,7 @@ describe("Dismissable InlineLabel", () => {
   it("triggers onDismiss", () => {
     const onDismissFn = jest.fn();
     const { getByLabelText } = render(
-      <InlineLabel
-        dismissable
-        dismissAriaLabel="Remove Label"
-        onDismiss={onDismissFn}
-      >
+      <InlineLabel dismissAriaLabel="Remove Label" onDismiss={onDismissFn}>
         My Label
       </InlineLabel>,
     );

--- a/packages/components/src/InlineLabel/InlineLabel.tsx
+++ b/packages/components/src/InlineLabel/InlineLabel.tsx
@@ -1,7 +1,9 @@
 import React, { ReactNode } from "react";
+import { XOR } from "ts-xor";
 import classnames from "classnames";
 import styles from "./InlineLabel.css";
 import { Typography } from "../Typography";
+import { ButtonDismiss } from "../ButtonDismiss";
 
 export type InlineLabelColors =
   | "greyBlue"
@@ -19,7 +21,7 @@ export type InlineLabelColors =
   | "lightBlue"
   | "indigo";
 
-interface InlineLabelProps {
+interface BaseInlineLabelProps {
   /**
    * The size of the label
    * @default base
@@ -33,6 +35,14 @@ interface InlineLabelProps {
   children: ReactNode;
 }
 
+interface DismissableInlineLabelProps extends BaseInlineLabelProps {
+  dismissable: boolean;
+  dismissAriaLabel: string;
+  onDismiss(): void;
+}
+
+type InlineLabelProps = XOR<BaseInlineLabelProps, DismissableInlineLabelProps>;
+
 interface SizeMapProps {
   [key: string]: "small" | "base" | "large";
 }
@@ -41,6 +51,9 @@ export function InlineLabel({
   size = "base",
   color = "greyBlue",
   children,
+  dismissable = false,
+  dismissAriaLabel,
+  onDismiss,
 }: InlineLabelProps) {
   const className = classnames(styles.inlineLabel, styles[size], styles[color]);
 
@@ -55,6 +68,15 @@ export function InlineLabel({
       <Typography element="span" size={sizeMapper[size]} textCase="uppercase">
         {children}
       </Typography>
+      {dismissable && (
+        <ButtonDismiss
+          onClick={() => {
+            onDismiss && onDismiss();
+          }}
+          ariaLabel={dismissAriaLabel || ""}
+          size="small"
+        />
+      )}
     </span>
   );
 }

--- a/packages/components/src/InlineLabel/InlineLabel.tsx
+++ b/packages/components/src/InlineLabel/InlineLabel.tsx
@@ -36,7 +36,6 @@ interface BaseInlineLabelProps {
 }
 
 interface DismissableInlineLabelProps extends BaseInlineLabelProps {
-  dismissable: boolean;
   dismissAriaLabel: string;
   onDismiss(): void;
 }
@@ -51,11 +50,11 @@ export function InlineLabel({
   size = "base",
   color = "greyBlue",
   children,
-  dismissable = false,
   dismissAriaLabel,
   onDismiss,
 }: InlineLabelProps) {
   const className = classnames(styles.inlineLabel, styles[size], styles[color]);
+  const dismissable = onDismiss != undefined;
 
   const sizeMapper: SizeMapProps = {
     base: "small",

--- a/packages/components/src/InlineLabel/__snapshots__/InlineLabel.test.tsx.snap
+++ b/packages/components/src/InlineLabel/__snapshots__/InlineLabel.test.tsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Basic InlineLabel renders correctly 1`] = `
+<div>
+  <span
+    class="inlineLabel base greyBlue"
+  >
+    <span
+      class="base regular small uppercase"
+    >
+      My Label
+    </span>
+  </span>
+</div>
+`;
+
+exports[`Dismissable InlineLabel renders correctly 1`] = `
+<div>
+  <span
+    class="inlineLabel base greyBlue"
+  >
+    <span
+      class="base regular small uppercase"
+    >
+      My Label
+    </span>
+    <div
+      class="closeButtonWrapper"
+    >
+      <button
+        aria-label="Remove Label"
+        class="button small onlyIcon cancel tertiary"
+        type="button"
+      >
+        <svg
+          class="ZDlJU6tECg7ouG-b27gya _isfJqqskSRqop8TStvGA"
+          data-testid="remove"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            class=""
+            d="M512 451.669l-225.835-225.835c-8.047-7.772-18.825-12.073-30.012-11.976s-21.888 4.585-29.799 12.495c-7.911 7.911-12.398 18.612-12.495 29.799s4.204 21.964 11.976 30.012l225.835 225.835-225.835 225.835c-7.772 8.047-12.073 18.825-11.976 30.012s4.585 21.888 12.495 29.798c7.91 7.91 18.612 12.399 29.799 12.497s21.965-4.203 30.012-11.977l225.835-225.835 225.835 225.835c8.047 7.774 18.825 12.075 30.012 11.977s21.888-4.587 29.798-12.497c7.91-7.91 12.399-18.611 12.497-29.798 0.094-11.187-4.203-21.965-11.977-30.012l-225.835-225.835 225.835-225.835c4.075-3.936 7.326-8.644 9.562-13.85s3.413-10.804 3.46-16.469c0.051-5.665-1.028-11.284-3.174-16.527s-5.312-10.007-9.318-14.013c-4.006-4.006-8.772-7.174-14.016-9.319-5.239-2.146-10.859-3.225-16.525-3.176s-11.264 1.226-16.469 3.462c-5.205 2.236-9.916 5.487-13.85 9.562l-225.835 225.835z"
+          />
+        </svg>
+        <span
+          class="base extraBold smaller uppercase"
+        />
+      </button>
+    </div>
+  </span>
+</div>
+`;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

`InlineLabel`'s seem like usage would be for tags to display status or select categories and feels appropriate to be able to dismiss selections. I would particularly be interested in having dismissible available so that a multi-select (either select or autocomplete) can use these to display selected values.

![image](https://user-images.githubusercontent.com/80279872/131396178-fd18c03f-4ca6-4c56-85c4-75a061c4c912.png)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added ability to configure a dismiss action for inline labels

## Testing

- See markdown document for `<InlineLabel />` and configure an `onDimiss` function which will show the dismissible button

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
