### PR TITLE
feat(design): Update surface reverse color

### DIFF
--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -5,6 +5,8 @@ route: /colors
 ---
 
 import { ColorSwatches } from "@jobber/docx";
+import { ColorSwatches as Swatch } from "@jobber/docz-tools";
+
 import colors from "../colors";
 
 # Colors
@@ -33,36 +35,13 @@ readability.
 
 #### Heading
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  background-color:var(--color-heading)"
-></div>
-
-`--color-heading`
+<Swatch colors={[`--color-heading`]} />
 
 Headings have a bold, high-contrast color to cement their hierarchy.
 
 #### Text
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-text)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-text--secondary)"
-  ></div>
-</div>
-
-`--color-text` | `--color-text--secondary`
+<Swatch colors={[`--color-text`, "--color-text--secondary"]} />
 
 A slightly softer color is used for body text for greater readability.
 
@@ -72,25 +51,9 @@ more important text content already present.
 
 ##### Text--Reverse
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;
-  box-shadow:var(--shadow-base);"
->
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-text--reverse)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-text--reverse--secondary)"
-  ></div>
-</div>
-
-`--color-text--reverse` | `--color-text--reverse--secondary`
+<Swatch
+  colors={[`--color-text--reverse`, "--color-text--reverse--secondary"]}
+/>
 
 When used against a [reversed surface](#surface--reverse), reversed text should
 be used to maintain readability.
@@ -110,94 +73,26 @@ currently tied our interactive color to our brand color._
 
 #### Interactive
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="width:100%;
-    height:var(--space-extravagant);
-    background-color:var(--color-interactive)"
-  ></div>
-  <div
-    style="width:100%;
-    height:var(--space-extravagant);
-    background-color:var(--color-interactive--hover)"
-  ></div>
-</div>
-
-`--color-interactive` | `--color-interactive--hover`
+<Swatch colors={[`--color-interactive`, "--color-interactive--hover"]} />
 
 The default color used for interactive elements.
 
 #### Destructive
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="width:100%;
-    height:var(--space-extravagant);
-    background-color:var(--color-destructive)"
-  ></div>
-  <div
-    style="width:100%;
-    height:var(--space-extravagant);
-    background-color:var(--color-destructive--hover)"
-  ></div>
-</div>
-
-`--color-destructive` | `--color-destructive--hover`
+<Swatch colors={[`--color-destructive`, "--color-destructive--hover"]} />
 
 Use to signify that an interaction will destroy something in the users’ account
 or workflow.
 
 #### Cancel
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="width:100%;
-    height:var(--space-extravagant);
-    background-color:var(--color-cancel)"
-  ></div>
-  <div
-    style="width:100%;
-    height:var(--space-extravagant);
-    background-color:var(--color-cancel--hover)"
-  ></div>
-</div>
-
-`--color-cancel` | `--color-cancel--hover`
+<Swatch colors={[`--color-cancel`, "--color-cancel--hover"]} />
 
 Use to signify that an interaction will cancel or exit a workflow.
 
 #### Disabled
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="width:100%;
-    height:var(--space-extravagant);
-    background-color:var(--color-disabled)"
-  ></div>
-  <div
-    style="width:100%;
-    height:var(--space-extravagant);
-    background-color:var(--color-disabled--secondary)"
-  ></div>
-</div>
-
-`--color-disabled` | `--color-disabled--secondary`
+<Swatch colors={[`--color-disabled`, "--color-disabled--secondary"]} />
 
 Use to signify that an interactive element is disabled.
 
@@ -231,142 +126,61 @@ sufficient color contrast.
 
 #### Critical
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-critical)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-critical--surface)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-critical--onSurface)"
-  ></div>
-</div>
-
-`--color-critical` | `--color-critical--surface` | `--color-critical--onSurface`
+<Swatch
+  colors={[
+    "--color-critical",
+    "--color-critical--surface",
+    "--color-critical--onSurface",
+  ]}
+/>
 
 Action required; user must see this status to be unblocked.
 
 #### Warning
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-warning)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-warning--surface)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-warning--onSurface)"
-  ></div>
-</div>
-
-`--color-warning` | `--color-warning--surface` | `--color-warning--onSurface`
+<Swatch
+  colors={[
+    "--color-warning",
+    "--color-warning--surface",
+    "--color-warning--onSurface",
+  ]}
+/>
 
 Action _may_ be required as a consequence of current state.
 
 #### Success
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-success)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-success--surface)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-success--onSurface)"
-  ></div>
-</div>
-
-`--color-success` | `--color-success--surface` | `--color-success--onSurface`
+<Swatch
+  colors={[
+    "--color-success",
+    "--color-success--surface",
+    "--color-success--onSurface",
+  ]}
+/>
 
 No action required; an action has completed successfully.
 
 #### Informative
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-informative)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-informative--surface)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-informative--onSurface)"
-  ></div>
-</div>
-
-`--color-informative` | `--color-informative--surface` |
-`--color-informative--onSurface`
+<Swatch
+  colors={[
+    "--color-informative",
+    "--color-informative--surface",
+    "--color-informative--onSurface",
+  ]}
+/>
 
 No action required; but helpful to know about.
 
 #### Inactive
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;"
->
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-inactive)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-inactive--surface)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-inactive--onSurface)"
-  ></div>
-</div>
-
-`--color-inactive` | `--color-inactive--surface` | `--color-inactive--onSurface`
+<Swatch
+  colors={[
+    "--color-inactive",
+    "--color-inactive--surface",
+    "--color-inactive--onSurface",
+  ]}
+/>
 
 No action required; not part of an active workflow.
 
@@ -378,30 +192,13 @@ focus.
 
 #### Surface
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  display:flex;
-  box-shadow: var(--shadow-base)"
->
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-surface)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-surface--hover)"
-  ></div>
-  <div
-    style="flex: 1;
-    height:var(--space-extravagant);
-    background-color:var(--color-surface--active)"
-  ></div>
-</div>
-
-`--color-surface` | `--color-surface--hover` | `--color-surface--active`
+<Swatch
+  colors={[
+    "--color-surface",
+    "--color-surface--hover",
+    "--color-surface--active",
+  ]}
+/>
 
 Most elements in Jobber have a light surface to indicate their nearness to the
 user; if interactive, they have a hover color and an active color to indicate
@@ -409,38 +206,20 @@ state.
 
 #### Surface--Background
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  background-color:var(--color-surface--background);"
-></div>
-
-`--color-surface--background`
+<Swatch colors={["--color-surface--background"]} />
 
 A slightly darker surface gives a receded appearance relative to main surfaces.
 
 #### Surface--Reverse
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  background-color:var(--color-surface--reverse);"
-></div>
-
-`--color-surface--reverse`
+<Swatch colors={["--color-surface--reverse"]} />
 
 Use a reversed surface when a strong contrast is needed with the rest of the
 application.
 
 #### Overlay
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  background-color:var(--color-overlay);"
-></div>
-
-`--color-overlay`
+<Swatch colors={["--color-overlay"]} />
 
 Use to mask an area of the interface to promote focus to a foreground action,
 such as a [Modal](/components/modal)’s appearance. Overlay includes built-in
@@ -448,14 +227,7 @@ opacity values.
 
 #### Overlay--Dimmed
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  background-color:var(--color-overlay--dimmed);
-  box-shadow: var(--shadow-base);"
-></div>
-
-`--color-overlay--dimmed`
+<Swatch colors={["--color-overlay--dimmed"]} />
 
 A transparent version of [Surface](#surface), this masks an area of the
 interface to indicate inactivity (i.e. waiting for updates). Overlay--Dimmed
@@ -500,26 +272,14 @@ Use these colors to represent the Jobber brand visual language.
 
 #### Brand
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  background-color:var(--color-brand);"
-></div>
-
-`--color-brand`
+<Swatch colors={["--color-brand"]} />
 
 The primary color associated with our brand, from website to ads to product; AKA
 “Jobber Green”.
 
 #### Brand--Highlight
 
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  background-color:var(--color-brand--highlight);"
-></div>
-
-`--color-brand--highlight`
+<Swatch colors={["--color-brand--highlight"]} />
 
 Use to highlight an element in a way that aligns with our website. Use with
 caution, it’s _bright!_

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -39,6 +39,8 @@ readability.
   background-color:var(--color-heading)"
 ></div>
 
+`--color-heading`
+
 Headings have a bold, high-contrast color to cement their hierarchy.
 
 #### Text
@@ -46,24 +48,57 @@ Headings have a bold, high-contrast color to cement their hierarchy.
 <div
   style="width:100%;
   height:var(--space-extravagant);
-  background-color:var(--color-text)"
-></div>
+  display:flex;"
+>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-text)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-text--secondary)"
+  ></div>
+</div>
+
+`--color-text` | `--color-text--secondary`
 
 A slightly softer color is used for body text for greater readability.
 
-##### Text--Secondary
+Text that is relevant but less important ("secondary") can be lower-contrast to
+suggest its’ reduced importance. This color should only be used when there is
+more important text content already present.
+
+##### Text--Reverse
 
 <div
   style="width:100%;
   height:var(--space-extravagant);
-  background-color:var(--color-text--secondary)"
-></div>
+  display:flex;
+  box-shadow:var(--shadow-base);"
+>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-text--reverse)"
+  ></div>
+  <div
+    style="flex: 1;
+    height:var(--space-extravagant);
+    background-color:var(--color-text--reverse--secondary)"
+  ></div>
+</div>
 
-Text that is relevant but less important can be lower-contrast to suggest its’
-reduced importance. This color should only be used when there is more important
-text content already present.
+`--color-text--reverse` | `--color-text--reverse--secondary`
 
-### Interactive
+When used against a [reversed surface](#surface--reverse), reversed text should
+be used to maintain readability.
+
+Reverse text also has a secondary value following the same rules outlined for
+standard secondary text.
+
+### Interactions
 
 Use these colors in buttons and form controls to communicate the presence and
 meaning of interaction. In cases such as [Buttons](/components/button) where the
@@ -78,8 +113,21 @@ currently tied our interactive color to our brand color._
 <div
   style="width:100%;
   height:var(--space-extravagant);
-  background-color:var(--color-interactive)"
-></div>
+  display:flex;"
+>
+  <div
+    style="width:100%;
+    height:var(--space-extravagant);
+    background-color:var(--color-interactive)"
+  ></div>
+  <div
+    style="width:100%;
+    height:var(--space-extravagant);
+    background-color:var(--color-interactive--hover)"
+  ></div>
+</div>
+
+`--color-interactive` | `--color-interactive--hover`
 
 The default color used for interactive elements.
 
@@ -88,8 +136,21 @@ The default color used for interactive elements.
 <div
   style="width:100%;
   height:var(--space-extravagant);
-  background-color:var(--color-destructive)"
-></div>
+  display:flex;"
+>
+  <div
+    style="width:100%;
+    height:var(--space-extravagant);
+    background-color:var(--color-destructive)"
+  ></div>
+  <div
+    style="width:100%;
+    height:var(--space-extravagant);
+    background-color:var(--color-destructive--hover)"
+  ></div>
+</div>
+
+`--color-destructive` | `--color-destructive--hover`
 
 Use to signify that an interaction will destroy something in the users’ account
 or workflow.
@@ -99,31 +160,49 @@ or workflow.
 <div
   style="width:100%;
   height:var(--space-extravagant);
-  background-color:var(--color-cancel)"
-></div>
+  display:flex;"
+>
+  <div
+    style="width:100%;
+    height:var(--space-extravagant);
+    background-color:var(--color-cancel)"
+  ></div>
+  <div
+    style="width:100%;
+    height:var(--space-extravagant);
+    background-color:var(--color-cancel--hover)"
+  ></div>
+</div>
 
-Use to signify that an interaction will cancel or exit a workflow
+`--color-cancel` | `--color-cancel--hover`
+
+Use to signify that an interaction will cancel or exit a workflow.
 
 #### Disabled
 
 <div
   style="width:100%;
   height:var(--space-extravagant);
-  background-color:var(--color-disabled)"
-></div>
+  display:flex;"
+>
+  <div
+    style="width:100%;
+    height:var(--space-extravagant);
+    background-color:var(--color-disabled)"
+  ></div>
+  <div
+    style="width:100%;
+    height:var(--space-extravagant);
+    background-color:var(--color-disabled--secondary)"
+  ></div>
+</div>
+
+`--color-disabled` | `--color-disabled--secondary`
 
 Use to signify that an interactive element is disabled.
 
-##### Disabled--Secondary
-
-<div
-  style="width:100%;
-  height:var(--space-extravagant);
-  background-color:var(--color-disabled--secondary)"
-></div>
-
-Use when a disabled element needs more than one color to be readable in a
-disabled state; for example, a button's background and label colors must be
+Use `secondary` when a disabled element needs more than one color to be readable
+in a disabled state; for example, a button's background and label colors must be
 different.
 
 #### Focus
@@ -134,6 +213,8 @@ different.
   background-color:var(--color-surface);
   box-shadow:var(--shadow-focus);"
 ></div>
+
+`--color-focus`
 
 Use to indicate that an element has been focused (ideally using the
 `--shadow-focus` property).
@@ -172,6 +253,8 @@ sufficient color contrast.
   ></div>
 </div>
 
+`--color-critical` | `--color-critical--surface` | `--color-critical--onSurface`
+
 Action required; user must see this status to be unblocked.
 
 #### Warning
@@ -197,6 +280,8 @@ Action required; user must see this status to be unblocked.
     background-color:var(--color-warning--onSurface)"
   ></div>
 </div>
+
+`--color-warning` | `--color-warning--surface` | `--color-warning--onSurface`
 
 Action _may_ be required as a consequence of current state.
 
@@ -224,6 +309,8 @@ Action _may_ be required as a consequence of current state.
   ></div>
 </div>
 
+`--color-success` | `--color-success--surface` | `--color-success--onSurface`
+
 No action required; an action has completed successfully.
 
 #### Informative
@@ -250,6 +337,9 @@ No action required; an action has completed successfully.
   ></div>
 </div>
 
+`--color-informative` | `--color-informative--surface` |
+`--color-informative--onSurface`
+
 No action required; but helpful to know about.
 
 #### Inactive
@@ -275,6 +365,8 @@ No action required; but helpful to know about.
     background-color:var(--color-inactive--onSurface)"
   ></div>
 </div>
+
+`--color-inactive` | `--color-inactive--surface` | `--color-inactive--onSurface`
 
 No action required; not part of an active workflow.
 
@@ -309,6 +401,8 @@ focus.
   ></div>
 </div>
 
+`--color-surface` | `--color-surface--hover` | `--color-surface--active`
+
 Most elements in Jobber have a light surface to indicate their nearness to the
 user; if interactive, they have a hover color and an active color to indicate
 state.
@@ -321,6 +415,8 @@ state.
   background-color:var(--color-surface--background);"
 ></div>
 
+`--color-surface--background`
+
 A slightly darker surface gives a receded appearance relative to main surfaces.
 
 #### Surface--Reverse
@@ -331,8 +427,10 @@ A slightly darker surface gives a receded appearance relative to main surfaces.
   background-color:var(--color-surface--reverse);"
 ></div>
 
-When a strong contrast is needed with the rest of the application, a reversed
-surface can be used.
+`--color-surface--reverse`
+
+Use a reversed surface when a strong contrast is needed with the rest of the
+application.
 
 #### Overlay
 
@@ -341,6 +439,8 @@ surface can be used.
   height:var(--space-extravagant);
   background-color:var(--color-overlay);"
 ></div>
+
+`--color-overlay`
 
 Use to mask an area of the interface to promote focus to a foreground action,
 such as a [Modal](/components/modal)’s appearance. Overlay includes built-in
@@ -355,9 +455,11 @@ opacity values.
   box-shadow: var(--shadow-base);"
 ></div>
 
-A transparent version of [Surface](#surface), this masks an area of the nterface
-to indicate inactivity (i.e. waiting for updates). Overlay--Dimmed includes
-built-in opacity values.
+`--color-overlay--dimmed`
+
+A transparent version of [Surface](#surface), this masks an area of the
+interface to indicate inactivity (i.e. waiting for updates). Overlay--Dimmed
+includes built-in opacity values.
 
 ### Borders
 
@@ -374,6 +476,8 @@ the subtle maintainers of layout structure. Learn more about borders in our
   border: var(--border-base) solid var(--color-border)"
 ></div>
 
+`--color-border`
+
 Most borders should use `--color-border` for subtle definition.
 
 #### Border--Section
@@ -384,6 +488,8 @@ Most borders should use `--color-border` for subtle definition.
   background-color:var(--color-surface);
   border: var(--border-base) solid var(--color-border--section)"
 ></div>
+
+`--color-border--section`
 
 Use `--color-border--section` where other bordered content is being further
 sectioned, such as table headers or list sections.
@@ -400,6 +506,8 @@ Use these colors to represent the Jobber brand visual language.
   background-color:var(--color-brand);"
 ></div>
 
+`--color-brand`
+
 The primary color associated with our brand, from website to ads to product; AKA
 “Jobber Green”.
 
@@ -410,6 +518,8 @@ The primary color associated with our brand, from website to ads to product; AKA
   height:var(--space-extravagant);
   background-color:var(--color-brand--highlight);"
 ></div>
+
+`--color-brand--highlight`
 
 Use to highlight an element in a way that aligns with our website. Use with
 caution, it’s _bright!_

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -53,8 +53,8 @@
   --color-border: var(--color-grey--lighter);
   --color-border--section: var(--color-blue);
 
-  --color-overlay: rgba(var(--color--greyBlue--rgb), 0.8);
-  --color-overlay--dimmed: rgba(var(--color--white--rgb), 0.6);
+  --color-overlay: rgba(var(--color-greyBlue--rgb), 0.8);
+  --color-overlay--dimmed: rgba(var(--color-white--rgb), 0.6);
 
   /* Brand */
   --color-brand: var(--color-green);
@@ -112,8 +112,8 @@
   --color-grey--lightest: rgb(244, 244, 244);
   --color-grey--dark: rgb(118, 118, 118);
 
-  --color--greyBlue--rgb: 101, 120, 132;
-  --color-greyBlue: rgb(var(--color--greyBlue--rgb));
+  --color-greyBlue--rgb: 101, 120, 132;
+  --color-greyBlue: rgb(var(--color-greyBlue--rgb));
   --color-greyBlue--light: rgb(147, 161, 169);
   --color-greyBlue--lighter: rgb(193, 201, 206);
   --color-greyBlue--lightest: rgb(232, 235, 237);

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -40,19 +40,21 @@
   --color-heading: var(--color-blue);
   --color-text: var(--color-greyBlue--dark);
   --color-text--secondary: var(--color-greyBlue);
+  --color-text--reverse: var(--color-white);
+  --color-text--reverse--secondary: var(--color-greyBlue--lighter);
 
   /* Surfaces and Borders */
   --color-surface: var(--color-white);
   --color-surface--hover: var(--color-yellow--lightest);
   --color-surface--active: var(--color-green--lightest);
   --color-surface--background: var(--color-grey--lightest);
-  --color-surface--reverse: var(--color-greyBlue--dark);
+  --color-surface--reverse: var(--color-blue);
 
   --color-border: var(--color-grey--lighter);
   --color-border--section: var(--color-blue);
 
-  --color-overlay: rgba(var(--color-greyBlue--rgb), 0.8);
-  --color-overlay--dimmed: rgba(var(--color-white--rgb), 0.6);
+  --color-overlay: rgba(var(--color--greyBlue--rgb), 0.8);
+  --color-overlay--dimmed: rgba(var(--color--white--rgb), 0.6);
 
   /* Brand */
   --color-brand: var(--color-green);
@@ -110,8 +112,8 @@
   --color-grey--lightest: rgb(244, 244, 244);
   --color-grey--dark: rgb(118, 118, 118);
 
-  --color-greyBlue--rgb: 101, 120, 132;
-  --color-greyBlue: rgb(var(--color-greyBlue--rgb));
+  --color--greyBlue--rgb: 101, 120, 132;
+  --color-greyBlue: rgb(var(--color--greyBlue--rgb));
   --color-greyBlue--light: rgb(147, 161, 169);
   --color-greyBlue--lighter: rgb(193, 201, 206);
   --color-greyBlue--lightest: rgb(232, 235, 237);

--- a/packages/docz-tools/index.ts
+++ b/packages/docz-tools/index.ts
@@ -5,3 +5,4 @@
 
 export { DoczTOC } from "./components/DoczTOC";
 export { PullRequestGenerator } from "./src/gatsby-theme-docz/components/PullRequestGenerator";
+export { ColorSwatches } from "./src/components/ColorSwatches";

--- a/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.module.css
+++ b/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.module.css
@@ -9,8 +9,15 @@
 }
 
 .swatch {
+  position: relative;
   height: var(--space-extravagant);
   margin-bottom: var(--space-small);
+}
+
+.button {
+  position: absolute;
+  top: var(--space-smaller);
+  right: var(--space-smaller);
 }
 
 .pre {
@@ -18,6 +25,6 @@
   margin: 0 0 var(--space-smaller);
   padding: var(--space-smallest) var(--space-small);
   border-radius: var(--radius-base);
-  font-size: var(--typography--fontSize-base);
+  font-size: var(--typography--fontSize-small);
   background: var(--color-surface--background);
 }

--- a/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.module.css
+++ b/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.module.css
@@ -1,0 +1,23 @@
+.colorbar {
+  display: flex;
+  width: 100%;
+}
+
+.color {
+  flex: 1;
+  text-align: center;
+}
+
+.swatch {
+  height: var(--space-extravagant);
+  margin-bottom: var(--space-small);
+}
+
+.pre {
+  display: inline-block;
+  margin: 0 0 var(--space-smaller);
+  padding: var(--space-smallest) var(--space-small);
+  border-radius: var(--radius-base);
+  font-size: var(--typography--fontSize-base);
+  background: var(--color-surface--background);
+}

--- a/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.module.css.d.ts
+++ b/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.module.css.d.ts
@@ -1,4 +1,5 @@
 export const colorbar: string;
 export const color: string;
 export const swatch: string;
+export const button: string;
 export const pre: string;

--- a/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.module.css.d.ts
+++ b/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.module.css.d.ts
@@ -1,0 +1,4 @@
+export const colorbar: string;
+export const color: string;
+export const swatch: string;
+export const pre: string;

--- a/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.tsx
+++ b/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import copy from "copy-text-to-clipboard";
+import { Button } from "@jobber/components/Button";
+import { showToast } from "@jobber/components/Toast";
+import styles from "./ColorSwatches.module.css";
+
+interface ColorSwatchesProps {
+  readonly colors: string[];
+}
+
+export function ColorSwatches({ colors }: ColorSwatchesProps) {
+  return (
+    <div className={styles.colorbar}>
+      {colors.map(color => (
+        <Color key={color} color={color} />
+      ))}
+    </div>
+  );
+}
+
+interface ColorProps {
+  readonly color: string;
+}
+
+function Color({ color }: ColorProps) {
+  const style = {
+    backgroundColor: `var(${color})`,
+  };
+  return (
+    <div className={styles.color}>
+      <div key={color} style={style} className={styles.swatch} />
+      <pre className={styles.pre}>{color}</pre>
+      <Button
+        size="small"
+        label="Copy to clipboard"
+        type="tertiary"
+        onClick={handleClick}
+      />
+    </div>
+  );
+
+  function handleClick() {
+    copy(`var(${color})`);
+    showToast({
+      message: `Color ${color} copied to clipboard`,
+    });
+  }
+}

--- a/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.tsx
+++ b/packages/docz-tools/src/components/ColorSwatches/ColorSwatches.tsx
@@ -11,7 +11,7 @@ interface ColorSwatchesProps {
 export function ColorSwatches({ colors }: ColorSwatchesProps) {
   return (
     <div className={styles.colorbar}>
-      {colors.map(color => (
+      {colors.map((color: string) => (
         <Color key={color} color={color} />
       ))}
     </div>
@@ -23,19 +23,26 @@ interface ColorProps {
 }
 
 function Color({ color }: ColorProps) {
+  const colorsWithBorders = [
+    "--color-overlay--dimmed",
+    "--color-surface",
+    "--color-text--reverse",
+  ];
   const style = {
     backgroundColor: `var(${color})`,
+    border: colorsWithBorders.includes(color)
+      ? "1px solid var(--color-border)"
+      : undefined,
   };
+
   return (
     <div className={styles.color}>
-      <div key={color} style={style} className={styles.swatch} />
+      <div key={color} style={style} className={styles.swatch}>
+        <div className={styles.button}>
+          <Button size="small" icon="copy" onClick={handleClick} />
+        </div>
+      </div>
       <pre className={styles.pre}>{color}</pre>
-      <Button
-        size="small"
-        label="Copy to clipboard"
-        type="tertiary"
-        onClick={handleClick}
-      />
     </div>
   );
 

--- a/packages/docz-tools/src/components/ColorSwatches/index.ts
+++ b/packages/docz-tools/src/components/ColorSwatches/index.ts
@@ -1,0 +1,1 @@
+export { ColorSwatches } from "./ColorSwatches";


### PR DESCRIPTION
## Motivations

@chriscarline did some work that redefines what our "reverse" surface is, so this is being reflected in our design system.

Further, the existence of a reverse surface implies the existence of reversed text, which makes sense.

Note: this is a scoped-down version of: https://github.com/GetJobber/atlantis/pull/595 in which I had also updated several components and Atlantis' layout. This PR is scoped to the colors themselves and the new docs.

## Changes

Surface reverse is now based on `--color-blue`

### Added

- `--color-text--reverse` and `--color-text--reverse--secondary` added to color system and docs

### Changed

- Improved swatch presentation for semantic values; readers of the docs can now copy the color swatch while reading the docs, rather than inspecting the DOM to copy and paste the values.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
