### PR TITLE
fix(hooks): update exports to include usePasswordStrength 

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -3,3 +3,4 @@ export * from "./useFormState";
 export * from "./useOnKeyDown";
 export * from "./useCollectionQuery";
 export * from "./useIsMounted";
+export * from "./usePasswordStrength";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Can't import `usePasswordStrength` as I had forgotten to export it from the base index file, it is still technically importable via `dist/usePasswordStrength`, however is not best, also is not how the markdown document says to import it.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Exported the `usePasswordStrength`, so you don't have to import via `dist/usePasswordStrength`, similar to other hooks.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
