### PR TITLE
feat(components): Add `event` argument to onClick events

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -159,7 +159,9 @@ Want help with your pull request title? We have a
 
 ##### Requesting review
 
-To request a review from Atlantis maintainers, use [Github's review tool](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review) and request from review from `GetJobber/McWeb`.
+To request a review from Atlantis maintainers, use
+[Github's review tool](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review)
+and request from review from `GetJobber/McWeb`.
 
 ## Guiding Principles
 

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -27,7 +27,7 @@ interface ButtonFoundationProps {
   readonly label?: string;
   readonly loading?: boolean;
   readonly size?: "small" | "base" | "large";
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<HTMLElement>): void;
 }
 
 interface ButtonIconProps extends ButtonFoundationProps {

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -27,7 +27,9 @@ interface ButtonFoundationProps {
   readonly label?: string;
   readonly loading?: boolean;
   readonly size?: "small" | "base" | "large";
-  onClick?(event: React.MouseEvent<HTMLElement>): void;
+  onClick?(
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ): void;
 }
 
 interface ButtonIconProps extends ButtonFoundationProps {

--- a/packages/components/src/ButtonDismiss/ButtonDismiss.tsx
+++ b/packages/components/src/ButtonDismiss/ButtonDismiss.tsx
@@ -3,7 +3,7 @@ import styles from "./ButtonDismiss.css";
 import { Button } from "../Button";
 
 interface ButtonDismissProps {
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<HTMLElement>): void;
   ariaLabel: string;
 }
 

--- a/packages/components/src/ButtonDismiss/ButtonDismiss.tsx
+++ b/packages/components/src/ButtonDismiss/ButtonDismiss.tsx
@@ -3,7 +3,9 @@ import styles from "./ButtonDismiss.css";
 import { Button } from "../Button";
 
 interface ButtonDismissProps {
-  onClick?(event: React.MouseEvent<HTMLElement>): void;
+  onClick?(
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ): void;
   ariaLabel: string;
 }
 

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -24,7 +24,7 @@ interface LinkCardProps extends CardProps {
 }
 
 interface ClickableCardProps extends CardProps {
-  onClick(event: React.MouseEvent<HTMLElement>): void;
+  onClick(event: React.MouseEvent<HTMLAnchorElement | HTMLDivElement>): void;
 }
 
 type CardPropOptions = XOR<CardProps, XOR<LinkCardProps, ClickableCardProps>>;
@@ -48,7 +48,7 @@ export function Card({
     href?: string;
     role?: "button";
     tabIndex?: 0;
-    onClick?(event: React.MouseEvent<HTMLElement>): void;
+    onClick?(event: React.MouseEvent<HTMLAnchorElement | HTMLDivElement>): void;
   }
 
   const Tag = url ? "a" : "div";

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -68,7 +68,7 @@ export interface ListItemProps {
   /**
    * Callback when a list item gets clicked.
    */
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<HTMLElement>): void;
 }
 
 export function ListItem({

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -68,7 +68,9 @@ export interface ListItemProps {
   /**
    * Callback when a list item gets clicked.
    */
-  onClick?(event: React.MouseEvent<HTMLElement>): void;
+  onClick?(
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ): void;
 }
 
 export function ListItem({

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -207,7 +207,7 @@ export interface ActionProps {
   /**
    * Callback when an action gets clicked
    */
-  onClick?(event: React.MouseEvent<HTMLElement>): void;
+  onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
 }
 
 function Action({ label, icon, onClick }: ActionProps) {

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -207,7 +207,7 @@ export interface ActionProps {
   /**
    * Callback when an action gets clicked
    */
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<HTMLElement>): void;
 }
 
 function Action({ label, icon, onClick }: ActionProps) {

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -82,7 +82,7 @@ export function Tabs({ children }: TabsProps) {
 interface TabProps {
   readonly label: string;
   readonly children: ReactNode | ReactNode[];
-  onClick?(event: React.MouseEvent<HTMLElement>): void;
+  onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
 }
 
 export function Tab({ label }: TabProps) {
@@ -93,7 +93,7 @@ interface InternalTabProps {
   readonly label: string;
   readonly selected: boolean;
   activateTab(): void;
-  onClick?(event: React.MouseEvent<HTMLElement>): void;
+  onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
 }
 
 export function InternalTab({

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -82,7 +82,7 @@ export function Tabs({ children }: TabsProps) {
 interface TabProps {
   readonly label: string;
   readonly children: ReactNode | ReactNode[];
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<HTMLElement>): void;
 }
 
 export function Tab({ label }: TabProps) {
@@ -93,7 +93,7 @@ interface InternalTabProps {
   readonly label: string;
   readonly selected: boolean;
   activateTab(): void;
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<HTMLElement>): void;
 }
 
 export function InternalTab({
@@ -111,9 +111,9 @@ export function InternalTab({
       type="button"
       role="tab"
       className={className}
-      onClick={() => {
+      onClick={event => {
         activateTab();
-        onClick();
+        onClick(event);
       }}
     >
       <Typography element="span" size="base" textColor={color}>

--- a/packages/generators/templates/component/{{name}}.tsx
+++ b/packages/generators/templates/component/{{name}}.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent } from "react";
+import React from "react";
 import classnames from "classnames";
 import styles from "./{{name}}.css";
 

--- a/packages/generators/templates/component/{{name}}.tsx
+++ b/packages/generators/templates/component/{{name}}.tsx
@@ -17,7 +17,7 @@ interface {{name}}Props {
   /**
    * Click handler.
    */
-  onClick?(event: React.MouseEvent<HTMLElement>): void;
+  onClick?(event: React.MouseEvent<HTMLDivElement>): void;
 }
 
 export function {{name}}({ loud = false, text, onClick }: {{name}}Props) {

--- a/packages/generators/templates/component/{{name}}.tsx
+++ b/packages/generators/templates/component/{{name}}.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { SyntheticEvent } from "react";
 import classnames from "classnames";
 import styles from "./{{name}}.css";
 
@@ -17,7 +17,7 @@ interface {{name}}Props {
   /**
    * Click handler.
    */
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<HTMLElement>): void;
 }
 
 export function {{name}}({ loud = false, text, onClick }: {{name}}Props) {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In some cases it is useful to have access to the mouse event when building more complex components that nest multiple components. In some cases it's needed to `event.stopPropagation()` or `event.preventDefault()`.

## Changes

### Added

- Added `event` argument for all existing onClick events

## Testing

<!-- How to test your changes. -->
- Use any of the components which have `onClick` events and log it when clicked!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
