### PR TITLE
feat(components): Add destructive  option for confirmation modal

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -56,15 +56,9 @@ interface ButtonLinkProps extends ButtonFoundationProps {
 }
 
 interface BaseActionProps extends ButtonFoundationProps {
-  readonly variation?: "work" | "learning" | "subtle";
+  readonly variation?: "work" | "learning" | "subtle" | "destructive";
   readonly type?: "primary" | "secondary" | "tertiary";
 }
-
-interface DestructiveActionProps extends ButtonFoundationProps {
-  readonly variation: "destructive";
-  readonly type?: "primary" | "secondary" | "tertiary";
-}
-
 interface CancelActionProps extends ButtonFoundationProps {
   readonly variation: "cancel";
   readonly type?: "secondary" | "tertiary";
@@ -72,7 +66,6 @@ interface CancelActionProps extends ButtonFoundationProps {
 
 interface SubmitActionProps
   extends Omit<ButtonFoundationProps, "external" | "onClick"> {
-  readonly variation?: "work";
   readonly type?: "primary";
   readonly submit: boolean;
 }
@@ -87,7 +80,7 @@ interface SubmitButtonProps
 
 export type ButtonProps = XOR<
   BaseActionProps,
-  XOR<DestructiveActionProps, XOR<CancelActionProps, SubmitActionProps>>
+  XOR<CancelActionProps, SubmitActionProps>
 > &
   XOR<SubmitButtonProps, XOR<ButtonLinkProps, ButtonAnchorProps>> &
   XOR<ButtonIconProps, ButtonLabelProps>;

--- a/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
@@ -109,6 +109,38 @@ that presents a confirm modal.
   }}
 </Playground>
 
+## Destructive
+
+If the user is confirming an action that will destroy, delete, or remove
+something, use a destructive ConfirmationModal to visually reinforce the
+potential consequences.
+
+<Playground>
+  {() => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button
+          label="Delete Bob"
+          variation="destructive"
+          type="secondary"
+          onClick={() => setOpen(true)}
+        />
+        <ConfirmationModal
+          title="Delete Bob?"
+          message={`Deleting Bob will remove their data from your account for good.`}
+          confirmLabel="Delete Bob"
+          open={open}
+          onConfirm={() => alert("Bob has been deleted")}
+          onCancel={() => alert("Bob will not be deleted")}
+          onRequestClose={() => setOpen(false)}
+          variation="destructive"
+        />
+      </>
+    );
+  }}
+</Playground>
+
 ## Related components
 
 - To present non-blocking, contextual, text-only content, use a

--- a/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
@@ -22,7 +22,6 @@ interface ConfirmationModalState {
 interface ConfirmOrCancelAction {
   type: "confirm" | "cancel";
 }
-
 interface DisplayAction {
   type: "display";
   title?: string;
@@ -108,6 +107,11 @@ interface BaseConfirmationModalProps {
   readonly cancelLabel?: string;
 
   /**
+   * Type (Work or destructive) for confirm button.
+   */
+  readonly variation?: "work" | "destructive";
+
+  /**
    * Callback for when the confirm button is pressed.
    */
   onConfirm?(): void;
@@ -148,6 +152,7 @@ export const ConfirmationModal = forwardRef(function ConfirmationModalInternal(
     onConfirm,
     onCancel,
     onRequestClose,
+    variation = "work",
   }: ConfirmationModalProps,
   ref: Ref<ConfirmationModalRef>,
 ) {
@@ -206,6 +211,7 @@ export const ConfirmationModal = forwardRef(function ConfirmationModalInternal(
       dismissible={false}
       primaryAction={{
         label: state.confirmLabel,
+        variation: variation === "destructive" ? "destructive" : "work",
         onClick: () => {
           dispatch({ type: "confirm" });
           onRequestClose && onRequestClose();

--- a/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx
+++ b/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx
@@ -134,3 +134,43 @@ test("message should handle markdown", () => {
 
   expect(getByText("hello")).toBeInstanceOf(HTMLHeadingElement);
 });
+
+test("should have work type button by default", () => {
+  const { getByText } = render(
+    <ConfirmationModal
+      title="Should we?"
+      message="Do something…"
+      open={true}
+      confirmLabel="okay"
+    />,
+  );
+  expect(getByText("okay").parentElement).toHaveClass("work");
+});
+
+test("destructive type should have destructive confirmation button", () => {
+  const { getByText } = render(
+    <ConfirmationModal
+      title="Should we?"
+      message="Do something…"
+      open={true}
+      confirmLabel="Pull the plug"
+      variation="destructive"
+    />,
+  );
+
+  expect(getByText("Pull the plug").parentElement).toHaveClass("destructive");
+});
+
+test("Work should have work styled confirmation button", () => {
+  const { getByText } = render(
+    <ConfirmationModal
+      title="Should we?"
+      message="Do something…"
+      open={true}
+      confirmLabel="Ok"
+      variation="work"
+    />,
+  );
+
+  expect(getByText("Ok").parentElement).toHaveClass("work");
+});


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Currently, the confirmation modal only accepts a primary “work” action, which breaks this pattern.

<!-- Why did you do what you did? -->
we have determined the pattern for this is to show a secondary destructive button, which triggers a confirmation modal with a primary destructive action

## Changes
Adding actionType work | Destructive to the confirmation Button

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
Adding actionType work | Destructive to the confirmation Button

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
