### PR TITLE
docs: consistency of displaying button variations

### DIFF
--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -168,16 +168,22 @@ out of completing an action they have triggered.
 > deprecated.
 
 <Playground>
+  <Content>
+    <Content>
+      <Button label="Cancel" type="primary" variation="subtle" />
+    </Content>
+    <Content>
+      <Button label="Cancel" type="secondary" variation="subtle" />
+    </Content>
+    <Content>
+      <Button label="Cancel" type="tertiary" variation="subtle" />
+    </Content>
+  </Content>
   <div style={{ backgroundColor:"var(--color-surface--background)", padding:"var(--space-base)" }}>
-    <Button label="Cancel" type="primary" variation="subtle" />
-    <Button label="Cancel" type="secondary" variation="subtle" />
-    <Button label="Cancel" type="tertiary" variation="subtle" />
-
     <Button variation="subtle" type="tertiary" icon="search" aria-label="search" />
     <Button variation="subtle" type="tertiary" icon="cog" aria-label="settings" />
     <Button variation="subtle" type="tertiary" icon="help" aria-label="help" />
     <Button variation="subtle" type="tertiary" icon="more" aria-label="more" />
-
   </div>
 </Playground>
 

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -156,6 +156,9 @@ A Secondary or tertiary destructive action will either...
 </Playground>
 
 ### Subtle Actions
+  
+> Subtle actions replace a previous concept of "cancel" actions which has been
+> deprecated.
 
 Use a subtle button when you want the visual appearance to be more, well...
 _subtle._ This variation of button uses subdued color, allowing it to sit
@@ -163,9 +166,14 @@ comfortably alongside more prominent content.
 
 Think of icon actions in a navigation bar, buttons to dismiss a modal, or opting
 out of completing an action they have triggered.
-
-> Subtle actions replace a previous concept of "cancel" actions which has been
-> deprecated.
+  
+#### Primary, Secondary, and Tertiary
+  
+A key distinction between subtle buttons and the other variations is that the 
+primary/secondary/tertiary scale is styled differently, but conceptual hierarchy 
+is the same. Notably, the tertiary subtle button has a transparent background,
+allowing it to be _extra_ subtle when placed overtop `surface--background` elements
+such as a Modal header.
 
 <Playground>
   <Content>

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -170,21 +170,23 @@ out of completing an action they have triggered.
 <Playground>
   <Content>
     <Content>
-      <Button label="Cancel" type="primary" variation="subtle" />
+      <Content>
+        <Button label="Cancel" type="primary" variation="subtle" />
+      </Content>
+      <Content>
+        <Button label="Cancel" type="secondary" variation="subtle" />
+      </Content>
+      <Content>
+        <Button label="Cancel" type="tertiary" variation="subtle" />
+      </Content>
     </Content>
-    <Content>
-      <Button label="Cancel" type="secondary" variation="subtle" />
-    </Content>
-    <Content>
-      <Button label="Cancel" type="tertiary" variation="subtle" />
-    </Content>
+    <div style={{ backgroundColor:"var(--color-surface--background)", padding:"var(--space-base)" }}>
+      <Button variation="subtle" type="tertiary" icon="search" aria-label="search" />
+      <Button variation="subtle" type="tertiary" icon="cog" aria-label="settings" />
+      <Button variation="subtle" type="tertiary" icon="help" aria-label="help" />
+      <Button variation="subtle" type="tertiary" icon="more" aria-label="more" />
+    </div>
   </Content>
-  <div style={{ backgroundColor:"var(--color-surface--background)", padding:"var(--space-base)" }}>
-    <Button variation="subtle" type="tertiary" icon="search" aria-label="search" />
-    <Button variation="subtle" type="tertiary" icon="cog" aria-label="settings" />
-    <Button variation="subtle" type="tertiary" icon="help" aria-label="help" />
-    <Button variation="subtle" type="tertiary" icon="more" aria-label="more" />
-  </div>
 </Playground>
 
 ## Disabled


### PR DESCRIPTION
## Motivations

We added subtle button, this treats the "sandbox" examples more like the other variations, with the Primary/SecondaryTertiary stacked atop each other.

## Changes

### Changed

- Stacked the subtle buttons

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
