### PR TITLE
fix(components): remove aria-hidden prop on trap focus

### DIFF
--- a/packages/components/src/Modal/useFocusTrap.test.tsx
+++ b/packages/components/src/Modal/useFocusTrap.test.tsx
@@ -37,20 +37,6 @@ it("should not trap the tabbing and focus on the first child node", () => {
   expect(getByTestId(targetId).previousElementSibling).toHaveFocus();
 });
 
-it("should have the proper aria-hidden on body and ref target when active trapping focus", () => {
-  const { getByTestId } = render(<TestComponent />);
-  expect(document.body.hasAttribute("aria-hidden")).toBeTruthy();
-  expect(document.body.getAttribute("aria-hidden")).toBe("true");
-  expect(getByTestId(targetId).hasAttribute("aria-hidden")).toBeTruthy();
-  expect(getByTestId(targetId).getAttribute("aria-hidden")).toBe("false");
-});
-
-it("should NOT have the aria-hidden on the body and ref target when not actively trapping focus", () => {
-  const { getByTestId } = render(<TestComponent trap={false} />);
-  expect(document.body.hasAttribute("aria-hidden")).toBeFalsy();
-  expect(getByTestId(targetId).hasAttribute("aria-hidden")).toBeFalsy();
-});
-
 interface TestComponentProps {
   readonly trap?: boolean;
 }

--- a/packages/components/src/Modal/useFocusTrap.ts
+++ b/packages/components/src/Modal/useFocusTrap.ts
@@ -37,15 +37,11 @@ export function useFocusTrap<T extends HTMLElement>(active: boolean) {
 
   useEffect(() => {
     if (active) {
-      document.body.setAttribute("aria-hidden", "true");
-      ref.current?.setAttribute("aria-hidden", "false");
       ref.current?.focus();
       ref.current?.addEventListener("keydown", handleKeyDown);
     }
 
     return () => {
-      document.body.removeAttribute("aria-hidden");
-      ref.current?.removeAttribute("aria-hidden");
       ref.current?.removeEventListener("keydown", handleKeyDown);
     };
   }, [active]);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Upon adding the modal to trap the focus (#634) I've added an `aria-hidden=true` on the body and `false` on the modal. I saw an example of that when dealing with tooltips and assumed that was one of the way to deal with hiding things behind the modal. Trapping still works tho.

So the `getByRole` (`findBy...`, `queryBy...`) [respects the `aria-hidden`](https://testing-library.com/docs/queries/byrole/#hidden), thus breaking all modal tests in Jobber Online from getting/finding the things inside the modal as it was aria-hidden through the body. It was just the test that was broken. UI wise, it all be working: trapping and screen readers.

Lesson: Confirm how aria-hidden works and pre-release test atlantis in jobber online (clicking around and running tests)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- The use of aria-hidden prop. Needs more exploration on that front.

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Install the prerelease in jobber `npm i @jobber/components@2.46.7-pre.0+276c588`
- Run test in Jobber online
- There should be no broken test
- Still in Jobber online
- Open any Atlantis modal
- Tab around - The focus should stay within the dialog

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
