### PR TITLE
feat(components): Add ability to specify default opened tab (#521)

### DIFF
--- a/packages/components/src/Tabs/Tabs.mdx
+++ b/packages/components/src/Tabs/Tabs.mdx
@@ -51,6 +51,28 @@ needs to access one sub-group at a time.
 Do not use Tabs as a means of navigating the view or in lieu of a Table of
 Contents.
 
+### With default tab
+
+<Playground>
+  <Tabs defaultTab={2}>
+    <Tab label="Eggs">
+      🍳 Some eggs are laid by female animals of many different species,
+      including birds, reptiles, amphibians, mammals, and fish, and have been
+      eaten by humans for thousands of years.
+    </Tab>
+    <Tab label="Cheese">
+      🧀 Cheese is a dairy product derived from milk that is produced in a wide
+      range of flavors, textures, and forms by coagulation of the milk protein
+      casein.
+    </Tab>
+    <Tab label="Berries">
+      🍓 A berry is a small, pulpy, and often edible fruit. Typically, berries
+      are juicy, rounded, brightly colored, sweet, sour or tart, and do not have
+      a stone or pit.
+    </Tab>
+  </Tabs>
+</Playground>
+
 ## Related Components
 
 To show multiple groupings of content at once, use [Card](card).

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import renderer from "react-test-renderer";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { Tab, Tabs } from ".";
 
@@ -19,8 +18,26 @@ const omelet = (
 );
 
 it("renders Tabs", () => {
-  const tree = renderer.create(omelet).toJSON();
-  expect(tree).toMatchSnapshot();
+  const { container } = render(omelet);
+  expect(container).toMatchSnapshot();
+});
+
+describe("default tab", () => {
+  it("should render default tab with an integer", () => {
+    const { queryByText } = render(
+      <Tabs defaultTab={1}>
+        <Tab label="Eggs">
+          <p>🍳</p>
+          <p>Eggs</p>
+        </Tab>
+        <Tab label="Cheese" onClick={() => count++}>
+          <p>🧀</p>
+        </Tab>
+      </Tabs>,
+    );
+    expect(queryByText("🍳")).toBeFalsy();
+    expect(queryByText("🧀")).toBeTruthy();
+  });
 });
 
 test("it should switch tabs", () => {

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactElement,
   ReactNode,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -12,10 +13,23 @@ import { Typography } from "../Typography";
 
 interface TabsProps {
   readonly children: ReactElement | ReactElement[];
+
+  /**
+   * The default selected tab
+   */
+  readonly defaultTab?: number | "first" | "last";
 }
 
-export function Tabs({ children }: TabsProps) {
-  const [activeTab, setActiveTab] = useState(0);
+export function Tabs({ children, defaultTab }: TabsProps) {
+  const defaultTabIndex = useMemo(() => {
+    const tabCount = React.Children.count(children);
+    if (defaultTab == "first" || defaultTab == undefined) return 0;
+    if (defaultTab == "last") return tabCount - 1;
+
+    return Math.min(tabCount - 1, defaultTab);
+  }, [children, defaultTab]);
+
+  const [activeTab, setActiveTab] = useState(defaultTabIndex);
   const [overflowRight, setOverflowRight] = useState(false);
   const [overflowLeft, setOverflowLeft] = useState(false);
   const tabRow = useRef() as MutableRefObject<HTMLUListElement>;

--- a/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -1,59 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders Tabs 1`] = `
-<div
-  className="tabs"
->
+<div>
   <div
-    className="overflow"
+    class="tabs"
   >
-    <ul
-      className="tabRow"
-      role="tablist"
+    <div
+      class="overflow"
     >
-      <li
-        role="presentation"
+      <ul
+        class="tabRow"
+        role="tablist"
       >
-        <button
-          className="tab selected"
-          id="Eggs"
-          onClick={[Function]}
-          role="tab"
-          type="button"
+        <li
+          role="presentation"
         >
-          <span
-            className="base regular base green"
+          <button
+            class="tab selected"
+            id="Eggs"
+            role="tab"
+            type="button"
           >
-            Eggs
-          </span>
-        </button>
-        <button
-          className="tab"
-          id="Cheese"
-          onClick={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className="base regular base heading"
+            <span
+              class="base regular base green"
+            >
+              Eggs
+            </span>
+          </button>
+          <button
+            class="tab"
+            id="Cheese"
+            role="tab"
+            type="button"
           >
-            Cheese
-          </span>
-        </button>
-      </li>
-    </ul>
+            <span
+              class="base regular base heading"
+            >
+              Cheese
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+    <section
+      aria-label="Eggs"
+      class="tabContent"
+      role="tabpanel"
+    >
+      <p>
+        🍳
+      </p>
+      <p>
+        Eggs
+      </p>
+    </section>
   </div>
-  <section
-    aria-label="Eggs"
-    className="tabContent"
-    role="tabpanel"
-  >
-    <p>
-      🍳
-    </p>
-    <p>
-      Eggs
-    </p>
-  </section>
 </div>
 `;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Closes #521
- Allow for a prop to determine the default selected tab using `defaultTab`

## Changes

### Added

- Added ability to specify default selected tab for Tabs component

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
