### PR TITLE
docs(design): Adding subscription definitions to concepts and items in our product vocabulary 

### DIFF
--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -453,7 +453,7 @@ quote, job or invoice.
 
 Use **subscription** in reference to an SP’s individual recurring payment and how it is managed.
 
-Use **subscribe(d)** as a verb referring to the act of choosing, or having chose, a plan.
+Use **subscribe(d)** as a verb referring to the act of choosing, or having chosen, a plan.
 
 Use **plan** in reference to [Jobber's pre-determined feature templates](https://getjobber.com/pricing/) users can subscribe to.
 

--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -449,6 +449,16 @@ quote, job or invoice.
 
 <br />
 
+### subscription / subscribe(d) / plan
+
+Use **subscription** in reference to an SP’s individual recurring payment and how it is managed.
+
+Use **subscribe(d)** as a verb referring to the act of choosing, or having chose, a plan.
+
+Use **plan** in reference to [Jobber's pre-determined feature templates](https://getjobber.com/pricing/) users can subscribe to.
+
+<br />
+
 ### task / basic task / to do
 
 Use **task** when referring to all task items in Jobber.


### PR DESCRIPTION
Adding definitions of 'Subscription' 'Subscribe(d)' and 'Plan' under Product Vocabulary 'Concepts and Items'

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To create rules around when and which subscription terms to use.

## Changes

None

### Added

Definitions around 'Subscription' 'Subscribe(d)' and 'Plan'

### Changed

None

### Deprecated

None

### Removed

None

### Fixed

None

### Security

None

## Testing

Read through definitions and click on the link to Jobber's plan pricing

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
