### PR TITLE
fix(components): Add small size to avatar

### DIFF
--- a/packages/components/src/Avatar/Avatar.css
+++ b/packages/components/src/Avatar/Avatar.css
@@ -24,6 +24,10 @@
   --avatar-border-size: var(--border-thick);
 }
 
+.small {
+  --avatar-size: calc(var(--base-unit) * 1.5);
+}
+
 .isDark {
   color: var(--color-white);
 }

--- a/packages/components/src/Avatar/Avatar.css.d.ts
+++ b/packages/components/src/Avatar/Avatar.css.d.ts
@@ -1,5 +1,6 @@
 export const avatar: string;
 export const large: string;
+export const small: string;
 export const isDark: string;
 export const initials: string;
 export const smallInitials: string;

--- a/packages/components/src/Avatar/Avatar.mdx
+++ b/packages/components/src/Avatar/Avatar.mdx
@@ -33,9 +33,11 @@ import { Avatar } from "@jobber/components/Avatar";
 
 ## Design & Usage Guidelines
 
-- Avatars are available in 2 sizes:
+- Avatars are available in 3 sizes:
   - `base`: Should be used by default.
   - `large`: Should be used when the avatar is the focal point.
+  - `small`: Refrain from using this unless absolutely necessary. I.e. Avatar
+    inside a Chip.
 - If an avatar is displayed without a name label, display a tooltip.
 - Initials and background color should have sufficient color contrast to meet
   AA.

--- a/packages/components/src/Avatar/Avatar.mdx
+++ b/packages/components/src/Avatar/Avatar.mdx
@@ -34,10 +34,9 @@ import { Avatar } from "@jobber/components/Avatar";
 ## Design & Usage Guidelines
 
 - Avatars are available in 3 sizes:
-  - `base`: Should be used by default.
-  - `large`: Should be used when the avatar is the focal point.
-  - `small`: Refrain from using this unless absolutely necessary. I.e. Avatar
-    inside a Chip.
+  - `base`: Used by default.
+  - `large`: Use when the avatar is the focal point.
+  - `small`: Use on higher-density/compact pages or components.
 - If an avatar is displayed without a name label, display a tooltip.
 - Initials and background color should have sufficient color contrast to meet
   AA.

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -25,7 +25,10 @@ interface AvatarFoundationProps {
    */
   readonly color?: string;
   /**
-   * @default 'base'
+   * Change the size of the avatar
+   * @property "large" - Make avatar to be the focal point
+   * @property "small" - For higher-density/compact places or components
+   * @default "base"
    */
   readonly size?: AvatarSize;
 }

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -5,7 +5,7 @@ import styles from "./Avatar.css";
 import { isDark } from "./utilities";
 import { Icon } from "../Icon";
 
-type AvatarSize = "base" | "large";
+type AvatarSize = "base" | "large" | "small";
 interface AvatarFoundationProps {
   /**
    * A url for the image that will be displayed
@@ -25,7 +25,7 @@ interface AvatarFoundationProps {
    */
   readonly color?: string;
   /**
-   * @default 'medium'
+   * @default 'base'
    */
   readonly size?: AvatarSize;
 }
@@ -59,6 +59,7 @@ export function Avatar({
   const shouldBeDark = color == undefined || isDark(color);
   const className = classnames(styles.avatar, {
     [styles.large]: size === "large",
+    [styles.small]: size === "small",
     [styles.hasBorder]: imageUrl && color,
     [styles.isDark]: shouldBeDark,
   });

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -60,9 +60,7 @@ export function Avatar({
   }
 
   const shouldBeDark = color == undefined || isDark(color);
-  const className = classnames(styles.avatar, {
-    [styles.large]: size === "large",
-    [styles.small]: size === "small",
+  const className = classnames(styles.avatar, size !== "base" && styles[size], {
     [styles.hasBorder]: imageUrl && color,
     [styles.isDark]: shouldBeDark,
   });


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- Chip component requires a smaller avatar than what "base" provides

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Small size type to reduce the size of the avatar to 24x24 px
- Document when to use small

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
