### PR TITLE
fix(components): clean up focus state on Avatar

### DIFF
--- a/packages/components/src/Avatar/Avatar.css
+++ b/packages/components/src/Avatar/Avatar.css
@@ -19,6 +19,11 @@
   background-size: cover;
 }
 
+.avatar:focus {
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}
+
 .large {
   --avatar-size: calc(var(--base-unit) * 4.5);
   --avatar-border-size: var(--border-thick);


### PR DESCRIPTION
## Motivations

We allowed for Tooltip's children to be focused, which is good! However, some elements that Tooltip wraps do not have a designed focus state, so they end up with an unintentional-looking default ring.

This PR adds a defined focus state to Avatar.

## Changes

Focus state on Avatar before:
![image](https://user-images.githubusercontent.com/39704901/134425313-1e03133d-fda7-4dc7-8030-b9f0dad81827.png)

After:
![image](https://user-images.githubusercontent.com/39704901/134425132-3509185f-7432-4a0a-b2f5-f159b9ba7812.png)

### Changed

- set no outline, use our `shadow-focus`

## Testing

- go to the Avatar docs page with the "use with Tooltip" section and focus the Avatar!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
