### PR TITLE
docs: use inverse examples for remove and delete

### DIFF
--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -172,7 +172,8 @@ Use an X icon with "**close**" as the accessible label for modals. Use
 ### delete / destroy / remove
 
 Use **delete** when permanently erasing information available in Jobber. Always
-follow up with a confirmation dialog.
+follow up with a confirmation dialog. Think of **delete** as the inverse of 
+[**create**](#add--create--new).
 
 | **✅ Do **    | **❌ Don't**  |
 | ------------- | ------------- |
@@ -180,7 +181,7 @@ follow up with a confirmation dialog.
 | Delete Client | Remove Client |
 
 Use **remove** when hiding information from the current view but not permanently
-erasing it.
+erasing it. Think of **remove** as the inverse of [**add**](#add--create--new).
 
 | **✅ Do **                        | **❌ Don't**                      |
 | --------------------------------- | --------------------------------- |


### PR DESCRIPTION
## Motivations

Had a discussion with designers where the example of using the inverse of create was a useful framing for when to use delete, vs remove.

## Changes

### Added

- A few lines about delete and remove and their relation to create and add.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
