### PR TITLE
feat: update sidenav to match Jobber appearance

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
@@ -15,12 +15,13 @@
   justify-content: space-between;
   padding: 0;
   border: none;
-  color: var(--color-greyBlue--lighter);
+  color: var(--color-text--reverse--secondary);
   font-family: "Poppins", sans-serif;
   font-size: var(--base-unit);
   font-weight: 700;
+  letter-spacing: 0.2px;
   text-decoration: none;
-  text-transform: uppercase;
+  text-transform: capitalize;
   background: none;
   cursor: pointer;
   transition: color var(--timing-base);
@@ -29,7 +30,7 @@
 
 .label:hover,
 .active {
-  color: var(--color-white);
+  color: var(--color-text-reverse);
 }
 
 /**
@@ -80,7 +81,7 @@
 
 .level2 .pageLabel.active,
 .level2 .pageLabel:hover {
-  color: var(--color-white);
+  color: var(--color-text-reverse);
 }
 
 .level2 .pageLabel.active::before {

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
@@ -30,7 +30,7 @@
 
 .label:hover,
 .active {
-  color: var(--color-text-reverse);
+  color: var(--color-text--reverse);
 }
 
 /**
@@ -81,7 +81,7 @@
 
 .level2 .pageLabel.active,
 .level2 .pageLabel:hover {
-  color: var(--color-text-reverse);
+  color: var(--color-text--reverse);
 }
 
 .level2 .pageLabel.active::before {

--- a/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Sidebar/styles.ts
@@ -1,6 +1,6 @@
 export const sidebar = (width: number, sidebarOffset: number) =>
   ({
-    bg: "greyBlueDark",
+    bg: "blue",
     height: `calc(100vh - ${sidebarOffset}px)`,
     position: "fixed",
     top: sidebarOffset,
@@ -15,7 +15,7 @@ export const sidebar = (width: number, sidebarOffset: number) =>
 export const search = {
   position: "relative",
   marginTop: "large",
-  marginX: "base",
+  marginX: "large",
 
   svg: {
     position: "absolute",
@@ -30,7 +30,7 @@ export const input = {
   appearance: "none",
   border: 0,
   width: "100%",
-  bg: "blue",
+  bg: "greyBlueLightest",
   outline: "none",
   transition: "box-shadow 300ms",
   borderRadius: "base",
@@ -39,9 +39,9 @@ export const input = {
   pl: "38px",
   fontSize: "base",
   fontFamily: "body",
-  color: "white",
+  color: "blue",
 
   "&:focus": {
-    boxShadow: (t: any) => `0 0 3px ${t.colors.greyBlueLightest}`,
+    boxShadow: (t: any) => `0 0 4px ${t.colors.blueDark}`,
   },
 } as const;


### PR DESCRIPTION
## Motivations

The initial design of the Atlantis sidenav was intended to match the Jobber web app's appearance. Since it has changed in product, we should change it here for a more consistent visual.

This will also be useful in other places that leverage the sidenav, such as our developer docs.

This PR is a more focused cut of an initial, much-too-broad change made in a [since-closed PR](https://github.com/GetJobber/atlantis/pull/595)

## Changes

Color and type styling of the side navigation modules and search.

### Changed

- sidenav now uses the equivalent of our `color-surface--reverse` [(color docs)](https://atlantis.getjobber.com/colors#surfaces)

-Before
![image](https://user-images.githubusercontent.com/39704901/134788306-efcf11d7-87a9-4d6d-b3fd-e4e31aed0be1.png)

- After
![image](https://user-images.githubusercontent.com/39704901/134788295-a9d25696-6983-4855-b24f-591eb2c6aee2.png)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
