### PR TITLE
refactor(components): use semantic values in Avatar

### DIFF
--- a/packages/components/src/Avatar/Avatar.css
+++ b/packages/components/src/Avatar/Avatar.css
@@ -11,8 +11,8 @@
   height: var(--avatar-size);
   min-width: var(--avatar-size);
   min-height: var(--avatar-size);
-  border-radius: 50%;
-  color: var(--color-blue--dark);
+  border-radius: var(--radius-circle);
+  color: var(--color-heading);
   font-size: var(--avatar-size);
   -webkit-font-smoothing: antialiased;
   background: no-repeat center center var(--color-greyBlue);
@@ -34,7 +34,7 @@
 }
 
 .isDark {
-  color: var(--color-white);
+  color: var(--color-text--reverse);
 }
 
 .initials {


### PR DESCRIPTION
## Motivations

Pulling out a very small change from the ashes of [this old PR.](https://github.com/GetJobber/atlantis/pull/595)

We introduced the concept of reversed text colors, this PR uses that in Avatar. Also applies some other Atlantis variables to the "dark" text, and use one of our [radius values](https://atlantis.getjobber.com/border-radius) in the border-radius of Avatar.

## Changes

Nothing visual, save for a ~8% less-dark text color in of Avatars with light backgrounds.

### Changed

- CSS variables used in Avatar

## Testing

Go to `Avatar` and see how it looks!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
