### PR TITLE
fix: adjust skipnav offset in hidden state

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Layout/Layout.module.css
@@ -61,7 +61,7 @@
 
 .skipNav {
   position: absolute;
-  top: calc(-1 * var(--space-large));
+  top: calc(-1 * var(--space-extravagant));
   left: var(--space-small);
   z-index: 3;
   width: calc(100% - var(--space-base));


### PR DESCRIPTION
## Motivations

The skip to content link is still present at the top of the view, even when it is invisible, leading to accidental clicks and bad times. It should be completely hidden to users operating via mouse/trackpad.

Initially tried to fix this in part of a larger, [less-reviewable PR.](https://github.com/GetJobber/atlantis/pull/595)

## Changes

Before:
https://user-images.githubusercontent.com/39704901/134788708-b4cfd0e8-6201-42bb-a7fc-007364bc97c6.mov

After:
https://user-images.githubusercontent.com/39704901/134788715-098cbb3f-f5a2-49ef-abef-0ec777de1211.mov

### Changed

- negative top offset of skipnav in hidden state to push it out of the viewport

### Fixed

- You can no longer click the skipnav when you hover over the top of the viewport with your cursor.

## Testing

Move your mouse cursor around the top ~32px of the viewport.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
