### PR TITLE
feat(components): export banner type

### DIFF
--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -9,6 +9,7 @@ import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { Banner } from ".";
 import { Content } from "@jobber/components/Content";
+import { Icon } from "@jobber/components/Icon";
 
 # Banner
 
@@ -30,7 +31,14 @@ import { Banner } from "@jobber/components/Banner";
 
 <Props of={Banner} />
 
----
+## Types of Banner
+
+BannerType could be any of the following
+
+- `notice` [<Icon name="link" />](#notice-message)
+- `success` [<Icon name="link" />](#success-message)
+- `warning`[<Icon name="link" />](#warning-message)
+- `error` [<Icon name="link" />](#error-message)
 
 ## Notice message
 

--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -33,7 +33,7 @@ import { Banner } from "@jobber/components/Banner";
 
 ## Types of Banner
 
-BannerType could be any of the following
+BannerType could be any of the followings
 
 - `notice` [<Icon name="link" />](#notice-message)
 - `success` [<Icon name="link" />](#success-message)

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -8,9 +8,11 @@ import { Icon } from "../Icon";
 import { Text } from "../Text";
 import { Button, ButtonProps } from "../Button";
 
+export type BannerType = "notice" | "success" | "warning" | "error";
+
 interface BannerProps {
   readonly children: ReactNode;
-  readonly type: "notice" | "success" | "warning" | "error";
+  readonly type: BannerType;
   /**
    * The default cta variation should be a 'work' variation. If the banner
    * 'type' is set to 'notice' we change the cta variation to 'learning'

--- a/packages/components/src/Banner/index.ts
+++ b/packages/components/src/Banner/index.ts
@@ -1,1 +1,1 @@
-export { Banner } from "./Banner";
+export { Banner, BannerType } from "./Banner";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In order to integrate the Banner component, we need the banner type to be exported. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->


### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

No banner type is exported

### Removed

### Fixed

Banner type is exported

### Security

- <!-- in case of vulnerabilities -->

## Testing

Banner type should be available to import 
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
