### PR TITLE
chore: fix README hyperlink to CONTRIBUTING.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -161,7 +161,7 @@ would run `npm install foo` from within the `components` directory.
 ## Contributing
 
 Everyone is a friend of Atlantis and we welcome pull requests. See the
-[contribution guidelines](/CONTRIBUTING.md) to learn how.
+[contribution guidelines](./CONTRIBUTING.md) to learn how.
 
 ## Publishing
 


### PR DESCRIPTION
## Motivations

Clicking contribution guidelines link in the README goes to `404` when clicked via https://github.com/GetJobber/atlantis
It works fine when clicking from https://atlantis.getjobber.com/

Closes #693 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- README.md hyperlink to contributing guidelines goes to correct URL when clicked from github

### Security

- <!-- in case of vulnerabilities -->

## Testing

Verify that Gatsby still generates the proper url.
1. `npm run build && npm run serve` 
2. open in a browser: http://localhost:3333/
3. verify that clicking contribution guidelines still navigates to `http://localhost:3333/CONTRIBUTING.md`
![image](https://user-images.githubusercontent.com/10420994/135174519-ed8493a0-f2b0-415c-a03c-146773c18544.png)

Verify that the link works on GitHub (fork).
1. open in a browser: https://github.com/linhub15/atlantis
2. verify that clicking contribution guidelines navigates to https://github.com/linhub15/atlantis/blob/master/docs/CONTRIBUTING.md

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
