### PR TITLE
feat(components): Add keyboard shortcut to close menu on Escape

### DIFF
--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import renderer from "react-test-renderer";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { Menu } from ".";
 import { Button } from "../Button";
@@ -7,9 +6,9 @@ import { Button } from "../Button";
 afterEach(cleanup);
 jest.mock("uuid");
 
-it("renders a Menu", () => {
-  const tree = renderer
-    .create(
+describe("Menu", () => {
+  it("renders", () => {
+    const { container } = render(
       <Menu
         items={[
           {
@@ -27,72 +26,124 @@ it("renders a Menu", () => {
           },
         ]}
       />,
-    )
-    .toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
-it("renders a Menu with custom activator", () => {
-  const tree = renderer
-    .create(
-      <Menu
-        activator={<Button label="Menu" />}
-        items={[
-          {
-            header: "Send as...",
-            actions: [
-              {
-                label: "Text Message",
-                icon: "sms",
-              },
-              {
-                label: "Email",
-                icon: "email",
-              },
-            ],
-          },
-        ]}
-      />,
-    )
-    .toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
-test("it should open and close the menu", async () => {
-  const header = "Mark as...";
-  const actionLabel = "Awaiting Response";
-  const clickHandler = jest.fn();
-  const actions = [
-    {
-      header: header,
-      actions: [{ label: actionLabel, onClick: clickHandler }],
-    },
-  ];
-
-  const { getByRole, queryAllByText } = render(<Menu items={actions} />);
-
-  fireEvent.click(getByRole("button"));
-  expect(queryAllByText(actionLabel).length).toBe(1);
-
-  fireEvent.click(getByRole("menuitem"));
-  expect(clickHandler).toHaveBeenCalledTimes(1);
-
-  await waitFor(() => {
-    expect(queryAllByText(actionLabel).length).toBe(0);
+    );
+    expect(container).toMatchSnapshot();
   });
-});
 
-test("it should passthrough an activator's click action", () => {
-  const clickHandler = jest.fn();
-  const actions = [];
+  describe("when clicking on the activator", () => {
+    it("should open the menu", async () => {
+      const header = "Mark as...";
+      const actionLabel = "Awaiting Response";
+      const clickHandler = jest.fn();
+      const actions = [
+        {
+          header: header,
+          actions: [{ label: actionLabel, onClick: clickHandler }],
+        },
+      ];
+      const { getByRole } = render(<Menu items={actions} />);
+      fireEvent.click(getByRole("button"));
+      await waitFor(() => {
+        expect(getByRole("menuitem")).toBeInTheDocument();
+      });
+    });
+  });
 
-  const { getByRole } = render(
-    <Menu
-      activator={<Button label="Menu" onClick={clickHandler} />}
-      items={actions}
-    />,
-  );
+  describe("when clicking on menu item", () => {
+    it("should close the menu and trigger onClick", async () => {
+      const header = "Mark as...";
+      const actionLabel = "Awaiting Response";
+      const clickHandler = jest.fn();
+      const actions = [
+        {
+          header: header,
+          actions: [{ label: actionLabel, onClick: clickHandler }],
+        },
+      ];
+      const { getByRole, queryByRole } = render(<Menu items={actions} />);
 
-  fireEvent.click(getByRole("button"));
-  expect(clickHandler).toHaveBeenCalledTimes(1);
+      fireEvent.click(getByRole("button"));
+      fireEvent.click(getByRole("menuitem"));
+      expect(clickHandler).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(queryByRole("menuitem")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when menu is opened and escape is pressed", () => {
+    const actionLabel = "Text Message";
+    it("should close the menu", async () => {
+      const { getByRole, queryByRole, container } = render(
+        <Menu
+          items={[
+            {
+              header: "Send as...",
+              actions: [
+                {
+                  label: actionLabel,
+                  icon: "sms",
+                },
+                {
+                  label: "Email",
+                  icon: "email",
+                },
+              ],
+            },
+          ]}
+        />,
+      );
+
+      fireEvent.click(getByRole("button"));
+      fireEvent.keyDown(container, {
+        key: "Escape",
+        code: "Escape",
+        ctrlKey: true,
+      });
+      await waitFor(() => {
+        expect(queryByRole("menuitem")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("with custom activator", () => {
+    it("renders", () => {
+      const { container } = render(
+        <Menu
+          activator={<Button label="Menu" />}
+          items={[
+            {
+              header: "Send as...",
+              actions: [
+                {
+                  label: "Text Message",
+                  icon: "sms",
+                },
+                {
+                  label: "Email",
+                  icon: "email",
+                },
+              ],
+            },
+          ]}
+        />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  it("should passthrough the onClick action", () => {
+    const clickHandler = jest.fn();
+    const actions = [];
+
+    const { getByRole } = render(
+      <Menu
+        activator={<Button label="Menu" onClick={clickHandler} />}
+        items={actions}
+      />,
+    );
+
+    fireEvent.click(getByRole("button"));
+    expect(clickHandler).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -9,6 +9,7 @@ import uuid from "uuid";
 import classnames from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
 import { IconNames } from "@jobber/design";
+import { useOnKeyDown } from "@jobber/hooks";
 import styles from "./Menu.css";
 import { Button } from "../Button";
 import { Typography } from "../Typography";
@@ -55,6 +56,7 @@ export interface SectionProps {
   actions: ActionProps[];
 }
 
+// eslint-disable-next-line max-statements
 export function Menu({ activator, items }: MenuProps) {
   const [visible, setVisible] = useState(false);
   const [position, setPosition] = useState<Position>({
@@ -65,6 +67,7 @@ export function Menu({ activator, items }: MenuProps) {
   const buttonID = uuid();
   const menuID = uuid();
 
+  useOnKeyDown(handleKeyboardShortcut, ["Escape"]);
   useLayoutEffect(() => {
     if (wrapperRef.current) {
       const bounds = wrapperRef.current.getBoundingClientRect();
@@ -170,6 +173,20 @@ export function Menu({ activator, items }: MenuProps) {
 
   function hide() {
     setVisible(false);
+  }
+
+  function handleKeyboardShortcut(event: KeyboardEvent) {
+    const { key } = event;
+    if (!visible) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    switch (key) {
+      case "Escape": {
+        hide();
+        break;
+      }
+    }
   }
 }
 

--- a/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
@@ -1,58 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a Menu 1`] = `
-<div
-  className="wrapper"
->
-  <button
-    aria-controls="123e4567-e89b-12d3-a456-426655440002"
-    aria-expanded={false}
-    aria-haspopup={true}
-    className="button base hasIconAndLabel work secondary fullWidth"
-    disabled={false}
-    id="123e4567-e89b-12d3-a456-426655440001"
-    onClick={[Function]}
-    type="button"
+exports[`Menu renders 1`] = `
+<div>
+  <div
+    class="wrapper"
   >
-    <svg
-      className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-      data-testid="more"
-      viewBox="0 0 1024 1024"
-      xmlns="http://www.w3.org/2000/svg"
+    <button
+      aria-controls="123e4567-e89b-12d3-a456-426655440004"
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="button base hasIconAndLabel work secondary fullWidth"
+      id="123e4567-e89b-12d3-a456-426655440003"
+      type="button"
     >
-      <path
-        className=""
-        d="M170.667 512c0-47.13 38.205-85.333 85.333-85.333s85.333 38.204 85.333 85.333c0 47.13-38.205 85.333-85.333 85.333s-85.333-38.204-85.333-85.333zM426.667 512c0-47.13 38.204-85.333 85.333-85.333s85.333 38.204 85.333 85.333c0 47.13-38.204 85.333-85.333 85.333s-85.333-38.204-85.333-85.333zM768 426.667c-47.13 0-85.333 38.204-85.333 85.333s38.204 85.333 85.333 85.333c47.13 0 85.333-38.204 85.333-85.333s-38.204-85.333-85.333-85.333z"
-      />
-    </svg>
-    <span
-      className="base extraBold small uppercase"
-    >
-      More Actions
-    </span>
-  </button>
+      <svg
+        class="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+        data-testid="more"
+        viewBox="0 0 1024 1024"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          class=""
+          d="M170.667 512c0-47.13 38.205-85.333 85.333-85.333s85.333 38.204 85.333 85.333c0 47.13-38.205 85.333-85.333 85.333s-85.333-38.204-85.333-85.333zM426.667 512c0-47.13 38.204-85.333 85.333-85.333s85.333 38.204 85.333 85.333c0 47.13-38.204 85.333-85.333 85.333s-85.333-38.204-85.333-85.333zM768 426.667c-47.13 0-85.333 38.204-85.333 85.333s38.204 85.333 85.333 85.333c47.13 0 85.333-38.204 85.333-85.333s-38.204-85.333-85.333-85.333z"
+        />
+      </svg>
+      <span
+        class="base extraBold small uppercase"
+      >
+        More Actions
+      </span>
+    </button>
+  </div>
 </div>
 `;
 
-exports[`renders a Menu with custom activator 1`] = `
-<div
-  className="wrapper"
->
-  <button
-    aria-controls="123e4567-e89b-12d3-a456-426655440004"
-    aria-expanded={false}
-    aria-haspopup={true}
-    className="button base work primary"
-    disabled={false}
-    id="123e4567-e89b-12d3-a456-426655440003"
-    onClick={[Function]}
-    type="button"
+exports[`Menu with custom activator renders 1`] = `
+<div>
+  <div
+    class="wrapper"
   >
-    <span
-      className="base extraBold small uppercase"
+    <button
+      aria-controls="123e4567-e89b-12d3-a456-426655440040"
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="button base work primary"
+      id="123e4567-e89b-12d3-a456-426655440039"
+      type="button"
     >
-      Menu
-    </span>
-  </button>
+      <span
+        class="base extraBold small uppercase"
+      >
+        Menu
+      </span>
+    </button>
+  </div>
 </div>
 `;

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -6,10 +6,12 @@ import { SectionProps } from "../Menu";
 
 jest.mock("@jobber/hooks", () => {
   return {
+    ...(jest.requireActual("@jobber/hooks") as {}),
     useResizeObserver: () => [
       { current: undefined },
       { width: 1000, height: 100 },
     ],
+
     Breakpoints: {
       base: 640,
       small: 500,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Closes #696

- The escape key does not worked as advertised with the assigned `menu` and `menuitem` roles
- Pressing the escape key should close the menu

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added keyboard shortcut listener for `Escape`

### Changed

- Updated and refactored Menu testing structure
- Updated how Page is mocking our hooks so that only the hooks we want to mock will be mocked, and other functions will work as expected.

## Testing

<!-- How to test your changes. -->
1. Go to the `<Menu />` component page
   1. Using mouse
      - Can click on the menu to open
      - Can click on the menu to close if open
      - Can click on anything other than menu and menu items to close
   2. Using keyboard
      - Can hit `enter` to open the menu
      - Can hit `enter` to close the menu when open and button is focused
      - Can hit `escape` to close the menu when it's open (no matter what has focus)
2. Perform the same tests using the `<Page />` component when it has more actions    

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
