### PR TITLE
feat(components): Autofocus on first Menu item

### DIFF
--- a/packages/components/src/Content/Paddings.css.d.ts
+++ b/packages/components/src/Content/Paddings.css.d.ts
@@ -1,8 +1,4 @@
-declare const styles: {
-  readonly "base": string;
-  readonly "small": string;
-  readonly "large": string;
-  readonly "none": string;
-};
-export = styles;
-
+export const base: string;
+export const small: string;
+export const large: string;
+export const none: string;

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { Menu } from ".";
 import { Button } from "../Button";
 
@@ -95,4 +101,31 @@ test("it should passthrough an activator's click action", () => {
 
   fireEvent.click(getByRole("button"));
   expect(clickHandler).toHaveBeenCalledTimes(1);
+});
+
+test("it should focus first action item from the menu when clicked", () => {
+  const { getByRole } = render(
+    <Menu
+      activator={<Button label="Menu" />}
+      items={[
+        {
+          header: "Send as...",
+          actions: [
+            {
+              label: "Text Message",
+              icon: "sms",
+            },
+            {
+              label: "Email",
+              icon: "email",
+            },
+          ],
+        },
+      ]}
+    />,
+  );
+
+  fireEvent.click(getByRole("button"));
+  const firstMenuItem = screen.getAllByRole("menuitem")[0];
+  expect(firstMenuItem).toHaveFocus();
 });

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -103,7 +103,7 @@ test("it should passthrough an activator's click action", () => {
   expect(clickHandler).toHaveBeenCalledTimes(1);
 });
 
-test("it should focus first action item from the menu when clicked", () => {
+it("should focus first action item from the menu when activated", () => {
   const { getByRole } = render(
     <Menu
       activator={<Button label="Menu" />}

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -151,10 +151,10 @@ export function Menu({ activator, items }: MenuProps) {
                 <div key={key} className={styles.section}>
                   {item.header && <SectionHeader text={item.header} />}
 
-                  {item.actions.map(action => (
+                  {item.actions.map((action, index) => (
                     <Action
                       key={action.label}
-                      shouldFocus={key === 0}
+                      shouldFocus={key === 0 && index === 0}
                       {...action}
                     />
                   ))}
@@ -169,8 +169,6 @@ export function Menu({ activator, items }: MenuProps) {
 
   function toggle(callbackPassthrough?: (event?: MouseEvent) => void) {
     return (event: MouseEvent) => {
-      console.log("Hello");
-
       setVisible(!visible);
       callbackPassthrough && callbackPassthrough(event);
     };

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -2,7 +2,9 @@ import React, {
   MouseEvent,
   ReactElement,
   createRef,
+  useEffect,
   useLayoutEffect,
+  useRef,
   useState,
 } from "react";
 import uuid from "uuid";
@@ -150,7 +152,11 @@ export function Menu({ activator, items }: MenuProps) {
                   {item.header && <SectionHeader text={item.header} />}
 
                   {item.actions.map(action => (
-                    <Action key={action.label} {...action} />
+                    <Action
+                      key={action.label}
+                      shouldFocus={key === 0}
+                      {...action}
+                    />
                   ))}
                 </div>
               ))}
@@ -163,6 +169,8 @@ export function Menu({ activator, items }: MenuProps) {
 
   function toggle(callbackPassthrough?: (event?: MouseEvent) => void) {
     return (event: MouseEvent) => {
+      console.log("Hello");
+
       setVisible(!visible);
       callbackPassthrough && callbackPassthrough(event);
     };
@@ -208,15 +216,30 @@ export interface ActionProps {
    * Callback when an action gets clicked
    */
   onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
+
+  /**
+   * Focuses explicitly if set to true
+   */
+  shouldFocus?: boolean;
 }
 
-function Action({ label, icon, onClick }: ActionProps) {
+function Action({ label, icon, onClick, shouldFocus = false }: ActionProps) {
+  // eslint-disable-next-line no-null/no-null
+  const actionButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (actionButtonRef.current && shouldFocus) {
+      actionButtonRef.current.focus();
+    }
+  }, [shouldFocus]);
+
   return (
     <button
       role="menuitem"
       className={styles.action}
       key={label}
       onClick={onClick}
+      ref={actionButtonRef}
     >
       {icon && (
         <span className={styles.icon}>

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -1,6 +1,7 @@
 import React, {
   MouseEvent,
   ReactElement,
+  RefObject,
   createRef,
   useEffect,
   useLayoutEffect,
@@ -54,7 +55,7 @@ export interface SectionProps {
   /**
    * List of actions.
    */
-  actions: ActionProps[];
+  actions: Omit<ActionProps, "shouldFocus">[];
 }
 
 export function Menu({ activator, items }: MenuProps) {
@@ -216,14 +217,14 @@ export interface ActionProps {
   onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
 
   /**
-   * Focuses explicitly if set to true
+   * Focus on the action when rendered
    */
   shouldFocus?: boolean;
 }
 
 function Action({ label, icon, onClick, shouldFocus = false }: ActionProps) {
   // eslint-disable-next-line no-null/no-null
-  const actionButtonRef = useRef<HTMLButtonElement | null>(null);
+  const actionButtonRef = useRef() as RefObject<HTMLButtonElement>;
 
   useEffect(() => {
     if (actionButtonRef.current && shouldFocus) {

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -223,7 +223,6 @@ export interface ActionProps {
 }
 
 function Action({ label, icon, onClick, shouldFocus = false }: ActionProps) {
-  // eslint-disable-next-line no-null/no-null
   const actionButtonRef = useRef() as RefObject<HTMLButtonElement>;
 
   useEffect(() => {

--- a/packages/components/src/Select/Select.css.d.ts
+++ b/packages/components/src/Select/Select.css.d.ts
@@ -1,11 +1,7 @@
-declare const styles: {
-  readonly "wrapper": string;
-  readonly "select": string;
-  readonly "small": string;
-  readonly "large": string;
-  readonly "icon": string;
-  readonly "disabled": string;
-  readonly "invalid": string;
-};
-export = styles;
-
+export const wrapper: string;
+export const select: string;
+export const small: string;
+export const large: string;
+export const icon: string;
+export const disabled: string;
+export const invalid: string;


### PR DESCRIPTION
## Motivations

Closes #697 

This change is better for user experience and accessibility as users can start selecting menu items using tabs. Otherwise, the tab indexing was traveled along the whole page which is a very long process 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added auto-focus of the first item of Menu 

### Changed

- Focuses the first item when menu is opened

## Testing

1. Run the local dev environment and search for the Menu component
2. Click on the `More Actions` in the examples.
3. Verify that the first item of the Menu is focused.
4. Also verify that pressing tab should move to the next item.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
