### PR TITLE
feat(components): Add vertical option for Divider and update Divider documentation

### DIFF
--- a/packages/components/src/Divider/Divider.css
+++ b/packages/components/src/Divider/Divider.css
@@ -8,3 +8,14 @@
 .large {
   border-bottom-width: var(--border-large);
 }
+
+.vertical {
+  width: var(--space-minuscule);
+  height: auto;
+  border-bottom: none;
+  border-right: var(--border-base) solid var(--color-border);
+}
+
+.vertical.large {
+  border-right-width: var(--border-large);
+}

--- a/packages/components/src/Divider/Divider.css.d.ts
+++ b/packages/components/src/Divider/Divider.css.d.ts
@@ -1,6 +1,3 @@
-declare const styles: {
-  readonly "divider": string;
-  readonly "large": string;
-};
-export = styles;
-
+export const divider: string;
+export const large: string;
+export const vertical: string;

--- a/packages/components/src/Divider/Divider.mdx
+++ b/packages/components/src/Divider/Divider.mdx
@@ -9,6 +9,8 @@ import { Playground, Props } from "docz";
 import { ComponentStatus } from "@jobber/docx";
 import { Content } from "@jobber/components/Content";
 import { Text } from "@jobber/components/Text";
+import { Heading } from "@jobber/components/Heading";
+import { Card } from "@jobber/components/Card";
 import { Divider } from ".";
 
 # Divider
@@ -37,3 +39,44 @@ should be used within a [`Content`](/components/content) component.
 ## Props
 
 <Props of={Divider} />
+
+## Usage
+
+### Size
+
+<Playground>
+  <Content>
+    <Content>Some amazing content</Content>
+    <Divider size="large" />
+    <Content>Even more amazing content</Content>
+  </Content>
+</Playground>
+
+### Vertical
+
+<Playground>
+  <Content>
+    <Heading level={4}>Types of Bananas</Heading>
+    <div style={{ display: "flex", gap: "var(--space-base)" }}>
+      <Card title="Burro">
+        <Content>
+          <Text>
+            Squatty and slightly square at the edges, these bananas are slightly
+            tangy and lemony. When ripe, the fruit is soft and the skin is
+            yellow with black spots. Also called Horse, Hog, or Orinoco bananas.
+          </Text>
+        </Content>
+      </Card>
+      <Divider vertical size="large" />
+      <Card title="Cavendish">
+        <Content>
+          <Text>
+            This is the familiar yellow banana sold in United States’
+            supermarkets. There are also other sizes of Cavendish, including
+            Dwarf and Giant, though they are difficult to find.
+          </Text>
+        </Content>
+      </Card>
+    </div>
+  </Content>
+</Playground>

--- a/packages/components/src/Divider/Divider.test.tsx
+++ b/packages/components/src/Divider/Divider.test.tsx
@@ -1,16 +1,38 @@
 import React from "react";
-import renderer from "react-test-renderer";
-import { cleanup } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { Divider } from ".";
 
 afterEach(cleanup);
 
-it("renders a Divider", () => {
-  const tree = renderer.create(<Divider />).toJSON();
-  expect(tree).toMatchSnapshot();
-});
+describe("Divider", () => {
+  it("should render", () => {
+    const { container } = render(<Divider />);
+    expect(container).toMatchSnapshot();
+  });
 
-it("renders a large Divider", () => {
-  const tree = renderer.create(<Divider size="large" />).toJSON();
-  expect(tree).toMatchSnapshot();
+  it("should render element as hr", () => {
+    const { queryByRole } = render(<Divider />);
+    expect(queryByRole("none").tagName).toBe("HR");
+  });
+
+  describe("when large", () => {
+    it("renders", () => {
+      const { container } = render(<Divider size="large" />);
+      expect(container).toMatchSnapshot();
+    });
+
+    describe("when also vertical", () => {
+      it("renders", () => {
+        const { container } = render(<Divider vertical size="large" />);
+        expect(container).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe("when vertical", () => {
+    it("should render as div", () => {
+      const { queryByRole } = render(<Divider vertical />);
+      expect(queryByRole("none").tagName).toBe("DIV");
+    });
+  });
 });

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -9,12 +9,20 @@ interface DividerProps {
    * @default "base"
    */
   readonly size?: "base" | "large";
+  /**
+   * Display the divider vertically
+   *
+   * @default false
+   */
+  readonly vertical?: boolean;
 }
 
-export function Divider({ size = "base" }: DividerProps) {
+export function Divider({ size = "base", vertical = false }: DividerProps) {
   const className = classnames(styles.divider, {
     [styles.large]: size === "large",
+    [styles.vertical]: vertical,
   });
 
-  return <hr className={className} role="none" />;
+  const Tag = vertical ? "div" : "hr";
+  return <Tag className={className} role="none" />;
 }

--- a/packages/components/src/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/packages/components/src/Divider/__snapshots__/Divider.test.tsx.snap
@@ -1,15 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a Divider 1`] = `
-<hr
-  className="divider"
-  role="none"
-/>
+exports[`Divider should render 1`] = `
+<div>
+  <hr
+    class="divider"
+    role="none"
+  />
+</div>
 `;
 
-exports[`renders a large Divider 1`] = `
-<hr
-  className="divider large"
-  role="none"
-/>
+exports[`Divider when large renders 1`] = `
+<div>
+  <hr
+    class="divider large"
+    role="none"
+  />
+</div>
+`;
+
+exports[`Divider when large when also vertical renders 1`] = `
+<div>
+  <div
+    class="divider large vertical"
+    role="none"
+  />
+</div>
 `;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

Closes #692

- Divider has no option to divide content in a left-to-right flow and currently only supports top-down flow

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added option to allow for vertical divider to divide content in a left-to-right flow
- Added documentation showing off usage for `size` and `vertical` props

![image](https://user-images.githubusercontent.com/80279872/135675741-765c988b-850e-46a7-8e5b-677ab3d4adf2.png)


### Changed

- Updated and refactored test cases for the divider component

## Testing

<!-- How to test your changes. -->
1. Open up the `<Divider />` component page
   1. Confirm the horizontal divider is not impacted (base size and large)
   2. Set the vertical prop to true and place divider in horizontal/row flex container
       - Divider should be a div element
       - Divider should take the full width of the parent container
    3. Also set the `size` prop to large
       - Divider should have a larger width 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
