### PR TITLE
feat(components): Remove drawer content padding and make title optional

### DIFF
--- a/packages/components/src/Drawer/Drawer.css
+++ b/packages/components/src/Drawer/Drawer.css
@@ -47,6 +47,10 @@
   align-items: center;
 }
 
+.headerWithoutTitle {
+  justify-content: flex-end;
+}
+
 .contentScroll {
   display: flex;
   width: 100%;
@@ -57,5 +61,4 @@
 
 .content {
   width: 100%;
-  padding: var(--drawer--base-padding);
 }

--- a/packages/components/src/Drawer/Drawer.css.d.ts
+++ b/packages/components/src/Drawer/Drawer.css.d.ts
@@ -1,10 +1,7 @@
-declare const styles: {
-  readonly "container": string;
-  readonly "drawer": string;
-  readonly "open": string;
-  readonly "header": string;
-  readonly "contentScroll": string;
-  readonly "content": string;
-};
-export = styles;
-
+export const container: string;
+export const drawer: string;
+export const open: string;
+export const header: string;
+export const headerWithoutTitle: string;
+export const contentScroll: string;
+export const content: string;

--- a/packages/components/src/Drawer/Drawer.test.tsx
+++ b/packages/components/src/Drawer/Drawer.test.tsx
@@ -4,45 +4,57 @@ import { Drawer } from ".";
 
 afterEach(cleanup);
 
-test("drawer shows the children and a close button", () => {
-  const title = "Drawer title";
-  const content = "Drawer content";
-  const handleClose = jest.fn();
-
-  const { getByLabelText, getByText, queryByTestId } = render(
-    <Drawer title={title} open={true} onRequestClose={handleClose}>
-      {content}
-    </Drawer>,
-  );
-
-  expect(queryByTestId("drawer-header")).not.toBeNull();
-  expect(getByText(title)).toBeTruthy();
-  expect(getByLabelText("Close drawer")).toBeTruthy();
-  expect(getByText(content)).toBeTruthy();
-});
-
-it("doesn't render a closed drawer", () => {
-  const handleClose = jest.fn();
-
-  const { queryByTestId } = render(
-    <Drawer title="Drawer" open={false} onRequestClose={handleClose}>
-      Drawer content
-    </Drawer>,
-  );
-  expect(
-    queryByTestId("drawer-container").classList.contains("open"),
-  ).toBeFalsy();
-});
-
-test("drawer fires onRequestClose when selecting the close button", () => {
-  const handleClose = jest.fn();
-
-  const { getByLabelText } = render(
-    <Drawer title="Drawer" onRequestClose={handleClose}>
-      Drawer content
-    </Drawer>,
-  );
-
-  fireEvent.click(getByLabelText("Close drawer"));
-  expect(handleClose).toHaveBeenCalledTimes(1);
+describe("Drawer", () => {
+  describe("when open", () => {
+    it("should render children and close button", () => {
+      const content = "Drawer Content";
+      const { container, getByText } = render(
+        <Drawer open onRequestClose={jest.fn}>
+          {content}
+        </Drawer>,
+      );
+      expect(getByText(content)).toBeInTheDocument();
+      expect(container).toMatchSnapshot();
+    });
+    describe("with title", () => {
+      it("should also render title", () => {
+        const title = "Drawer Title";
+        const content = "Drawer Content";
+        const { container, getByText } = render(
+          <Drawer title={title} open onRequestClose={jest.fn}>
+            {content}
+          </Drawer>,
+        );
+        expect(getByText(content)).toBeInTheDocument();
+        expect(getByText(title)).toBeInTheDocument();
+        expect(container).toMatchSnapshot();
+      });
+    });
+    describe("when clicking on dismiss button", () => {
+      it("should trigger request close", () => {
+        const onRequestCloseFn = jest.fn();
+        const { getByLabelText } = render(
+          <Drawer open onRequestClose={onRequestCloseFn}>
+            {"Drawer Content"}
+          </Drawer>,
+        );
+        fireEvent.click(getByLabelText("Close drawer"));
+        expect(onRequestCloseFn).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+  describe("when closed", () => {
+    it("shouldnt render the children", () => {
+      const content = "Drawer Content";
+      const { container, debug, getByTestId } = render(
+        <Drawer open={false} onRequestClose={jest.fn}>
+          {content}
+        </Drawer>,
+      );
+      debug(container);
+      expect(
+        getByTestId("drawer-container").classList.contains("open"),
+      ).toBeFalsy();
+    });
+  });
 });

--- a/packages/components/src/Drawer/Drawer.tsx
+++ b/packages/components/src/Drawer/Drawer.tsx
@@ -6,7 +6,7 @@ import { ButtonDismiss } from "../ButtonDismiss";
 
 interface DrawerProps {
   readonly children: ReactNode | ReactNode[];
-  readonly title: string;
+  readonly title?: string;
   /**
    * @default true
    */
@@ -46,22 +46,26 @@ export function Drawer({
 }
 
 interface HeaderProps {
-  title: string;
+  title?: string;
   onRequestClose?(): void;
 }
 
 function Header({ title, onRequestClose }: HeaderProps) {
+  const classname = classnames(styles.header, {
+    [styles.headerWithoutTitle]: !title,
+  });
   return (
-    <div className={styles.header} data-testid="drawer-header">
-      <Typography
-        element="h3"
-        size="large"
-        textCase="uppercase"
-        fontWeight="extraBold"
-      >
-        {title}
-      </Typography>
-
+    <div className={classname} data-testid="drawer-header">
+      {title && (
+        <Typography
+          element="h3"
+          size="large"
+          textCase="uppercase"
+          fontWeight="extraBold"
+        >
+          {title}
+        </Typography>
+      )}
       <ButtonDismiss onClick={onRequestClose} ariaLabel="Close drawer" />
     </div>
   );

--- a/packages/components/src/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/components/src/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Drawer when open should render children and close button 1`] = `
+<div>
+  <aside
+    class="container open"
+    data-testid="drawer-container"
+  >
+    <div
+      class="drawer"
+    >
+      <div
+        class="header headerWithoutTitle"
+        data-testid="drawer-header"
+      >
+        <div
+          class="closeButtonWrapper"
+        >
+          <button
+            aria-label="Close drawer"
+            class="button base onlyIcon cancel tertiary"
+            type="button"
+          >
+            <svg
+              class="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+              data-testid="remove"
+              viewBox="0 0 1024 1024"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class=""
+                d="M512 451.669l-225.835-225.835c-8.047-7.772-18.825-12.073-30.012-11.976s-21.888 4.585-29.799 12.495c-7.911 7.911-12.398 18.612-12.495 29.799s4.204 21.964 11.976 30.012l225.835 225.835-225.835 225.835c-7.772 8.047-12.073 18.825-11.976 30.012s4.585 21.888 12.495 29.798c7.91 7.91 18.612 12.399 29.799 12.497s21.965-4.203 30.012-11.977l225.835-225.835 225.835 225.835c8.047 7.774 18.825 12.075 30.012 11.977s21.888-4.587 29.798-12.497c7.91-7.91 12.399-18.611 12.497-29.798 0.094-11.187-4.203-21.965-11.977-30.012l-225.835-225.835 225.835-225.835c4.075-3.936 7.326-8.644 9.562-13.85s3.413-10.804 3.46-16.469c0.051-5.665-1.028-11.284-3.174-16.527s-5.312-10.007-9.318-14.013c-4.006-4.006-8.772-7.174-14.016-9.319-5.239-2.146-10.859-3.225-16.525-3.176s-11.264 1.226-16.469 3.462c-5.205 2.236-9.916 5.487-13.85 9.562l-225.835 225.835z"
+              />
+            </svg>
+            <span
+              class="base extraBold small uppercase"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="contentScroll"
+      >
+        <div
+          class="content"
+        >
+          Drawer Content
+        </div>
+      </div>
+    </div>
+  </aside>
+</div>
+`;
+
+exports[`Drawer when open with title should also render title 1`] = `
+<div>
+  <aside
+    aria-label="Drawer Title"
+    class="container open"
+    data-testid="drawer-container"
+  >
+    <div
+      class="drawer"
+    >
+      <div
+        class="header"
+        data-testid="drawer-header"
+      >
+        <h3
+          class="base extraBold large uppercase"
+        >
+          Drawer Title
+        </h3>
+        <div
+          class="closeButtonWrapper"
+        >
+          <button
+            aria-label="Close drawer"
+            class="button base onlyIcon cancel tertiary"
+            type="button"
+          >
+            <svg
+              class="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+              data-testid="remove"
+              viewBox="0 0 1024 1024"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class=""
+                d="M512 451.669l-225.835-225.835c-8.047-7.772-18.825-12.073-30.012-11.976s-21.888 4.585-29.799 12.495c-7.911 7.911-12.398 18.612-12.495 29.799s4.204 21.964 11.976 30.012l225.835 225.835-225.835 225.835c-7.772 8.047-12.073 18.825-11.976 30.012s4.585 21.888 12.495 29.798c7.91 7.91 18.612 12.399 29.799 12.497s21.965-4.203 30.012-11.977l225.835-225.835 225.835 225.835c8.047 7.774 18.825 12.075 30.012 11.977s21.888-4.587 29.798-12.497c7.91-7.91 12.399-18.611 12.497-29.798 0.094-11.187-4.203-21.965-11.977-30.012l-225.835-225.835 225.835-225.835c4.075-3.936 7.326-8.644 9.562-13.85s3.413-10.804 3.46-16.469c0.051-5.665-1.028-11.284-3.174-16.527s-5.312-10.007-9.318-14.013c-4.006-4.006-8.772-7.174-14.016-9.319-5.239-2.146-10.859-3.225-16.525-3.176s-11.264 1.226-16.469 3.462c-5.205 2.236-9.916 5.487-13.85 9.562l-225.835 225.835z"
+              />
+            </svg>
+            <span
+              class="base extraBold small uppercase"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="contentScroll"
+      >
+        <div
+          class="content"
+        >
+          Drawer Content
+        </div>
+      </div>
+    </div>
+  </aside>
+</div>
+`;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

As the drawer is similar to the Card, the content padding shouldn't be automatically applied, and the title should be optional. Instead should use the `<Content />` component to provide styling

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Made title an optional prop for the Drawer

### Removed

- Content padding in the Drawer component

## Testing

<!-- How to test your changes. -->
1. In the Drawer documentation/playground, create a drawer without a title:
```tsx
<Drawer open onRequestClose={() => {}}>
  Drawer Content
</Drawer>,
```
  - The Drawer content shouldn't have any padding on any sides of the content (unless inherited from other components such as `<p>` tag
  - The Drawer shouldn't have a title and the dismiss button should be on the right, just as it would if there's a title

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
