### PR TITLE
feat(components): Add onClick to Avatar and refactor tests

### DIFF
--- a/packages/components/src/Avatar/Avatar.css
+++ b/packages/components/src/Avatar/Avatar.css
@@ -5,18 +5,20 @@
 
 .avatar {
   display: flex;
-  align-items: center;
-  justify-content: center;
   width: var(--avatar-size);
   height: var(--avatar-size);
   min-width: var(--avatar-size);
   min-height: var(--avatar-size);
+  box-shadow: var(--shadow-base);
+  border-color: transparent;
   border-radius: var(--radius-circle);
   color: var(--color-heading);
   font-size: var(--avatar-size);
   -webkit-font-smoothing: antialiased;
   background: no-repeat center center var(--color-greyBlue);
   background-size: cover;
+  align-items: center;
+  justify-content: center;
 }
 
 .avatar:focus {
@@ -52,4 +54,13 @@
   box-shadow: 0 0 0 var(--border-thick) var(--color-white) inset;
   border-style: solid;
   border-width: var(--avatar-border-size);
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.clickable:focus {
+  box-shadow: var(--shadow-focus);
+  outline: none;
 }

--- a/packages/components/src/Avatar/Avatar.css.d.ts
+++ b/packages/components/src/Avatar/Avatar.css.d.ts
@@ -1,11 +1,8 @@
-declare const styles: {
-  readonly "avatar": string;
-  readonly "large": string;
-  readonly "small": string;
-  readonly "isDark": string;
-  readonly "initials": string;
-  readonly "smallInitials": string;
-  readonly "hasBorder": string;
-};
-export = styles;
-
+export const avatar: string;
+export const large: string;
+export const small: string;
+export const isDark: string;
+export const initials: string;
+export const smallInitials: string;
+export const hasBorder: string;
+export const clickable: string;

--- a/packages/components/src/Avatar/Avatar.mdx
+++ b/packages/components/src/Avatar/Avatar.mdx
@@ -115,6 +115,22 @@ If an avatar is displayed without a name label, display a tooltip.
   }}
 </Playground>
 
+## Usage with onClick
+
+<Playground>
+  {() => {
+    return (
+      <Avatar
+        size="large"
+        initials="JBLR"
+        onClick={() => {
+          alert("Hey! You clicked me 😡");
+        }}
+      />
+    );
+  }}
+</Playground>
+
 ##### Avatar image credit
 
 [Gabrielle Henderson on Unplash](https://unsplash.com/photos/noSpEJztSMc)

--- a/packages/components/src/Avatar/Avatar.test.tsx
+++ b/packages/components/src/Avatar/Avatar.test.tsx
@@ -1,47 +1,67 @@
 import React from "react";
-import renderer from "react-test-renderer";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { Avatar } from ".";
 
 afterEach(cleanup);
 
-it("renders a Avatar", () => {
-  const tree = renderer
-    .create(
-      <Avatar
-        imageUrl="https://api.adorable.io/avatars/150/jobbler"
-        name="The Jobbler"
-        size="large"
-      />,
-    )
-    .toJSON();
+describe("Avatar", () => {
+  describe("with image", () => {
+    it("renders", () => {
+      const { container } = render(
+        <Avatar
+          imageUrl="https://api.adorable.io/avatars/150/jobbler"
+          name="The Jobbler"
+          size="large"
+        />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+  });
 
-  expect(tree).toMatchSnapshot();
-});
+  describe("with initials", () => {
+    it("renders", () => {
+      const { container } = render(<Avatar initials="JBLR" />);
+      expect(container).toMatchSnapshot();
+    });
 
-it("displays initials if no image is set", () => {
-  const tree = renderer.create(<Avatar initials="JBLR" />).toJSON();
-  expect(tree).toMatchSnapshot();
-});
+    it("trims to the first 3 characters", () => {
+      const { getByText } = render(
+        <Avatar initials="JBLR ARE 2 MANY LETTERS" />,
+      );
+      expect(getByText("JBL").innerHTML.length).toBeLessThanOrEqual(3);
+      expect(getByText("JBL").innerHTML).toBe("JBL");
+    });
 
-it("Initials are trimmed to the first 3 characters", () => {
-  const { getByText } = render(<Avatar initials="JBLR ARE 2 MANY LETTERS" />);
-  expect(getByText("JBL").innerHTML.length).toBeLessThanOrEqual(3);
-  expect(getByText("JBL").innerHTML).toBe("JBL");
-});
+    describe("with dark color", () => {
+      it("renders with light text", () => {
+        const { getByText } = render(<Avatar initials="JB" color="black" />);
+        expect(getByText("JB").closest("div").classList).toContain("isDark");
+      });
+    });
+  });
 
-it("displays an icon if no image and no initials are set", () => {
-  // Disabling typecheck here to test a fallback. This version of avatar
-  // should never be used, but is created as an extra safety.
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
-  const tree = renderer.create(<Avatar />).toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  describe("without image or initials", () => {
+    // Disabling typecheck here to test a fallback. This version of avatar
+    // should never be used, but is created as an extra safety.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    const { container } = render(<Avatar />);
+    expect(container).toMatchSnapshot();
+  });
 
-it("Renders light text color if `color` is dark", () => {
-  const { props } = renderer
-    .create(<Avatar initials="JB" color="black" />)
-    .toJSON();
-  expect(props.className).toContain("isDark");
+  describe("with onClick", () => {
+    it("renders as a button", () => {
+      const { getByText } = render(<Avatar initials="JB" onClick={jest.fn} />);
+      expect(getByText("JB").closest("button")).toBeInTheDocument();
+    });
+
+    it("triggers onClick when clicked", () => {
+      const onClickFn = jest.fn();
+      const { getByText } = render(
+        <Avatar initials="JB" onClick={onClickFn} />,
+      );
+      fireEvent.click(getByText("JB"));
+      expect(onClickFn).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -31,6 +31,12 @@ interface AvatarFoundationProps {
    * @default "base"
    */
   readonly size?: AvatarSize;
+
+  /**
+   * The action to perform when the avatar is clicked on.
+   * Also supports keyboard shortcuts.
+   */
+  onClick?(): void;
 }
 
 interface AvatarWithImageProps extends AvatarFoundationProps {
@@ -49,6 +55,7 @@ export function Avatar({
   initials,
   size = "base",
   color,
+  onClick,
 }: AvatarProps) {
   const style: CSSProperties = {
     backgroundColor: color,
@@ -59,23 +66,27 @@ export function Avatar({
     style.backgroundImage = `url(${imageUrl})`;
   }
 
+  const clickable = onClick != undefined;
   const shouldBeDark = color == undefined || isDark(color);
   const className = classnames(styles.avatar, size !== "base" && styles[size], {
     [styles.hasBorder]: imageUrl && color,
     [styles.isDark]: shouldBeDark,
+    [styles.clickable]: clickable,
   });
+  const Tag = clickable ? "button" : "div";
 
   return (
-    <div
+    <Tag
       className={className}
       style={style}
       role={imageUrl && "img"}
       aria-label={name}
+      onClick={onClick}
     >
       {!imageUrl && (
         <Initials initials={initials} dark={shouldBeDark} iconSize={size} />
       )}
-    </div>
+    </Tag>
   );
 }
 

--- a/packages/components/src/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/components/src/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -1,62 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`displays an icon if no image and no initials are set 1`] = `
-<div
-  className="avatar isDark"
-  style={
-    Object {
-      "backgroundColor": undefined,
-      "borderColor": undefined,
-    }
-  }
->
-  <svg
-    className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-    data-testid="person"
-    viewBox="0 0 1024 1024"
-    xmlns="http://www.w3.org/2000/svg"
+exports[` 1`] = `
+<div>
+  <div
+    class="avatar isDark"
   >
-    <path
-      className="_2GsLyQLHv8yNULHeXGdver _29W47x5R7CHDPdmq99tUBc"
-      d="M512 469.333c-94.255 0-170.665-76.41-170.665-170.667s76.41-170.667 170.665-170.667c94.259 0 170.667 76.41 170.667 170.667s-76.407 170.667-170.667 170.667zM512 384c47.13 0 85.333-38.205 85.333-85.333s-38.204-85.333-85.333-85.333c-47.125 0-85.333 38.205-85.333 85.333s38.208 85.333 85.333 85.333z"
-    />
-    <path
-      className="_2GsLyQLHv8yNULHeXGdver _29W47x5R7CHDPdmq99tUBc"
-      d="M225.679 810.667h572.644c-36.698-123.392-151.1-213.333-286.323-213.333s-249.623 89.941-286.321 213.333zM810.795 810.654l-0.115 0.013zM213.322 810.667l-0.114-0.013zM129.919 811.332c38.557-171.341 199.096-299.332 382.081-299.332 182.989 0 343.629 127.991 382.187 299.332 1.263 5.615 1.788 11.123 1.647 16.461-0.068 2.722-0.311 5.402-0.717 8.026-5.303 34.441-38.46 60.181-76.902 60.181h-612.327c-39.024 0-72.603-26.526-77.123-61.756-0.939-7.313-0.624-15.006 1.155-22.912z"
-    />
-  </svg>
+    <svg
+      class="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+      data-testid="person"
+      viewBox="0 0 1024 1024"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        class="_2GsLyQLHv8yNULHeXGdver _29W47x5R7CHDPdmq99tUBc"
+        d="M512 469.333c-94.255 0-170.665-76.41-170.665-170.667s76.41-170.667 170.665-170.667c94.259 0 170.667 76.41 170.667 170.667s-76.407 170.667-170.667 170.667zM512 384c47.13 0 85.333-38.205 85.333-85.333s-38.204-85.333-85.333-85.333c-47.125 0-85.333 38.205-85.333 85.333s38.208 85.333 85.333 85.333z"
+      />
+      <path
+        class="_2GsLyQLHv8yNULHeXGdver _29W47x5R7CHDPdmq99tUBc"
+        d="M225.679 810.667h572.644c-36.698-123.392-151.1-213.333-286.323-213.333s-249.623 89.941-286.321 213.333zM810.795 810.654l-0.115 0.013zM213.322 810.667l-0.114-0.013zM129.919 811.332c38.557-171.341 199.096-299.332 382.081-299.332 182.989 0 343.629 127.991 382.187 299.332 1.263 5.615 1.788 11.123 1.647 16.461-0.068 2.722-0.311 5.402-0.717 8.026-5.303 34.441-38.46 60.181-76.902 60.181h-612.327c-39.024 0-72.603-26.526-77.123-61.756-0.939-7.313-0.624-15.006 1.155-22.912z"
+      />
+    </svg>
+  </div>
 </div>
 `;
 
-exports[`displays initials if no image is set 1`] = `
-<div
-  className="avatar isDark"
-  style={
-    Object {
-      "backgroundColor": undefined,
-      "borderColor": undefined,
-    }
-  }
->
-  <span
-    className="initials smallInitials"
-  >
-    JBL
-  </span>
+exports[`Avatar with image renders 1`] = `
+<div>
+  <div
+    aria-label="The Jobbler"
+    class="avatar large isDark"
+    role="img"
+    style="background-image: url(https://api.adorable.io/avatars/150/jobbler);"
+  />
 </div>
 `;
 
-exports[`renders a Avatar 1`] = `
-<div
-  aria-label="The Jobbler"
-  className="avatar large isDark"
-  role="img"
-  style={
-    Object {
-      "backgroundColor": undefined,
-      "backgroundImage": "url(https://api.adorable.io/avatars/150/jobbler)",
-      "borderColor": undefined,
-    }
-  }
-/>
+exports[`Avatar with initials renders 1`] = `
+<div>
+  <div
+    class="avatar isDark"
+  >
+    <span
+      class="initials smallInitials"
+    >
+      JBL
+    </span>
+  </div>
+</div>
 `;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
It would be nice to have the capability to have avatar as an activator for the Menu component, similarly to how it's used within GitHub.
![image](https://user-images.githubusercontent.com/80279872/135706229-8d93074b-d1f8-4b8f-a5a7-e3a8ac9fef69.png)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added onClick to the avatar component

### Changed

- Refactored the Avatar testing

## Testing

<!-- How to test your changes. -->
- Go to tooltip documentation and browse to the `usage with onclick` example, and click on it!
- Also supported keyboard shortcut enter, as it's a button
- Also can add onClick to any type of avatar (image or initial)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
