### PR TITLE
fix(components): Fix formatting of css declaration files to unbreak Lerna

### DIFF
--- a/packages/components/src/Content/Paddings.css.d.ts
+++ b/packages/components/src/Content/Paddings.css.d.ts
@@ -1,4 +1,7 @@
-export const base: string;
-export const small: string;
-export const large: string;
-export const none: string;
+declare const styles: {
+  readonly "base": string;
+  readonly "small": string;
+  readonly "large": string;
+  readonly "none": string;
+};
+export = styles;

--- a/packages/components/src/Select/Select.css.d.ts
+++ b/packages/components/src/Select/Select.css.d.ts
@@ -1,7 +1,10 @@
-export const wrapper: string;
-export const select: string;
-export const small: string;
-export const large: string;
-export const icon: string;
-export const disabled: string;
-export const invalid: string;
+declare const styles: {
+  readonly "wrapper": string;
+  readonly "select": string;
+  readonly "small": string;
+  readonly "large": string;
+  readonly "icon": string;
+  readonly "disabled": string;
+  readonly "invalid": string;
+};
+export = styles;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Latest PR merge formatted some CSS declaration files which is causing issues with Lerna and releasing.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Fixed css declaration files
  - `Paddings.css.d.ts`
  - `Select.css.d.ts`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
