### PR TITLE
fix(components): Card no longer overrides border color variable

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -4,9 +4,10 @@
 }
 
 .card {
+  --card-border-color: var(--color-border);
   display: block;
   width: 100%;
-  border: var(--border-base) solid var(--color-border);
+  border: var(--border-base) solid var(--card-border-color);
   border-radius: var(--radius-base);
   outline-color: var(--color-focus);
   background-color: var(--color-surface);
@@ -41,8 +42,7 @@
 }
 
 .clickable {
-  --color-border: transparent;
-
+  --card-border-color: transparent;
   box-shadow: var(--shadow-base);
   color: inherit;
   text-decoration: inherit;

--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -4,10 +4,10 @@
 }
 
 .card {
-  --card-border-color: var(--color-border);
+  --card--border-color: var(--color-border);
   display: block;
   width: 100%;
-  border: var(--border-base) solid var(--card-border-color);
+  border: var(--border-base) solid var(--card--border-color);
   border-radius: var(--radius-base);
   outline-color: var(--color-focus);
   background-color: var(--color-surface);
@@ -42,7 +42,7 @@
 }
 
 .clickable {
-  --card-border-color: transparent;
+  --card--border-color: transparent;
   box-shadow: var(--shadow-base);
   color: inherit;
   text-decoration: inherit;


### PR DESCRIPTION


<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Fixes #716

When using a clickable card, the `--color-border` css variable is overridden, which causes issues when using buttons or divider as a child component.

- Changed usage from `--color-border` to it's own variable `--card-border-color`
- `--card-border-color` still gets correctly updated to a transparent value as intended

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Card no longer overrides `--color-border` for children components

## Testing

<!-- How to test your changes. -->
- To see reproduction of the issue, [see minimal reproduction](https://codesandbox.io/s/716-card-overriding-border-color-css-variable-repro-z36jt?file=/src/App.js)
- To see fixed version, pull down PR and import `Divider` component in the `Card` documentation page, and insert the divider in a clickable card  


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
