### PR TITLE
docs: Add content guidelines to Banner component 

### DIFF
--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -170,6 +170,19 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
   </Content>
 </Playground>
 
+## Content Guidelines
+
+Content in banner should:
+
+<ul>
+  <li>Be concise and kept to only 1 to 2 sentences where possible</li>
+  <li>Avoid exceeding 200 characters</li>
+  <li>Follow the product vocabulary guide where applicable</li>
+  <li>
+    In the case of warning or error banners, explain how to resolve the issue
+  </li>
+</ul>
+
 ## Related components
 
 - To provide low priority, temporary feedback on the outcome of a user action,

--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -174,14 +174,10 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
 
 Content in banner should:
 
-<ul>
-  <li>Be concise and kept to only 1 to 2 sentences where possible</li>
-  <li>Avoid exceeding 200 characters</li>
-  <li>Follow the product vocabulary guide where applicable</li>
-  <li>
-    In the case of warning or error banners, explain how to resolve the issue
-  </li>
-</ul>
+- Be concise and kept to only 1 to 2 sentences where possible
+- Avoid exceeding 200 characters
+- Follow the [product vocabulary](/content/product-vocabulary) where applicable
+- In the case of warning or error banners, explain how to resolve the issue
 
 ## Related components
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? --> Realized documentation guidelines for Banner were not available around how much content is appropriate for this component.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ --> 

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
