### PR TITLE
feat(components): RadioGroup - Added aria-labeledby attribute

### DIFF
--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -3,6 +3,10 @@
   flex-direction: column;
 }
 
+.groupLabel {
+  display: none;
+}
+
 .input {
   /* Hide checkbox on UI but not screen readers and still allow focus state */
   position: absolute;

--- a/packages/components/src/RadioGroup/RadioGroup.css.d.ts
+++ b/packages/components/src/RadioGroup/RadioGroup.css.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "radioGroup": string;
+  readonly "groupLabel": string;
   readonly "input": string;
   readonly "label": string;
   readonly "description": string;

--- a/packages/components/src/RadioGroup/RadioGroup.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.mdx
@@ -30,7 +30,7 @@ import { RadioGroup } from "@jobber/components/RadioGroup";
   {() => {
     const [company, setCompany] = useState("apple");
     return (
-      <RadioGroup onChange={setCompany} value={company}>
+      <RadioGroup onChange={setCompany} value={company} label="Companies">
         <RadioOption value="apple" label="Apple" />
         <RadioOption value="google" label="Google" />
         <RadioOption value="microsoft" label="Microsoft" />
@@ -58,7 +58,7 @@ option will prevent a user from being able to select the option.
     const [checked, setChecked] = useState(true);
     return (
       <Content spacing="large">
-        <RadioGroup onChange={setCompany} value={company}>
+        <RadioGroup onChange={setCompany} value={company} label="Companies">
           <RadioOption value="apple" label="Apple" />
           <RadioOption value="google" label="Google" />
           <RadioOption value="amazon" label="Amazon" disabled={true} />
@@ -87,7 +87,7 @@ A `description` can be used to further describe the label of the `RadioOption`.
   {() => {
     const [company, setCompany] = useState("apple");
     return (
-      <RadioGroup onChange={setCompany} value={company}>
+      <RadioGroup onChange={setCompany} value={company} label="Companies">
         <RadioOption
           value="apple"
           label="Apple"
@@ -134,7 +134,7 @@ text, an `aria-label` should be provided.
       <>
         <Content>
           <Text>Select a user</Text>
-          <RadioGroup onChange={setPhoto} value={company}>
+          <RadioGroup onChange={setPhoto} value={company} label="Users">
             {users.map(user => (
               <RadioOption value={user.name}>
                 <Avatar initials={user.initials} name={user.name} />

--- a/packages/components/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.test.tsx
@@ -28,7 +28,12 @@ test("it should not call the handler if the value does not change", () => {
 test("it should be able to disable options", () => {
   const handleChange = jest.fn();
   const { container } = render(
-    <RadioGroup name="Foo" value="foo" onChange={handleChange}>
+    <RadioGroup
+      name="Foo"
+      value="foo"
+      onChange={handleChange}
+      label="Test Label"
+    >
       <RadioOption value="foo"></RadioOption>
       <RadioOption value="bear" disabled={true}></RadioOption>
     </RadioGroup>,
@@ -55,7 +60,7 @@ test("it should have unique ids on all radio options", () => {
 
 test("it should render an option from `label` prop", () => {
   const { getByText } = render(
-    <RadioGroup value="" onChange={jest.fn()}>
+    <RadioGroup value="" onChange={jest.fn()} label="Test Label">
       <RadioOption value="foo" label="Radio" />
     </RadioGroup>,
   );
@@ -65,7 +70,7 @@ test("it should render an option from `label` prop", () => {
 
 test("it should render an option from `children` prop", () => {
   const { getByText } = render(
-    <RadioGroup value="" onChange={jest.fn()}>
+    <RadioGroup value="" onChange={jest.fn()} label="Test Label">
       <RadioOption value="foo">Radio</RadioOption>
     </RadioGroup>,
   );
@@ -75,12 +80,22 @@ test("it should render an option from `children` prop", () => {
 
 test("it should render a description", () => {
   const { getByText } = render(
-    <RadioGroup value="" onChange={jest.fn()}>
+    <RadioGroup value="" onChange={jest.fn()} label="Test Label">
       <RadioOption value="foo" description="A sound box" label="Radio" />
     </RadioGroup>,
   );
 
   expect(getByText("A sound box")).toBeInstanceOf(HTMLParagraphElement);
+});
+
+test("it should render a span", () => {
+  const { getByText } = render(
+    <RadioGroup value="" onChange={jest.fn()} label="Test Label">
+      <RadioOption value="foo" description="A sound box" label="Radio" />
+    </RadioGroup>,
+  );
+
+  expect(getByText("Test Label")).toBeInstanceOf(HTMLSpanElement);
 });
 
 interface MockProps {
@@ -92,11 +107,19 @@ function MockRadioGroup({ onChange }: MockProps) {
   const [valueTwo, setValueTwo] = useState("one");
   return (
     <>
-      <RadioGroup onChange={handleFirstChange} value={value}>
+      <RadioGroup
+        onChange={handleFirstChange}
+        value={value}
+        label="Test Label 1"
+      >
         <RadioOption value="one" label="One" />
         <RadioOption value="two" label="Two" />
       </RadioGroup>
-      <RadioGroup onChange={handleSecondChange} value={valueTwo}>
+      <RadioGroup
+        onChange={handleSecondChange}
+        value={valueTwo}
+        label="Test Label 2"
+      >
         <RadioOption value="one" label="One" />
         <RadioOption value="two" label="Two" />
       </RadioGroup>

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -19,6 +19,11 @@ interface RadioGroupProps {
   onChange(newValue: string | number): void;
 
   /**
+   * Defines the label that describes the radio group.
+   */
+  readonly label: string;
+
+  /**
    * The name of the radio group, that links the radio options back up
    * to the group.
    *
@@ -30,22 +35,34 @@ interface RadioGroupProps {
 export function RadioGroup({
   children,
   value,
+  label,
   onChange,
   name = uuid.v1(),
 }: RadioGroupProps) {
+  const labelId = `${name}_label`;
+
   return (
-    <div role="radiogroup" className={styles.radioGroup}>
-      {React.Children.map(children, option => (
-        <InternalRadioOption
-          checked={value === option.props.value}
-          name={name}
-          onChange={handleChange}
-          {...option.props}
-        >
-          {option.props.children}
-        </InternalRadioOption>
-      ))}
-    </div>
+    <>
+      <span id={labelId} className={styles.groupLabel}>
+        {label}
+      </span>
+      <div
+        role="radiogroup"
+        aria-labelledby={labelId}
+        className={styles.radioGroup}
+      >
+        {React.Children.map(children, option => (
+          <InternalRadioOption
+            checked={value === option.props.value}
+            name={name}
+            onChange={handleChange}
+            {...option.props}
+          >
+            {option.props.children}
+          </InternalRadioOption>
+        ))}
+      </div>
+    </>
   );
 
   function handleChange(newValue: string) {

--- a/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -2,7 +2,14 @@
 
 exports[`renders a RadioGroup 1`] = `
 <div>
+  <span
+    class="groupLabel"
+    id="123e4567-e89b-12d3-a456-426655440001_label"
+  >
+    Test Label 1
+  </span>
   <div
+    aria-labelledby="123e4567-e89b-12d3-a456-426655440001_label"
     class="radioGroup"
     role="radiogroup"
   >
@@ -38,7 +45,14 @@ exports[`renders a RadioGroup 1`] = `
       </label>
     </div>
   </div>
+  <span
+    class="groupLabel"
+    id="123e4567-e89b-12d3-a456-426655440004_label"
+  >
+    Test Label 2
+  </span>
   <div
+    aria-labelledby="123e4567-e89b-12d3-a456-426655440004_label"
     class="radioGroup"
     role="radiogroup"
   >


### PR DESCRIPTION
## Motivations

The RadioGroup has a div that wraps all of the RadioOptions within. This div has a role of radiogroup so that assistive technology can better identify it

The RadioGroup should have an aria-label, aria-labelledby relationship, or a label, so that the group makes sense.

Closes: #690 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

### Changed

Added a new required prop to the `RadioGroup.tsx` component to represent an aria label for the radio group. The label is rendered as a `<span>`, but is visually hidden. The `<div>` with the `radiogroup` `role` references the id of the new element with the `aria-labeledby` attribute. This allows screen readers to better identify the purpose of a radio group.

### Deprecated

### Removed

### Fixed

### Security

## Testing

A new Jest test was added to ensure that the new label `<span>` is rendered. The snapshot was also updated to make sure that the snapshot test reflects the new markup.
