### PR TITLE
feat(components): update banner close position

### DIFF
--- a/packages/components/src/Banner/Banner.css
+++ b/packages/components/src/Banner/Banner.css
@@ -7,14 +7,10 @@
   display: flex;
   position: relative;
   box-shadow: var(--shadow-base);
-  padding: var(--flash--inset--small) var(--flash--inset);
+  padding: var(--flash--inset);
   color: var(--color-black);
   background-color: var(--color-grey--lightest);
   align-items: flex-start;
-}
-
-.flash.medium {
-  padding: var(--flash--inset);
 }
 
 .bannerContent {
@@ -26,7 +22,7 @@
 }
 
 .dismissibleSpacing {
-  padding-top: var(--space-smaller);
+  padding-top: var(--space-smallest);
   padding-right: var(--flash--inset);
 }
 
@@ -36,7 +32,12 @@
 }
 
 .bannerContent > *:first-child {
+  margin-top: 0;
   margin-right: var(--space-base);
+}
+
+.bannerContent > *:last-child {
+  margin-bottom: 0;
 }
 
 .medium .bannerContent {


### PR DESCRIPTION
## Motivations

Banner's dismiss button being so close to the edge of the component and having snug spacing between itself and the CTA has come up as an accessibility concern. This PR changes the alignment to flow with the rest of the content.

## Changes

Before:
![image](https://user-images.githubusercontent.com/39704901/137185247-a0024313-9a5b-43aa-9aa0-b1b80823a74c.png)

After:
![image](https://user-images.githubusercontent.com/39704901/137185368-5589f533-a857-4ccb-a516-0a9d2363031c.png)

### Changed

- CSS styling (removed absolute positioning, made close button work in flow of flex layout)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
