### PR TITLE
fix: update CSS types order on Banner

### DIFF
--- a/packages/components/src/Banner/Banner.css.d.ts
+++ b/packages/components/src/Banner/Banner.css.d.ts
@@ -1,8 +1,8 @@
 declare const styles: {
   readonly "flash": string;
-  readonly "medium": string;
   readonly "bannerContent": string;
   readonly "dismissibleSpacing": string;
+  readonly "medium": string;
   readonly "bannerAction": string;
   readonly "closeButton": string;
 };


### PR DESCRIPTION
## Motivations

Atlantis is broken on CI, I think it is because I forgot to re-run npm ci when @eddysims told me to.

![image](https://user-images.githubusercontent.com/39704901/137205518-c57e0dc5-7c56-4565-ae66-51af23e224f6.png)

https://app.circleci.com/pipelines/github/GetJobber/atlantis/4624/workflows/2e660759-6304-4e55-882b-1c35214eda92/jobs/20573?invite=true#step-108-21

## Changes

### Changed

- ran `npm ci` and it re-ordered my CSS types, hopefully that is the fix

### Fixed

- Atlantis does not want to build

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
