### PR TITLE
fix(components): Prevent animating and centering the placeholder label for time inputs

### DIFF
--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -44,7 +44,9 @@ export function FormFieldWrapper({
     align && styles[align],
     {
       [styles.miniLabel]:
-        (placeholder && value !== "") || (placeholder && type === "select"),
+        (placeholder && value !== "") ||
+        (placeholder && type === "select") ||
+        (placeholder && type === "time"),
       [styles.textarea]: type === "textarea",
       [styles.invalid]: invalid ?? error,
       [styles.disabled]: disabled,


### PR DESCRIPTION
Small fix that prevents centering the label for time inputs since those always have dashes even when empty:

*Before*:
![image](https://user-images.githubusercontent.com/14314519/137515269-477adb26-169a-44ed-a310-35d197aa3517.png)
 
*After*:
![image](https://user-images.githubusercontent.com/14314519/137515372-d6ce102b-02d7-4968-8a4b-fa42f159641f.png)
