### PR TITLE
fix(components): don't show tooltip when it's not truncated [JOB-36864]

### DIFF
--- a/packages/components/src/Chips/InternalChip.tsx
+++ b/packages/components/src/Chips/InternalChip.tsx
@@ -50,6 +50,6 @@ export function InternalChip({
   function isTruncated() {
     const truncateParentHeight = truncateRef?.parentElement?.offsetHeight || 0;
     const truncateChildHeight = truncateRef?.offsetHeight || 0;
-    return truncateChildHeight > truncateParentHeight * 2;
+    return truncateChildHeight >= truncateParentHeight * 2;
   }
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We add a tooltip when the chip starts truncating

![image](https://user-images.githubusercontent.com/15986172/137534657-be9e342a-91f5-4624-b4d8-f089b3ff22b1.png)

But there's no easy way to know if a text is truncating or not so we determine it by the height of the content compared to the parent. If the height of the content is bigger then we can assume that it is truncated.

That logic fails on firefox and mobile safari as it adds a little bit more height to the content (.5 px to be exact) thus, triggering the tooltip to exist.

### How did you fix it

- Calculate the height of the content and the parent
- Since we know that the truncation happens by clamping the text to only show 1 line, if the content height is twice the size of the parent, then it is truncating
### Known limitations
- If you resize the screen and the chip starts truncating, the tooltip won't show as it is triggered via render rather than resize
  - Left it as is with the assumption that it'll rarely happen
  - Also happens vice versa

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- the logic on determining if a tooltip shows up or not

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- On firefox, ensure the tooltip doesn't show on any example
- On mobile safari, ensure the tooltip doesn't show on any example

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
