### PR TITLE
docs(components): add width guidance to Page

### DIFF
--- a/packages/components/src/Page/Page.mdx
+++ b/packages/components/src/Page/Page.mdx
@@ -47,7 +47,7 @@ Use a `narrow` Page when the content is optimized for a single column, such as a
 #### Standard
 
 Use a `standard` Page for most "show" state layouts, as it allows for a mix of contents in a 
-mutli-column layout while keeping things constrained so the user does not have to track too far left-to-right
+multi-column layout while keeping things constrained so the user does not have to track too far left-to-right
 as they interact.
 
 #### Fill


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

@agglasaur asked: when can i use narrow over standard page pattern

## Changes

### Added

- guidance around page widths

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
