### PR TITLE
fix: Pull Request Title Generator layout and `components` issues

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/components/PullRequestGenerator/PullRequestGenerator.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/PullRequestGenerator/PullRequestGenerator.tsx
@@ -7,6 +7,7 @@ import { Option, Select } from "@jobber/components/Select";
 import { InputText } from "@jobber/components/InputText";
 import { Heading } from "@jobber/components/Heading";
 import { Banner } from "@jobber/components/Banner";
+import { Divider } from "@jobber/components/Divider";
 import { showToast } from "@jobber/components/Toast";
 
 export function PullRequestGenerator() {
@@ -22,27 +23,18 @@ export function PullRequestGenerator() {
     <Content>
       <Card title="Tell us about your pull request">
         <Content spacing="large">
-          <Text>
-            I want to{" "}
-            <Select
-              inline
-              size="small"
-              value={type}
-              onChange={(val: string) => setType(val)}
-            >
+          <Content spacing="small">
+            <Text>I want to...</Text>
+            <Select value={type} onChange={(val: string) => setType(val)}>
               <Option value="fix">fix something that&apos;s broken</Option>
               <Option value="feat">add some new functionality</Option>
               <Option value="docs">write documentation</Option>
               <Option value="build">improve the build system</Option>
               <Option value="chore">do something else important</Option>
-            </Select>{" "}
-            in our{" "}
-            <Select
-              inline
-              size="small"
-              value={type}
-              onChange={(val: string) => setScope(val)}
-            >
+            </Select>
+            <Text>in our...</Text>
+            <Select value={type} onChange={(val: string) => setScope(val)}>
+              <Option value="---">---</Option>
               <Option value="components">component library</Option>
               <Option value="hooks">hooks library</Option>
               <Option value="design">design foundation system</Option>
@@ -50,12 +42,12 @@ export function PullRequestGenerator() {
               <Option value="eslint-config">eslint config</Option>
               <Option value="stylelint-config">stylelint config</Option>
             </Select>
-          </Text>
+          </Content>
+          <Divider />
           <Content>
             <InputText
               placeholder="Description"
               multiline
-              size="small"
               rows={2}
               onChange={(val: string) => setDescription(val)}
             />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The PR title gen tool had some layout issues with the `small` `inline` Selects. They looked good, except at some point the carets on the Select started overlapping the values. 

In addition, there's a bug in the onChange event in the second select that causes the first option (in this case `components` ) value to never be passed in to the generated title. 

![image](https://user-images.githubusercontent.com/39704901/138542947-af234977-9c7b-4569-8ca5-88f684be0b57.png)

This PR adjusts the layout so it's less nifty, but less broken. The second Select now has a "---" default value so the user can update the generated title to any of the available options.

![image](https://user-images.githubusercontent.com/39704901/138543076-2f66f2c4-8ddb-42c6-be1b-000f5c2d6c71.png)

## Changes

### Fixed

- User can generate a PR title with a scope of `components`
- Caret on Selects does not overlap values

## Testing

Go to the PR title generator and try it out!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
