### PR TITLE
fix: Stop search results from lagging by one keystroke.

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.tsx
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.tsx
@@ -49,7 +49,7 @@ function List({ items, level = 1, initialOpen, sidebarRef }: ListProps) {
     <ul className={listClass}>
       {items.map(item => (
         <Item
-          key={item.id}
+          key={`${item.id} - ${items.length}`}
           initialOpen={initialOpen}
           item={item}
           sidebarRef={sidebarRef}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Resolves an issue where search lags by a keystroke.

### Security

- <!-- in case of vulnerabilities -->

## Testing

Search for `tab`.

### Before

![image](https://user-images.githubusercontent.com/131327/138999426-edacedda-3010-4701-9de1-c0e92a984bf2.png)

### After

![image](https://user-images.githubusercontent.com/131327/138999703-c7fc93c8-9075-49bc-b401-dd264cfc5fc5.png)



---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
