### PR TITLE
feat(components): Menu component respects fullwidth on custom activator such as button

### DIFF
--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -119,3 +119,7 @@
     background-color: transparent;
   }
 }
+
+.fullWidth {
+  width: 100%;
+}

--- a/packages/components/src/Menu/Menu.css.d.ts
+++ b/packages/components/src/Menu/Menu.css.d.ts
@@ -10,6 +10,7 @@ declare const styles: {
   readonly "action": string;
   readonly "icon": string;
   readonly "overlay": string;
+  readonly "fullWidth": string;
 };
 export = styles;
 

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -62,6 +62,7 @@ export interface SectionProps {
 // eslint-disable-next-line max-statements
 export function Menu({ activator, items }: MenuProps) {
   const [visible, setVisible] = useState(false);
+  const fullWidth = activator?.props?.fullWidth || false;
   const [position, setPosition] = useState<Position>({
     vertical: "below",
     horizontal: "right",
@@ -90,7 +91,7 @@ export function Menu({ activator, items }: MenuProps) {
 
       setPosition(newPosition);
     }
-  }, [visible]);
+  }, [visible, fullWidth]);
 
   if (!activator) {
     activator = (
@@ -111,8 +112,12 @@ export function Menu({ activator, items }: MenuProps) {
     position.horizontal === "right" && styles.right,
   );
 
+  const wrapperClasses = classnames(styles.wrapper, {
+    [styles.fullWidth]: fullWidth,
+  });
+
   return (
-    <div className={styles.wrapper} ref={wrapperRef}>
+    <div className={wrapperClasses} ref={wrapperRef}>
       {React.cloneElement(activator, {
         onClick: toggle(activator.props.onClick),
         id: buttonID,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

In smaller layouts, it is ideal to update menu to take the full width of the container it's in so that it can span the entire screen, such as on smaller screens. Button's support this behaviour with a `fullWidth` prop, however, when used in custom activator it's ignored as the parent container doesn't grow to full width.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added conditional css class to make menu grow to full width when custom activator has `fullWidth` prop. 

## Testing

<!-- How to test your changes. -->

```
<Menu
  activator={<Button fullWidth label="My Fancy Menu" />}
  items={[
    {
      actions: [
        {
          label: 'Edit',
          icon: 'edit',
          onClick: () => {
            alert('✏️')
          },
        },
      ],
    },
    {
      header: 'Send as...',
      actions: [
        {
          label: 'Text Message',
          icon: 'sms',
          onClick: () => {
            alert('📱')
          },
        },
        {
          label: 'Email',
          icon: 'email',
          onClick: () => {
            alert('📨')
          },
        },
      ],
    },
  ]}
/>
```

See the custom activator take the full width of the container

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
