### PR TITLE
fix(components): Fix form field inconsistent spacing when used under Form and InputGroup JOB-37646

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -5,33 +5,37 @@ exports[`it should display headers when headers are passed in 1`] = `
   className="autocomplete"
 >
   <div
-    className="wrapper"
-    style={
-      Object {
-        "--formField-maxLength": undefined,
-      }
-    }
+    className="padded small"
   >
     <div
-      className="inputWrapper"
+      className="wrapper"
+      style={
+        Object {
+          "--formField-maxLength": undefined,
+        }
+      }
     >
-      <label
-        className="label"
-        htmlFor="123e4567-e89b-12d3-a456-426655440035"
+      <div
+        className="inputWrapper"
       >
-        placeholder_name
-      </label>
-      <input
-        autoComplete="autocomplete-off"
-        className="input"
-        id="123e4567-e89b-12d3-a456-426655440035"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        type="text"
-        value=""
-      />
+        <label
+          className="label"
+          htmlFor="123e4567-e89b-12d3-a456-426655440035"
+        >
+          placeholder_name
+        </label>
+        <input
+          autoComplete="autocomplete-off"
+          className="input"
+          id="123e4567-e89b-12d3-a456-426655440035"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -42,33 +46,37 @@ exports[`renders an Autocomplete 1`] = `
   className="autocomplete"
 >
   <div
-    className="wrapper"
-    style={
-      Object {
-        "--formField-maxLength": undefined,
-      }
-    }
+    className="padded small"
   >
     <div
-      className="inputWrapper"
+      className="wrapper"
+      style={
+        Object {
+          "--formField-maxLength": undefined,
+        }
+      }
     >
-      <label
-        className="label"
-        htmlFor="123e4567-e89b-12d3-a456-426655440001"
+      <div
+        className="inputWrapper"
       >
-        placeholder_name
-      </label>
-      <input
-        autoComplete="autocomplete-off"
-        className="input"
-        id="123e4567-e89b-12d3-a456-426655440001"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        type="text"
-        value=""
-      />
+        <label
+          className="label"
+          htmlFor="123e4567-e89b-12d3-a456-426655440001"
+        >
+          placeholder_name
+        </label>
+        <input
+          autoComplete="autocomplete-off"
+          className="input"
+          id="123e4567-e89b-12d3-a456-426655440001"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -277,7 +277,3 @@
 .miniLabel:not(.small) .affixLabel {
   padding-top: calc(var(--field--padding-top) - 2px);
 }
-
-.description {
-  margin-top: var(--space-smaller);
-}

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -19,7 +19,6 @@ declare const styles: {
   readonly "suffix": string;
   readonly "hasAction": string;
   readonly "affixLabel": string;
-  readonly "description": string;
 };
 export = styles;
 

--- a/packages/components/src/FormField/FormFieldDescription.tsx
+++ b/packages/components/src/FormField/FormFieldDescription.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styles from "./FormField.css";
 import { Text } from "../Text";
 
 interface FormFieldDescriptionProps {
@@ -12,7 +11,7 @@ export function FormFieldDescription({
   description,
 }: FormFieldDescriptionProps) {
   return (
-    <div id={id} className={styles.description}>
+    <div id={id}>
       <Text variation="subdued">{description}</Text>
     </div>
   );

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -1,4 +1,5 @@
 import React, {
+  Fragment,
   PropsWithChildren,
   RefObject,
   useEffect,
@@ -11,6 +12,7 @@ import styles from "./FormField.css";
 import { AffixIcon, AffixLabel } from "./FormFieldAffix";
 import { FormFieldDescription } from "./FormFieldDescription";
 import { InputValidation } from "../InputValidation";
+import { Content } from "../Content";
 
 interface FormFieldWrapperProps extends FormFieldProps {
   error: string;
@@ -76,8 +78,10 @@ export function FormFieldWrapper({
     setLabelStyle(getAffixPaddding);
   }, [value]);
 
+  const Tag = inline ? Fragment : Content;
+
   return (
-    <>
+    <Tag {...(!inline && { spacing: "small" })}>
       <div className={wrapperClasses} style={wrapperInlineStyle}>
         {prefix?.icon && <AffixIcon {...prefix} size={size} />}
         <div className={styles.inputWrapper}>
@@ -100,14 +104,18 @@ export function FormFieldWrapper({
           <AffixIcon {...suffix} variation="suffix" size={size} />
         )}
       </div>
-      {description && !inline && (
-        <FormFieldDescription
-          id={descriptionIdentifier}
-          description={description}
-        />
+      {!inline && (description || error) && (
+        <div>
+          {description && (
+            <FormFieldDescription
+              id={descriptionIdentifier}
+              description={description}
+            />
+          )}
+          {error && <InputValidation message={error} />}
+        </div>
       )}
-      {error && !inline && <InputValidation message={error} />}
-    </>
+    </Tag>
   );
 
   function getAffixPaddding() {

--- a/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
+++ b/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
@@ -3,21 +3,25 @@
 exports[`FormField when small renders 1`] = `
 <div>
   <div
-    class="wrapper small"
+    class="padded small"
   >
     <div
-      class="inputWrapper"
+      class="wrapper small"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440005"
-      />
-      <input
-        class="input"
-        id="123e4567-e89b-12d3-a456-426655440005"
-        type="text"
-        value=""
-      />
+      <div
+        class="inputWrapper"
+      >
+        <label
+          class="label"
+          for="123e4567-e89b-12d3-a456-426655440005"
+        />
+        <input
+          class="input"
+          id="123e4567-e89b-12d3-a456-426655440005"
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -26,21 +30,25 @@ exports[`FormField when small renders 1`] = `
 exports[`FormField with no props renders 1`] = `
 <div>
   <div
-    class="wrapper"
+    class="padded small"
   >
     <div
-      class="inputWrapper"
+      class="wrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440001"
-      />
-      <input
-        class="input"
-        id="123e4567-e89b-12d3-a456-426655440001"
-        type="text"
-        value=""
-      />
+      <div
+        class="inputWrapper"
+      >
+        <label
+          class="label"
+          for="123e4567-e89b-12d3-a456-426655440001"
+        />
+        <input
+          class="input"
+          id="123e4567-e89b-12d3-a456-426655440001"
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/components/src/InputGroup/InputGroup.css
+++ b/packages/components/src/InputGroup/InputGroup.css
@@ -3,8 +3,8 @@
 }
 
 .horizontal {
-  display: flex;
-  align-items: flex-end;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
 }
 
 .horizontal > *:not(:last-child) {

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -9,31 +9,35 @@ it("renders an input type number", () => {
   const tree = renderer.create(<InputNumber value={123} />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440001"
-        />
-        <input
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440001"
-          name="generatedName--123e4567-e89b-12d3-a456-426655440001"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          type="number"
-          value={123}
-        />
+        <div
+          className="inputWrapper"
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440001"
+          />
+          <input
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440001"
+            name="generatedName--123e4567-e89b-12d3-a456-426655440001"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            type="number"
+            value={123}
+          />
+        </div>
       </div>
     </div>
   `);

--- a/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
+++ b/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
@@ -3,21 +3,25 @@
 exports[`<InputPassword /> renders an input type password 1`] = `
 <div>
   <div
-    class="wrapper"
+    class="padded small"
   >
     <div
-      class="inputWrapper"
+      class="wrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440001"
-      />
-      <input
-        class="input"
-        id="123e4567-e89b-12d3-a456-426655440001"
-        type="password"
-        value="123"
-      />
+      <div
+        class="inputWrapper"
+      >
+        <label
+          class="label"
+          for="123e4567-e89b-12d3-a456-426655440001"
+        />
+        <input
+          class="input"
+          id="123e4567-e89b-12d3-a456-426655440001"
+          type="password"
+          value="123"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -10,32 +10,36 @@ it("renders a regular input for text and numbers", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440001"
+        <div
+          className="inputWrapper"
         >
-          Favourite colour
-        </label>
-        <input
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440001"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          type="text"
-          value=""
-        />
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440001"
+          >
+            Favourite colour
+          </label>
+          <input
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440001"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   `);
@@ -49,32 +53,36 @@ it("renders a textarea", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper textarea"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper textarea"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440003"
+        <div
+          className="inputWrapper"
         >
-          Describe your favourite colour?
-        </label>
-        <textarea
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440003"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          rows={3}
-          value=""
-        />
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440003"
+          >
+            Describe your favourite colour?
+          </label>
+          <textarea
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440003"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            rows={3}
+            value=""
+          />
+        </div>
       </div>
     </div>
   `);
@@ -92,32 +100,36 @@ it("renders a textarea with 4 rows", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper textarea"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper textarea"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440005"
+        <div
+          className="inputWrapper"
         >
-          Describe your favourite colour?
-        </label>
-        <textarea
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440005"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          rows={4}
-          value=""
-        />
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440005"
+          >
+            Describe your favourite colour?
+          </label>
+          <textarea
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440005"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            rows={4}
+            value=""
+          />
+        </div>
       </div>
     </div>
   `);

--- a/packages/components/src/InputTime/InputTime.test.tsx
+++ b/packages/components/src/InputTime/InputTime.test.tsx
@@ -10,30 +10,34 @@ it("renders a InputTime", () => {
   const tree = renderer.create(<InputTime />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440001"
-        />
-        <input
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440001"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          type="time"
-          value=""
-        />
+        <div
+          className="inputWrapper"
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440001"
+          />
+          <input
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440001"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            type="time"
+            value=""
+          />
+        </div>
       </div>
     </div>
   `);
@@ -45,30 +49,34 @@ it("renders an initial time when given 'defaultValue'", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440007"
-        />
-        <input
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440007"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          type="time"
-          value="11:23"
-        />
+        <div
+          className="inputWrapper"
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440007"
+          />
+          <input
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440007"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            type="time"
+            value="11:23"
+          />
+        </div>
       </div>
     </div>
   `);
@@ -80,31 +88,35 @@ it("renders correctly in a readonly state", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440009"
-        />
-        <input
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440009"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={true}
-          type="time"
-          value="11:23"
-        />
+        <div
+          className="inputWrapper"
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440009"
+          />
+          <input
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440009"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            readOnly={true}
+            type="time"
+            value="11:23"
+          />
+        </div>
       </div>
     </div>
   `);
@@ -116,31 +128,35 @@ it("adds a error border when invalid", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440015"
-        />
-        <input
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440015"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={true}
-          type="time"
-          value="11:23"
-        />
+        <div
+          className="inputWrapper"
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440015"
+          />
+          <input
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440015"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            readOnly={true}
+            type="time"
+            value="11:23"
+          />
+        </div>
       </div>
     </div>
   `);
@@ -150,30 +166,34 @@ it("should set the value when given 'value' and 'onChange'", () => {
   const tree = renderer.create(<InputTime invalid />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper invalid"
-      style={
-        Object {
-          "--formField-maxLength": undefined,
-        }
-      }
+      className="padded small"
     >
       <div
-        className="inputWrapper"
+        className="wrapper invalid"
+        style={
+          Object {
+            "--formField-maxLength": undefined,
+          }
+        }
       >
-        <label
-          className="label"
-          htmlFor="123e4567-e89b-12d3-a456-426655440021"
-        />
-        <input
-          className="input"
-          id="123e4567-e89b-12d3-a456-426655440021"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          type="time"
-          value=""
-        />
+        <div
+          className="inputWrapper"
+        >
+          <label
+            className="label"
+            htmlFor="123e4567-e89b-12d3-a456-426655440021"
+          />
+          <input
+            className="input"
+            id="123e4567-e89b-12d3-a456-426655440021"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            type="time"
+            value=""
+          />
+        </div>
       </div>
     </div>
   `);

--- a/packages/components/src/InputValidation/InputValidation.css
+++ b/packages/components/src/InputValidation/InputValidation.css
@@ -1,7 +1,3 @@
-.hasValidationMessage {
-  margin-top: var(--space-smaller);
-}
-
 .message {
   display: flex;
   align-items: center;

--- a/packages/components/src/InputValidation/InputValidation.css.d.ts
+++ b/packages/components/src/InputValidation/InputValidation.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "hasValidationMessage": string;
   readonly "message": string;
 };
 export = styles;

--- a/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
@@ -2,321 +2,349 @@
 
 exports[`renders a Select with many options 1`] = `
 <div
-  className="wrapper select"
-  style={
-    Object {
-      "--formField-maxLength": undefined,
-    }
-  }
+  className="padded small"
 >
   <div
-    className="inputWrapper"
+    className="wrapper select"
+    style={
+      Object {
+        "--formField-maxLength": undefined,
+      }
+    }
   >
-    <label
-      className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440005"
-    />
-    <select
-      className="input"
-      id="123e4567-e89b-12d3-a456-426655440005"
-      onChange={[Function]}
-      value=""
+    <div
+      className="inputWrapper"
     >
-      <option>
-        Foo
-      </option>
-      <option>
-        Bar
-      </option>
-      <option>
-        Baz
-      </option>
-      <option>
-        Quux
-      </option>
-    </select>
-    <span
-      className="postfix"
-    >
-      <svg
-        className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-        data-testid="arrowDown"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
+      <label
+        className="label"
+        htmlFor="123e4567-e89b-12d3-a456-426655440005"
+      />
+      <select
+        className="input"
+        id="123e4567-e89b-12d3-a456-426655440005"
+        onChange={[Function]}
+        value=""
       >
-        <path
-          className=""
-          d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
-        />
-      </svg>
-    </span>
+        <option>
+          Foo
+        </option>
+        <option>
+          Bar
+        </option>
+        <option>
+          Baz
+        </option>
+        <option>
+          Quux
+        </option>
+      </select>
+      <span
+        className="postfix"
+      >
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="arrowDown"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className=""
+            d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
+          />
+        </svg>
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders a Select with no options 1`] = `
 <div
-  className="wrapper select"
-  style={
-    Object {
-      "--formField-maxLength": undefined,
-    }
-  }
+  className="padded small"
 >
   <div
-    className="inputWrapper"
+    className="wrapper select"
+    style={
+      Object {
+        "--formField-maxLength": undefined,
+      }
+    }
   >
-    <label
-      className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440001"
-    />
-    <select
-      className="input"
-      id="123e4567-e89b-12d3-a456-426655440001"
-      onChange={[Function]}
-      value=""
-    />
-    <span
-      className="postfix"
+    <div
+      className="inputWrapper"
     >
-      <svg
-        className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-        data-testid="arrowDown"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
+      <label
+        className="label"
+        htmlFor="123e4567-e89b-12d3-a456-426655440001"
+      />
+      <select
+        className="input"
+        id="123e4567-e89b-12d3-a456-426655440001"
+        onChange={[Function]}
+        value=""
+      />
+      <span
+        className="postfix"
       >
-        <path
-          className=""
-          d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
-        />
-      </svg>
-    </span>
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="arrowDown"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className=""
+            d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
+          />
+        </svg>
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders a Select with one option 1`] = `
 <div
-  className="wrapper select"
-  style={
-    Object {
-      "--formField-maxLength": undefined,
-    }
-  }
+  className="padded small"
 >
   <div
-    className="inputWrapper"
+    className="wrapper select"
+    style={
+      Object {
+        "--formField-maxLength": undefined,
+      }
+    }
   >
-    <label
-      className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440003"
-    />
-    <select
-      className="input"
-      id="123e4567-e89b-12d3-a456-426655440003"
-      onChange={[Function]}
-      value=""
+    <div
+      className="inputWrapper"
     >
-      <option>
-        Foo
-      </option>
-    </select>
-    <span
-      className="postfix"
-    >
-      <svg
-        className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-        data-testid="arrowDown"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
+      <label
+        className="label"
+        htmlFor="123e4567-e89b-12d3-a456-426655440003"
+      />
+      <select
+        className="input"
+        id="123e4567-e89b-12d3-a456-426655440003"
+        onChange={[Function]}
+        value=""
       >
-        <path
-          className=""
-          d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
-        />
-      </svg>
-    </span>
+        <option>
+          Foo
+        </option>
+      </select>
+      <span
+        className="postfix"
+      >
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="arrowDown"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className=""
+            d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
+          />
+        </svg>
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders correctly as large 1`] = `
 <div
-  className="wrapper large select"
-  style={
-    Object {
-      "--formField-maxLength": undefined,
-    }
-  }
+  className="padded small"
 >
   <div
-    className="inputWrapper"
+    className="wrapper large select"
+    style={
+      Object {
+        "--formField-maxLength": undefined,
+      }
+    }
   >
-    <label
-      className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440009"
-    />
-    <select
-      className="input"
-      id="123e4567-e89b-12d3-a456-426655440009"
-      onChange={[Function]}
-      value=""
+    <div
+      className="inputWrapper"
     >
-      <option>
-        Foo
-      </option>
-    </select>
-    <span
-      className="postfix"
-    >
-      <svg
-        className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-        data-testid="arrowDown"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
+      <label
+        className="label"
+        htmlFor="123e4567-e89b-12d3-a456-426655440009"
+      />
+      <select
+        className="input"
+        id="123e4567-e89b-12d3-a456-426655440009"
+        onChange={[Function]}
+        value=""
       >
-        <path
-          className=""
-          d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
-        />
-      </svg>
-    </span>
+        <option>
+          Foo
+        </option>
+      </select>
+      <span
+        className="postfix"
+      >
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="arrowDown"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className=""
+            d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
+          />
+        </svg>
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders correctly as small 1`] = `
 <div
-  className="wrapper small select"
-  style={
-    Object {
-      "--formField-maxLength": undefined,
-    }
-  }
+  className="padded small"
 >
   <div
-    className="inputWrapper"
+    className="wrapper small select"
+    style={
+      Object {
+        "--formField-maxLength": undefined,
+      }
+    }
   >
-    <label
-      className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440007"
-    />
-    <select
-      className="input"
-      id="123e4567-e89b-12d3-a456-426655440007"
-      onChange={[Function]}
-      value=""
+    <div
+      className="inputWrapper"
     >
-      <option>
-        Foo
-      </option>
-    </select>
-    <span
-      className="postfix"
-    >
-      <svg
-        className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-        data-testid="arrowDown"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
+      <label
+        className="label"
+        htmlFor="123e4567-e89b-12d3-a456-426655440007"
+      />
+      <select
+        className="input"
+        id="123e4567-e89b-12d3-a456-426655440007"
+        onChange={[Function]}
+        value=""
       >
-        <path
-          className=""
-          d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
-        />
-      </svg>
-    </span>
+        <option>
+          Foo
+        </option>
+      </select>
+      <span
+        className="postfix"
+      >
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="arrowDown"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className=""
+            d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
+          />
+        </svg>
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders correctly when disabled 1`] = `
 <div
-  className="wrapper disabled select"
-  style={
-    Object {
-      "--formField-maxLength": undefined,
-    }
-  }
+  className="padded small"
 >
   <div
-    className="inputWrapper"
+    className="wrapper disabled select"
+    style={
+      Object {
+        "--formField-maxLength": undefined,
+      }
+    }
   >
-    <label
-      className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440011"
-    />
-    <select
-      className="input"
-      disabled={true}
-      id="123e4567-e89b-12d3-a456-426655440011"
-      onChange={[Function]}
-      value=""
+    <div
+      className="inputWrapper"
     >
-      <option>
-        Foo
-      </option>
-    </select>
-    <span
-      className="postfix"
-    >
-      <svg
-        className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-        data-testid="arrowDown"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
+      <label
+        className="label"
+        htmlFor="123e4567-e89b-12d3-a456-426655440011"
+      />
+      <select
+        className="input"
+        disabled={true}
+        id="123e4567-e89b-12d3-a456-426655440011"
+        onChange={[Function]}
+        value=""
       >
-        <path
-          className=""
-          d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
-        />
-      </svg>
-    </span>
+        <option>
+          Foo
+        </option>
+      </select>
+      <span
+        className="postfix"
+      >
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="arrowDown"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className=""
+            d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
+          />
+        </svg>
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`renders correctly when invalid 1`] = `
 <div
-  className="wrapper invalid select"
-  style={
-    Object {
-      "--formField-maxLength": undefined,
-    }
-  }
+  className="padded small"
 >
   <div
-    className="inputWrapper"
+    className="wrapper invalid select"
+    style={
+      Object {
+        "--formField-maxLength": undefined,
+      }
+    }
   >
-    <label
-      className="label"
-      htmlFor="123e4567-e89b-12d3-a456-426655440013"
-    />
-    <select
-      className="input"
-      id="123e4567-e89b-12d3-a456-426655440013"
-      onChange={[Function]}
-      value=""
+    <div
+      className="inputWrapper"
     >
-      <option>
-        Foo
-      </option>
-    </select>
-    <span
-      className="postfix"
-    >
-      <svg
-        className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-        data-testid="arrowDown"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
+      <label
+        className="label"
+        htmlFor="123e4567-e89b-12d3-a456-426655440013"
+      />
+      <select
+        className="input"
+        id="123e4567-e89b-12d3-a456-426655440013"
+        onChange={[Function]}
+        value=""
       >
-        <path
-          className=""
-          d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
-        />
-      </svg>
-    </span>
+        <option>
+          Foo
+        </option>
+      </select>
+      <span
+        className="postfix"
+      >
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="arrowDown"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className=""
+            d="M328.677 353.767c-8.333-8.309-19.249-12.453-30.16-12.433-10.876 0.019-21.745 4.175-30.042 12.466s-12.456 19.153-12.475 30.021c-0.019 10.918 4.139 21.842 12.475 30.172l213.334 213.51c8.337 8.333 19.264 12.497 30.191 12.497s21.854-4.164 30.191-12.497l213.333-213.33c8.337-8.33 12.497-19.254 12.476-30.172-0.021-10.868-4.177-21.729-12.476-30.021-8.294-8.291-19.166-12.447-30.042-12.466-10.91-0.019-21.828 4.125-30.161 12.433l-183.322 182.979-183.323-183.159z"
+          />
+        </svg>
+      </span>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The `<Input* />` components aren't contained in a single tag. In some cases, those are okay but the input's also renders an error and now description below the field, thus opening those elements to be updated by anything that encapsulates it such as `<Form />` and `<InputGroup />`.

### Standalone input 

![image](https://user-images.githubusercontent.com/15986172/139473572-652523bb-8a11-45ec-964f-f0ef348663ab.png)

### In a `<Form />`

![image](https://user-images.githubusercontent.com/15986172/139473755-176069a0-e056-4938-8c78-cfc731128214.png)

### In an `<InputGroup />`

![image](https://user-images.githubusercontent.com/15986172/139473831-27185ae5-0bff-4a36-8d7f-8765c5236927.png)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

#### Standalone input 

![image](https://user-images.githubusercontent.com/15986172/139474108-3b8386ae-c2bc-4732-8b46-41d003e209bd.png)


#### In a `<Form />`

![image](https://user-images.githubusercontent.com/15986172/139474049-78335e2d-2868-42e0-a634-3821ddcf0711.png)


#### In an `<InputGroup />`

![image](https://user-images.githubusercontent.com/15986172/139474173-d574c928-6ed2-4dd9-a0cb-431bee7b5a68.png)


### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
