### PR TITLE
feat(components): Add variation to FormField suffix

### DIFF
--- a/packages/components/src/FormField/FormFieldAffix.tsx
+++ b/packages/components/src/FormField/FormFieldAffix.tsx
@@ -8,12 +8,12 @@ import { Icon } from "../Icon";
 
 interface AffixLabelProps extends Affix {
   labelRef: RefObject<HTMLDivElement>;
-  variation?: "prefix" | "suffix";
+  affixVariation?: "prefix" | "suffix";
 }
 
 export function AffixLabel({
   label,
-  variation = "prefix",
+  affixVariation: variation = "prefix",
   labelRef,
 }: AffixLabelProps) {
   const affixLabelClass = classnames(styles.affixLabel, {
@@ -27,24 +27,27 @@ export function AffixLabel({
   );
 }
 interface AffixIconProps extends Pick<FormFieldProps, "size"> {
-  readonly variation?: "prefix" | "suffix";
+  readonly affixVariation?: "prefix" | "suffix";
 }
 
 export function AffixIcon({
   icon,
   onClick,
   ariaLabel,
-  variation = "prefix",
+  affixVariation = "prefix",
+  variation,
   size,
 }: AffixIconProps & XOR<Affix, Suffix>) {
   const affixIconClass = classnames(styles.affixIcon, {
-    [styles.suffix]: variation === "suffix",
+    [styles.suffix]: affixVariation === "suffix",
     [styles.hasAction]: onClick,
   });
 
   const iconSize = size === "small" ? "small" : "base";
 
   if (!icon) return <></>;
+
+  console.log(variation);
 
   return (
     <div className={affixIconClass}>
@@ -58,6 +61,7 @@ export function AffixIcon({
           icon={icon}
           onClick={onClick}
           type="tertiary"
+          variation={variation}
           size={iconSize}
         />
       ) : (

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -33,6 +33,7 @@ interface BaseSuffix extends Affix {
 
 export interface Suffix extends BaseSuffix {
   onClick(): void;
+  readonly variation?: "learning" | "subtle" | "destructive";
   readonly ariaLabel: string;
 }
 

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -93,11 +93,15 @@ export function FormFieldWrapper({
           {prefix?.label && <AffixLabel {...prefix} labelRef={prefixRef} />}
           {children}
           {suffix?.label && (
-            <AffixLabel {...suffix} labelRef={suffixRef} variation="suffix" />
+            <AffixLabel
+              {...suffix}
+              labelRef={suffixRef}
+              affixVariation="suffix"
+            />
           )}
         </div>
         {suffix?.icon && (
-          <AffixIcon {...suffix} variation="suffix" size={size} />
+          <AffixIcon {...suffix} affixVariation="suffix" size={size} />
         )}
       </div>
       {description && !inline && (

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -91,6 +91,38 @@ The textarea will start at a specified minimum and grow to a specified maximum.
   />
 </Playground>
 
+<Playground>
+  <Content>
+    <InputText
+      placeholder="Destructive"
+      suffix={{
+        icon: "trash",
+        variation: "destructive",
+        ariaLabel: "Delete me!",
+        onClick: () => alert("I've been deleted!"),
+      }}
+    />
+    <InputText
+      placeholder="Some field"
+      suffix={{
+        icon: "redo",
+        variation: "subtle",
+        ariaLabel: "Restart",
+        onClick: () => alert("Restarted!"),
+      }}
+    />
+    <InputText
+      placeholder="Some field"
+      suffix={{
+        icon: "help",
+        variation: "learning",
+        ariaLabel: "What does this mean?",
+        onClick: () => alert("You tell me!"),
+      }}
+    />
+  </Content>
+</Playground>
+
 ## Validation message
 
 You can add your own custom validation messages on a field. However, this


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Certain suffix actions could warrant a different type of action, and using variation can convey this information, such as with destructive, subtle or learning variations.

## Changes

### Added

- `variation` prop added to FormField suffix when `onClick` present

## Testing

See `InputText` documentation in the `Prefix/Suffix` section 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
