### PR TITLE
docs(components): add warning to InputValidation

### DIFF
--- a/packages/components/src/InputValidation/InputValidation.mdx
+++ b/packages/components/src/InputValidation/InputValidation.mdx
@@ -18,9 +18,12 @@ import { InputValidation } from ".";
 <ComponentStatus stage="ready" responsive="yes" accessible="yes" />
 
 <Banner type="warning">
-  90% of validation for inputs will be handled out-of-the-box by the [input
-  component's validation](/components/input-text/#validation-message). Check
-  that you cannot use the built-in validation before using this component.
+  90% of validation for inputs will be handled out-of-the-box by the{" "}
+  <a href="/components/input-text/#validation-message">
+    input component's validation
+  </a>
+  . Check that you cannot use the built-in validation before using this
+  component.
 </Banner>
 
 `InputValidation` allows you to show the validation messages in cases where an

--- a/packages/components/src/InputValidation/InputValidation.mdx
+++ b/packages/components/src/InputValidation/InputValidation.mdx
@@ -8,6 +8,7 @@ showDirectoryLink: true
 import { Playground, Props } from "docz";
 import { useState } from "react";
 import { ComponentStatus } from "@jobber/docx";
+import { Banner } from "@jobber/components/Banner";
 import { Text } from "@jobber/components/Text";
 import { InputText } from "@jobber/components/InputText";
 import { InputValidation } from ".";
@@ -16,8 +17,16 @@ import { InputValidation } from ".";
 
 <ComponentStatus stage="ready" responsive="yes" accessible="yes" />
 
-`InputValidation` allows you to show the validation messages separate from a
-particular input component.
+<Banner type="warning">
+  90% of validation for inputs will be handled out-of-the-box
+  by the [input component's validation](/components/input-text/#validation-message).
+  Check that you cannot use the built-in validation before using this
+  component.
+<Banner/>
+
+`InputValidation` allows you to show the validation messages in cases where an 
+[input's built-in validation](/components/input-text/#validation-message) is not 
+available, such as in `inline` usage.
 
 For more information about `validations` using any of the `Input` components,
 see the [InputText](/components/input-text/#validation-message) documentation.

--- a/packages/components/src/InputValidation/InputValidation.mdx
+++ b/packages/components/src/InputValidation/InputValidation.mdx
@@ -18,14 +18,13 @@ import { InputValidation } from ".";
 <ComponentStatus stage="ready" responsive="yes" accessible="yes" />
 
 <Banner type="warning">
-  90% of validation for inputs will be handled out-of-the-box
-  by the [input component's validation](/components/input-text/#validation-message).
-  Check that you cannot use the built-in validation before using this
-  component.
-<Banner/>
+  90% of validation for inputs will be handled out-of-the-box by the [input
+  component's validation](/components/input-text/#validation-message). Check
+  that you cannot use the built-in validation before using this component.
+</Banner>
 
-`InputValidation` allows you to show the validation messages in cases where an 
-[input's built-in validation](/components/input-text/#validation-message) is not 
+`InputValidation` allows you to show the validation messages in cases where an
+[input's built-in validation](/components/input-text/#validation-message) is not
 available, such as in `inline` usage.
 
 For more information about `validations` using any of the `Input` components,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The use case for Input Validation should be limited to cases where an input does not provide validation out of the box. This isn't clear from the docs.

## Changes

### Added

- Warning that directs readers to the docs for built-in input validation

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
