### PR TITLE
refactor: Fix linting and tests on Drawer

### DIFF
--- a/packages/components/src/Drawer/Drawer.test.tsx
+++ b/packages/components/src/Drawer/Drawer.test.tsx
@@ -15,7 +15,7 @@ describe("Drawer", () => {
     );
     expect(getByTestId("drawer-header")).toBeInTheDocument();
     expect(getByText(title)).toBeInTheDocument();
-    expect(getByLabelText("Close drawer")).toBeInTheDocument();
+    expect(getByLabelText(`Close ${title}`)).toBeInTheDocument();
     expect(getByText(content)).toBeInTheDocument();
   });
 
@@ -28,7 +28,7 @@ describe("Drawer", () => {
             {"Drawer Content"}
           </Drawer>,
         );
-        fireEvent.click(getByLabelText("Close drawer"));
+        fireEvent.click(getByLabelText("Close My drawer"));
         expect(onRequestCloseFn).toHaveBeenCalledTimes(1);
       });
     });

--- a/packages/components/src/Drawer/Drawer.tsx
+++ b/packages/components/src/Drawer/Drawer.tsx
@@ -65,7 +65,10 @@ function Header({ title, onRequestClose }: HeaderProps) {
       >
         {title}
       </Typography>
-      <ButtonDismiss onClick={onRequestClose} ariaLabel={`Close ${title || "drawer"}`} />
+      <ButtonDismiss
+        onClick={onRequestClose}
+        ariaLabel={`Close ${title || "drawer"}`}
+      />
     </div>
   );
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Linting and testing was ❌  on master, this fixes that.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Linting and tests on `Drawer`

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
