### PR TITLE
docs(design): Focus on focus

### DIFF
--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -114,8 +114,8 @@ different.
 
 `--color-focus`
 
-Use to indicate that an element has been focused (ideally using the
-`--shadow-focus` property).
+Used by the `--shadow-focus` property to indicate that an element has received
+focus. Avoid using `--color-focus` directly on UI elements.
 
 ### Status
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Attempt to resolve some confusion around the appropriate usage of the `--color-focus` property.

## Changes

### Changed

- Made more explicit the intended usage of `--color-focus` in the `--shadow-focus` property, and not in isolation

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
