### PR TITLE
fix(components): use correct colors for disabled text

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -26,6 +26,8 @@
   --field--padding-left: var(--space-base);
   --field--padding-right: var(--space-base);
 
+  --field--value-color: var(--color-heading);
+
   --field--border-color: var(--color-border);
   --field--background-color: var(--color-surface);
 
@@ -43,7 +45,7 @@
   border-bottom-right-radius: var(--public-field--bottom-right-radius);
   border-bottom-left-radius: var(--public-field--bottom-left-radius);
   border-top-left-radius: var(--public-field--top-left-radius);
-  color: var(--color-blue);
+  color: var(--field--value-color);
   font-size: var(--base-unit);
   background-color: var(--field--background-color);
 }
@@ -75,10 +77,9 @@
 
 .disabled {
   --field--placeholder-color: var(--color-disabled);
+  --field--value-color: var(--color-disabled);
   --field--background-color: var(--color-surface--background);
   --field--border-color: var(--color-disabled--secondary);
-
-  opacity: 0.6;
 }
 
 .small {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Atlantis FormFields were initially built with some legacy styling that has since been updated. This introduces usage of the intended colors for disabled states in FormField and its' inheriting components.

### Before:

- Uses an opacity of 0.6 on the entire input
- Value does not change color, but "dims" thanks to the use of opacity

![image](https://user-images.githubusercontent.com/39704901/141854609-e9b403f5-1186-48d8-a162-ad0e3bf8fbd3.png)

### After:

- Uses our semantic color of `disabled` for the value when the input is disabled
- No longer using opacity value

![image](https://user-images.githubusercontent.com/39704901/141854771-3085059d-0a33-4f51-9792-4d9f44925531.png)

## Changes

### Changed

- CSS changes to remove opacity and introduce usage of `color-disabled` for the FormField's `value` text elements.

### Fixed

- FormField with a value no longer uses a combination of opacity-changes and `blue` to create a "disabled" appearance, instead uses our specified semantic colors.

## Testing

Add the following snippets into the sandboxes for each component. There are more components that use `FormField`, but this should be a representative sample:

### InputText

```
<Content>
<InputText disabled placeholder="Ship Name" />
<InputText disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputText size="small" disabled placeholder="Ship Name" />
<InputText size="small" disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputText size="large" disabled placeholder="Ship Name" />
<InputText size="large" disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputText prefix={{ icon:'search', label:'Search for' }} disabled placeholder="Ship Name" />
<InputText prefix={{ icon:'search', label:'Search for' }}  disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputText prefix={{ icon:'search', label:'Search for' }}  size="small" disabled placeholder="Ship Name" />
<InputText prefix={{ icon:'search', label:'Search for' }}  size="small" disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputText prefix={{ icon:'search', label:'Search for' }}  size="large" disabled placeholder="Ship Name" />
<InputText prefix={{ icon:'search', label:'Search for' }}  size="large" disabled defaultValue="Rocinante" placeholder="Ship Name" />
</Content>
```

### InputPassword

```
<InputPassword disabled placeholder="Ship Name" />
<InputPassword disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputPassword size="small" disabled placeholder="Ship Name" />
<InputPassword size="small" disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputPassword size="large" disabled placeholder="Ship Name" />
<InputPassword size="large" disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputPassword prefix={{ icon:'search', label:'Search for' }} disabled placeholder="Ship Name" />
<InputPassword prefix={{ icon:'search', label:'Search for' }}  disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputPassword prefix={{ icon:'search', label:'Search for' }}  size="small" disabled placeholder="Ship Name" />
<InputPassword prefix={{ icon:'search', label:'Search for' }}  size="small" disabled defaultValue="Rocinante" placeholder="Ship Name" />
<InputPassword prefix={{ icon:'search', label:'Search for' }}  size="large" disabled placeholder="Ship Name" />
<InputPassword prefix={{ icon:'search', label:'Search for' }}  size="large" disabled defaultValue="Rocinante" placeholder="Ship Name" />
```

### Select

```
<Select disabled placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select disabled defaultValue="Rocinante" placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select size="small" disabled placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select size="small" disabled defaultValue="Rocinante" placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select size="large" disabled placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select size="large" disabled defaultValue="Rocinante" placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select prefix={{ icon:'search', label:'Search for' }} disabled placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select prefix={{ icon:'search', label:'Search for' }}  disabled defaultValue="Rocinante" placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select prefix={{ icon:'search', label:'Search for' }}  size="small" disabled placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select prefix={{ icon:'search', label:'Search for' }}  size="small" disabled defaultValue="Rocinante" placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select prefix={{ icon:'search', label:'Search for' }}  size="large" disabled placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
<Select prefix={{ icon:'search', label:'Search for' }}  size="large" disabled defaultValue="Rocinante" placeholder="Ship Name" >
    <Option value="tony">Rocinante</Option>
  <Option value="quincy">Quincy</Option>
  <Option value="peppa">Peppa Pig</Option>
</Select>
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
