### PR TITLE
feat(components): Use focus shadow instead of focus border

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -53,7 +53,9 @@
 }
 
 .wrapper:focus-within {
-  --field--border-color: var(--color-focus);
+  position: relative;
+  z-index: var(--field--base-elevation);
+  box-shadow: var(--shadow-focus);
 }
 
 .miniLabel {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Similar to #776 , Atlantis inputs were designed with legacy styling in mind that we should be OK to move on from.

In particular, the lack of a focus "ring" and leveraging border-color in lieu led to issues where you could not clearly tell if you had focused an input with an error; this makes it harder to fix the error as it adds a bit of cognitive load.

### Before:

Input in isolation
![image](https://user-images.githubusercontent.com/39704901/141860835-183638fc-afc9-4c4e-a3f8-5fbab4733bb6.png)

Input focused + invalid (note that you can't see the "focus" color because the border has taken the "error" color)
![image](https://user-images.githubusercontent.com/39704901/141860958-b5b56ff0-4acd-44ba-890e-fae8ef276a85.png)

Input in a group (note that bottom border is also hidden by subsequent input)
![image](https://user-images.githubusercontent.com/39704901/141860800-ec07818f-ffa6-4a58-9d11-61dce0d8714c.png)

Input in a modal
![image](https://user-images.githubusercontent.com/39704901/141860755-3ea69b1b-5c1a-42e8-8fc5-098ef0721478.png)

### After:

Input in isolation:
![image](https://user-images.githubusercontent.com/39704901/141860658-f8d3dac5-98f6-44b2-bf49-12eaf92a6ce9.png)

Input focused + invalid
![image](https://user-images.githubusercontent.com/39704901/141860923-cf6b798b-9454-4b26-8d4f-a14b1af5a4a6.png)

Input in a group:
![image](https://user-images.githubusercontent.com/39704901/141860599-0f401d05-5b6e-4572-a1b4-5f2ccba51c58.png)

Input in a modal (showing that z-index usage is not creating any conflicts with other "elevated" elements)
![image](https://user-images.githubusercontent.com/39704901/141860518-b82d5091-1fdc-407f-9d4d-c9cd54afdcc5.png)

## Changes

### Added

- Focus shadow styling to FormField

### Changed

- Focus state now uses "shadow" focus style, and (although not a visual change) relies on z-index to ensure focus ring is visible when Inputs are in an InputGroup

## Testing

- [x] Focus [InputText](https://deploy-preview-777--jobber-atlantis.netlify.app/components/input-text)
- [x] Focus [InputGroup](https://deploy-preview-777--jobber-atlantis.netlify.app/components/input-group)
- [x] Focus [Select](https://deploy-preview-777--jobber-atlantis.netlify.app/components/select)
- [x] Focus the input in a [Modal in the "with Actions" demo of Modal](https://deploy-preview-777--jobber-atlantis.netlify.app/components/modal/#with-actions)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
