### PR TITLE
docs(design): Write spacing guidelines

### DIFF
--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -6,7 +6,74 @@ route: /space
 
 # Spacing
 
-Spacing for the Jobber Atlantis Design System
+Our spacing system exists to support the foundational visual design 
+principle of [proximity-based grouping:](https://www.nngroup.com/articles/gestalt-proximity/) 
+
+> Using varying amounts of whitespace to either unite or separate elements 
+> is key to communicating meaningful groupings.
+
+In the shortest, simplest, terms: the closer two elements are related, 
+the tighter the spacing between them should be. 
+
+With in mind, let’s start small and work our way up.
+
+## Spacing guidelines
+
+### Miniscule and Smallest
+
+At their respective sizes (`1px` and `2px` equivalent), these values should mostly be 
+used to provide optical adjustments where an element is visually off-centered.
+
+### Smaller
+
+The `smaller` spacing value can be used between contents of a single component. 
+For example, see the spacing between an Icon and the label inside of a [Button.](/components/button#icons)
+
+![image](https://user-images.githubusercontent.com/39704901/143130466-6754b6bc-5eb6-423c-b1a5-8ac7203f116a.png)
+
+#### Small
+
+Sibling items within a container can be separated by the `small` value to reflect their relation 
+to each other. An example would be the spacing between [Chips in a selection group.](/components/chips#single-select)
+
+![image](https://user-images.githubusercontent.com/39704901/143130218-5ecbd5ea-557b-494f-a949-7da93ac1f595.png)
+
+#### Base
+
+Use `base` as the default spacing in larger content containers with multiple children of their own, 
+such as [Card.](/components/card) This should also be used as the default starting point for spacing between
+[Form](/components/form) elements.
+
+![image](https://user-images.githubusercontent.com/39704901/143130996-ee2e8c1b-9b3f-41a2-a417-be280f3144a4.png)
+
+#### Large
+
+Use `large` spacing if you need a section to breathe a bit more. [Modal](/components/modal) uses `large` 
+spacing in its' header and around the edges to give itself a bit more prominence as a "standalone" view.
+
+![image](https://user-images.githubusercontent.com/39704901/143131252-280d81e6-7c01-4960-ae83-998dd4f92096.png)
+
+#### Larger
+
+`Larger` doubles the value of `base` to very clearly delineate two groups of content that themselves use `base`. 
+It may be useful if you have a long list of `Cards` that need to be broken up.
+
+![image](https://user-images.githubusercontent.com/39704901/143132579-943e8f40-82c2-44ba-950b-51b1f400ccb2.png)
+
+#### Largest and Extravagant
+
+You’ll probably never need these unless you’re doing a custom layout, but they’re here if you need ‘em.
+These values are equivalent to `48px` and `64px` respectively.
+
+## Implementation
+
+### Content
+
+Use the [Content component](/components/content) for any instances where you need uniform spacing beween elements.
+
+Content can set its' spacing to either `small`, `base`, or `large`; follow the guidelines above as needed.
+
+### Values
 
 export function Example({ of: size }) {
   const style = {

--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -15,7 +15,7 @@ Our spacing system exists to support the foundational visual design principle of
 In the shortest, simplest terms: the closer two elements are related, the
 tighter the spacing between them should be.
 
-With in mind, let’s start small and work our way up.
+With this in mind, let’s start small and work our way up.
 
 ## Design & usage guidelines
 

--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -12,7 +12,7 @@ principle of [proximity-based grouping:](https://www.nngroup.com/articles/gestal
 > Using varying amounts of whitespace to either unite or separate elements 
 > is key to communicating meaningful groupings.
 
-In the shortest, simplest, terms: the closer two elements are related, 
+In the shortest, simplest terms: the closer two elements are related, 
 the tighter the spacing between them should be. 
 
 With in mind, let’s start small and work our way up.
@@ -71,9 +71,9 @@ These values are equivalent to `48px` and `64px` respectively.
 
 ### Content
 
-Use the [Content component](/components/content) for any instances where you need uniform spacing beween elements.
+Use the [Content component](/components/content) for any instances where you need uniform spacing between elements.
 
-Content can set its' spacing to either `small`, `base`, or `large`; follow the guidelines above as needed.
+Content can set its spacing to either `small`, `base`, or `large`; follow the guidelines above as needed.
 
 ### Values
 

--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -29,14 +29,14 @@ used to provide optical adjustments where an element is visually off-centered.
 The `smaller` spacing value can be used between contents of a single component. 
 For example, see the spacing between an Icon and the label inside of a [Button.](/components/button#icons)
 
-![image](https://user-images.githubusercontent.com/39704901/143130466-6754b6bc-5eb6-423c-b1a5-8ac7203f116a.png)
+![illustration of a smaller space between icon and button label](https://user-images.githubusercontent.com/39704901/143141489-679fa61b-5497-4e81-bfe0-b5f463673e4b.png)
 
 ### Small
 
 Sibling items within a container can be separated by the `small` value to reflect their relation 
 to each other. An example would be the spacing between [Chips in a selection group.](/components/chips#single-select)
 
-![image](https://user-images.githubusercontent.com/39704901/143130218-5ecbd5ea-557b-494f-a949-7da93ac1f595.png)
+![illustration of a small space between Chip components](https://user-images.githubusercontent.com/39704901/143141613-193ceeb2-b393-44ab-a5e8-21d2f88c67c4.png)
 
 ### Base
 
@@ -44,21 +44,21 @@ Use `base` as the default spacing in larger content containers with multiple chi
 such as [Card.](/components/card) This should also be used as the default starting point for spacing between
 [Form](/components/form) elements.
 
-![image](https://user-images.githubusercontent.com/39704901/143130996-ee2e8c1b-9b3f-41a2-a417-be280f3144a4.png)
+![illustration of spacing between form elements inside of a card](https://user-images.githubusercontent.com/39704901/143141662-0f20eec4-8b27-44fe-96f5-1bf1c4d567aa.png)
 
 ### Large
 
 Use `large` spacing if you need a section to breathe a bit more. [Modal](/components/modal) uses `large` 
 spacing in its' header and around the edges to give itself a bit more prominence as a "standalone" view.
 
-![image](https://user-images.githubusercontent.com/39704901/143131252-280d81e6-7c01-4960-ae83-998dd4f92096.png)
+![illustration of the large space around a Modal's header and content](https://user-images.githubusercontent.com/39704901/143141691-159b1b4c-0b0a-4b61-97d2-15ad06526d69.png)
 
 ### Larger
 
 `Larger` doubles the value of `base` to very clearly delineate two groups of content that themselves use `base`. 
-It may be useful if you have a long list of `Cards` that need to be broken up.
+It may be useful if you have a long list of mixed content types that need to be broken up.
 
-![image](https://user-images.githubusercontent.com/39704901/143132579-943e8f40-82c2-44ba-950b-51b1f400ccb2.png)
+![illustration of larger spacing being used to break up unrelated sections of content](https://user-images.githubusercontent.com/39704901/143141846-43606573-1383-4ad2-9d95-46611488cbae.png)
 
 ### Largest and Extravagant
 

--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -17,7 +17,7 @@ the tighter the spacing between them should be.
 
 With in mind, let’s start small and work our way up.
 
-## Spacing guidelines
+## Design & usage guidelines
 
 ### Miniscule and Smallest
 
@@ -31,14 +31,14 @@ For example, see the spacing between an Icon and the label inside of a [Button.]
 
 ![image](https://user-images.githubusercontent.com/39704901/143130466-6754b6bc-5eb6-423c-b1a5-8ac7203f116a.png)
 
-#### Small
+### Small
 
 Sibling items within a container can be separated by the `small` value to reflect their relation 
 to each other. An example would be the spacing between [Chips in a selection group.](/components/chips#single-select)
 
 ![image](https://user-images.githubusercontent.com/39704901/143130218-5ecbd5ea-557b-494f-a949-7da93ac1f595.png)
 
-#### Base
+### Base
 
 Use `base` as the default spacing in larger content containers with multiple children of their own, 
 such as [Card.](/components/card) This should also be used as the default starting point for spacing between
@@ -46,24 +46,26 @@ such as [Card.](/components/card) This should also be used as the default starti
 
 ![image](https://user-images.githubusercontent.com/39704901/143130996-ee2e8c1b-9b3f-41a2-a417-be280f3144a4.png)
 
-#### Large
+### Large
 
 Use `large` spacing if you need a section to breathe a bit more. [Modal](/components/modal) uses `large` 
 spacing in its' header and around the edges to give itself a bit more prominence as a "standalone" view.
 
 ![image](https://user-images.githubusercontent.com/39704901/143131252-280d81e6-7c01-4960-ae83-998dd4f92096.png)
 
-#### Larger
+### Larger
 
 `Larger` doubles the value of `base` to very clearly delineate two groups of content that themselves use `base`. 
 It may be useful if you have a long list of `Cards` that need to be broken up.
 
 ![image](https://user-images.githubusercontent.com/39704901/143132579-943e8f40-82c2-44ba-950b-51b1f400ccb2.png)
 
-#### Largest and Extravagant
+### Largest and Extravagant
 
 You’ll probably never need these unless you’re doing a custom layout, but they’re here if you need ‘em.
 These values are equivalent to `48px` and `64px` respectively.
+
+---
 
 ## Implementation
 

--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -53,12 +53,12 @@ elements.
 ### Large
 
 Use `large` spacing for higher-level "parent" containers.
-[Modal](/components/modal) uses `large` spacing in its' header and around the
+[Modal](/components/modal) uses `large` spacing in its header and around the
 edges to give itself a bit more prominence as a "standalone" view, in a similar
 manner to [Page](/components/page).
 
 `Large` can also be used to help give a "floating" element some clear separation
-from the edge of its' container, as seen in [Toast](/components/toast).
+from the edge of its container, as seen in [Toast](/components/toast).
 
 ![illustration of the large space around a Modal's header and content, a Page's outer padding, and a Toast near the bottom of a viewport](https://user-images.githubusercontent.com/39704901/143152557-8fca3292-dc07-4f9b-a33b-f4d4603c9dd2.png)
 

--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -60,7 +60,7 @@ manner to [Page](/components/page).
 `Large` can also be used to help give a "floating" element some clear separation
 from the edge of its' container, as seen in [Toast](/components/toast).
 
-![illustration of the large space around a Modal's header and content](https://user-images.githubusercontent.com/39704901/143141691-159b1b4c-0b0a-4b61-97d2-15ad06526d69.png)
+![illustration of the large space around a Modal's header and content, a Page's outer padding, and a Toast near the bottom of a viewport](https://user-images.githubusercontent.com/39704901/143152557-8fca3292-dc07-4f9b-a33b-f4d4603c9dd2.png)
 
 ### Larger
 

--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -23,7 +23,7 @@ With this in mind, let’s start small and work our way up.
 
 At their respective sizes (`1px` and `2px` equivalent), these values should
 mostly be used to provide optical adjustments where an element is visually
-off-centered.
+misaligned.
 
 ### Smaller
 

--- a/packages/design/src/Spacing.mdx
+++ b/packages/design/src/Spacing.mdx
@@ -6,14 +6,14 @@ route: /space
 
 # Spacing
 
-Our spacing system exists to support the foundational visual design 
-principle of [proximity-based grouping:](https://www.nngroup.com/articles/gestalt-proximity/) 
+Our spacing system exists to support the foundational visual design principle of
+[proximity-based grouping:](https://www.nngroup.com/articles/gestalt-proximity/)
 
-> Using varying amounts of whitespace to either unite or separate elements 
-> is key to communicating meaningful groupings.
+> Using varying amounts of whitespace to either unite or separate elements is
+> key to communicating meaningful groupings.
 
-In the shortest, simplest terms: the closer two elements are related, 
-the tighter the spacing between them should be. 
+In the shortest, simplest terms: the closer two elements are related, the
+tighter the spacing between them should be.
 
 With in mind, let’s start small and work our way up.
 
@@ -21,49 +21,60 @@ With in mind, let’s start small and work our way up.
 
 ### Miniscule and Smallest
 
-At their respective sizes (`1px` and `2px` equivalent), these values should mostly be 
-used to provide optical adjustments where an element is visually off-centered.
+At their respective sizes (`1px` and `2px` equivalent), these values should
+mostly be used to provide optical adjustments where an element is visually
+off-centered.
 
 ### Smaller
 
-The `smaller` spacing value can be used between contents of a single component. 
-For example, see the spacing between an Icon and the label inside of a [Button.](/components/button#icons)
+The `smaller` spacing value can be used between contents of a single component.
+For example, see the spacing between an Icon and the label inside of a
+[Button.](/components/button#icons)
 
 ![illustration of a smaller space between icon and button label](https://user-images.githubusercontent.com/39704901/143141489-679fa61b-5497-4e81-bfe0-b5f463673e4b.png)
 
 ### Small
 
-Sibling items within a container can be separated by the `small` value to reflect their relation 
-to each other. An example would be the spacing between [Chips in a selection group.](/components/chips#single-select)
+Sibling items within a container can be separated by the `small` value to
+reflect their relation to each other. An example would be the spacing between
+[Chips in a selection group.](/components/chips#single-select)
 
 ![illustration of a small space between Chip components](https://user-images.githubusercontent.com/39704901/143141613-193ceeb2-b393-44ab-a5e8-21d2f88c67c4.png)
 
 ### Base
 
-Use `base` as the default spacing in larger content containers with multiple children of their own, 
-such as [Card.](/components/card) This should also be used as the default starting point for spacing between
-[Form](/components/form) elements.
+Use `base` as the default spacing in larger content containers with multiple
+children of their own, such as [Card.](/components/card) This should also be
+used as the default starting point for spacing between [Form](/components/form)
+elements.
 
 ![illustration of spacing between form elements inside of a card](https://user-images.githubusercontent.com/39704901/143141662-0f20eec4-8b27-44fe-96f5-1bf1c4d567aa.png)
 
 ### Large
 
-Use `large` spacing if you need a section to breathe a bit more. [Modal](/components/modal) uses `large` 
-spacing in its' header and around the edges to give itself a bit more prominence as a "standalone" view.
+Use `large` spacing for higher-level "parent" containers.
+[Modal](/components/modal) uses `large` spacing in its' header and around the
+edges to give itself a bit more prominence as a "standalone" view, in a similar
+manner to [Page](/components/page).
+
+`Large` can also be used to help give a "floating" element some clear separation
+from the edge of its' container, as seen in [Toast](/components/toast).
 
 ![illustration of the large space around a Modal's header and content](https://user-images.githubusercontent.com/39704901/143141691-159b1b4c-0b0a-4b61-97d2-15ad06526d69.png)
 
 ### Larger
 
-`Larger` doubles the value of `base` to very clearly delineate two groups of content that themselves use `base`. 
-It may be useful if you have a long list of mixed content types that need to be broken up.
+`Larger` doubles the value of `base` to very clearly delineate two groups of
+content that themselves use `base`. It may be useful if you have a long list of
+mixed content types that need to be broken up.
 
 ![illustration of larger spacing being used to break up unrelated sections of content](https://user-images.githubusercontent.com/39704901/143141846-43606573-1383-4ad2-9d95-46611488cbae.png)
 
 ### Largest and Extravagant
 
-You’ll probably never need these unless you’re doing a custom layout, but they’re here if you need ‘em.
-These values are equivalent to `48px` and `64px` respectively.
+You’ll probably never need these unless you’re doing a custom layout, but
+they’re here if you need ‘em. These values are equivalent to `48px` and `64px`
+respectively.
 
 ---
 
@@ -71,9 +82,11 @@ These values are equivalent to `48px` and `64px` respectively.
 
 ### Content
 
-Use the [Content component](/components/content) for any instances where you need uniform spacing between elements.
+Use the [Content component](/components/content) for any instances where you
+need uniform spacing between elements.
 
-Content can set its spacing to either `small`, `base`, or `large`; follow the guidelines above as needed.
+Content can set its spacing to either `small`, `base`, or `large`; follow the
+guidelines above as needed.
 
 ### Values
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
We've never had any guidelines or examples of how to use Spacing. We should have that, so that designers can follow defined patterns and we're not just doing what seems good on a case-by-case basis.

## Changes

### Added

- Adds usage guidelines to Spacing.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
