### PR TITLE
docs(components): include layout considerations in Banner guidelines

### DIFF
--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -31,16 +31,29 @@ import { Banner } from "@jobber/components/Banner";
 
 <Props of={Banner} />
 
-## Types of Banner
+## Design & usage guidelines
 
-BannerType could be any of the followings
+### Layout and alignment
+
+Banner should align to the left and right of the content it is related to.
+
+When using a Banner within a modal or a page layout, this means Banner should align to the 
+text, inputs or other UI elements beneath it. For best results, use [Content](/components/content)
+to ensure consistent vertical spacing between Banner and adjacent elements.
+
+If the Banner is being used as a system-wide message or some other context in which it is
+outside of the main application layout, it should take up the full available width.
+
+### Types of Banner
+
+There are four types of Banner, each with guidelines for their usage:
 
 - `notice` [<Icon name="link" />](#notice-message)
 - `success` [<Icon name="link" />](#success-message)
 - `warning`[<Icon name="link" />](#warning-message)
 - `error` [<Icon name="link" />](#error-message)
 
-## Notice message
+### Notice message
 
 Use notice banners to provide information about:
 
@@ -59,7 +72,7 @@ or change is important if context is not provided elsewhere.
   </Banner>
 </Playground>
 
-## Success message
+### Success message
 
 Success banners are appropriate when:
 
@@ -83,7 +96,7 @@ Otherwise, use [toasts](toast) as the default for success messages.
   </Banner>
 </Playground>
 
-## Warning message
+### Warning message
 
 Use warning banners when:
 
@@ -104,7 +117,7 @@ workflow.
   </Banner>
 </Playground>
 
-## Error message
+### Error message
 
 Use error banners when:
 
@@ -140,6 +153,15 @@ to resolve or troubleshoot the issue if possible.
   </Banner>
 </Playground>
 
+## Content Guidelines
+
+Content in banner should:
+
+- Be concise and kept to only 1 to 2 sentences where possible
+- Avoid exceeding 200 characters
+- Follow the [product vocabulary](/content/product-vocabulary) where applicable
+- In the case of warning or error banners, explain how to resolve the issue
+
 ## Actions in Banners
 
 It is discouraged to use a `<Button />` component when requiring an action
@@ -169,15 +191,6 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
     </Banner>
   </Content>
 </Playground>
-
-## Content Guidelines
-
-Content in banner should:
-
-- Be concise and kept to only 1 to 2 sentences where possible
-- Avoid exceeding 200 characters
-- Follow the [product vocabulary](/content/product-vocabulary) where applicable
-- In the case of warning or error banners, explain how to resolve the issue
 
 ## Related components
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There are some questions about the preferred approach to using Banner within various layout types. This attempts to address those questions!

## Changes

### Added

- Layout guidance to Banner design guidelines

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
