### PR TITLE
docs(components): update warning banner content for use case clarity

### DIFF
--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -110,6 +110,9 @@ possibly unknown impact a user’s changes or actions will have. They should not
 begin with "Warning:" and should not be used as a way to block or redirect a
 workflow.
 
+You should use [ConfirmationModal](/components/confirmation-modal) when you need to
+get explicit confirmation from the user before they complete an action.
+
 <Playground>
   <Banner type="warning">
     Your subscription will be automatically upgraded in 8 days
@@ -194,4 +197,6 @@ within a `Banner`. If you require an action, use the `primaryActions` prop. The
 ## Related components
 
 - To provide low priority, temporary feedback on the outcome of a user action,
-  use [Toast](toast) instead.
+  use [Toast](toast) instead
+- Use [ConfirmationModal](/components/confirmation-modal) when you need to
+get explicit confirmation from the user before they complete an action

--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -111,7 +111,7 @@ begin with "Warning:" and should not be used as a way to block or redirect a
 workflow.
 
 You should use [ConfirmationModal](/components/confirmation-modal) when you need to
-get explicit confirmation from the user before they complete an action.
+get explicit confirmation from the user before they complete an action that is difficult to reverse.
 
 <Playground>
   <Banner type="warning">

--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -112,8 +112,7 @@ workflow.
 
 <Playground>
   <Banner type="warning">
-    Editing this schedule will replace all incomplete visits with the updated
-    information for this job
+    Your subscription will be automatically upgraded in 8 days
   </Banner>
 </Playground>
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Sample warning banner was using an outdated use case that's better served by ConfirmationModal.

## Changes

### Added

- update to related components

### Changed

- Sample content in `warning` banner

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
