### PR TITLE
feat(components): Adjust formfield suffix actions to subtle

### DIFF
--- a/packages/components/src/FormField/FormFieldAffix.tsx
+++ b/packages/components/src/FormField/FormFieldAffix.tsx
@@ -57,6 +57,7 @@ export function AffixIcon({
           ariaLabel={ariaLabel as string}
           icon={icon}
           onClick={onClick}
+          variation="subtle"
           type="tertiary"
           size={iconSize}
         />

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -77,18 +77,36 @@ The textarea will start at a specified minimum and grow to a specified maximum.
 
 ## Prefix/Suffix
 
+Use a prefix or suffix when additional visual cues about an input's function may
+be helpful.
+
+Some fields have common visual patterns such as “search” having a magnifying
+glass icon, “Select” having a downwards arrow, or currency inputs having a
+currency symbol. These signifiers reinforce the purpose of the input to increase
+[Recognition over Recall](https://www.nngroup.com/articles/ten-usability-heuristics/)
+and align the input with
+[Consistency and Standards](https://www.nngroup.com/articles/ten-usability-heuristics/).
+With clearer guidance around the purpose of inputs, the user is able to better
+focus on the task at hand.
+
 <Playground>
-  <InputText
-    defaultValue="1,000,000"
-    placeholder="Invoice Total"
-    prefix={{ label: "$", icon: "invoice" }}
-    suffix={{
-      label: "💰💰💰",
-      icon: "paidInvoice",
-      ariaLabel: "Tell me i'm rich",
-      onClick: () => alert("You're rich!"),
-    }}
-  />
+  <Content>
+    <InputText
+      defaultValue="1,000,000"
+      placeholder="Invoice Total"
+      prefix={{ label: "$", icon: "invoice" }}
+      suffix={{ label: ".00" }}
+    />
+    <InputText
+      placeholder="Search"
+      prefix={{ icon: "search" }}
+      suffix={{
+        icon: "cross",
+        ariaLabel: "clear search",
+        onClick: () => alert("This could clear a search value"),
+      }}
+    />
+  </Content>
 </Playground>
 
 ## Validation message


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Aligned with design team on the question of whether we want to...

- change all “clickable” icons to use subtle
- keep all “clickable” icons using work
- allow the clickable icons to have the ability to configure the button “type” (demonstrated in #767 )
- other (allow to choose either work/subtle ?)

**Answer:** we'll use subtle for all FieldAffix actions

## Changes

### Changed

- when FieldAffix has an onClick event, the rendered Button uses the `subtle` variation
- also brought in some usage guidance from the initial design proposal

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
