### PR TITLE
feat(components): InputPhoneNumber component

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -4792,6 +4792,14 @@
 				"warning": "^4.0.3"
 			}
 		},
+		"react-number-format": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-4.8.0.tgz",
+			"integrity": "sha512-oGGiQpqzvKTR5PD2/AJbyUsci8jyupaoKxpuSPevjpWHMhFkUtmo390t+EIpJOgnuAHZogLu6PHiXgb/OXETKA==",
+			"requires": {
+				"prop-types": "^15.7.2"
+			}
+		},
 		"react-onclickoutside": {
 			"version": "6.12.0",
 			"resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.0.tgz",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,6 +44,7 @@
     "react-hook-form": "^6.7.2",
     "react-image-lightbox": "^5.1.1",
     "react-markdown": "^4.1.0",
+    "react-number-format": "^4.8.0",
     "react-popper": "^2.2.5",
     "react-router-dom": "^5.2.0",
     "time-input-polyfill": "^1.0.7",

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -358,4 +358,68 @@ describe("FormField", () => {
       });
     });
   });
+
+  describe("with masking", () => {
+    describe("when invalid data is entered", () => {
+      it("should render a masked input with placeholder values", async () => {
+        const maskingProperties = {
+          allowEmptyFormatting: false,
+          format: `### * ###`,
+          mask: "_",
+          prefix: "$$$ ",
+        };
+        const onChange = jest.fn();
+
+        const rendered = render(
+          <FormField
+            type="maskedNumber"
+            maskingProperties={maskingProperties}
+            onChange={onChange}
+            placeholder={"Phone Number"}
+          />,
+        );
+
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "abcde~!@#$%^&*()_+={}[]\\|`?/\"-'`" },
+        });
+
+        expect(onChange).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe("when valid data is entered", () => {
+      it("should render a masked input with the entered data in the correct spots", async () => {
+        const maskingProperties = {
+          allowEmptyFormatting: false,
+          format: `### * ###`,
+          mask: "_",
+          prefix: "$$$ ",
+        };
+        const onChange = jest.fn();
+
+        const rendered = render(
+          <FormField
+            type="maskedNumber"
+            maskingProperties={maskingProperties}
+            onChange={onChange}
+            placeholder={"Phone Number"}
+          />,
+        );
+
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "42" },
+        });
+
+        expect(onChange).toHaveBeenCalledWith("42_ * ___");
+      });
+    });
+  });
 });

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import uuid from "uuid";
 import { Controller, useForm, useFormContext } from "react-hook-form";
+import NumberFormat from "react-number-format";
 import { FormFieldProps } from "./FormFieldTypes";
 import styles from "./FormField.css";
 import { FormFieldWrapper } from "./FormFieldWrapper";
@@ -40,6 +41,7 @@ export function FormField(props: FormFieldProps) {
     onFocus,
     onBlur,
     onValidation,
+    maskingProperties,
   } = props;
 
   const { control, errors, setValue, watch } =
@@ -134,6 +136,21 @@ export function FormField(props: FormFieldProps) {
                   ref={inputRef as MutableRefObject<HTMLTextAreaElement>}
                 />
               );
+            case "maskedNumber":
+              return (
+                <>
+                  <NumberFormat
+                    {...textFieldProps}
+                    {...maskingProperties}
+                    thousandSeparator={true}
+                    prefix={"$"}
+                    onValueChange={handleOnValueChange}
+                    getInputRef={inputRef}
+                    onChange={maskedOnChangeHandler}
+                  />
+                  {loading && <FormFieldPostFix variation="spinner" />}
+                </>
+              );
             default:
               return (
                 <>
@@ -165,6 +182,17 @@ export function FormField(props: FormFieldProps) {
           }
 
           onChange && onChange(newValue);
+          onControllerChange(event);
+        }
+        function handleOnValueChange(values: {
+          formattedValue: string;
+          originalValue: string;
+        }) {
+          const { formattedValue } = values;
+          onChange && onChange(formattedValue);
+        }
+
+        function maskedOnChangeHandler(event: ChangeEvent<HTMLInputElement>) {
           onControllerChange(event);
         }
 

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -142,8 +142,6 @@ export function FormField(props: FormFieldProps) {
                   <NumberFormat
                     {...textFieldProps}
                     {...maskingProperties}
-                    thousandSeparator={true}
-                    prefix={"$"}
                     onValueChange={handleOnValueChange}
                     getInputRef={inputRef}
                     onChange={maskedOnChangeHandler}

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -149,8 +149,6 @@ export interface FormFieldProps extends CommonFormFieldProps {
    */
   readonly keyboard?: "numeric";
 
-  readonly maskingProperties?: NumberMaskingPropertyTypes;
-
   /**
    * Specifies the maximum numerical or date value that a user can type
    */
@@ -212,6 +210,11 @@ export interface FormFieldProps extends CommonFormFieldProps {
    * Determines what kind of form field should the component give you.
    */
   readonly type?: FormFieldTypes;
+
+  /**
+   * Properties for masking the input when the `type` is `numberMask`
+   */
+  readonly maskingProperties?: NumberMaskingPropertyTypes;
 
   /**
    * Show an error message above the field. This also

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -19,10 +19,10 @@ export type AutocompleteTypes =
   | "address-line2";
 
 interface NumberMaskingPropertyTypes {
-  format: string;
-  mask: string;
-  prefix: string;
-  allowEmptyFormatting: boolean;
+  prefix?: string;
+  format?: string;
+  mask?: string;
+  allowEmptyFormatting?: boolean;
 }
 
 export interface FieldActionsRef {

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -10,12 +10,20 @@ export type FormFieldTypes =
   | "time"
   | "textarea"
   | "select"
-  | "email";
+  | "email"
+  | "maskedNumber";
 
 export type AutocompleteTypes =
   | "one-time-code"
   | "address-line1"
   | "address-line2";
+
+interface NumberMaskingPropertyTypes {
+  format: string;
+  mask: string;
+  prefix: string;
+  allowEmptyFormatting: boolean;
+}
 
 export interface FieldActionsRef {
   setValue(value: string | number): void;
@@ -140,6 +148,8 @@ export interface FormFieldProps extends CommonFormFieldProps {
    * Determines what kind of keyboard appears on mobile web.
    */
   readonly keyboard?: "numeric";
+
+  readonly maskingProperties?: NumberMaskingPropertyTypes;
 
   /**
    * Specifies the maximum numerical or date value that a user can type

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.css
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.css
@@ -1,0 +1,10 @@
+.inputPhoneNumber {
+  --message-weight: 400;
+
+  font-weight: var(--message-weight);
+}
+
+.bold {
+  --message-weight: 800;
+  transform: uppercase;
+}

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.css.d.ts
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "inputPhoneNumber": string;
+  readonly "bold": string;
+};
+export = styles;
+

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.mdx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.mdx
@@ -7,9 +7,13 @@ showDirectoryLink: true
 
 import { Playground, Props } from "docz";
 import { InputPhoneNumber } from ".";
+import AllowedCountries from "./InputPhoneNumber";
 import { Heading } from "../Heading";
 
 # Input Phone Number
+
+Input phone number is used in anywhere you need to accept phone numbers as
+input.
 
 ```ts
 import { InputPhoneNumber } from "@jobber/components/InputPhoneNumber";
@@ -17,122 +21,47 @@ import { Heading } from "@jobber/components/Heading";
 ```
 
 <Playground>
-  <InputPhoneNumber text="Bob" country={"NorthAmerica"} />
+  <InputPhoneNumber country={"NorthAmerica"} />
 </Playground>
 
-<!--
-  INTERFACE: This is for the proposal stage of the component
+## Design Usage & Guidelines
 
-  Provide an example of what the component looks like in code. How would you use
-  it from another React component? This should consist primarily of code blocks.
-  This section can be deleted once the component is built, when the Playground
-  will demonstrate this at a higher fidelity.
--->
+This component is best suited for when you want to ensure the user adhears to a
+specific phone number format and present that information in a friendly-easily
+consumable way.
 
 ## Props
 
 <Props of={InputPhoneNumber} />
 
-<!--
-  It is not necessary to provide an example of each prop. Use usage examples to
-  highlight key features of a component or particular considerations.
+## Country Selection
 
-  See `Button.mdx` for a good example of this.
--->
+You can select between the countries that are supported.
 
-## Countries
+<ul>
+  <li> North America </li>
+  <li> Great Britain </li>
+</ul>
 
 <Playground>
-  <InputPhoneNumber
-    text="Bob"
-    country={"GreatBritain"}
-    showCountryCode={true}
-  />
+  <InputPhoneNumber country={"GreatBritain"} showCountryCode={true} />
 </Playground>
 
 ## Always Show Mask
 
+By default the option is set to true. However, you may not want the mask to
+apear until a user begins to interact with the input, in which case you would
+set this value to false.
+
 <Playground>
-  <InputPhoneNumber
-    text="Bob"
-    country={"NorthAmerica"}
-    alwaysShowMask={false}
-  />
+  <InputPhoneNumber country={"NorthAmerica"} alwaysShowMask={false} />
 </Playground>
 
 ## Show Country Code
 
+This switch just hides or shows the country code that precedes the rest of the
+input. By default this value is set to false.
+
 <Playground>
-  <InputPhoneNumber
-    text="Bob"
-    country={"NorthAmerica"}
-    showCountryCode={true}
-  />
+  <InputPhoneNumber country={"NorthAmerica"} showCountryCode={true} />
 </Playground>
-
-## Usage Guidelines
-
-The `<InputPhoneNumber>` will... _Add a brief description of the component_
-
-<!--
-  What is the design purpose of this component? How do its responsibilities
-  relate to other components? What should this component not be used for? What
-  are some related components in Atlantis? Try to describe this component not
-  in terms of what it looks like or what elements make it up, but what function
-  it performs or how it enables a user to perform tasks (e.g. “Buttons allow users
-  to initiate, complete, and reverse actions.” vs “Buttons are rectangular elements
-  that have a green background and white text”).
--->
-
-## Content Guidelines
-
-<!--
-  What type of content does this component present (documents, text, images, other components)?
-  What is the recommended, or expected, amount of content? What is the components’ behaviour when
-  the provided content diverges from what is expected (image aspect ratio, amount of text, video
-  vs audio, filesize)? Are there any important references to the [Product Vocabulary](https://atlantis.getjobber.com/guides/product-vocabulary)
-  that should be made regarding this component? What happens when content is unavailable or unreliable
-  (poor connection, empty states, flaky GPS data?)
--->
-
-## Accessibility
-
-<!--
-  Describe the accessibility concerns for the component. How does it handle touch vs cursor vs
-  keyboard events? Should it capture input? What should a screen reader see when it's focuse?
--->
-
-## Responsiveness
-
-<!--
-  How should the component behave on an iPhone 8? An iPad? A 1920x1080 monitor? How does the
-  component appear when the component itself is less than 375px wide? Less than 640px wide?
-  Less than 1200px wide? Greater than 1200px? Does it change when the device DPI is higher
-  or lower?
--->
-
-## Mockup
-
-<iframe
-  style="border: 1px solid rgba(0, 0, 0, 0.1);"
-  width="800"
-  height="450"
-  src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F3BXCXXD9glMtj8RAHjXiQC%2FDesign-System-Contribution-TEMPLATE%3Fnode-id%3D332%253A5526"
-  allowfullscreen
-></iframe>
-
-<!--
-  Insert a Figma mockup from the [Design System Contribution template](https://www.figma.com/file/3BXCXXD9glMtj8RAHjXiQC/Design-System-Contribution-TEMPLATE?node-id=26%3A2)
-  that conveys the visual design of the component, with variants and state accounted for.
-  Consider progressive enhancement; might this rely on newer browser features that aren’t
-  widely supported yet?
--->
-
-## Notes
-
-<!--
-  What decisions worth remembering have gone into this component? Did we consider any potentially valuable
-  functionality that we’re not implementing right now for scope purposes? Are there any design decisions
-  that might need explaining beyond the usage guidelines? This will help consumers understand this component
-  more fully.
--->

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.mdx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.mdx
@@ -21,7 +21,7 @@ import { Heading } from "@jobber/components/Heading";
 ```
 
 <Playground>
-  <InputPhoneNumber country={"NorthAmerica"} />
+  <InputPhoneNumber showCountryCode={true} />
 </Playground>
 
 ## Design Usage & Guidelines
@@ -34,34 +34,40 @@ consumable way.
 
 <Props of={InputPhoneNumber} />
 
-## Country Selection
+## Region Selection
 
 You can select between the countries that are supported.
+
+By default, we will assume `NorthAmerica`
 
 <ul>
   <li> North America </li>
   <li> Great Britain </li>
+  <li> Unknown </li>
 </ul>
 
 <Playground>
-  <InputPhoneNumber country={"GreatBritain"} showCountryCode={true} />
+  <InputPhoneNumber region={"GreatBritain"} showCountryCode={true} />
 </Playground>
 
 ## Always Show Mask
 
-By default the option is set to true. However, you may not want the mask to
-apear until a user begins to interact with the input, in which case you would
-set this value to false.
+You may not want the mask to appear until a user begins to interact with the
+input, in which case you would set this value to false.
+
+By default, we will assume `true`.
 
 <Playground>
-  <InputPhoneNumber country={"NorthAmerica"} alwaysShowMask={false} />
+  <InputPhoneNumber region={"NorthAmerica"} alwaysShowMask={false} />
 </Playground>
 
 ## Show Country Code
 
 This switch just hides or shows the country code that precedes the rest of the
-input. By default this value is set to false.
+input.
+
+By default, we will assume `false`.
 
 <Playground>
-  <InputPhoneNumber country={"NorthAmerica"} showCountryCode={true} />
+  <InputPhoneNumber region={"NorthAmerica"} showCountryCode={true} />
 </Playground>

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.mdx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.mdx
@@ -1,0 +1,138 @@
+---
+name: InputPhoneNumber
+menu: Components
+route: /components/input-phone-number
+showDirectoryLink: true
+---
+
+import { Playground, Props } from "docz";
+import { InputPhoneNumber } from ".";
+import { Heading } from "../Heading";
+
+# Input Phone Number
+
+```ts
+import { InputPhoneNumber } from "@jobber/components/InputPhoneNumber";
+import { Heading } from "@jobber/components/Heading";
+```
+
+<Playground>
+  <InputPhoneNumber text="Bob" country={"NorthAmerica"} />
+</Playground>
+
+<!--
+  INTERFACE: This is for the proposal stage of the component
+
+  Provide an example of what the component looks like in code. How would you use
+  it from another React component? This should consist primarily of code blocks.
+  This section can be deleted once the component is built, when the Playground
+  will demonstrate this at a higher fidelity.
+-->
+
+## Props
+
+<Props of={InputPhoneNumber} />
+
+<!--
+  It is not necessary to provide an example of each prop. Use usage examples to
+  highlight key features of a component or particular considerations.
+
+  See `Button.mdx` for a good example of this.
+-->
+
+## Countries
+
+<Playground>
+  <InputPhoneNumber
+    text="Bob"
+    country={"GreatBritain"}
+    showCountryCode={true}
+  />
+</Playground>
+
+## Always Show Mask
+
+<Playground>
+  <InputPhoneNumber
+    text="Bob"
+    country={"NorthAmerica"}
+    alwaysShowMask={false}
+  />
+</Playground>
+
+## Show Country Code
+
+<Playground>
+  <InputPhoneNumber
+    text="Bob"
+    country={"NorthAmerica"}
+    showCountryCode={true}
+  />
+</Playground>
+
+## Usage Guidelines
+
+The `<InputPhoneNumber>` will... _Add a brief description of the component_
+
+<!--
+  What is the design purpose of this component? How do its responsibilities
+  relate to other components? What should this component not be used for? What
+  are some related components in Atlantis? Try to describe this component not
+  in terms of what it looks like or what elements make it up, but what function
+  it performs or how it enables a user to perform tasks (e.g. “Buttons allow users
+  to initiate, complete, and reverse actions.” vs “Buttons are rectangular elements
+  that have a green background and white text”).
+-->
+
+## Content Guidelines
+
+<!--
+  What type of content does this component present (documents, text, images, other components)?
+  What is the recommended, or expected, amount of content? What is the components’ behaviour when
+  the provided content diverges from what is expected (image aspect ratio, amount of text, video
+  vs audio, filesize)? Are there any important references to the [Product Vocabulary](https://atlantis.getjobber.com/guides/product-vocabulary)
+  that should be made regarding this component? What happens when content is unavailable or unreliable
+  (poor connection, empty states, flaky GPS data?)
+-->
+
+## Accessibility
+
+<!--
+  Describe the accessibility concerns for the component. How does it handle touch vs cursor vs
+  keyboard events? Should it capture input? What should a screen reader see when it's focuse?
+-->
+
+## Responsiveness
+
+<!--
+  How should the component behave on an iPhone 8? An iPad? A 1920x1080 monitor? How does the
+  component appear when the component itself is less than 375px wide? Less than 640px wide?
+  Less than 1200px wide? Greater than 1200px? Does it change when the device DPI is higher
+  or lower?
+-->
+
+## Mockup
+
+<iframe
+  style="border: 1px solid rgba(0, 0, 0, 0.1);"
+  width="800"
+  height="450"
+  src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F3BXCXXD9glMtj8RAHjXiQC%2FDesign-System-Contribution-TEMPLATE%3Fnode-id%3D332%253A5526"
+  allowfullscreen
+></iframe>
+
+<!--
+  Insert a Figma mockup from the [Design System Contribution template](https://www.figma.com/file/3BXCXXD9glMtj8RAHjXiQC/Design-System-Contribution-TEMPLATE?node-id=26%3A2)
+  that conveys the visual design of the component, with variants and state accounted for.
+  Consider progressive enhancement; might this rely on newer browser features that aren’t
+  widely supported yet?
+-->
+
+## Notes
+
+<!--
+  What decisions worth remembering have gone into this component? Did we consider any potentially valuable
+  functionality that we’re not implementing right now for scope purposes? Are there any design decisions
+  that might need explaining beyond the usage guidelines? This will help consumers understand this component
+  more fully.
+-->

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.mdx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.mdx
@@ -12,7 +12,7 @@ import { Heading } from "../Heading";
 
 # Input Phone Number
 
-Input phone number is used in anywhere you need to accept phone numbers as
+Input phone number should be used anywhere you need to accept phone numbers as
 input.
 
 ```ts

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.test.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.test.tsx
@@ -4,98 +4,118 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 import { InputPhoneNumber } from ".";
 
 afterEach(cleanup);
-//TODO: do we want to keep this?
-it("renders a InputPhoneNumber", () => {
-  const tree = renderer
-    .create(<InputPhoneNumber country={"NorthAmerica"} />)
-    .toJSON();
-  expect(tree).toMatchSnapshot();
-});
 
-it("will only accept numerical characters", () => {
-  const rendered = render(
-    <InputPhoneNumber
-      country={"NorthAmerica"}
-      placeholder="Phone Number"
-      data-testid="custom-element"
-    />,
-  );
-  const numberInput = rendered.getByLabelText(
-    "Phone Number",
-  ) as HTMLInputElement;
-
-  fireEvent.click(numberInput);
-  fireEvent.change(numberInput, {
-    target: { value: "abcde~!@#$%^&*()_+={}[]\\|`?/\"-'`" },
+describe("InputPhoneNumber", () => {
+  it("renders a InputPhoneNumber", () => {
+    const tree = renderer
+      .create(<InputPhoneNumber country={"NorthAmerica"} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
-  expect(numberInput.value).toBe(" (___) ___-____");
-});
+  it("will only accept numerical characters", () => {
+    const onChangeHandler = jest.fn();
 
-it("will return the correct phone number with formatting", () => {
-  const onChangeHandler = jest.fn();
-  const rendered = render(
-    <InputPhoneNumber
-      country={"NorthAmerica"}
-      placeholder="Phone Number"
-      data-testid="custom-element"
-      onChange={onChangeHandler}
-    />,
-  );
-  const numberInput = rendered.getByLabelText(
-    "Phone Number",
-  ) as HTMLInputElement;
+    const rendered = render(
+      <InputPhoneNumber
+        country={"NorthAmerica"}
+        placeholder="Phone Number"
+        onChange={onChangeHandler}
+      />,
+    );
+    const numberInput = rendered.getByLabelText(
+      "Phone Number",
+    ) as HTMLInputElement;
 
-  fireEvent.click(numberInput);
-  fireEvent.change(numberInput, {
-    target: { value: "7802424496" },
+    fireEvent.change(numberInput, {
+      target: { value: "abcde~!@#$%^&*()_+={}[]\\|`?/\"-'`" },
+    });
+
+    expect(onChangeHandler).toHaveBeenCalledTimes(0);
   });
 
-  expect(onChangeHandler).toHaveBeenCalledWith(" (780) 242-4496");
-});
+  it("will return the correct phone number with formatting", () => {
+    const onChangeHandler = jest.fn();
+    const rendered = render(
+      <InputPhoneNumber
+        country={"NorthAmerica"}
+        placeholder="Phone Number"
+        data-testid="custom-element"
+        onChange={onChangeHandler}
+      />,
+    );
+    const numberInput = rendered.getByLabelText(
+      "Phone Number",
+    ) as HTMLInputElement;
 
-it("will return the correct phone number with formatting for Great Britain and the Country Code", () => {
-  const onChangeHandler = jest.fn();
-  const rendered = render(
-    <InputPhoneNumber
-      country={"GreatBritain"}
-      placeholder="Phone Number"
-      data-testid="custom-element"
-      onChange={onChangeHandler}
-      showCountryCode={true}
-    />,
-  );
-  const numberInput = rendered.getByLabelText(
-    "Phone Number",
-  ) as HTMLInputElement;
+    fireEvent.change(numberInput, {
+      target: { value: "7802424496" },
+    });
 
-  fireEvent.click(numberInput);
-  fireEvent.change(numberInput, {
-    target: { value: "020 7183 8750" },
+    expect(onChangeHandler).toHaveBeenCalledWith(" (780) 242-4496");
   });
 
-  expect(onChangeHandler).toHaveBeenCalledWith("+44 (020) 7183 8750");
-});
+  it("will return the correct phone number with formatting for Great Britain and the Country Code", () => {
+    const onChangeHandler = jest.fn();
+    const rendered = render(
+      <InputPhoneNumber
+        country={"GreatBritain"}
+        placeholder="Phone Number"
+        data-testid="custom-element"
+        onChange={onChangeHandler}
+        showCountryCode={true}
+      />,
+    );
+    const numberInput = rendered.getByLabelText(
+      "Phone Number",
+    ) as HTMLInputElement;
 
-it("will hide the mask until the user begins to enter valid input", () => {
-  const rendered = render(
-    <InputPhoneNumber
-      country={"NorthAmerica"}
-      placeholder="Phone Number"
-      data-testid="custom-element"
-      alwaysShowMask={false}
-    />,
-  );
-  const numberInput = rendered.getByLabelText(
-    "Phone Number",
-  ) as HTMLInputElement;
+    fireEvent.change(numberInput, {
+      target: { value: "020 7183 8750" },
+    });
 
-  expect(numberInput.value).toBe("");
-
-  fireEvent.click(numberInput);
-  fireEvent.change(numberInput, {
-    target: { value: "7802424496" },
+    expect(onChangeHandler).toHaveBeenCalledWith("+44 (020) 7183 8750");
   });
 
-  expect(numberInput.value).toBe(" (780) 242-4496");
+  it("will hide the mask until the user begins to enter valid input", () => {
+    const rendered = render(
+      <InputPhoneNumber
+        country={"NorthAmerica"}
+        placeholder="Phone Number"
+        data-testid="custom-element"
+        alwaysShowMask={false}
+      />,
+    );
+    const numberInput = rendered.getByLabelText(
+      "Phone Number",
+    ) as HTMLInputElement;
+
+    expect(numberInput.value).toBe("");
+
+    fireEvent.change(numberInput, {
+      target: { value: "7802424496" },
+    });
+
+    expect(numberInput.value).toBe(" (780) 242-4496");
+  });
+
+  it("will mask the unentered values", () => {
+    const rendered = render(
+      <InputPhoneNumber
+        country={"NorthAmerica"}
+        placeholder="Phone Number"
+        data-testid="custom-element"
+        alwaysShowMask={false}
+      />,
+    );
+    const numberInput = rendered.getByLabelText(
+      "Phone Number",
+    ) as HTMLInputElement;
+
+    fireEvent.change(numberInput, {
+      target: { value: "78024244" },
+    });
+
+    expect(numberInput.value).toBe(" (780) 242-44__");
+  });
 });

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.test.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { InputPhoneNumber } from ".";
+
+afterEach(cleanup);
+
+it("renders a InputPhoneNumber", () => {
+  const tree = renderer.create(<InputPhoneNumber text="Foo" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders a loud InputPhoneNumber", () => {
+  const tree = renderer
+    .create(<InputPhoneNumber text="Foo" loud={true} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("it should call the handler with the new value", () => {
+  const clickHandler = jest.fn();
+  const text = "Foo";
+  const { getByText } = render(
+    <InputPhoneNumber onClick={clickHandler} text={text} />,
+  );
+
+  fireEvent.click(getByText(text));
+  expect(clickHandler).toHaveBeenCalled();
+
+  // E.g. If you need a change event, rather than a click event:
+  //
+  // fireEvent.change(getByLabelText(placeholder), {
+  //   target: { value: newValue },
+  // });
+  // expect(changeHandler).toHaveBeenCalledWith(newValue);
+});

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.test.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.test.tsx
@@ -4,33 +4,98 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 import { InputPhoneNumber } from ".";
 
 afterEach(cleanup);
-
+//TODO: do we want to keep this?
 it("renders a InputPhoneNumber", () => {
-  const tree = renderer.create(<InputPhoneNumber text="Foo" />).toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
-it("renders a loud InputPhoneNumber", () => {
   const tree = renderer
-    .create(<InputPhoneNumber text="Foo" loud={true} />)
+    .create(<InputPhoneNumber country={"NorthAmerica"} />)
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-test("it should call the handler with the new value", () => {
-  const clickHandler = jest.fn();
-  const text = "Foo";
-  const { getByText } = render(
-    <InputPhoneNumber onClick={clickHandler} text={text} />,
+it("will only accept numerical characters", () => {
+  const rendered = render(
+    <InputPhoneNumber
+      country={"NorthAmerica"}
+      placeholder="Phone Number"
+      data-testid="custom-element"
+    />,
   );
+  const numberInput = rendered.getByLabelText(
+    "Phone Number",
+  ) as HTMLInputElement;
 
-  fireEvent.click(getByText(text));
-  expect(clickHandler).toHaveBeenCalled();
+  fireEvent.click(numberInput);
+  fireEvent.change(numberInput, {
+    target: { value: "abcde~!@#$%^&*()_+={}[]\\|`?/\"-'`" },
+  });
 
-  // E.g. If you need a change event, rather than a click event:
-  //
-  // fireEvent.change(getByLabelText(placeholder), {
-  //   target: { value: newValue },
-  // });
-  // expect(changeHandler).toHaveBeenCalledWith(newValue);
+  expect(numberInput.value).toBe(" (___) ___-____");
+});
+
+it("will return the correct phone number with formatting", () => {
+  const onChangeHandler = jest.fn();
+  const rendered = render(
+    <InputPhoneNumber
+      country={"NorthAmerica"}
+      placeholder="Phone Number"
+      data-testid="custom-element"
+      onChange={onChangeHandler}
+    />,
+  );
+  const numberInput = rendered.getByLabelText(
+    "Phone Number",
+  ) as HTMLInputElement;
+
+  fireEvent.click(numberInput);
+  fireEvent.change(numberInput, {
+    target: { value: "7802424496" },
+  });
+
+  expect(onChangeHandler).toHaveBeenCalledWith(" (780) 242-4496");
+});
+
+it("will return the correct phone number with formatting for Great Britain and the Country Code", () => {
+  const onChangeHandler = jest.fn();
+  const rendered = render(
+    <InputPhoneNumber
+      country={"GreatBritain"}
+      placeholder="Phone Number"
+      data-testid="custom-element"
+      onChange={onChangeHandler}
+      showCountryCode={true}
+    />,
+  );
+  const numberInput = rendered.getByLabelText(
+    "Phone Number",
+  ) as HTMLInputElement;
+
+  fireEvent.click(numberInput);
+  fireEvent.change(numberInput, {
+    target: { value: "020 7183 8750" },
+  });
+
+  expect(onChangeHandler).toHaveBeenCalledWith("+44 (020) 7183 8750");
+});
+
+it("will hide the mask until the user begins to enter valid input", () => {
+  const rendered = render(
+    <InputPhoneNumber
+      country={"NorthAmerica"}
+      placeholder="Phone Number"
+      data-testid="custom-element"
+      alwaysShowMask={false}
+    />,
+  );
+  const numberInput = rendered.getByLabelText(
+    "Phone Number",
+  ) as HTMLInputElement;
+
+  expect(numberInput.value).toBe("");
+
+  fireEvent.click(numberInput);
+  fireEvent.change(numberInput, {
+    target: { value: "7802424496" },
+  });
+
+  expect(numberInput.value).toBe(" (780) 242-4496");
 });

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.test.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.test.tsx
@@ -2,23 +2,228 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { InputPhoneNumber } from ".";
+import { AllowedRegions } from "./InputPhoneNumber";
 
 afterEach(cleanup);
 
 describe("InputPhoneNumber", () => {
   it("renders a InputPhoneNumber", () => {
     const tree = renderer
-      .create(<InputPhoneNumber country={"NorthAmerica"} />)
+      .create(<InputPhoneNumber region={"NorthAmerica"} />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
 
+  describe("region", () => {
+    describe("when region is NorthAmerica", () => {
+      itWillValidateInput("NorthAmerica");
+
+      it("will return the correct phone number with formatting", () => {
+        const onChangeHandler = jest.fn();
+        const rendered = render(
+          <InputPhoneNumber
+            region={"NorthAmerica"}
+            placeholder="Phone Number"
+            onChange={onChangeHandler}
+          />,
+        );
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "7802424496" },
+        });
+
+        expect(onChangeHandler).toHaveBeenCalledWith("(780) 242-4496");
+      });
+
+      it("will return the correct phone number with formatting and country code", () => {
+        const onChangeHandler = jest.fn();
+        const rendered = render(
+          <InputPhoneNumber
+            region={"NorthAmerica"}
+            placeholder="Phone Number"
+            showCountryCode={true}
+            onChange={onChangeHandler}
+          />,
+        );
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "7802424496" },
+        });
+
+        expect(onChangeHandler).toHaveBeenCalledWith("+1 (780) 242-4496");
+      });
+
+      it("will mask the unentered values", () => {
+        const rendered = render(
+          <InputPhoneNumber
+            region={"NorthAmerica"}
+            placeholder="Phone Number"
+            alwaysShowMask={false}
+          />,
+        );
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "78024244" },
+        });
+
+        expect(numberInput.value).toBe("(780) 242-44__");
+      });
+    });
+
+    describe("when region is GreatBritain", () => {
+      itWillValidateInput("GreatBritain");
+
+      it("will return the correct phone number with formatting", () => {
+        const onChangeHandler = jest.fn();
+        const rendered = render(
+          <InputPhoneNumber
+            region={"GreatBritain"}
+            placeholder="Phone Number"
+            onChange={onChangeHandler}
+          />,
+        );
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "7802424496" },
+        });
+
+        expect(onChangeHandler).toHaveBeenCalledWith("7802424496");
+      });
+
+      it("will return the correct phone number with formatting and country code", () => {
+        const onChangeHandler = jest.fn();
+        const rendered = render(
+          <InputPhoneNumber
+            region={"GreatBritain"}
+            placeholder="Phone Number"
+            showCountryCode={true}
+            onChange={onChangeHandler}
+          />,
+        );
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "7802424496" },
+        });
+
+        expect(onChangeHandler).toHaveBeenCalledWith("+44 7802424496");
+      });
+    });
+
+    describe("when region is Unknown", () => {
+      itWillValidateInput("Unknown");
+
+      it("will return the correct phone number with formatting", () => {
+        const onChangeHandler = jest.fn();
+        const rendered = render(
+          <InputPhoneNumber
+            region={"Unknown"}
+            placeholder="Phone Number"
+            onChange={onChangeHandler}
+          />,
+        );
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "7802424496" },
+        });
+
+        expect(onChangeHandler).toHaveBeenCalledWith("7802424496");
+      });
+
+      it("will return the correct phone number with formatting and country code (no country code for unknown)", () => {
+        const onChangeHandler = jest.fn();
+        const rendered = render(
+          <InputPhoneNumber
+            region={"Unknown"}
+            placeholder="Phone Number"
+            showCountryCode={true}
+            onChange={onChangeHandler}
+          />,
+        );
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "7802424496" },
+        });
+
+        expect(onChangeHandler).toHaveBeenCalledWith("7802424496");
+      });
+    });
+
+    describe("when region is not provided", () => {
+      itWillValidateInput(undefined);
+
+      it("will return a NorthAmerican formatting", () => {
+        const onChangeHandler = jest.fn();
+        const rendered = render(
+          <InputPhoneNumber
+            placeholder="Phone Number"
+            onChange={onChangeHandler}
+          />,
+        );
+        const numberInput = rendered.getByLabelText(
+          "Phone Number",
+        ) as HTMLInputElement;
+
+        fireEvent.change(numberInput, {
+          target: { value: "7802424496" },
+        });
+
+        expect(onChangeHandler).toHaveBeenCalledWith("(780) 242-4496");
+      });
+    });
+  });
+
+  describe("alwaysShowMask", () => {
+    it("will hide the mask until the user begins to enter valid input", () => {
+      const rendered = render(
+        <InputPhoneNumber
+          region={"NorthAmerica"}
+          placeholder="Phone Number"
+          alwaysShowMask={false}
+        />,
+      );
+      const numberInput = rendered.getByLabelText(
+        "Phone Number",
+      ) as HTMLInputElement;
+
+      expect(numberInput.value).toBe("");
+
+      fireEvent.change(numberInput, {
+        target: { value: "7802424496" },
+      });
+
+      expect(numberInput.value).toBe("(780) 242-4496");
+    });
+  });
+});
+
+function itWillValidateInput(region?: keyof AllowedRegions) {
   it("will only accept numerical characters", () => {
     const onChangeHandler = jest.fn();
 
     const rendered = render(
       <InputPhoneNumber
-        country={"NorthAmerica"}
+        region={region}
         placeholder="Phone Number"
         onChange={onChangeHandler}
       />,
@@ -28,94 +233,9 @@ describe("InputPhoneNumber", () => {
     ) as HTMLInputElement;
 
     fireEvent.change(numberInput, {
-      target: { value: "abcde~!@#$%^&*()_+={}[]\\|`?/\"-'`" },
+      target: { value: "abcde~!@#$%^&*()_+={}[]\\|`?/\"'`" },
     });
 
     expect(onChangeHandler).toHaveBeenCalledTimes(0);
   });
-
-  it("will return the correct phone number with formatting", () => {
-    const onChangeHandler = jest.fn();
-    const rendered = render(
-      <InputPhoneNumber
-        country={"NorthAmerica"}
-        placeholder="Phone Number"
-        data-testid="custom-element"
-        onChange={onChangeHandler}
-      />,
-    );
-    const numberInput = rendered.getByLabelText(
-      "Phone Number",
-    ) as HTMLInputElement;
-
-    fireEvent.change(numberInput, {
-      target: { value: "7802424496" },
-    });
-
-    expect(onChangeHandler).toHaveBeenCalledWith(" (780) 242-4496");
-  });
-
-  it("will return the correct phone number with formatting for Great Britain and the Country Code", () => {
-    const onChangeHandler = jest.fn();
-    const rendered = render(
-      <InputPhoneNumber
-        country={"GreatBritain"}
-        placeholder="Phone Number"
-        data-testid="custom-element"
-        onChange={onChangeHandler}
-        showCountryCode={true}
-      />,
-    );
-    const numberInput = rendered.getByLabelText(
-      "Phone Number",
-    ) as HTMLInputElement;
-
-    fireEvent.change(numberInput, {
-      target: { value: "020 7183 8750" },
-    });
-
-    expect(onChangeHandler).toHaveBeenCalledWith("+44 (020) 7183 8750");
-  });
-
-  it("will hide the mask until the user begins to enter valid input", () => {
-    const rendered = render(
-      <InputPhoneNumber
-        country={"NorthAmerica"}
-        placeholder="Phone Number"
-        data-testid="custom-element"
-        alwaysShowMask={false}
-      />,
-    );
-    const numberInput = rendered.getByLabelText(
-      "Phone Number",
-    ) as HTMLInputElement;
-
-    expect(numberInput.value).toBe("");
-
-    fireEvent.change(numberInput, {
-      target: { value: "7802424496" },
-    });
-
-    expect(numberInput.value).toBe(" (780) 242-4496");
-  });
-
-  it("will mask the unentered values", () => {
-    const rendered = render(
-      <InputPhoneNumber
-        country={"NorthAmerica"}
-        placeholder="Phone Number"
-        data-testid="custom-element"
-        alwaysShowMask={false}
-      />,
-    );
-    const numberInput = rendered.getByLabelText(
-      "Phone Number",
-    ) as HTMLInputElement;
-
-    fireEvent.change(numberInput, {
-      target: { value: "78024244" },
-    });
-
-    expect(numberInput.value).toBe(" (780) 242-44__");
-  });
-});
+}

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
@@ -3,7 +3,8 @@ import { FormField, FormFieldProps } from "../FormField";
 
 export interface RegionSettings {
   countryCode?: number;
-  format?: string;
+  format: string;
+  mask: string;
 }
 
 export interface AllowedRegions {
@@ -13,9 +14,11 @@ export interface AllowedRegions {
 }
 
 const REGION_SETTINGS: AllowedRegions = {
-  NorthAmerica: { countryCode: 1, format: "(###) ###-####" },
-  GreatBritain: { countryCode: 44 },
-  Unknown: {},
+  NorthAmerica: { countryCode: 1, format: "(###) ###-####", mask: "_" },
+  // Allows a max of 12 digits (not including country code) which is the max in the UK.
+  GreatBritain: { countryCode: 44, format: "############", mask: "" },
+  // Allowing for up to 16 digits. That should be enough for all numbers
+  Unknown: { format: "################", mask: "" },
 };
 
 // should it be form field or common form field?
@@ -57,19 +60,11 @@ export function InputPhoneNumber({
   function getMaskingProperties(
     settings: RegionSettings,
   ): FormFieldProps["maskingProperties"] {
-    const hasFormat = !!settings.format;
-    const countryCodeString = getDisplayedCountryCode(regionSettings);
-
-    if (!hasFormat) {
-      return {
-        prefix: countryCodeString,
-      };
-    }
-
+    const countryCodeString = getDisplayedCountryCode(settings);
     return {
-      format: `${countryCodeString}${regionSettings.format}`,
+      format: `${countryCodeString}${settings.format}`,
       allowEmptyFormatting: alwaysShowMask,
-      mask: "_",
+      mask: settings.mask,
     };
   }
 }

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
@@ -21,7 +21,6 @@ const REGION_SETTINGS: AllowedRegions = {
   Unknown: { format: "################", mask: "" },
 };
 
-// should it be form field or common form field?
 export interface InputPhoneNumberProps extends FormFieldProps {
   alwaysShowMask?: boolean;
   region?: keyof AllowedRegions;

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
@@ -29,12 +29,14 @@ export function InputPhoneNumber({
   const displayedCountryCode = showCountryCode
     ? `+${countries[country].countryCode}`
     : "";
+
   const maskingProperties = {
     allowEmptyFormatting: alwaysShowMask,
     format: `${displayedCountryCode} ${countries[country].format}`,
     mask: "_",
     prefix: `${displayedCountryCode}`,
   };
+
   return (
     <FormField
       value={rest.value}

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { FormField, FormFieldProps } from "../FormField";
+
+interface AllowedCountries {
+  NorthAmerica: { countryCode: number; format: string };
+  GreatBritain: { countryCode: number; format: string };
+}
+//TODO decide on this number formatting if it is best for the UK
+const countries: AllowedCountries = {
+  NorthAmerica: { countryCode: 1, format: "(###) ###-####" },
+  GreatBritain: { countryCode: 1, format: "(###) #### ######" },
+};
+
+// should it be form field or common form field?
+interface InputPhoneNumberProps extends FormFieldProps {
+  alwaysShowMask?: boolean;
+  country: keyof AllowedCountries;
+  placeholder?: string;
+  showCountryCode?: boolean;
+}
+
+export function InputPhoneNumber({
+  country,
+  placeholder,
+  alwaysShowMask = true,
+  showCountryCode = false,
+  ...rest
+}: InputPhoneNumberProps) {
+  const [value, setValue] = React.useState("");
+  const displayedCountryCode = showCountryCode
+    ? `+${countries[country].countryCode}`
+    : "";
+  const maskingProperties = {
+    allowEmptyFormatting: alwaysShowMask,
+    format: `${displayedCountryCode} ${countries[country].format}`,
+    mask: "_",
+    prefix: `${displayedCountryCode}`,
+  };
+  return (
+    <FormField
+      value={value}
+      onChange={handleChange}
+      type="maskedNumber"
+      maskingProperties={maskingProperties}
+      placeholder={placeholder}
+      {...rest}
+    />
+  );
+
+  function handleChange(userInput: string) {
+    setValue(userInput);
+  }
+}

--- a/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
+++ b/packages/components/src/InputPhoneNumber/InputPhoneNumber.tsx
@@ -8,7 +8,7 @@ interface AllowedCountries {
 //TODO decide on this number formatting if it is best for the UK
 const countries: AllowedCountries = {
   NorthAmerica: { countryCode: 1, format: "(###) ###-####" },
-  GreatBritain: { countryCode: 1, format: "(###) #### ######" },
+  GreatBritain: { countryCode: 44, format: "(###) #### ####" },
 };
 
 // should it be form field or common form field?
@@ -26,7 +26,6 @@ export function InputPhoneNumber({
   showCountryCode = false,
   ...rest
 }: InputPhoneNumberProps) {
-  const [value, setValue] = React.useState("");
   const displayedCountryCode = showCountryCode
     ? `+${countries[country].countryCode}`
     : "";
@@ -38,16 +37,12 @@ export function InputPhoneNumber({
   };
   return (
     <FormField
-      value={value}
-      onChange={handleChange}
+      value={rest.value}
+      onChange={rest.onChange}
       type="maskedNumber"
       maskingProperties={maskingProperties}
       placeholder={placeholder}
       {...rest}
     />
   );
-
-  function handleChange(userInput: string) {
-    setValue(userInput);
-  }
 }

--- a/packages/components/src/InputPhoneNumber/__snapshots__/InputPhoneNumber.test.tsx.snap
+++ b/packages/components/src/InputPhoneNumber/__snapshots__/InputPhoneNumber.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a InputPhoneNumber 1`] = `
+exports[`InputPhoneNumber renders a InputPhoneNumber 1`] = `
 <div
   className="wrapper"
   style={

--- a/packages/components/src/InputPhoneNumber/__snapshots__/InputPhoneNumber.test.tsx.snap
+++ b/packages/components/src/InputPhoneNumber/__snapshots__/InputPhoneNumber.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a InputPhoneNumber 1`] = `
+<div
+  className="wrapper"
+  style={
+    Object {
+      "--formField-maxLength": undefined,
+    }
+  }
+>
+  <div
+    className="inputWrapper"
+  >
+    <label
+      className="label"
+      htmlFor="123e4567-e89b-12d3-a456-426655440001"
+    />
+    <input
+      className="input"
+      id="123e4567-e89b-12d3-a456-426655440001"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onMouseUp={[Function]}
+      type="text"
+      value=" (___) ___-____"
+    />
+  </div>
+</div>
+`;

--- a/packages/components/src/InputPhoneNumber/__snapshots__/InputPhoneNumber.test.tsx.snap
+++ b/packages/components/src/InputPhoneNumber/__snapshots__/InputPhoneNumber.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`InputPhoneNumber renders a InputPhoneNumber 1`] = `
       onKeyDown={[Function]}
       onMouseUp={[Function]}
       type="text"
-      value=" (___) ___-____"
+      value="(___) ___-____"
     />
   </div>
 </div>

--- a/packages/components/src/InputPhoneNumber/index.ts
+++ b/packages/components/src/InputPhoneNumber/index.ts
@@ -1,0 +1,1 @@
+export { InputPhoneNumber } from "./InputPhoneNumber";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
We wanted to introduce a formatted phone number input for our users to reduce the rate at which they enter bad data, and make it clear at a glance what we're asking for.

## Changes

### Added
- Adds a new `InputPhoneNumber` component with a phone number mask applied to it
- Adds a new library for handling the input masking of numeric fields. We evaluated several option, this was the only one that had ongoing maintenance, a large amount of support and usage, and worked well with our `react-form-hooks`.

Does Not:
- Mask non numeric inputs. It's very easy to determine the cursor position when you limit the input values to just numeric values. There are not a lot of libraries that allow generic input masking with non-numeric characters.

### Changed
- Adds a `numberMask` type to the `FormField` component so that other inputs can leverage this masking behaviour

## Testing
This URL will take you to the input phone number component and you can play around with it there.

http://localhost:3333/components/input-phone-number

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
