### PR TITLE
docs(components): add more detail to datepicker usage

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.mdx
+++ b/packages/components/src/DatePicker/DatePicker.mdx
@@ -47,7 +47,7 @@ Use Datepicker when you are looking to provide the user with a highly visual
 interface for intuitive date selections.
 
 A classic use case for a standalone Datepicker would be as a means to navigate
-a more content-heavy calendar interface.
+within a larger calendar interface.
 
 It may be beneficial to supplement the Datepicker with alternate means of
 entering their date selection, such as providing a `date` input.

--- a/packages/components/src/DatePicker/DatePicker.mdx
+++ b/packages/components/src/DatePicker/DatePicker.mdx
@@ -119,7 +119,7 @@ If using a custom activator, ensure that the activator is keyboard-operable.
 ## Related Components
 
 - If you are looking to use the `DatePicker` in a `Form`, consider the
-  [InputDate](#) component.
+  [InputDate](/components/input-date) component.
 - For a time input, use [InputTime](/components/input-time)
 - To present dates that have already been selected in a consistent format, use
   [FormatDate](/components/date-formatter)
@@ -128,5 +128,4 @@ If using a custom activator, ensure that the activator is keyboard-operable.
 
 ## Notes
 
-> InputDate is not currently available, but is in development and should be
-> ready for use in the near future.
+As mentioned above, the Datepicker wraps [React DatePicker](https://reactdatepicker.com/).

--- a/packages/components/src/DatePicker/DatePicker.mdx
+++ b/packages/components/src/DatePicker/DatePicker.mdx
@@ -46,6 +46,9 @@ import { DatePicker } from "@jobber/components/DatePicker";
 Use Datepicker when you are looking to provide the user with a highly visual
 interface for intuitive date selections.
 
+A classic use case for a standalone Datepicker would be as a means to navigate
+a more content-heavy calendar interface.
+
 It may be beneficial to supplement the Datepicker with alternate means of
 entering their date selection, such as providing a `date` input.
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Got a question of "when should I actually use a datepicker on its own, vs in an InputDate format?"

## Changes

### Added

- Just a bit more of a tangible example use case for datepicker as a standalone

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
