### PR TITLE
feat(components): update toast visuals and timing [JOB-27572]

### DIFF
--- a/packages/components/src/Toast/Toast.css
+++ b/packages/components/src/Toast/Toast.css
@@ -15,7 +15,7 @@
   flex-direction: column;
   align-items: center;
   padding: 0 var(--space-large);
-  color: var(--color-text);
+  color: var(--color-text--reverse);
   font-size: var(--typography--fontSize-large);
   pointer-events: none;
 }
@@ -35,7 +35,7 @@
   align-items: center;
   padding: calc(var(--space-small) / 1.25) var(--space-base);
   border-radius: var(--radius-base);
-  background: var(--color-surface);
+  background: var(--color-surface--reverse);
 }
 
 .icon {

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -80,7 +80,7 @@ export function Toast({
                 ariaLabel={"Hide Notification"}
                 onClick={handleToastClose}
                 type="tertiary"
-                variation="cancel"
+                variation="subtle"
               />
             </div>
           </div>
@@ -102,9 +102,9 @@ export function Toast({
   }
 
   function getTimeout() {
-    const min = 2000;
-    const max = 5000;
-    const time = message.length * 100;
+    const min = 5000;
+    const max = 10000;
+    const time = message.length * 200;
 
     if (time < min) return min;
     if (time > max) return max;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The Toast, while intended as a quick, non-critical message, is a bit too unobtrusive; admins are missing the success messages when they save changes, for example.

This is particularly problematic on larger/multiple monitor setups, which we know many of our admins are operating on.

## Changes

### Changed

- Toast now uses the `reverse` colors from the theme for high contrast against the main application surface
- Toast now has longer min and max durations, and a longer auto-calculated duration

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
