### PR TITLE
docs(components): remove error toast from examples

### DIFF
--- a/packages/components/src/Toast/Toast.mdx
+++ b/packages/components/src/Toast/Toast.mdx
@@ -51,20 +51,20 @@ When contributing to or consuming the Toast component, consider the following:
 - Don't use `Dismiss` or `Cancel` as an action label.
   - Examples of action labels: `Undo`, `View`, `Refresh`.
 
-### Errors
-
-Only use Toast for errors if there is some other mechanism alerting the user of
-the problem (such as [InputValidation](input-validation)) so that they can
-recover from the error.
-
-In most cases, use [Banner](banner) so the user can appropriately assess and
-recover from the error.
-
 ## Related Components
 
 For more persistent feedback (such as displaying errors), communicating a
 background process that is ongoing, or for feedback that has a longer reading
 length or CTA, use [Banner.](banner)
+  
+### Errors
+
+> Do not use Toast for errors. This is currently an available variation, but should
+> be considered deprecated and not propagated.
+
+Use [Banner](banner) and, where necessary, targeted error messaging
+(such as [InputValidation](input-validation)) so that the user can appropriately assess and
+recover from the error.
 
 ## Props
 
@@ -72,10 +72,10 @@ length or CTA, use [Banner.](banner)
 
 ## Variations
 
-Toasts have 3 variations, `info`, `success`, and `error`. Each should be used
-appropriately when using Toast.
-
 The primary use case for Toast is success messages.
+  
+In some cases, an informational Toast may be used to
+inform the user of some background system activity.
 
 <Playground>
   {() => {
@@ -86,7 +86,7 @@ The primary use case for Toast is success messages.
           variation="learning"
           onClick={() =>
             showToast({
-              message: "Toast is crispy bread",
+              message: "Toasting is underway",
               variation: "info",
             })
           }
@@ -97,16 +97,6 @@ The primary use case for Toast is success messages.
             showToast({
               message: "Toast is ready",
               variation: "success",
-            })
-          }
-        />
-        <Button
-          label="Error Toast"
-          variation="destructive"
-          onClick={() =>
-            showToast({
-              message: "Toast is burnt",
-              variation: "error",
             })
           }
         />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We should not be using toasts for error messages. There should be work to actively remove this functionality from Toast, but in lieu of having capacity for that, we should not make it a suggested usage.

## Changes

### Removed

- examples of Toast being used for an error message

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
