### PR TITLE
fix(components): Fix Activator Test

### DIFF
--- a/packages/components/src/DatePicker/DatePickerActivator.test.tsx
+++ b/packages/components/src/DatePicker/DatePickerActivator.test.tsx
@@ -32,5 +32,5 @@ it("removes fullWidth and activator props if a basic html element is the activat
     <DatePickerActivator activator={<div>activate me</div>} fullWidth={true} />,
   );
   expect(getByText("activate me")).toBeInTheDocument();
-  expect(getByText("activate me")).not.toHaveClass("fullWidth");
+  expect(getByText("activate me")).not.toHaveAttribute("fullWidth");
 });


### PR DESCRIPTION
### Fixed

- The test being fixed initially will always pass since `fullWidth` will never add a class name but will add an HTML attribute on the activator.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
