### PR TITLE
fix(components): Fix button labels for basic images [JOB-37183]

### DIFF
--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -227,7 +227,7 @@ function getLabels(
     ? "or drag files here to upload"
     : "or drag a file here to upload";
 
-  if (allowedTypes === "images") {
+  if (allowedTypes === "images" || allowedTypes === "basicImages") {
     buttonLabel = multiple ? "Upload Images" : "Upload Image";
     hintText = multiple
       ? "or drag images here to upload"


### PR DESCRIPTION
## Motivations

When adding the `basicImage` type, I didn't realize would also need to update the label to use the same terminology as for `images`. 

## Changes

`basicImages` now use the labels associated with Images ("or drag images here to upload") instead of Files (e.g. "drag files here to upload")

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
