### PR TITLE
fix(components): Make countdown label smarter [JOB-39652]

### DIFF
--- a/packages/components/src/Countdown/Countdown.test.tsx
+++ b/packages/components/src/Countdown/Countdown.test.tsx
@@ -9,7 +9,7 @@ afterEach(cleanup);
 it(`Shows units`, () => {
   const { container } = render(
     <Countdown
-      date={new Date(new Date().getTime() + 25 * 3600 * 1000)}
+      date={new Date(new Date().getTime() + 48 * 3600 * 1000)}
       granularity="dhms"
       showUnits={true}
     />,
@@ -24,7 +24,7 @@ it(`Shows units`, () => {
 it(`Should have the right units show up when they're supposed to`, () => {
   const { container } = render(
     <Countdown
-      date={new Date(new Date().getTime() + 25 * 3600 * 1000)}
+      date={new Date(new Date().getTime() + 48 * 3600 * 1000)}
       granularity="d"
       showUnits={true}
     />,

--- a/packages/components/src/Countdown/Countdown.tsx
+++ b/packages/components/src/Countdown/Countdown.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { CivilDate } from "@std-proposal/temporal";
 import ReactCountdown, { CountdownRenderProps } from "react-countdown";
+import { computeTimeUnit } from "./computeTimeUnit";
 
 /**
  * Options for deciding how much information is shown to the user
@@ -86,16 +87,27 @@ function RenderedCountdown({
     const totalSeconds = 60 * totalMinutes + Number(seconds);
 
     const times: TimesType = {
-      d: { total: days, remainder: days, unit: "days" },
-      h: { total: totalHours, remainder: hours, unit: "hours" },
-      m: { total: totalMinutes, remainder: minutes, unit: "minutes" },
-      s: { total: totalSeconds, remainder: seconds, unit: "seconds" },
+      d: { total: days, remainder: days, unit: computeTimeUnit(days, "day") },
+      h: {
+        total: totalHours,
+        remainder: hours,
+        unit: computeTimeUnit(hours, "hour"),
+      },
+      m: {
+        total: totalMinutes,
+        remainder: minutes,
+        unit: computeTimeUnit(minutes, "minute"),
+      },
+      s: {
+        total: totalSeconds,
+        remainder: seconds,
+        unit: computeTimeUnit(seconds, "second"),
+      },
     };
 
     return timeFormatter(times, granularity, showUnits);
   }
 }
-
 interface TimeType {
   /**
    * The total amount of that unit (assuming there is no parent unit)

--- a/packages/components/src/Countdown/computeTimeUnit.test.tsx
+++ b/packages/components/src/Countdown/computeTimeUnit.test.tsx
@@ -1,0 +1,21 @@
+import { computeTimeUnit } from "./computeTimeUnit";
+
+describe("computeTimeUnit", () => {
+  describe("when remainder time is not equal to one", () => {
+    it("should return a plural unit", () => {
+      expect(computeTimeUnit("0123", "day")).toEqual("days");
+      expect(computeTimeUnit("0", "minute")).toEqual("minutes");
+      expect(computeTimeUnit("0123", "second")).toEqual("seconds");
+      expect(computeTimeUnit("0123", "hour")).toEqual("hours");
+    });
+  });
+
+  describe("when remainder time is equal to one", () => {
+    it("should return a singular unit", () => {
+      expect(computeTimeUnit("01", "day")).toEqual("day");
+      expect(computeTimeUnit("01", "hour")).toEqual("hour");
+      expect(computeTimeUnit("01", "minute")).toEqual("minute");
+      expect(computeTimeUnit("01", "second")).toEqual("second");
+    });
+  });
+});

--- a/packages/components/src/Countdown/computeTimeUnit.tsx
+++ b/packages/components/src/Countdown/computeTimeUnit.tsx
@@ -1,0 +1,5 @@
+type TimeUnitOptions = "day" | "hour" | "minute" | "second";
+
+export function computeTimeUnit(remainder: string, unit: TimeUnitOptions) {
+  return parseInt(remainder, 10) !== 1 ? `${unit}s` : unit;
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
- We want the countdown labels to be smarter by implementing smarter labeling of time units.

## Changes
- When there is a singular time left (i.e 1 hour, 1 day, 1 second), we will show a singular unit instead of a pluralized unit
- before:
![image](https://user-images.githubusercontent.com/54861184/145897033-e9fc34f3-0cf4-4f27-9a81-80ea1f54afb3.png)
- after:
![image](https://user-images.githubusercontent.com/54861184/145896978-85740b94-0cef-4b7b-9c69-d4db9bf9b6a2.png)


## Testing
- Open up the Atlantis Playground > Countdown component > modify the time remaining 
- [ ] When the remaining time is not equal to `1` it should show a pluralized time unit (hours, days, etc)
- [ ] When the remaining time is equal to `1` > it should show a singular time unit (hour, day, etc)
<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
