### PR TITLE
feat(components): More dividers to align with mobile conventions

### DIFF
--- a/packages/components/src/Divider/Divider.css
+++ b/packages/components/src/Divider/Divider.css
@@ -8,6 +8,17 @@
 
 .large {
   --divider-width: var(--border-thick);
+  opacity: 0.875;
+}
+
+.larger {
+  --divider-width: var(--border-thicker);
+  opacity: 0.625;
+}
+
+.largest {
+  --divider-width: var(--border-thickest);
+  opacity: 0.375;
 }
 
 .horizontal {

--- a/packages/components/src/Divider/Divider.css.d.ts
+++ b/packages/components/src/Divider/Divider.css.d.ts
@@ -1,6 +1,8 @@
 declare const styles: {
   readonly "divider": string;
   readonly "large": string;
+  readonly "larger": string;
+  readonly "largest": string;
   readonly "horizontal": string;
   readonly "vertical": string;
 };

--- a/packages/components/src/Divider/Divider.mdx
+++ b/packages/components/src/Divider/Divider.mdx
@@ -40,7 +40,7 @@ should be used within a [`Content`](/components/content) component.
 
 <Props of={Divider} />
 
-## Usage
+## Design & Usage Guidelines
 
 ### Size
 
@@ -88,3 +88,8 @@ Use a vertical divider when the content to be divided runs horizontally.
     </Card>
   </div>
 </Playground>
+
+## Related Components
+
+- To segment different groups of content, use [Card.](/components/card)
+- For guidance on borders in general, see our [Borders guide.](/borders)

--- a/packages/components/src/Divider/Divider.mdx
+++ b/packages/components/src/Divider/Divider.mdx
@@ -44,8 +44,15 @@ should be used within a [`Content`](/components/content) component.
 
 ### Size
 
+For different levels of segmentation, you may find the need to use larger
+Dividers. As Dividers increase in size, they get lighter to offset the visual
+impact of their additional weight.
+
 <Playground>
   <Content>
+    <Heading level={2}>Intro Section</Heading>
+    <Text>Important main content</Text>
+    <Divider size="largest" />
     <Content>Some amazing content</Content>
     <Divider size="large" />
     <Content>Even more amazing content</Content>
@@ -53,6 +60,8 @@ should be used within a [`Content`](/components/content) component.
 </Playground>
 
 ### Vertical
+
+Use a vertical divider when the content to be divided runs horizontally.
 
 <Playground>
   <div style={{ width: "fit-content" }}>

--- a/packages/components/src/Divider/Divider.test.tsx
+++ b/packages/components/src/Divider/Divider.test.tsx
@@ -25,4 +25,36 @@ describe("Divider", () => {
       });
     });
   });
+
+  describe("when larger", () => {
+    it("renders", () => {
+      const { container } = render(<Divider size="larger" />);
+      expect(container).toMatchSnapshot();
+    });
+
+    describe("when also vertical", () => {
+      it("renders", () => {
+        const { container } = render(
+          <Divider direction="vertical" size="larger" />,
+        );
+        expect(container).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe("when largest", () => {
+    it("renders", () => {
+      const { container } = render(<Divider size="largest" />);
+      expect(container).toMatchSnapshot();
+    });
+
+    describe("when also vertical", () => {
+      it("renders", () => {
+        const { container } = render(
+          <Divider direction="vertical" size="largest" />,
+        );
+        expect(container).toMatchSnapshot();
+      });
+    });
+  });
 });

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -8,7 +8,7 @@ interface DividerProps {
    *
    * @default "base"
    */
-  readonly size?: "base" | "large";
+  readonly size?: "base" | "large" | "larger" | "largest";
   /**
    * The direction of the divider
    *
@@ -23,6 +23,8 @@ export function Divider({
 }: DividerProps) {
   const className = classnames(styles.divider, {
     [styles.large]: size === "large",
+    [styles.larger]: size === "larger",
+    [styles.largest]: size === "largest",
     [styles.horizontal]: direction == "horizontal",
     [styles.vertical]: direction == "vertical",
   });

--- a/packages/components/src/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/packages/components/src/Divider/__snapshots__/Divider.test.tsx.snap
@@ -26,3 +26,39 @@ exports[`Divider when large when also vertical renders 1`] = `
   />
 </div>
 `;
+
+exports[`Divider when larger renders 1`] = `
+<div>
+  <div
+    class="divider larger horizontal"
+    role="none presentation"
+  />
+</div>
+`;
+
+exports[`Divider when larger when also vertical renders 1`] = `
+<div>
+  <div
+    class="divider larger vertical"
+    role="none presentation"
+  />
+</div>
+`;
+
+exports[`Divider when largest renders 1`] = `
+<div>
+  <div
+    class="divider largest horizontal"
+    role="none presentation"
+  />
+</div>
+`;
+
+exports[`Divider when largest when also vertical renders 1`] = `
+<div>
+  <div
+    class="divider largest vertical"
+    role="none presentation"
+  />
+</div>
+`;

--- a/packages/design/src/Borders.mdx
+++ b/packages/design/src/Borders.mdx
@@ -32,11 +32,12 @@ export function Example({ of: size }) {
   return <div style={style} />;
 }
 
-| Width              | Visual                   |
-| :----------------- | :----------------------- |
-| `--border-base`    | <Example of="base" />    |
-| `--border-thick`   | <Example of="thick" />   |
-| `--border-thicker` | <Example of="thicker" /> |
+| Width               | Visual                    |
+| :------------------ | :------------------------ |
+| `--border-base`     | <Example of="base" />     |
+| `--border-thick`    | <Example of="thick" />    |
+| `--border-thicker`  | <Example of="thicker" />  |
+| `--border-thickest` | <Example of="thickest" /> |
 
 The `base` border width should be used for most use cases (see
 [`Card`](https://atlantis.getjobber.com/components/card) and

--- a/packages/design/src/borders.css
+++ b/packages/design/src/borders.css
@@ -2,4 +2,5 @@
   --border-base: var(--space-minuscule);
   --border-thick: var(--space-smallest);
   --border-thicker: var(--space-smaller);
+  --border-thickest: var(--space-small);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We recently expanded our suite of dividers on mobile and I'd like to keep Atlantis in sync for such a simple change.

## Changes

### Added

- New `larger` and `largest` Dividers
- New value `border-thickest` that can be applied to the mobile divider (replacing current usage of `space-small`

### Changed

- Opacity of `large` Divider to align with approach on mobile

### Testing

- [Click here!](https://deploy-preview-799--jobber-atlantis.netlify.app/components/divider)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
