### PR TITLE
build: Decrease max old space size back to Node 10 value of 1400MB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,10 @@ jobs:
       - *restore_npm_cache
       - *npm_install
       - *generate_base_path
-      - run: npm run build -- --base "/${BASE_PATH}/"
+      - run:
+          command: node -v && node -e 'console.log(`heap_size_limit = ${v8.getHeapStatistics().heap_size_limit / (1024 * 1024)} MB`)' && npm run build -- --base "/${BASE_PATH}/"
+          environment:
+            NODE_OPTIONS: --max_old_space_size=1400
       - store_artifacts:
           path: ~/atlantis/.docz/dist
           destination: docs


### PR DESCRIPTION
## Motivations

<!-- Why did you do what you did? -->
Investigating setting max heap memory on the Medium CI container (4GB) to see if it impacts what the memory consumption looks like.

In Node 10, as described [here](https://jobber.atlassian.net/wiki/spaces/JTW/pages/1311211576/TED+41+-+Node+Max+Memory), the maximum heap size is 1400 MB. In Node 12 and higher, it's dynamic for lower amounts of RAM (embedded devices), but once you get into 4GB territory, it maxes out once again - but at a new higher maximum of 2048.

This means that upgrading node from 10 to something higher on a Medium (4GB) will inherently give it a 600MB boost, in the absence of any other configuration changes.

For whatever reason, this additional memory makes the workflow step in question start to misbehave.

The solution? Use a special environment variable to REDUCE the upper limit back to 1400 MB.

I decided to leave a bit of logging diagnostics in place as well, as this probably won't be the last time this issue is visited.

## Max Heap Size 3GB
![image](https://user-images.githubusercontent.com/6880880/146133184-b542fe63-a39c-43d1-a0a0-abd9380f02f6.png)
Result: process killed

## Max Heap Size 4GB
![image](https://user-images.githubusercontent.com/6880880/146135187-1d058921-47b6-4130-a5a1-ffd0ef8fd498.png)
Result: process killed

Attempt two... it succeeds, but is pinned at 4GB for several minutes (probably SHOULD have been killed):
![image](https://user-images.githubusercontent.com/6880880/146137025-53c4fba3-8e19-47c0-ad8d-dfd72f136a19.png)

## Max Heap Size 1400MB (emulating what it was on Node 10)
![image](https://user-images.githubusercontent.com/6880880/146140521-c23b3729-a477-4412-846f-783159f9f9c8.png)
Result: success
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
