### PR TITLE
fix(components): Prevent date picker from flickering / closing when click the activator again

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.test.tsx
+++ b/packages/components/src/DatePicker/DatePicker.test.tsx
@@ -65,3 +65,15 @@ it("always appears when inline", () => {
 
   expect(getByText("15")).toBeInstanceOf(HTMLDivElement);
 });
+
+it("should not add the `react-datepicker-ignore-onclickoutside` when inline", () => {
+  const { container, rerender } = render(<DatePicker onChange={jest.fn()} />);
+
+  const target = container.firstChild;
+  const className = "react-datepicker-ignore-onclickoutside";
+  expect(target).toHaveClass(className);
+
+  rerender(<DatePicker onChange={jest.fn()} inline />);
+
+  expect(target).not.toHaveClass(className);
+});

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -70,6 +70,13 @@ export function DatePicker({
     [styles.inline]: inline,
   });
   const wrapperClassName = classnames(styles.datePickerWrapper, {
+    // react date picker uses this class name to not close the date picker when
+    // the activator is clicked
+    // https://github.com/Hacker0x01/react-datepicker/blob/master/src/index.jsx#L905
+    // It uses react-onclickoutside and declaring some elements to be ignored
+    // via said class name
+    // https://www.npmjs.com/package/react-onclickoutside#marking-elements-as-skip-over-this-one-during-the-event-loop
+    "react-datepicker-ignore-onclickoutside": !inline,
     [styles.fullWidth]: fullWidth,
   });
 

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, RefObject, useRef } from "react";
+import React, { ReactElement } from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
 /**
@@ -70,20 +70,19 @@ export function DatePicker({
     [styles.inline]: inline,
   });
   const wrapperClassName = classnames(styles.datePickerWrapper, {
-    // react date picker uses this class name to not close the date picker when
+    // react-datepicker uses this class name to not close the date picker when
     // the activator is clicked
     // https://github.com/Hacker0x01/react-datepicker/blob/master/src/index.jsx#L905
-    // It uses react-onclickoutside and declaring some elements to be ignored
-    // via said class name
+    //
+    // It uses react-onclickoutside package and declaring some elements to be
+    // ignored via said class name
     // https://www.npmjs.com/package/react-onclickoutside#marking-elements-as-skip-over-this-one-during-the-event-loop
     "react-datepicker-ignore-onclickoutside": !inline,
     [styles.fullWidth]: fullWidth,
   });
 
-  const datePickerRef = useRef() as RefObject<HTMLDivElement>;
-
   return (
-    <div className={wrapperClassName} ref={datePickerRef}>
+    <div className={wrapperClassName}>
       <ReactDatePicker
         calendarClassName={datePickerClassNames}
         showPopperArrow={false}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

On button activator, the date picker flickers when you click it
On InputDate, the date picker closes permanently when you click/focus on the field again

It shouldn't be like that. It should just keep the date picker open when clicking the activator again

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Added the `react-datepicker-ignore-onclickoutside` class name on our custom component
  - Investigated how [react date picker](https://reactdatepicker.com/) works and that's how it determines if the calendar stays open or not

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
