### PR TITLE
chore(components): Make datepicker import css module instead of general css [JOB-38626]

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.css
+++ b/packages/components/src/DatePicker/DatePicker.css
@@ -1,3 +1,5 @@
+@import "react-datepicker/dist/react-datepicker.module.css";
+
 .datePickerWrapper {
   display: inline-block;
 }

--- a/packages/components/src/DatePicker/DatePicker.css.d.ts
+++ b/packages/components/src/DatePicker/DatePicker.css.d.ts
@@ -1,4 +1,5 @@
 declare const styles: {
+  readonly "react-datepicker__month--selecting-range": string;
   readonly "datePickerWrapper": string;
   readonly "fullWidth": string;
   readonly "datePicker": string;

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,12 +1,6 @@
 import React, { ReactElement, RefObject, useRef } from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
-/**
- * Disabling no-internal-modules here because we need
- * to reach into the package to get the css file.
- */
-// eslint-disable-next-line import/no-internal-modules
-import "react-datepicker/dist/react-datepicker.css";
 import { XOR } from "ts-xor";
 import styles from "./DatePicker.css";
 import { DatePickerCustomHeader } from "./DatePickerCustomHeader";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
- we are now importing the CSS module of react-datepicker into our component to unchoke our NEXTJS builds.

## Testing
- [ ] go into datepicker and input date and see that the CSS from react-datepicker is being properly applied 
<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
