### PR TITLE
fix: DatePicker smart focus [JOB-39118, JOB-38255]

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.test.tsx
+++ b/packages/components/src/DatePicker/DatePicker.test.tsx
@@ -111,6 +111,28 @@ describe("Ensure ReactDatePicker CSS class names exists", () => {
   });
 });
 
+describe("Smart autofocus", () => {
+  it("should focus on the selected date", async () => {
+    const { getByTestId } = render(
+      <DatePicker selected={new Date()} onChange={jest.fn} />,
+    );
+    await popperUpdate(() => fireEvent.click(getByTestId("calendar")));
+
+    expect(document.activeElement).toHaveClass(
+      "react-datepicker__day--selected",
+    );
+  });
+
+  it("should NOT focus on the selected date if there's none", async () => {
+    const { getByTestId } = render(<DatePicker onChange={jest.fn} />);
+    await popperUpdate(() => fireEvent.click(getByTestId("calendar")));
+
+    expect(document.activeElement).not.toHaveClass(
+      "react-datepicker__day--selected",
+    );
+  });
+});
+
 async function popperUpdate(event: Function) {
   event();
   // Wait for the Popper update() so jest doesn't throw an act warning

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,10 @@
-import React, { MutableRefObject, ReactElement, useRef } from "react";
+import React, {
+  MutableRefObject,
+  ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
 /**
@@ -8,6 +14,7 @@ import ReactDatePicker from "react-datepicker";
 // eslint-disable-next-line import/no-internal-modules
 import "react-datepicker/dist/react-datepicker.module.css";
 import { XOR } from "ts-xor";
+import { useRefocusOnActivator } from "@jobber/hooks";
 import styles from "./DatePicker.css";
 import { DatePickerCustomHeader } from "./DatePickerCustomHeader";
 import {
@@ -74,6 +81,7 @@ export function DatePicker({
   smartAutofocus = true,
 }: DatePickerProps) {
   const datePickerRef = useRef() as MutableRefObject<HTMLDivElement>;
+  const [open, setOpen] = useState(false);
   const wrapperClassName = classnames(styles.datePickerWrapper, {
     // react-datepicker uses this class name to not close the date picker when
     // the activator is clicked
@@ -88,6 +96,11 @@ export function DatePicker({
   const datePickerClassNames = classnames(styles.datePicker, {
     [styles.inline]: inline,
   });
+
+  if (smartAutofocus) {
+    useRefocusOnActivator(open);
+    useEffect(focusOnSelectedDate, [open]);
+  }
 
   return (
     <div className={wrapperClassName} ref={datePickerRef}>
@@ -105,6 +118,7 @@ export function DatePicker({
         }
         renderCustomHeader={props => <DatePickerCustomHeader {...props} />}
         onCalendarOpen={handleCalendarOpen}
+        onCalendarClose={handleCalendarClose}
       />
     </div>
   );
@@ -114,8 +128,14 @@ export function DatePicker({
   }
 
   function handleCalendarOpen() {
-    if (!smartAutofocus) return;
+    setOpen(true);
+  }
 
+  function handleCalendarClose() {
+    setOpen(false);
+  }
+
+  function focusOnSelectedDate() {
     const selectedDateClass = ".react-datepicker__day--selected";
     const selectedDate =
       datePickerRef.current?.querySelector(selectedDateClass);

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -22,6 +22,12 @@ interface BaseDatePickerProps {
   readonly selected?: Date;
 
   /**
+   * Determines if the focus moves to the selected date (if any) or back to
+   * the activator
+   */
+  readonly smartAutofocus?: boolean;
+
+  /**
    * Change handler that will return the date selected.
    */
   onChange(val: Date): void;
@@ -65,6 +71,7 @@ export function DatePicker({
   readonly = false,
   disabled = false,
   fullWidth = false,
+  smartAutofocus = true,
 }: DatePickerProps) {
   const datePickerRef = useRef() as MutableRefObject<HTMLDivElement>;
   const wrapperClassName = classnames(styles.datePickerWrapper, {
@@ -107,8 +114,9 @@ export function DatePicker({
   }
 
   function handleCalendarOpen() {
-    const selectedDateClass = ".react-datepicker__day--selected";
+    if (!smartAutofocus) return;
 
+    const selectedDateClass = ".react-datepicker__day--selected";
     const selectedDate =
       datePickerRef.current?.querySelector(selectedDateClass);
 

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { MutableRefObject, ReactElement, useRef } from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
 /**
@@ -66,9 +66,7 @@ export function DatePicker({
   disabled = false,
   fullWidth = false,
 }: DatePickerProps) {
-  const datePickerClassNames = classnames(styles.datePicker, {
-    [styles.inline]: inline,
-  });
+  const datePickerRef = useRef() as MutableRefObject<HTMLDivElement>;
   const wrapperClassName = classnames(styles.datePickerWrapper, {
     // react-datepicker uses this class name to not close the date picker when
     // the activator is clicked
@@ -80,9 +78,12 @@ export function DatePicker({
     "react-datepicker-ignore-onclickoutside": !inline,
     [styles.fullWidth]: fullWidth,
   });
+  const datePickerClassNames = classnames(styles.datePicker, {
+    [styles.inline]: inline,
+  });
 
   return (
-    <div className={wrapperClassName}>
+    <div className={wrapperClassName} ref={datePickerRef}>
       <ReactDatePicker
         calendarClassName={datePickerClassNames}
         showPopperArrow={false}
@@ -96,11 +97,23 @@ export function DatePicker({
           <DatePickerActivator activator={activator} fullWidth={fullWidth} />
         }
         renderCustomHeader={props => <DatePickerCustomHeader {...props} />}
+        onCalendarOpen={handleCalendarOpen}
       />
     </div>
   );
 
   function handleChange(value: Date) {
     onChange(value);
+  }
+
+  function handleCalendarOpen() {
+    const selectedDateClass = ".react-datepicker__day--selected";
+
+    const selectedDate =
+      datePickerRef.current?.querySelector(selectedDateClass);
+
+    if (selectedDate instanceof HTMLDivElement) {
+      selectedDate.focus();
+    }
   }
 }

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -91,7 +91,7 @@ export function DatePicker({
         disabled={disabled}
         readOnly={readonly}
         onChange={handleChange}
-        formatWeekDay={date => date.substr(0, 3)}
+        formatWeekDay={date => date.substring(0, 3)}
         customInput={
           <DatePickerActivator activator={activator} fullWidth={fullWidth} />
         }

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -38,6 +38,7 @@ export function InputDate(inputProps: InputDateProps) {
       disabled={inputProps.disabled}
       readonly={inputProps.readonly}
       fullWidth={!inputProps.inline}
+      smartAutofocus={false}
       activator={activatorProps => {
         const { onChange, onClick, value } = activatorProps;
         const newActivatorProps = omit(activatorProps, ["activator"]);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Focusing on the selected date when the date picker opens was removed when we added the input date. This brings it back. This also makes the date picker refocus on the activator.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Adds back the autofocus on selected date
- Refocus on activator 
  - After selecting a date
  - After hitting escape (only when the calendar itself is focused) 

### Changed

- 

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- When the date picker is opened
  - When a date is selected
    - It should move the focus to the selected date
    - Hitting `esc` key should put the focus back to the activator
    - Choosing another date should close the date picker and put the focus back to the activator
  - When a date is NOT selected
    - The focus should still be in the activator
    - Choosing a date should close the date picker and put the focus back to the activator
    - Tabbing to the date picker and hitting esc should put the focus back to the activator
  - Through InputDate
    - It should not do any of the above

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
