### PR TITLE
chore(components): Update package json to accommodate the DatePicker import

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "prestart": "cd packages/components",
     "start": "USE_ATLANTIS_ALIASES=true docz dev",
     "start:withPrivateComponents": "USE_ATLANTIS_ALIASES=true PRIVATE_COMPONENTS=visible docz dev",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
-    "prestart": "cd packages/components && npm run build:cssTypes",
+    "prestart": "cd packages/components",
     "start": "USE_ATLANTIS_ALIASES=true docz dev",
     "start:withPrivateComponents": "USE_ATLANTIS_ALIASES=true PRIVATE_COMPONENTS=visible docz dev",
     "test": "jest",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,9 +7,8 @@
   "scripts": {
     "patch": "npx patch-package",
     "prebuild": "npm run patch",
-    "build": "npm run build:cssTypes && npm run build:rollup",
+    "build": "npm run build:rollup",
     "build:rollup": "rollup --config",
-    "build:cssTypes": "tcm src",
     "clean": "rm -rf dist/* tsconfig.tsbuildinfo",
     "prepublishOnly": "ts-node --project ../../tsconfig.bin.json scripts/entryPoints.ts",
     "prepare": "npm run clean; npm run build",

--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -3,6 +3,7 @@ import multiInput from "rollup-plugin-multi-input";
 import typescript from "rollup-plugin-typescript2";
 import postcss from "rollup-plugin-postcss";
 import commonjs from "rollup-plugin-commonjs";
+import tcm from "typed-css-modules";
 
 export default {
   input: `src/*/index.ts`,
@@ -16,7 +17,9 @@ export default {
         generateScopedName: "[hash:base64]",
         globalModulePaths: [/node_modules/],
       },
+      loader: "postcss-loader",
       plugins: [
+        tcm(),
         require("postcss-import"),
         require("autoprefixer"),
         // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/components/src/DatePicker/DatePicker.css
+++ b/packages/components/src/DatePicker/DatePicker.css
@@ -1,3 +1,5 @@
+@import "react-datepicker/dist/react-datepicker.module.css";
+
 .datePickerWrapper {
   display: inline-block;
 }

--- a/packages/components/src/DatePicker/DatePicker.css.d.ts
+++ b/packages/components/src/DatePicker/DatePicker.css.d.ts
@@ -1,4 +1,5 @@
 declare const styles: {
+  readonly "react-datepicker__month--selecting-range": string;
   readonly "datePickerWrapper": string;
   readonly "fullWidth": string;
   readonly "datePicker": string;

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,12 +1,6 @@
 import React, { ReactElement } from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
-/**
- * Disabling no-internal-modules here because we need
- * to reach into the package to get the css file.
- */
-// eslint-disable-next-line import/no-internal-modules
-import "react-datepicker/dist/react-datepicker.module.css";
 import { XOR } from "ts-xor";
 import styles from "./DatePicker.css";
 import { DatePickerCustomHeader } from "./DatePickerCustomHeader";


### PR DESCRIPTION
## Motivations
- we are now importing the CSS module of react-datepicker CSS into our component to unchoke our NEXTJS builds. The postcss-import is the plugin that handles the importation of external CSS into our CSS modules which is only run during `npm run build` and `npm start` in our local dev.  In production, this is not the case hence why it fails.
- `package.json` has now been updated to not run `npm run build:CSS` in components since we are already pushing up the CSS types created from the gatsby/webpack `postcss-import` plugin.  This script is the reason why it is breaking because it keeps overwriting what we currently have committed in our branch.
- this `package.json` configuration `"build:cssTypes": "tcm src",` creates the CSS types but is missing the import CSS types because it does not run the postcss-import plugin like this example`"build:css:icons": "postcss src/icons/*.css --dir icons/ --use postcss-import"` that exists in `packages/foundation`.  
<!-- Why did you do what you did? -->

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![charlie-day](https://i.imgur.com/0ZnWnAS.gif?noredirect)