### PR TITLE
build(deps): Uninstall @types/jest under hooks

### DIFF
--- a/packages/hooks/package-lock.json
+++ b/packages/hooks/package-lock.json
@@ -119,6 +119,12 @@
         "chalk": "^4.0.0"
       }
     },
+    "@jobber/formatters": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@jobber/formatters/-/formatters-0.2.0.tgz",
+      "integrity": "sha512-RraFVvzBm+fRMTMtTYLWgpUSWDitKwTGocTsZsHttsu1Rvssg+E4k/XL/AUkB4L6j3kQp5mOf/F2fQ2/bay8sA==",
+      "dev": true
+    },
     "@testing-library/dom": {
       "version": "7.28.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.28.1.tgz",
@@ -186,16 +192,6 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "@types/jest": {
-      "version": "26.0.23",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
-      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
-      "dev": true,
-      "requires": {
-        "jest-diff": "^26.0.0",
-        "pretty-format": "^26.0.0"
       }
     },
     "@types/lodash": {
@@ -412,12 +408,6 @@
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
       "dev": true
     },
-    "diff-sequences": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-      "dev": true
-    },
     "dom-accessibility-api": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
@@ -481,24 +471,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
-    },
-    "jest-diff": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^26.6.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.2"
-      }
-    },
-    "jest-get-type": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
       "dev": true
     },
     "js-tokens": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,7 +18,6 @@
     "@jobber/formatters": "^0.2.0",
     "@testing-library/react": "^10.2.1",
     "@testing-library/react-hooks": "^7.0.0",
-    "@types/jest": "^26.0.23",
     "@types/lodash": "4.14.136",
     "@types/react": "16.14.2",
     "@types/react-dom": "16.9.10",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Hooks is the only package that has @types/jest directly. This should already be handled by the root folder so it can be removed from hooks.

This got brought up when dependabot created a PR to bump one of its dependencies under hooks. See more context in https://github.com/GetJobber/atlantis/pull/674

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- Uninstall @types/jest under hooks

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- [x] CircleCI passes
- [x] Local test passes (especially hooks) 
![image](https://user-images.githubusercontent.com/15986172/147118788-6ff697c8-209b-469e-8bce-dfd7e0792b80.png)
- [x] Jobber online test passes 
![image](https://user-images.githubusercontent.com/15986172/147133745-9e142cc8-1fb5-4f54-afdc-9ae33c91be0e.png)  **Hit a flaky test but that's unrelated**
- [x] `npm ci` and `npm start` runs with no errors or new warnings
- [x] `npm run lint` has no error
- [x] Hooks still works

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
