### PR TITLE
fix(components): Move focus to hook

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.test.tsx
+++ b/packages/components/src/DatePicker/DatePicker.test.tsx
@@ -111,28 +111,6 @@ describe("Ensure ReactDatePicker CSS class names exists", () => {
   });
 });
 
-describe("Smart autofocus", () => {
-  it("should focus on the selected date", async () => {
-    const { getByTestId } = render(
-      <DatePicker selected={new Date()} onChange={jest.fn} />,
-    );
-    await popperUpdate(() => fireEvent.click(getByTestId("calendar")));
-
-    expect(document.activeElement).toHaveClass(
-      "react-datepicker__day--selected",
-    );
-  });
-
-  it("should NOT focus on the selected date if there's none", async () => {
-    const { getByTestId } = render(<DatePicker onChange={jest.fn} />);
-    await popperUpdate(() => fireEvent.click(getByTestId("calendar")));
-
-    expect(document.activeElement).not.toHaveClass(
-      "react-datepicker__day--selected",
-    );
-  });
-});
-
 async function popperUpdate(event: Function) {
   event();
   // Wait for the Popper update() so jest doesn't throw an act warning

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useState } from "react";
 import classnames from "classnames";
-import { ReactDatePicker } from "react-datepicker";
+import ReactDatePicker from "react-datepicker";
 /**
  * Disabling no-internal-modules here because we need
  * to reach into the package to get the css file.

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,12 +1,6 @@
-import React, {
-  MutableRefObject,
-  ReactElement,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 import classnames from "classnames";
-import ReactDatePicker from "react-datepicker";
+import { ReactDatePicker } from "react-datepicker";
 /**
  * Disabling no-internal-modules here because we need
  * to reach into the package to get the css file.
@@ -21,6 +15,7 @@ import {
   DatePickerActivator,
   DatePickerActivatorProps,
 } from "./DatePickerActivator";
+import { useFocusOnSelectedDate } from "./useFocusOnSelectedDate";
 
 interface BaseDatePickerProps {
   /**
@@ -80,7 +75,7 @@ export function DatePicker({
   fullWidth = false,
   smartAutofocus = true,
 }: DatePickerProps) {
-  const datePickerRef = useRef() as MutableRefObject<HTMLDivElement>;
+  const { ref, focusOnSelectedDate } = useFocusOnSelectedDate();
   const [open, setOpen] = useState(false);
   const wrapperClassName = classnames(styles.datePickerWrapper, {
     // react-datepicker uses this class name to not close the date picker when
@@ -103,7 +98,7 @@ export function DatePicker({
   }
 
   return (
-    <div className={wrapperClassName} ref={datePickerRef}>
+    <div className={wrapperClassName} ref={ref}>
       <ReactDatePicker
         calendarClassName={datePickerClassNames}
         showPopperArrow={false}
@@ -133,15 +128,5 @@ export function DatePicker({
 
   function handleCalendarClose() {
     setOpen(false);
-  }
-
-  function focusOnSelectedDate() {
-    const selectedDateClass = ".react-datepicker__day--selected";
-    const selectedDate =
-      datePickerRef.current?.querySelector(selectedDateClass);
-
-    if (selectedDate instanceof HTMLDivElement) {
-      selectedDate.focus();
-    }
   }
 }

--- a/packages/components/src/DatePicker/useFocusOnSelectedDate.test.tsx
+++ b/packages/components/src/DatePicker/useFocusOnSelectedDate.test.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { useFocusOnSelectedDate } from "./useFocusOnSelectedDate";
+
+describe("useFocusOnSelectedDate hook", () => {
+  it("focuses when the selected class name exists in the dom", async () => {
+    const { getByTestId } = render(<TestComponent hasSelectedDay={true} />);
+    await waitFor(() => {
+      expect(getByTestId("this is it")).toHaveFocus();
+    });
+  });
+
+  it("doesn't focus when the selected class name doesn't exist in the dom", async () => {
+    render(<TestComponent hasSelectedDay={false} />);
+    await waitFor(() => {
+      expect(document.body).toHaveFocus();
+    });
+  });
+});
+
+interface TestComponentProps {
+  hasSelectedDay?: boolean;
+}
+
+function TestComponent({ hasSelectedDay }: TestComponentProps) {
+  const { ref, focusOnSelectedDate } = useFocusOnSelectedDate();
+
+  useEffect(focusOnSelectedDate, []);
+
+  return (
+    <div ref={ref}>
+      {hasSelectedDay && (
+        <div
+          data-testid="this is it"
+          className="react-datepicker__day--selected"
+          tabIndex={0}
+        />
+      )}
+      <div />
+    </div>
+  );
+}

--- a/packages/components/src/DatePicker/useFocusOnSelectedDate.ts
+++ b/packages/components/src/DatePicker/useFocusOnSelectedDate.ts
@@ -1,0 +1,16 @@
+import { MutableRefObject, useRef } from "react";
+
+export function useFocusOnSelectedDate() {
+  const ref = useRef() as MutableRefObject<HTMLDivElement>;
+
+  function focusOnSelectedDate() {
+    const selectedDateClass = ".react-datepicker__day--selected";
+    const selectedDate = ref.current?.querySelector(selectedDateClass);
+
+    if (selectedDate instanceof HTMLDivElement) {
+      selectedDate.focus();
+    }
+  }
+
+  return { ref, focusOnSelectedDate };
+}


### PR DESCRIPTION
## Motivations

Hook was introduced because the DatePicker test [here](https://github.com/GetJobber/atlantis/blob/master/packages/components/src/DatePicker/DatePicker.test.tsx#L114) was a false positive because initially the DatePicker library focuses on mount, so it would be the case that the test will always pass.

To fix this @darryltec suggested creating a separate hook that handles focusing on the date hence `useFocusOnSelectedDate`   

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
