### PR TITLE
fix(components): check for window before attempting to execute document methods (JOB-39898)

### DIFF
--- a/packages/components/src/Card/CardClickable.tsx
+++ b/packages/components/src/Card/CardClickable.tsx
@@ -36,7 +36,9 @@ export function CardClickable({
   );
 
   function isCardFocused() {
-    return document.activeElement === cardRef.current;
+    return (
+      typeof window === "object" && document.activeElement === cardRef.current
+    );
   }
 
   function handleKeyup(event: React.KeyboardEvent<HTMLDivElement>) {

--- a/packages/components/src/Chips/InternalChipButton.tsx
+++ b/packages/components/src/Chips/InternalChipButton.tsx
@@ -45,6 +45,7 @@ export function InternalChipButton({
 
   function handleKeyUp(event: KeyboardEvent) {
     if (
+      typeof window === "object" &&
       document.activeElement === buttonRef.current &&
       (event.key === " " || event.key === "Enter")
     ) {
@@ -54,7 +55,11 @@ export function InternalChipButton({
   }
 
   function handleKeyDown(event: KeyboardEvent) {
-    if (document.activeElement === buttonRef.current && event.key === " ") {
+    if (
+      typeof window === "object" &&
+      document.activeElement === buttonRef.current &&
+      event.key === " "
+    ) {
       // Don't scroll down
       event.preventDefault();
     }

--- a/packages/components/src/Form/Form.tsx
+++ b/packages/components/src/Form/Form.tsx
@@ -83,12 +83,14 @@ export const Form = forwardRef(function InternalForm(
 
   function errorHandler(errs: ErrorOption) {
     const firstErrName = Object.keys(errs)[0];
-    const element = document.querySelector(
-      `[name="${firstErrName}"]`,
-    ) as HTMLElement;
+    if (typeof window === "object") {
+      const element = document.querySelector(
+        `[name="${firstErrName}"]`,
+      ) as HTMLElement;
 
-    if (typeof element != undefined) {
-      element?.focus();
+      if (typeof element != undefined) {
+        element?.focus();
+      }
     }
   }
 });

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -88,7 +88,11 @@ export function Modal({
     </AnimatePresence>
   );
 
-  return ReactDOM.createPortal(template, document.body);
+  return typeof window === "object" ? (
+    ReactDOM.createPortal(template, document.body)
+  ) : (
+    <></>
+  );
 
   function handleRequestClose() {
     if (open && onRequestClose) {

--- a/packages/components/src/Modal/useFocusTrap.ts
+++ b/packages/components/src/Modal/useFocusTrap.ts
@@ -16,7 +16,11 @@ export function useFocusTrap<T extends HTMLElement>(active: boolean) {
   const ref = useRef<T>(null);
 
   function handleKeyDown(event: KeyboardEvent) {
-    if (!(active && ref.current) || event.key !== "Tab") {
+    if (
+      !(typeof window === "object") ||
+      !(active && ref.current) ||
+      event.key !== "Tab"
+    ) {
       return;
     }
 

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -46,7 +46,7 @@ export function Tooltip({ message, children }: TooltipProps) {
     placement === "above" && styles.above,
   );
 
-  return (
+  return typeof window === "object" ? (
     <>
       <span className={styles.shadowActivator} ref={shadowRef} />
       {children}
@@ -83,6 +83,8 @@ export function Tooltip({ message, children }: TooltipProps) {
         </div>
       </TooltipPortal>
     </>
+  ) : (
+    <></>
   );
 
   function initializeListeners() {

--- a/packages/hooks/src/useRefocusOnActivator/useRefocusOnActivator.ts
+++ b/packages/hooks/src/useRefocusOnActivator/useRefocusOnActivator.ts
@@ -10,7 +10,7 @@ export function useRefocusOnActivator(active: boolean) {
   useEffect(() => {
     let activator: Element | null | undefined;
 
-    if (active && !activator) {
+    if (typeof window === "object" && active && !activator) {
       activator = document.activeElement;
     }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
- when using chips component in nextjs project, it is breaking due to document object (which is a browser object) not existing during nextjs rendering

<!-- Why did you do what you did? -->

## Changes
- there is a check for window object existence before executing a document method
<!-- https://keepachangelog.com/en/1.0.0/ -->

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://i.pinimg.com/originals/f3/a5/b7/f3a5b790798ea9b3b132bf53d842b514.gif)
