### PR TITLE
fix: Allow space bar key deselect on single select chip

### DIFF
--- a/packages/components/src/Chips/InternalChipSingleSelect.tsx
+++ b/packages/components/src/Chips/InternalChipSingleSelect.tsx
@@ -46,7 +46,7 @@ export function InternalChipSingleSelect({
 
     return (event: KeyboardEvent<HTMLInputElement>) => {
       if (event.key === " ") {
-        // Wait for dom changes before applying the new change.
+        // Wait for DOM changes before applying the new change.
         setTimeout(() => handleChange(value), 0);
       }
     };

--- a/packages/components/src/Chips/InternalChipSingleSelect.tsx
+++ b/packages/components/src/Chips/InternalChipSingleSelect.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent } from "react";
+import React, { KeyboardEvent, MouseEvent } from "react";
 import { v1 as uuidv1 } from "uuid";
 import styles from "./InternalChip.css";
 import { InternalChip } from "./InternalChip";
@@ -18,33 +18,49 @@ export function InternalChipSingleSelect({
 }: InternalChipChoiceProps) {
   return (
     <div className={styles.wrapper} data-testid="singleselect-chips">
-      {React.Children.map(children, child => (
-        <label>
-          <input
-            type="radio"
-            checked={child.props.value === selected}
-            className={styles.input}
-            name={name}
-            onClick={handleClick(child.props.value)}
-            onChange={() => {
-              /* No op. onClick handles the change to allow deselecting. */
-            }}
-            disabled={child.props.disabled}
-          />
-          <InternalChip
-            {...child.props}
-            active={child.props.value === selected}
-          />
-        </label>
-      ))}
+      {React.Children.map(children, child => {
+        const isSelected = child.props.value === selected;
+        return (
+          <label>
+            <input
+              type="radio"
+              checked={isSelected}
+              className={styles.input}
+              name={name}
+              onClick={handleClick(child.props.value)}
+              onKeyUp={handleKeyUp(isSelected, child.props.value)}
+              onChange={() => {
+                /* No op. onClick handles the change to allow deselecting. */
+              }}
+              disabled={child.props.disabled}
+            />
+            <InternalChip {...child.props} active={isSelected} />
+          </label>
+        );
+      })}
     </div>
   );
+
+  function handleKeyUp(active: boolean, value: string) {
+    if (!active) return;
+
+    return (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === " ") {
+        // Wait for dom changes before applying the new change.
+        setTimeout(() => handleChange(value), 0);
+      }
+    };
+  }
 
   function handleClick(value: string) {
     return (event: MouseEvent<HTMLInputElement>) => {
       onClick?.(event, value);
-      const newValue = value !== selected ? value : undefined;
-      onChange(newValue);
+      handleChange(value);
     };
+  }
+
+  function handleChange(value: string) {
+    const newValue = value !== selected ? value : undefined;
+    onChange(newValue);
   }
 }

--- a/packages/components/src/Chips/tests/InternalChipSingleSelect.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipSingleSelect.test.tsx
@@ -67,11 +67,10 @@ describe("onClick", () => {
   });
 });
 
-describe("Keyboard shortcut", () => {
-  it("should deselect the chip on space bar press", async () => {
-    const target = chips[0];
+describe("On space bar press", () => {
+  it("should deselect the selected chip", async () => {
     const element = within(
-      screen.getByLabelText(target).closest("label"),
+      screen.getByLabelText(selectedChip).closest("label"),
     ).getByRole("radio");
     fireEvent.keyUp(element, { key: " " });
 

--- a/packages/components/src/Chips/tests/InternalChipSingleSelect.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipSingleSelect.test.tsx
@@ -1,5 +1,12 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Chip } from "..";
 import { InternalChipSingleSelect } from "../InternalChipSingleSelect";
@@ -57,5 +64,21 @@ describe("onClick", () => {
     userEvent.click(screen.getByLabelText(target));
     expect(handleClickChip).toHaveBeenCalledTimes(1);
     expect(handleClickChip).toHaveReturnedWith(target);
+  });
+});
+
+describe("Keyboard shortcut", () => {
+  it("should deselect the chip on space bar press", async () => {
+    const target = chips[0];
+    const element = within(
+      screen.getByLabelText(target).closest("label"),
+    ).getByRole("radio");
+    fireEvent.keyUp(element, { key: " " });
+
+    // Wait for next tick
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveReturnedWith(undefined);
+    });
   });
 });


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Since the single select chips are just an input radio behind the scenes, deselecting via space bar isn't really a default interaction for them. This make it support the ability to deselect a chip via a space bar press

Q: What about enter press?
A: Since radio's and checkboxes doesn't get selected on "enter" press, I didn't bother including it. You can, however, select both via a space bar so it seems natural to only support said key.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Allow single select chips to be deselected on enter press
- Test that new interaction

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- You should be able to deselect a single select chip using the space bar

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
