### PR TITLE
build: Speed Up CI Config Steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,13 +137,12 @@ jobs:
           path: coverage
 
   build_docs:
+    resource_class: medium+
     <<: *container_config
     steps:
       - *attach_workspace
       - run:
           command: node -v && node -e 'console.log(`heap_size_limit = ${v8.getHeapStatistics().heap_size_limit / (1024 * 1024)} MB`)' && npm run build -- --base "/${BASE_PATH}/"
-          environment:
-            NODE_OPTIONS: --max_old_space_size=1400
       - store_artifacts:
           path: ~/atlantis/.docz/dist
           destination: docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
     steps:
       - *restore_repo
       - checkout
+      - *persist_to_workspace
       - save_cache:
           key: v1-repo-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -72,7 +73,7 @@ jobs:
   install_dependencies:
     <<: *container_config
     steps:
-      - *restore_repo
+      - *attach_workspace
       - *sum_lockfiles
       - *restore_npm_cache
       - *npm_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
     <<: *container_config
     steps:
       - *attach_workspace
+      - *generate_base_path
       - run:
           command: node -v && node -e 'console.log(`heap_size_limit = ${v8.getHeapStatistics().heap_size_limit / (1024 * 1024)} MB`)' && npm run build -- --base "/${BASE_PATH}/"
       - store_artifacts:
@@ -158,6 +159,7 @@ jobs:
     <<: *container_config
     steps:
       - *attach_workspace
+      - *github_authenticity
       - add_ssh_keys:
           fingerprints:
             - "39:99:9f:56:1c:70:0e:53:6a:ed:64:14:c3:a8:e2:ce"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,16 @@ references:
         - npm-cache-v1-{{ arch }}-{{ checksum "/tmp/lock-sums" }}
         - npm-cache-v1
 
+  attach_workspace: &attach_workspace
+    attach_workspace:
+        at: .
+
+  persist_to_workspace: &persist_to_workspace
+    persist_to_workspace:
+      root: .
+      paths:
+        - '*'
+
   npm_install: &npm_install
     run:
       name: Install Dependencies
@@ -66,6 +76,7 @@ jobs:
       - *sum_lockfiles
       - *restore_npm_cache
       - *npm_install
+      - *persist_to_workspace
       - save_cache:
           name: Save npm cache
           key: npm-cache-v1-{{ arch }}-{{ checksum "/tmp/lock-sums" }}
@@ -75,10 +86,7 @@ jobs:
   check_for_manual_release:
     <<: *container_config
     steps:
-      - *restore_repo
-      - *sum_lockfiles
-      - *restore_npm_cache
-      - *npm_install
+      - *attach_workspace
       - run:
           name: Check for manual releases
           command: |
@@ -92,10 +100,7 @@ jobs:
   lint_javascript:
     <<: *container_config
     steps:
-      - *restore_repo
-      - *sum_lockfiles
-      - *restore_npm_cache
-      - *npm_install
+      - *attach_workspace
       - run: npm run lint:js -- --format junit -o reports/junit/js-lint-results.xml
       - store_test_results:
           path: reports/junit
@@ -105,10 +110,7 @@ jobs:
   lint_css:
     <<: *container_config
     steps:
-      - *restore_repo
-      - *sum_lockfiles
-      - *restore_npm_cache
-      - *npm_install
+      - *attach_workspace
       - run: mkdir -p reports/junit
       - run: npm run lint:css -- --custom-formatter node_modules/stylelint-junit-formatter > reports/junit/css-lint-results.xml
       - store_test_results:
@@ -119,10 +121,7 @@ jobs:
   test:
     <<: *container_config
     steps:
-      - *restore_repo
-      - *sum_lockfiles
-      - *restore_npm_cache
-      - *npm_install
+      - *attach_workspace
       - run:
           name: "Run tests with jest"
           command:
@@ -139,11 +138,7 @@ jobs:
   build_docs:
     <<: *container_config
     steps:
-      - *restore_repo
-      - *sum_lockfiles
-      - *restore_npm_cache
-      - *npm_install
-      - *generate_base_path
+      - *attach_workspace
       - run:
           command: node -v && node -e 'console.log(`heap_size_limit = ${v8.getHeapStatistics().heap_size_limit / (1024 * 1024)} MB`)' && npm run build -- --base "/${BASE_PATH}/"
           environment:
@@ -162,11 +157,7 @@ jobs:
   release:
     <<: *container_config
     steps:
-      - *restore_repo
-      - *sum_lockfiles
-      - *restore_npm_cache
-      - *npm_install
-      - *github_authenticity
+      - *attach_workspace
       - add_ssh_keys:
           fingerprints:
             - "39:99:9f:56:1c:70:0e:53:6a:ed:64:14:c3:a8:e2:ce"


### PR DESCRIPTION
## Motivations
While investigating parallel test runs @darryltec noticed that `npm ci` was being called over and over at each step after `install_dependencies`.  This was probably due to a mistake in implementation of the caching inside `config.yml`    

Decrease the total time of Atlantis builds:
Before: 11m 21s (without release step) and ~14m 45s (with release step)
After: ~8m 37s (without release step)

## Changes

- Instead of using caching after `install_dependencies` we are persisting a workspace.  Caching works from branch to branch, but persisting a workspace works during a single pipeline instance.  This is why caching is still kept during `install_dependencies` since it could be the case that the cache will be hit on another branch that uses the same dependencies.  Commits [here](https://github.com/GetJobber/atlantis/pull/837/commits/186d26cb8521ab86fbdcc8cc5cc1b9ea07a49484) and [here](https://github.com/GetJobber/atlantis/pull/837/commits/55ddfb3f3c6e5ea1979f7255681fdeb1d222d7f4)

- The `medium+` resource class is now being used for `build_docs` because we are able to use the extra resources towards something else now that we shaved off ~4mins from the build.  This change shaves off ~1min of time too!  The heap size doesn't seem to be an issue as the RAM usage stays below 80% after several runs.  Commit [here](https://github.com/GetJobber/atlantis/pull/837/commits/7970ed41674e1db89cd122e460fe248260ff3f80)

- The max limit of 1400Mb (via `NODE_OPTIONS: --max_old_space_size=1400`) can be removed now that we are using the medium+ resource, since the RAM is not being maxed out.  This limit was initially set to mimic Node 10's smaller heap size, as Node 12+ begins killing the build with it's larger one.  See Jc's PR [here](https://github.com/GetJobber/atlantis/pull/805) for more detail

- Check out these times below:

## Before (on master w/release step too)
![Screen Shot 2022-01-18 at 5 54 05 PM](https://user-images.githubusercontent.com/88052089/150043425-4a8d8431-d7af-4607-9ec8-3d57dbd409cf.png)

## After
![Screen Shot 2022-01-18 at 5 53 34 PM](https://user-images.githubusercontent.com/88052089/150043454-74f6846c-1c4a-48bb-8462-f89feb64e89b.png)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
