### PR TITLE
build: @jobber/hooks use the src dir instead of dist

### DIFF
--- a/packages/docz-tools/gatsby-node.js
+++ b/packages/docz-tools/gatsby-node.js
@@ -36,11 +36,15 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
     ],
   });
 
+  console.log("=====================");
+  console.log("running gatsby node");
+  console.log("=====================");
+
   if (useAtlantisAliases) {
     config.resolve.alias = {
       ...config.resolve.alias,
       "@jobber/components": path.resolve(__dirname, "../components/src"),
-      "@jobber/hooks": path.resolve(__dirname, "../hooks"),
+      "@jobber/hooks": path.resolve(__dirname, "../hooks/src"),
     };
   }
 

--- a/packages/docz-tools/gatsby-node.js
+++ b/packages/docz-tools/gatsby-node.js
@@ -36,10 +36,6 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
     ],
   });
 
-  console.log("=====================");
-  console.log("running gatsby node");
-  console.log("=====================");
-
   if (useAtlantisAliases) {
     config.resolve.alias = {
       ...config.resolve.alias,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When working in Atlantis, the development mode was looking into the `dist` directory for hooks. This was causing developers to have to run an `npm run build` each time they saved their hook in order to see changes. This will change that to look in the `src` directory.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Alias to `@jobber/hooks`

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
