### PR TITLE
feat(components): Left-align wrapping button labels when Icon is present 

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -210,6 +210,7 @@ a.button.disabled:hover {
 }
 
 .hasIconAndLabel > *:first-child {
+  flex-shrink: 0;
   margin-right: var(--space-small);
 }
 

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -205,6 +205,10 @@ a.button.disabled:hover {
   width: auto;
 }
 
+.hasIconAndLabel > * {
+  text-align: start;
+}
+
 .hasIconAndLabel > *:first-child {
   margin-right: var(--space-small);
 }


### PR DESCRIPTION
## Motivations

When a button label is large enough, the text wraps. For visual balance, this wrapping should be left-aligned when an icon is present. Additionally, when both an icon and a long text label is present, it should not squish the icon down into nothingness.

### Before

<img width="836" alt="Screen Shot 2022-01-20 at 10 18 50 AM" src="https://user-images.githubusercontent.com/872151/150390148-a861abdd-cd6e-424f-8f85-405656a26426.png">

### With Left-Aligned Text change

<img width="802" alt="Screen Shot 2022-01-20 at 10 19 15 AM" src="https://user-images.githubusercontent.com/872151/150390189-21265275-18aa-4a83-a110-20c0b76d223f.png">

### With Icon-shrinking fix

<img width="796" alt="Screen Shot 2022-01-20 at 10 19 39 AM" src="https://user-images.githubusercontent.com/872151/150390223-f6bc4613-c77e-4ee3-aa12-25dabf0f78c5.png">

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Buttons with Icons and long text labels now have left-aligned text labels

### Fixed

- Buttons with Icons and long text labels do not shrink the Icon down

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
