### PR TITLE
build: Revert back ssh key to make release pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ references:
   github_authenticity: &github_authenticity
     run:
       name: Establishing GitHub Authenticity
-      command: mkdir -p ~/.ssh; echo 'github.com ssh-rsa ${GH_AUTHENTICITY}' >> ~/.ssh/known_hosts
+      command: mkdir -p ~/.ssh; echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
 
   generate_base_path: &generate_base_path
     run:
@@ -152,7 +152,7 @@ jobs:
       - *github_authenticity
       - add_ssh_keys:
           fingerprints:
-            - "${RELEASE_SSH_FINGERPRINT}"
+            - "39:99:9f:56:1c:70:0e:53:6a:ed:64:14:c3:a8:e2:ce"
       - run:
           name: Authenticate with npm
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/atlantis/.npmrc


### PR DESCRIPTION
## Motivations

Releases are failing now because of the SSH key variable added for this PR: https://github.com/GetJobber/atlantis/pull/840

More investigation is required into why it's failing.  So for now, it's best to unblock the release process until the solution can be finalized!!!


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
