### PR TITLE
feat(components): add explicit "Heading" color to Card header

### DIFF
--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -62,6 +62,7 @@ export function Card({
             size="large"
             textCase="uppercase"
             fontWeight="extraBold"
+            textColor="heading"
           >
             {title}
           </Typography>

--- a/packages/components/src/Card/tests/Card.test.tsx
+++ b/packages/components/src/Card/tests/Card.test.tsx
@@ -38,7 +38,7 @@ it("renders a card", () => {
         className="header"
       >
         <h3
-          className="base extraBold large uppercase"
+          className="base extraBold large uppercase heading"
         >
           The Undiscovered Country
         </h3>


### PR DESCRIPTION
## Motivations

Card in Atlantis is not representative of desired output. It should use the `heading` color in the header, and because it had previously only been used in projects (Jobber) that had the desired color for `h3` elements set in global CSS, the production output was never an issue.

However as external applications are being built that leverage Atlantis, we should specify the heading color so that it does not inherit from whatever the external app's `body` color is set to.

## Changes

### Added

- set `textColor` on Card's heading

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
