### PR TITLE
feat(components): expose minDate and maxDate props from react-datepicker (JOB-40742)

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.css
+++ b/packages/components/src/DatePicker/DatePicker.css
@@ -62,6 +62,11 @@
   background: var(--color-surface--background);
 }
 
+.datePicker :global(.react-datepicker__day--disabled) {
+  color: var(--color-disabled--secondary);
+  cursor: default;
+}
+
 .datePicker :global(.react-datepicker__month) {
   margin: 0;
 }
@@ -100,6 +105,20 @@
 .datePicker :global(.react-datepicker__day--selected):hover,
 .datePicker :global(.react-datepicker__day--selected):focus {
   background: var(--color-interactive--hover);
+}
+
+.datePicker :global(.react-datepicker__day--disabled):hover,
+.datePicker :global(.react-datepicker__day--disabled):focus {
+  box-shadow: none;
+  background: transparent;
+}
+
+.datePicker
+  :global(.react-datepicker__day--disabled.react-datepicker__day--outside-month):hover,
+.datePicker
+  :global(.react-datepicker__day--disabled.react-datepicker__day--outside-month):focus {
+  box-shadow: none;
+  background: var(--color-surface--background);
 }
 
 .month {

--- a/packages/components/src/DatePicker/DatePicker.mdx
+++ b/packages/components/src/DatePicker/DatePicker.mdx
@@ -99,6 +99,31 @@ pass a `React` component as the `activator`.
   }}
 </Playground>
 
+## Disabling dates
+
+If you want to enable for selection only for a set of dates you can pass
+`minDate` or `maxDate` to the component as props.
+
+<Playground>
+  {() => {
+    const [date, setDate] = useState(new Date("02/17/2022"));
+    return (
+      <Content>
+        <div>
+          <DatePicker
+            minDate={new Date("02/07/2022")}
+            maxDate={new Date("02/27/2022")}
+            selected={date}
+            inline
+            onChange={setDate}
+          />
+        </div>
+        {date && <DataDump defaultOpen data={date} />}
+      </Content>
+    );
+  }}
+</Playground>
+
 ## Accessibility
 
 At this point, the `DatePicker` component is a wrapped version of

--- a/packages/components/src/DatePicker/DatePicker.test.tsx
+++ b/packages/components/src/DatePicker/DatePicker.test.tsx
@@ -40,6 +40,23 @@ it("returns the dates from onChange", async () => {
   expect(changeHandler).toHaveBeenCalledWith(expect.any(Date));
 });
 
+it("should not call onChange handler if date is disabled", async () => {
+  const changeHandler = jest.fn();
+  const { getByTestId, getByText } = render(
+    <DatePicker
+      minDate={new Date(2021, 3, 4)}
+      maxDate={new Date(2021, 3, 17)}
+      selected={new Date()}
+      onChange={changeHandler}
+    />,
+  );
+  await popperUpdate(() => fireEvent.click(getByTestId("calendar")));
+  await popperUpdate(() => fireEvent.click(getByText("2")));
+  await popperUpdate(() => fireEvent.click(getByText("21")));
+
+  expect(changeHandler).not.toHaveBeenCalled();
+});
+
 it("allows for a custom activator to open the DatePicker", async () => {
   const { getByText } = render(
     <DatePicker
@@ -97,12 +114,18 @@ describe("Ensure ReactDatePicker CSS class names exists", () => {
       ".react-datepicker__day--selected",
       ".react-datepicker__day-names",
       ".react-datepicker__day-name",
+      ".react-datepicker__day--disabled",
     ];
 
     classNames.forEach(className => {
       it(`should have ${className}`, async () => {
         const { getByRole, container } = render(
-          <ReactDatePicker selected={new Date()} onChange={jest.fn} />,
+          <ReactDatePicker
+            minDate={new Date(2021, 3, 4)}
+            maxDate={new Date(2021, 3, 27)}
+            selected={new Date()}
+            onChange={jest.fn}
+          />,
         );
         await popperUpdate(() => fireEvent.focus(getByRole("textbox")));
         expect(container.querySelector(className)).toBeTruthy();

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -13,6 +13,16 @@ import { useFocusOnSelectedDate } from "./useFocusOnSelectedDate";
 
 interface BaseDatePickerProps {
   /**
+   * The maximum selectable date.
+   */
+  readonly maxDate?: Date;
+
+  /**
+   * The minimum selectable date.
+   */
+  readonly minDate?: Date;
+
+  /**
    * The selected Date object
    */
   readonly selected?: Date;
@@ -68,6 +78,8 @@ export function DatePicker({
   disabled = false,
   fullWidth = false,
   smartAutofocus = true,
+  maxDate,
+  minDate,
 }: DatePickerProps) {
   const { ref, focusOnSelectedDate } = useFocusOnSelectedDate();
   const [open, setOpen] = useState(false);
@@ -101,6 +113,8 @@ export function DatePicker({
         disabled={disabled}
         readOnly={readonly}
         onChange={handleChange}
+        maxDate={maxDate}
+        minDate={minDate}
         formatWeekDay={date => date.substring(0, 3)}
         customInput={
           <DatePickerActivator activator={activator} fullWidth={fullWidth} />

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -27,6 +27,29 @@ it("fires onChange with the new value when you click a date", () => {
   fireEvent.click(selectDate);
   expect(changeHandler).toHaveBeenCalledWith(new Date(newDate));
 });
+it("shouldn't call onChange with the new value when you click a disabled date", () => {
+  const date = "11/11/2011";
+  const minDate = "11/9/2011";
+  const maxDate = "11/15/2011";
+  const changeHandler = jest.fn();
+  const { getByDisplayValue, getByText } = render(
+    <InputDate
+      minDate={new Date(minDate)}
+      maxDate={new Date(maxDate)}
+      value={new Date(date)}
+      onChange={changeHandler}
+    />,
+  );
+
+  const form = getByDisplayValue(date);
+  fireEvent.focus(form);
+
+  const selectDate1 = getByText("7");
+  fireEvent.click(selectDate1);
+  const selectDate2 = getByText("17");
+  fireEvent.click(selectDate2);
+  expect(changeHandler).not.toHaveBeenCalled();
+});
 
 it("fires onChange with the new value when you type a different date", () => {
   const date = "11/11/2011";

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -28,6 +28,15 @@ interface InputDateProps
    * */
   readonly value?: Date;
   onChange(newValue: Date): void;
+  /**
+   * The maximum selectable date.
+   */
+  readonly maxDate?: Date;
+
+  /**
+   * The minimum selectable date.
+   */
+  readonly minDate?: Date;
 }
 
 export function InputDate(inputProps: InputDateProps) {
@@ -38,6 +47,8 @@ export function InputDate(inputProps: InputDateProps) {
       disabled={inputProps.disabled}
       readonly={inputProps.readonly}
       fullWidth={!inputProps.inline}
+      minDate={inputProps.minDate}
+      maxDate={inputProps.maxDate}
       smartAutofocus={false}
       activator={activatorProps => {
         const { onChange, onClick, value } = activatorProps;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Provides the ability of disabling a range of dates. This could help the developer to make the user unable to select dates that could cause issues or edge cases.

![image](https://user-images.githubusercontent.com/31483287/154531583-f7dc2fcf-56e3-456a-915b-40babe8c9db6.png)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `minDate` and `maxDate` props to DatePicker and InputDate

### Changed

- added ability to disable dates by using said props

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
