### PR TITLE
feat(design): update overlay color to black

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -43,8 +43,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(--color-blue--dark);
-  opacity: 0.3;
+  background-color: var(--color-overlay);
   mix-blend-mode: multiply;
 }
 

--- a/packages/components/src/LightBox/LightBox.css
+++ b/packages/components/src/LightBox/LightBox.css
@@ -9,7 +9,6 @@
   width: 100%;
   height: 100%;
   background-color: var(--color-overlay);
-  opacity: 0.8;
 }
 
 .wrapper:global(.ril__outer .ril__captionContent) {

--- a/packages/components/src/LightBox/LightBox.css
+++ b/packages/components/src/LightBox/LightBox.css
@@ -8,7 +8,7 @@
   display: block;
   width: 100%;
   height: 100%;
-  background-color: var(--color-greyBlue);
+  background-color: var(--color-overlay);
   opacity: 0.8;
 }
 

--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -108,12 +108,7 @@
   bottom: 0;
   left: 0;
   z-index: var(--elevation-menu);
-  background-color: rgba(
-    101,
-    120,
-    132,
-    0.8
-  ); /* until we figure out rgba + color vars... */
+  background-color: var(--color-overlay);
 
   @media (--medium-screens) {
     background-color: transparent;

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -28,7 +28,6 @@
 
 .overlay {
   background-color: var(--color-overlay);
-  opacity: 0.8;
 }
 
 .modal {

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -27,7 +27,7 @@
 }
 
 .overlay {
-  background-color: var(--color-greyBlue);
+  background-color: var(--color-overlay);
   opacity: 0.8;
 }
 

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -53,7 +53,7 @@
   --color-border: var(--color-grey--lighter);
   --color-border--section: var(--color-blue);
 
-  --color-overlay: rgba(var(--color-greyBlue--rgb), 0.8);
+  --color-overlay: rgba(var(--color-black--rgb), 0.32);
   --color-overlay--dimmed: rgba(var(--color-white--rgb), 0.6);
 
   /* Brand */
@@ -169,4 +169,7 @@
 
   --color-white--rgb: 255, 255, 255;
   --color-white: rgba(var(--color-white--rgb), 1);
+
+  --color-black--rgb: 0, 0, 0;
+  --color-black: rgba(var(--color-black--rgb), 1);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We'd like to replace our grey-blue overlay color as it very different than native mobile alert overlays which can be jarring particularly if they appear back-to-back. Also I can't remember what Josh said exactly, but the grey-blue looks off/dated.

## Changes

- Overlay color set to default Material overlay values
<img width="1066" alt="Screen Shot 2022-02-25 at 2 36 50 PM" src="https://user-images.githubusercontent.com/19555235/155806458-1b507747-865f-4ef6-9272-3986120db324.png">
<img width="1588" alt="Screen Shot 2022-02-25 at 2 37 17 PM" src="https://user-images.githubusercontent.com/19555235/155806460-a0b3489c-51cc-4118-ba4d-5014702bd98a.png">

<img width="1497" alt="Screen Shot 2022-02-28 at 10 56 06 AM" src="https://user-images.githubusercontent.com/19555235/156033754-30e27bdb-9bce-4ed4-838b-75cead7913b9.png">
<img width="1035" alt="Screen Shot 2022-02-28 at 10 56 24 AM" src="https://user-images.githubusercontent.com/19555235/156033762-20e8b1bb-8fc2-44a5-b302-33b33c06dd62.png">


### Added

- Added black as a base color to use as a base for the overlay color.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
