### PR TITLE
fix(components): Update tooltip to use react-popper

### DIFF
--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -2,14 +2,13 @@ import React, {
   ReactElement,
   ReactNode,
   useLayoutEffect,
-  useRef,
   useState,
 } from "react";
 import classnames from "classnames";
 import ReactDOM from "react-dom";
 import { motion } from "framer-motion";
-import { usePopper } from "react-popper";
 import styles from "./Tooltip.css";
+import { useTooltipPositioning } from "./useTooltipPositioning";
 import { Text } from "../Text";
 
 const variation = {
@@ -27,32 +26,22 @@ interface TooltipProps {
 
 export function Tooltip({ message, children }: TooltipProps) {
   const [show, setShow] = useState(false);
-  const shadowRef = useRef<HTMLSpanElement>(null); // eslint-disable-line no-null/no-null
-  const [positionElement, setPositionedElementRef] =
-    useState<HTMLElement | null>();
-  const [arrowElement, setArrowElement] = useState<HTMLElement | null>();
 
-  const popper = usePopper(
-    shadowRef.current?.nextElementSibling,
-    positionElement,
-    {
-      placement: "top",
-      modifiers: [
-        { name: "flip", options: { fallbackPlacements: ["bottom"] } },
-        {
-          name: "arrow",
-          options: { element: arrowElement, padding: 10 },
-        },
-      ],
-    },
-  );
+  const {
+    attributes,
+    placement,
+    shadowRef,
+    styles: popperStyles,
+    setArrowRef,
+    setTooltipRef,
+  } = useTooltipPositioning();
 
   initializeListeners();
 
   const toolTipClassNames = classnames(
     styles.tooltipWrapper,
-    popper.state?.placement === "bottom" && styles.below,
-    popper.state?.placement === "top" && styles.above,
+    placement === "bottom" && styles.below,
+    placement === "top" && styles.above,
   );
 
   return (
@@ -63,10 +52,10 @@ export function Tooltip({ message, children }: TooltipProps) {
         {show && (
           <div
             className={toolTipClassNames}
-            style={popper.styles.popper}
-            ref={setPositionedElementRef}
+            style={popperStyles.popper}
+            ref={setTooltipRef}
             role="tooltip"
-            {...popper.attributes.popper}
+            {...attributes.popper}
           >
             <motion.div
               className={styles.tooltip}
@@ -82,8 +71,8 @@ export function Tooltip({ message, children }: TooltipProps) {
             >
               <Text>{message}</Text>
               <div
-                ref={setArrowElement}
-                style={popper.styles.arrow}
+                ref={setArrowRef}
+                style={popperStyles.arrow}
                 className={styles.arrow}
               />
             </motion.div>

--- a/packages/components/src/Tooltip/useTooltipPositioning.ts
+++ b/packages/components/src/Tooltip/useTooltipPositioning.ts
@@ -1,0 +1,31 @@
+import { useRef, useState } from "react";
+import { usePopper } from "react-popper";
+
+export function useTooltipPositioning() {
+  const shadowRef = useRef<HTMLSpanElement>(null); // eslint-disable-line no-null/no-null
+  const [positionElement, setTooltipRef] = useState<HTMLDivElement | null>();
+  const [arrowElement, setArrowRef] = useState<HTMLDivElement | null>();
+
+  const popper = usePopper(
+    shadowRef.current?.nextElementSibling,
+    positionElement,
+    {
+      placement: "top",
+      modifiers: [
+        { name: "flip", options: { fallbackPlacements: ["bottom"] } },
+        {
+          name: "arrow",
+          options: { element: arrowElement },
+        },
+      ],
+    },
+  );
+
+  return {
+    ...popper,
+    placement: popper.state?.placement,
+    shadowRef,
+    setArrowRef,
+    setTooltipRef,
+  };
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- An issue was raised around tooltip arrows aren't aligning to the middle on both Atlantis and Jobber
  - The Atlantis issue was pretty straightforward but, the Jobber issue was a mystery
- Updating tooltip to use `react-popper`'s `usePopper` instead of `@popperjs/core`'s `createPopper` is long overdue so that needed to be updated anyway
  - We hoped that it fixes all the issues since it also removes the cruft that came with using `createPopper` and that it did!

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- replaced `createPopper` with `usePopper`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- Transition out has been removed because it doesn't work well with `usePopper`. Lesser of the 2 ~evils~ things and whatnot

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- [ ] The arrow is rendered in the middle of the activator
  - it's on the activator instead of the tooltip because if the tooltip renders at the edge and there's no space, it will reposition itself but the arrow is aligned to the center of the activator
- [ ] Tooltips in Jobber are rendering the same as the previous test
  - to test this, install a prerelease of Atlantis with `npm install @jobber/components@2.78.1-pre.2+176f0bc`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
