### PR TITLE
docs(components): Document multiline loading={true} limitation 

### DIFF
--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -52,7 +52,7 @@ Use this to allow users to provide short answers.
 ## Multiline
 
 Use this to allow users to provide long answers. The default number of rows is
-three.
+three. Note that `loading={true}` is unimplemented for multiline input text.
 
 <Playground>
   <InputText
@@ -281,7 +281,8 @@ Determine what default keyboard appears on mobile web.
 
 ## Loading
 
-Add a loading state to content.
+Add a loading state to content. Note that `loading={true}` is unimplemented
+for multiline input text, i.e., when `multiline={true}`.
 
 <Playground>
   <InputText


### PR DESCRIPTION
* Document that loading={true} does not work when multiline={true}

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Without these notes, users might be confused when `loading={true}` does not work.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Notes that `loading={true}` does not work when `multiline={true}`.

