### PR TITLE
fix(components): Update popover elevation and width

### DIFF
--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -20,8 +20,8 @@
 }
 
 .popover {
-  z-index: var(--elevation-base);
-  width: 100%;
+  z-index: var(--elevation-tooltip);
+  width: max-content;
   max-width: var(--popover--width);
   box-shadow: var(--shadow-base);
   border: var(--border-base) solid var(--color-border);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
* Popover component was being displayed **under** some elements on Jobber online
* Additionally, the popover width was limited by the width of the element it was attached to
<!-- Why did you do what you did? -->

#### Before
<img width="1056" alt="popover-before" src="https://user-images.githubusercontent.com/3407664/158881543-fc1914c6-0e40-41dd-8839-e8260e35ddf7.png">

#### After
<img width="1062" alt="popover-after" src="https://user-images.githubusercontent.com/3407664/158881866-11dbc5ad-1463-4858-9bc4-c42dce58d36c.png">

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

* Replaced the component's previous z-index, `--elevation-base` with `--elevation-tooltip`
* Replace the component's previous width, `100%` with `max-content`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

* [ ] The popover is rendered above other elements on the page
* [ ] On Jobber Online, the popover width depends on its content size rather than the reference element's width
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
