### PR TITLE
feat(components): create statuslabel component

### DIFF
--- a/packages/components/src/StatusLabel/StatusLabel.css
+++ b/packages/components/src/StatusLabel/StatusLabel.css
@@ -1,0 +1,24 @@
+:root {
+  --statusLabel-icon-diameter: calc(var(--space-base) - var(--space-smaller));
+}
+
+.statusLabelRow {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: var(--space-small);
+  width: fit-content;
+}
+
+.statusIndicator {
+  width: var(--statusLabel-icon-diameter);
+  height: var(--statusLabel-icon-diameter);
+  margin-top: var(--space-smallest);
+  border-radius: var(--radius-base);
+  background-color: var(--color-success);
+  flex-shrink: 0;
+}
+
+.labelTextEndAligned {
+  flex-direction: row-reverse;
+}

--- a/packages/components/src/StatusLabel/StatusLabel.css.d.ts
+++ b/packages/components/src/StatusLabel/StatusLabel.css.d.ts
@@ -1,0 +1,7 @@
+declare const styles: {
+  readonly "statusLabelRow": string;
+  readonly "statusIndicator": string;
+  readonly "labelTextEndAligned": string;
+};
+export = styles;
+

--- a/packages/components/src/StatusLabel/StatusLabel.mdx
+++ b/packages/components/src/StatusLabel/StatusLabel.mdx
@@ -34,19 +34,22 @@ representations:
 
 ### Success
 
-Convey that an item is in a successful state.
+Convey that an item is in a successful state, such as approved or paid.
 
 ### Critical
 
-Alert the user to a critically important issue.
+Alert the user to a critically important issue such as a late appointment or an
+overdue payment.
 
 ### Warning
 
-Warn the user of a potential forthcoming issue.
+Warn the user of a potential forthcoming issue like an upcoming deadline or an
+item awaiting response.
 
 ### Informative
 
-Inform the user about something that may not require action.
+Inform the user about something that may not require action, such as a quote
+that has already been converted into a job.
 
 ### Inactive
 
@@ -92,10 +95,14 @@ The label should be short, ideally no longer than two words.
 
 ## Accessibility
 
+The StatusLabel has a `role` of `status` which is communicated to assistive
+technology. It does not pull focus to itself but informs the user of its'
+purpose.
+
 The label portion of StatusLabel should be readable by assistive technology.
 
-The color indicator is supplemented by the label to ensure that users who cannot
-distinguish color have the same understanding of the labeled item's status.
+The color indicator is always used with a text label so that color is not the
+only method of communicating status.
 
 ## Responsiveness
 

--- a/packages/components/src/StatusLabel/StatusLabel.mdx
+++ b/packages/components/src/StatusLabel/StatusLabel.mdx
@@ -1,0 +1,108 @@
+---
+name: StatusLabel
+menu: Components
+route: /components/status-label
+showDirectoryLink: true
+---
+
+import { Playground, Props } from "docz";
+import { StatusLabel } from ".";
+import { Content } from "../Content";
+
+# Status Label
+
+The `<StatusLabel>` component is a visual component that allows users to quickly
+determine the status of an item (e.g., "Active", "Overdue").
+
+```ts
+import { StatusLabel } from "@jobber/components/StatusLabel";
+```
+
+<Playground>
+  <StatusLabel label="Bob" />
+</Playground>
+
+## Props
+
+<Props of={StatusLabel} />
+
+## Usage Guidelines
+
+StatusLabel is a more opinionated version of
+[InlineLabel](/components/inline-label) and offers only 5 possible status
+representations:
+
+### Success
+
+Convey that an item is in a successful state.
+
+### Critical
+
+Alert the user to a critically important issue.
+
+### Warning
+
+Warn the user of a potential forthcoming issue.
+
+### Informative
+
+Inform the user about something that may not require action.
+
+### Inactive
+
+Signify that an item has been archived, closed, or otherwise removed from an
+active workflow.
+
+<Playground>
+  <Content>
+    <StatusLabel label="Success" status="success" alignment="start" />
+    <StatusLabel label="Critical" status="critical" alignment="start" />
+    <StatusLabel label="Informative" status="informative" alignment="start" />
+    <StatusLabel label="Warning" status="warning" alignment="start" />
+    <StatusLabel label="Inactive" status="inactive" alignment="start" />
+  </Content>
+</Playground>
+
+### Alignment
+
+Align the color indicator with the start or end of a layout as needed.
+
+For example, in a [List](/components/list) where the StatusLabel is on the
+right, use the `end` alignment.
+
+<Playground>
+  <div style={{ display: "flex", justifyContent: "space-between" }}>
+    <StatusLabel label="Start" status="inactive" alignment="start" />
+    <StatusLabel label="End" status="inactive" alignment="end" />
+  </div>
+</Playground>
+
+## Related Components
+
+- [InlineLabel](/components/inline-label) should be replaced with StatusLabel
+  where possible to provide a more intentional communication of status to users
+
+## Content Guidelines
+
+StatusLabel does not accept any child content. It presents only a text-based
+label describing the status, and a visual color indicator to reinforce the
+status.
+
+The label should be short, ideally no longer than two words.
+
+## Accessibility
+
+The label portion of StatusLabel should be readable by assistive technology.
+
+The color indicator is supplemented by the label to ensure that users who cannot
+distinguish color have the same understanding of the labeled item's status.
+
+## Responsiveness
+
+StatusLabel should take up as much space as is available. If StatusLabel's label
+is longer than the space available, the label should wrap.
+
+## Notes
+
+- StatusLabel should replace [InlineLabel](/components/inline-label) where
+  possible.

--- a/packages/components/src/StatusLabel/StatusLabel.test.tsx
+++ b/packages/components/src/StatusLabel/StatusLabel.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { cleanup } from "@testing-library/react";
+import { StatusLabel } from ".";
+
+afterEach(cleanup);
+
+it("renders an inactive StatusLabel", () => {
+  const tree = renderer
+    .create(<StatusLabel label="Foo" status="inactive" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders a successful StatusLabel", () => {
+  const tree = renderer
+    .create(<StatusLabel label="Foo" status="success" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders a warning StatusLabel", () => {
+  const tree = renderer
+    .create(<StatusLabel label="Foo" status="warning" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders a critical StatusLabel", () => {
+  const tree = renderer
+    .create(<StatusLabel label="Foo" status="critical" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders an informative StatusLabel", () => {
+  const tree = renderer
+    .create(<StatusLabel label="Foo" status="informative" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it("renders an end-aligned StatusLabel", () => {
+  const tree = renderer
+    .create(<StatusLabel label="Foo" status="informative" alignment="end" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/components/src/StatusLabel/StatusLabel.tsx
+++ b/packages/components/src/StatusLabel/StatusLabel.tsx
@@ -23,14 +23,14 @@ interface StatusLabelProps {
 
   /**
    * Alignment of label
-   **
+   *
    * @default "start"
    */
   readonly alignment?: "start" | "end";
 
   /**
    * Status color of the indicator beside text
-   *  **
+   *
    * @default "inactive"
    */
   readonly status: StatusType;
@@ -47,7 +47,7 @@ export function StatusLabel({
   );
 
   return (
-    <div className={containerClassNames}>
+    <div role="status" className={containerClassNames}>
       <StatusLabelIcon status={status} />
       <Text size="small" align={alignment}>
         {label}

--- a/packages/components/src/StatusLabel/StatusLabel.tsx
+++ b/packages/components/src/StatusLabel/StatusLabel.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import classnames from "classnames";
+import styles from "./StatusLabel.css";
+import { Text } from "../Text";
+
+export type StatusType =
+  | "success"
+  | "warning"
+  | "critical"
+  | "inactive"
+  | "informative";
+
+export interface StatusLabelType {
+  readonly statusLabel: string;
+  readonly statusType?: StatusType;
+}
+
+interface StatusLabelProps {
+  /**
+   * Text to display
+   */
+  readonly label: string;
+
+  /**
+   * Alignment of label
+   **
+   * @default "start"
+   */
+  readonly alignment?: "start" | "end";
+
+  /**
+   * Status color of the indicator beside text
+   *  **
+   * @default "inactive"
+   */
+  readonly status: StatusType;
+}
+
+export function StatusLabel({
+  label,
+  alignment = "start",
+  status = "inactive",
+}: StatusLabelProps): JSX.Element {
+  const containerClassNames = classnames(
+    styles.statusLabelRow,
+    alignment === "end" && styles.labelTextEndAligned,
+  );
+
+  return (
+    <div className={containerClassNames}>
+      <StatusLabelIcon status={status} />
+      <Text size="small" align={alignment}>
+        {label}
+      </Text>
+    </div>
+  );
+}
+
+interface StatusLabelIconProps {
+  status: StatusType;
+}
+
+function StatusLabelIcon({ status }: StatusLabelIconProps) {
+  return (
+    <div
+      style={{ backgroundColor: `var(--color-${status}` }}
+      className={styles.statusIndicator}
+    />
+  );
+}

--- a/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`renders a critical StatusLabel 1`] = `
 <div
   className="statusLabelRow"
+  role="status"
 >
   <div
     className="statusIndicator"
@@ -23,6 +24,7 @@ exports[`renders a critical StatusLabel 1`] = `
 exports[`renders a successful StatusLabel 1`] = `
 <div
   className="statusLabelRow"
+  role="status"
 >
   <div
     className="statusIndicator"
@@ -43,6 +45,7 @@ exports[`renders a successful StatusLabel 1`] = `
 exports[`renders a warning StatusLabel 1`] = `
 <div
   className="statusLabelRow"
+  role="status"
 >
   <div
     className="statusIndicator"
@@ -63,6 +66,7 @@ exports[`renders a warning StatusLabel 1`] = `
 exports[`renders an end-aligned StatusLabel 1`] = `
 <div
   className="statusLabelRow labelTextEndAligned"
+  role="status"
 >
   <div
     className="statusIndicator"
@@ -83,6 +87,7 @@ exports[`renders an end-aligned StatusLabel 1`] = `
 exports[`renders an inactive StatusLabel 1`] = `
 <div
   className="statusLabelRow"
+  role="status"
 >
   <div
     className="statusIndicator"
@@ -103,6 +108,7 @@ exports[`renders an inactive StatusLabel 1`] = `
 exports[`renders an informative StatusLabel 1`] = `
 <div
   className="statusLabelRow"
+  role="status"
 >
   <div
     className="statusIndicator"

--- a/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a critical StatusLabel 1`] = `
+<div
+  className="statusLabelRow"
+>
+  <div
+    className="statusIndicator"
+    style={
+      Object {
+        "backgroundColor": "var(--color-critical",
+      }
+    }
+  />
+  <p
+    className="base regular small text"
+  >
+    Foo
+  </p>
+</div>
+`;
+
+exports[`renders a successful StatusLabel 1`] = `
+<div
+  className="statusLabelRow"
+>
+  <div
+    className="statusIndicator"
+    style={
+      Object {
+        "backgroundColor": "var(--color-success",
+      }
+    }
+  />
+  <p
+    className="base regular small text"
+  >
+    Foo
+  </p>
+</div>
+`;
+
+exports[`renders a warning StatusLabel 1`] = `
+<div
+  className="statusLabelRow"
+>
+  <div
+    className="statusIndicator"
+    style={
+      Object {
+        "backgroundColor": "var(--color-warning",
+      }
+    }
+  />
+  <p
+    className="base regular small text"
+  >
+    Foo
+  </p>
+</div>
+`;
+
+exports[`renders an end-aligned StatusLabel 1`] = `
+<div
+  className="statusLabelRow labelTextEndAligned"
+>
+  <div
+    className="statusIndicator"
+    style={
+      Object {
+        "backgroundColor": "var(--color-informative",
+      }
+    }
+  />
+  <p
+    className="base regular small text end"
+  >
+    Foo
+  </p>
+</div>
+`;
+
+exports[`renders an inactive StatusLabel 1`] = `
+<div
+  className="statusLabelRow"
+>
+  <div
+    className="statusIndicator"
+    style={
+      Object {
+        "backgroundColor": "var(--color-inactive",
+      }
+    }
+  />
+  <p
+    className="base regular small text"
+  >
+    Foo
+  </p>
+</div>
+`;
+
+exports[`renders an informative StatusLabel 1`] = `
+<div
+  className="statusLabelRow"
+>
+  <div
+    className="statusIndicator"
+    style={
+      Object {
+        "backgroundColor": "var(--color-informative",
+      }
+    }
+  />
+  <p
+    className="base regular small text"
+  >
+    Foo
+  </p>
+</div>
+`;

--- a/packages/components/src/StatusLabel/index.ts
+++ b/packages/components/src/StatusLabel/index.ts
@@ -1,0 +1,1 @@
+export { StatusLabel } from "./StatusLabel";


### PR DESCRIPTION
## Motivations

With the introduction of the [StatusLabel component to the mobile app](https://atlantis-mobile.jobber.dev/?path=/docs/core-status-and-feedback-statuslabel--status-label) (internal Jobber access only) and some in-Jobber cleanup to remove a deprecated internal "StatusLabel" component, this seems a good time to carry out the plan to introduce component parity with mobile and add our desired StatusLabel to Atlantis for web.

The approach here is largely informed by the approach @dmcrorieGIT used in building our mobile component, with some adjustments for web.

## Changes

### Added

- StatusLabel component, docs, and test suite

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
