### PR TITLE
fix(components): set radio labels to base fontSize

### DIFF
--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -11,8 +11,9 @@
 
 .label {
   display: inline-flex;
-  align-items: center;
+  font-size: var(--typography--fontSize-base);
   cursor: pointer;
+  align-items: center;
 }
 
 .input + .label::before {


### PR DESCRIPTION
## Motivations

Radio labels were inheriting font-size from the document body, making them larger than other input elements and `p` elements.

![image](https://user-images.githubusercontent.com/39704901/166327847-444e2208-75f0-414a-949e-540257fb9646.png)

## Changes

### Added

- Explicit font-size declaration on radio labels

### Changed

- Radio labels will no longer rely on their parent site's `body` to determine font-size

## Testing

### Check RadioGroup on production
![image](https://user-images.githubusercontent.com/39704901/166327220-d899a1b8-9afc-4c02-afce-1f55d82b2d34.png)
![image](https://user-images.githubusercontent.com/39704901/166327251-8807b3c0-1fcd-4656-a5f0-ee76a3b6b300.png)

### Check locally/on [preview build](https://af270339.atlantis.pages.dev/)
![image](https://user-images.githubusercontent.com/39704901/166327147-29662fe8-eebb-400a-911f-1488b5cd7ff0.png)
![image](https://user-images.githubusercontent.com/39704901/166327095-433ae157-13e9-4dff-8243-bb060c3b7e94.png)

- [ ] Radio labels are `base` (equivalent to 16px) on local/preview builds

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
