### PR TITLE
docs: add multiplication notes to content guides

### DIFF
--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -561,3 +561,13 @@ on using "valid".
 | Enter a valid expiration year | The expiration year is invalid, please try again |
 
 <br />
+
+## Symbols and Punctuation
+
+### Multiplication
+
+Use the `×` symbol to indicate multiplication whenever possible, rather than an `x`.
+
+| **✅ Do**     | **❌ Don't** |
+| ------------- | ----------- |
+| 12 × $48.00   | 12 x $48.00 |


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We have a mix of x and × to indicate multiplication

## Changes

### Added

- guide on proper use of multiply symbol ×

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
