### PR TITLE
feat(components): JOB-40406 Allow PUT requests in InputFile component

### DIFF
--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -4,12 +4,11 @@ import axios from "axios";
 import { InputFile } from ".";
 
 jest.mock("axios", () => {
-  return { put: jest.fn(), post: jest.fn() };
+  return { request: jest.fn() };
 });
 
 beforeEach(() => {
-  (axios.put as jest.Mock).mockReturnValue(Promise.resolve());
-  (axios.post as jest.Mock).mockReturnValue(Promise.resolve());
+  (axios.request as jest.Mock).mockReturnValue(Promise.resolve());
 });
 
 afterEach(cleanup);
@@ -121,14 +120,13 @@ describe("Post Requests", () => {
         ...baseMatch,
         progress: 0,
       });
-      expect(axios.post).toHaveBeenCalledWith(
-        "https://httpbin.org/post",
-        expect.any(FormData),
-        {
-          headers: { "X-Requested-With": "XMLHttpRequest" },
-          onUploadProgress: expect.any(Function),
-        },
-      );
+      expect(axios.request).toHaveBeenCalledWith({
+        data: expect.any(FormData),
+        headers: { "X-Requested-With": "XMLHttpRequest" },
+        method: "POST",
+        onUploadProgress: expect.any(Function),
+        url: "https://httpbin.org/post",
+      });
       expect(handleComplete).toHaveBeenCalledWith({
         ...baseMatch,
         progress: 1,
@@ -149,7 +147,7 @@ describe("PUT requests", () => {
         "Content-Type": "sol_badguy",
         "Content-MD5": "dragon_install",
       },
-      httpMethod: "PUT",
+      httpMethod: "PUT" as "PUT" | "POST",
     });
   }
 
@@ -172,7 +170,10 @@ describe("PUT requests", () => {
     fireEvent.change(input, { target: { files: [testFile] } });
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith("definitely_fake_url", testFile, {
+      expect(axios.request).toHaveBeenCalledWith({
+        data: testFile,
+        url: "definitely_fake_url",
+        method: "PUT",
         headers: {
           "Content-MD5": "dragon_install",
           "Content-Type": "sol_badguy",

--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import axios from "axios";
 import { InputFile } from ".";
+
+jest.mock("axios", () => {
+  return { put: jest.fn(), post: jest.fn() };
+});
+
+beforeEach(() => {
+  (axios.put as jest.Mock).mockReturnValue(Promise.resolve());
+  (axios.post as jest.Mock).mockReturnValue(Promise.resolve());
+});
 
 afterEach(cleanup);
 
@@ -8,112 +18,167 @@ const testFile = new File(["🔱 Atlantis"], "atlantis.png", {
   type: "image/png",
 });
 
-it("renders a InputFile", () => {
-  const { container } = render(
-    <InputFile getUploadParams={fetchUploadParams} />,
-  );
+describe("Post Requests", () => {
+  function fetchUploadParams(file: File) {
+    return Promise.resolve({
+      key: file.name,
+      url: "https://httpbin.org/post",
+      fields: { secret: "🤫" },
+    });
+  }
 
-  expect(container).toMatchSnapshot();
-});
+  it("renders an InputFile", () => {
+    const { container } = render(
+      <InputFile getUploadParams={fetchUploadParams} />,
+    );
 
-it("renders an InputFile with multiple uploads", () => {
-  const { container } = render(
-    <InputFile allowMultiple={true} getUploadParams={fetchUploadParams} />,
-  );
-  expect(container).toMatchSnapshot();
-});
+    expect(container).toMatchSnapshot();
+  });
 
-it("renders an InputFile with only images allowed", () => {
-  const { container } = render(
-    <InputFile allowedTypes="images" getUploadParams={fetchUploadParams} />,
-  );
-  expect(container).toMatchSnapshot();
-});
+  it("renders an InputFile with multiple uploads", () => {
+    const { container } = render(
+      <InputFile allowMultiple={true} getUploadParams={fetchUploadParams} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
 
-it("renders an InputFile with multiple images allowed", () => {
-  const { container } = render(
-    <InputFile
-      allowedTypes="images"
-      allowMultiple={true}
-      getUploadParams={fetchUploadParams}
-    />,
-  );
-  expect(container).toMatchSnapshot();
-});
+  it("renders an InputFile with only images allowed", () => {
+    const { container } = render(
+      <InputFile allowedTypes="images" getUploadParams={fetchUploadParams} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
 
-it("renders an InputFile with proper variations", () => {
-  const { container } = render(
-    <>
-      <InputFile getUploadParams={fetchUploadParams} />
-      <InputFile size="small" getUploadParams={fetchUploadParams} />
-      <InputFile variation="button" getUploadParams={fetchUploadParams} />
+  it("renders an InputFile with multiple images allowed", () => {
+    const { container } = render(
       <InputFile
-        variation="button"
-        size="small"
+        allowedTypes="images"
+        allowMultiple={true}
         getUploadParams={fetchUploadParams}
-      />
-    </>,
-  );
-  expect(container).toMatchSnapshot();
-});
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
 
-it("supports custom button label", () => {
-  const buttonLabel = "Custom Label";
-  const { getByText } = render(
-    <InputFile buttonLabel={buttonLabel} getUploadParams={fetchUploadParams} />,
-  );
-  expect(getByText(buttonLabel)).toBeInstanceOf(HTMLElement);
-});
+  it("renders an InputFile with proper variations", () => {
+    const { container } = render(
+      <>
+        <InputFile getUploadParams={fetchUploadParams} />
+        <InputFile size="small" getUploadParams={fetchUploadParams} />
+        <InputFile variation="button" getUploadParams={fetchUploadParams} />
+        <InputFile
+          variation="button"
+          size="small"
+          getUploadParams={fetchUploadParams}
+        />
+      </>,
+    );
+    expect(container).toMatchSnapshot();
+  });
 
-it("properly notifies upload callbacks", async () => {
-  const fetchParams = jest.fn(fetchUploadParams);
-  const handleStart = jest.fn();
-  const handleProgress = jest.fn();
-  const handleComplete = jest.fn();
+  it("supports custom button label", () => {
+    const buttonLabel = "Custom Label";
+    const { getByText } = render(
+      <InputFile
+        buttonLabel={buttonLabel}
+        getUploadParams={fetchUploadParams}
+      />,
+    );
+    expect(getByText(buttonLabel)).toBeInstanceOf(HTMLElement);
+  });
 
-  const { container } = render(
-    <InputFile
-      getUploadParams={fetchParams}
-      onUploadStart={handleStart}
-      onUploadProgress={handleProgress}
-      onUploadComplete={handleComplete}
-    />,
-  );
-  const input = container.querySelector("input[type=file]");
+  it("properly notifies upload callbacks", async () => {
+    const fetchParams = jest.fn(fetchUploadParams);
+    const handleStart = jest.fn();
+    const handleProgress = jest.fn();
+    const handleComplete = jest.fn();
 
-  fireEvent.change(input, { target: { files: [testFile] } });
+    const { container } = render(
+      <InputFile
+        getUploadParams={fetchParams}
+        onUploadStart={handleStart}
+        onUploadProgress={handleProgress}
+        onUploadComplete={handleComplete}
+      />,
+    );
+    const input = container.querySelector("input[type=file]");
 
-  const baseMatch = {
-    key: "atlantis.png",
-    name: "atlantis.png",
-    size: expect.any(Number),
-    progress: expect.any(Number),
-    src: expect.any(Function),
-    type: "image/png",
-  };
+    fireEvent.change(input, { target: { files: [testFile] } });
 
-  await waitFor(() => {
-    expect(fetchParams).toHaveBeenCalledTimes(1);
+    const baseMatch = {
+      key: "atlantis.png",
+      name: "atlantis.png",
+      size: expect.any(Number),
+      progress: expect.any(Number),
+      src: expect.any(Function),
+      type: "image/png",
+    };
 
-    expect(handleStart).toHaveBeenCalledWith({
-      ...baseMatch,
-      progress: 0,
+    await waitFor(() => {
+      expect(fetchParams).toHaveBeenCalledTimes(1);
+
+      expect(handleStart).toHaveBeenCalledWith({
+        ...baseMatch,
+        progress: 0,
+      });
+      expect(axios.post).toHaveBeenCalledWith(
+        "https://httpbin.org/post",
+        expect.any(FormData),
+        {
+          headers: { "X-Requested-With": "XMLHttpRequest" },
+          onUploadProgress: expect.any(Function),
+        },
+      );
+      expect(handleComplete).toHaveBeenCalledWith({
+        ...baseMatch,
+        progress: 1,
+      });
+
+      expect(handleStart).toHaveBeenCalledTimes(1);
+      expect(handleComplete).toHaveBeenCalledTimes(1);
     });
-    expect(handleProgress).toHaveBeenCalledWith(baseMatch);
-    expect(handleComplete).toHaveBeenCalledWith({
-      ...baseMatch,
-      progress: 1,
-    });
-
-    expect(handleStart).toHaveBeenCalledTimes(1);
-    expect(handleComplete).toHaveBeenCalledTimes(1);
   });
 });
 
-function fetchUploadParams(file: File) {
-  return Promise.resolve({
-    key: file.name,
-    url: "https://httpbin.org/post",
-    fields: { secret: "🤫" },
+describe("PUT requests", () => {
+  function putUploadParams(file: File) {
+    return Promise.resolve({
+      key: file.name,
+      url: "definitely_fake_url",
+      fields: {
+        "Content-Type": "sol_badguy",
+        "Content-MD5": "dragon_install",
+      },
+      httpMethod: "PUT",
+    });
+  }
+
+  it("uses the returned fields as headers in a PUT request", async () => {
+    const fetchParams = jest.fn(putUploadParams);
+    const handleStart = jest.fn();
+    const handleProgress = jest.fn();
+    const handleComplete = jest.fn();
+
+    const { container } = render(
+      <InputFile
+        getUploadParams={fetchParams}
+        onUploadStart={handleStart}
+        onUploadProgress={handleProgress}
+        onUploadComplete={handleComplete}
+      />,
+    );
+    const input = container.querySelector("input[type=file]");
+
+    fireEvent.change(input, { target: { files: [testFile] } });
+
+    await waitFor(() => {
+      expect(axios.put).toHaveBeenCalledWith("definitely_fake_url", testFile, {
+        headers: {
+          "Content-MD5": "dragon_install",
+          "Content-Type": "sol_badguy",
+        },
+        onUploadProgress: expect.any(Function),
+      });
+    });
   });
-}
+});

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -207,12 +207,16 @@ export function InputFile({
     const fileUpload = getFileUpload(file, key);
     onUploadStart && onUploadStart({ ...fileUpload });
 
-    const uploadProgressUpdate = (progressEvent: any) => {
+    const handleUploadProgress = (progressEvent: any) => {
       onUploadProgress &&
         onUploadProgress({
           ...fileUpload,
           progress: progressEvent.loaded / progressEvent.total,
         });
+    };
+
+    const handleUploadComplete = () => {
+      onUploadComplete?.({ ...fileUpload, progress: 1 });
     };
 
     if (httpMethod === "POST") {
@@ -225,19 +229,19 @@ export function InputFile({
       axios
         .post(url, formData, {
           headers: { "X-Requested-With": "XMLHttpRequest" },
-          onUploadProgress: uploadProgressUpdate,
+          onUploadProgress: handleUploadProgress,
         })
         .then(() => {
-          onUploadComplete && onUploadComplete({ ...fileUpload, progress: 1 });
+          handleUploadComplete();
         });
     } else if (httpMethod === "PUT") {
       axios
         .put(url, file, {
           headers: fields,
-          onUploadProgress: uploadProgressUpdate,
+          onUploadProgress: handleUploadProgress,
         })
         .then(() => {
-          onUploadComplete && onUploadComplete({ ...fileUpload, progress: 1 });
+          handleUploadComplete();
         });
     }
   }

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -129,14 +129,16 @@ interface InputFileProps {
   onUploadComplete?(file: FileUpload): void;
 }
 
-interface RequestParams extends Omit<UploadParams, "key"> {
+interface CreateAxiosConfigParams extends Omit<UploadParams, "key"> {
   /**
    * The file being uploaded
    */
-  file: File;
+  readonly file: File;
 
   /**
-   *
+   * The uploadProgress callback used by axios.
+   * The axios request config type from the library specifies
+   * the input to this function as `any`
    */
   handleUploadProgress(progress: any): void;
 }
@@ -250,7 +252,7 @@ function createAxiosConfig({
   fields = {},
   file,
   handleUploadProgress,
-}: RequestParams): AxiosRequestConfig {
+}: CreateAxiosConfigParams): AxiosRequestConfig {
   let data: FormData | File;
   let headers: { [field: string]: string };
 

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -62,8 +62,14 @@ export interface UploadParams {
 
   /**
    * The HTTP method which we wish to use for the upload
-   * If unspecified, it will default to POST
-   * The `fields` will then be used as headers for the request
+   *
+   * When the HTTP method is `"PUT"`, the `fields` will
+   * be used as headers for the request
+   *
+   * When the HTTP method is `"POST"` the `fields` are
+   * form fields
+   *
+   * @default "POST"
    */
   readonly httpMethod?: "POST" | "PUT";
 }
@@ -240,9 +246,7 @@ export function InputFile({
       file,
       handleUploadProgress,
     });
-    axios.request(axiosConfig).then(() => {
-      handleUploadComplete();
-    });
+    axios.request(axiosConfig).then(handleUploadComplete);
   }
 }
 

--- a/packages/components/src/InputFile/__snapshots__/InputFile.test.tsx.snap
+++ b/packages/components/src/InputFile/__snapshots__/InputFile.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a InputFile 1`] = `
+exports[`Post Requests renders an InputFile 1`] = `
 <div>
   <div
     class="dropZoneBase dropZone"
@@ -35,7 +35,7 @@ exports[`renders a InputFile 1`] = `
 </div>
 `;
 
-exports[`renders an InputFile with multiple images allowed 1`] = `
+exports[`Post Requests renders an InputFile with multiple images allowed 1`] = `
 <div>
   <div
     class="dropZoneBase dropZone"
@@ -72,7 +72,7 @@ exports[`renders an InputFile with multiple images allowed 1`] = `
 </div>
 `;
 
-exports[`renders an InputFile with multiple uploads 1`] = `
+exports[`Post Requests renders an InputFile with multiple uploads 1`] = `
 <div>
   <div
     class="dropZoneBase dropZone"
@@ -108,7 +108,7 @@ exports[`renders an InputFile with multiple uploads 1`] = `
 </div>
 `;
 
-exports[`renders an InputFile with only images allowed 1`] = `
+exports[`Post Requests renders an InputFile with only images allowed 1`] = `
 <div>
   <div
     class="dropZoneBase dropZone"
@@ -144,7 +144,7 @@ exports[`renders an InputFile with only images allowed 1`] = `
 </div>
 `;
 
-exports[`renders an InputFile with proper variations 1`] = `
+exports[`Post Requests renders an InputFile with proper variations 1`] = `
 <div>
   <div
     class="dropZoneBase dropZone"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Allowing the component to handle PUT requests makes it more flexible. ActiveStorage creates pre-signed URLs that are to be used with PUT requests, so it is required for our work.

## Changes
The `InputFile` component now allows PUT requests to be performed.

## Testing
In your local Atlantis playground, you can go to the `InputFile` page and modify it so that its `getUploadParams` prop/ method returns the following in a promise:
```Javascript
{
  url: "https://address_where_you_can_put.com",
  fields: {
    "Content-Type": "image/jpeg",
    "OTHER-APPROPRIATE-HEADERS": "appropriate_header"
  },
  httpMethod: "PUT" 
}
```

example:
 
![Screen Shot 2022-06-01 at 16 10 21](https://user-images.githubusercontent.com/81261618/171492750-aad8d6e6-64e9-462d-8c0e-9284a7cdc2ec.png)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
