### PR TITLE
JOB-40406 Modify FormField Altantis Component For Thumbnail Functionality

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -40,7 +40,7 @@
   height: 168px;
 }
 
-.default {
+.base {
   width: 56px;
   height: 56px;
 }

--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -10,14 +10,14 @@
 
 .expanded {
   display: grid;
+  position: relative;
   grid-template-columns: auto max-content;
   gap: var(--file-card--base-padding);
   align-items: center;
+  padding-right: var(--space-small);
   border: var(--border-base) solid var(--file-card--border-color);
   border-radius: var(--radius-base);
   background-color: var(--file-card--background-color);
-  padding-right: var(--space-small);
-  position: relative;
 }
 
 .compact {
@@ -29,10 +29,10 @@
   grid-template-columns: max-content auto;
   gap: var(--file-card--base-padding);
   align-items: center;
-  border: none;
-  background-color: var(--color-transparent);
   padding: 0;
+  border: none;
   text-align: left;
+  background-color: var(--color-transparent);
 }
 
 .large {
@@ -57,6 +57,10 @@
   justify-content: center;
 }
 
+.expanded .wrapper {
+  outline: none;
+}
+
 .compact .wrapper:focus {
   box-shadow: var(--shadow-focus);
   outline: none;
@@ -64,10 +68,6 @@
 
 .compact .thumbnail {
   border-radius: var(--radius-base);
-}
-
-.expanded .wrapper{
-  outline: none;
 }
 
 .expanded .wrapper:focus::after {
@@ -82,9 +82,9 @@
 }
 
 .expanded .thumbnail {
-  border-top-left-radius: var(--radius-base);
-  border-bottom-left-radius: var(--radius-base);
   border-right: none;
+  border-bottom-left-radius: var(--radius-base);
+  border-top-left-radius: var(--radius-base);
 }
 
 .clickable {
@@ -136,13 +136,13 @@
   right: var(--space-smaller);
 }
 
-.deleteable~.deleteButton {
+.deleteable ~ .deleteButton {
   visibility: hidden;
 }
 
-.deleteable:hover~.deleteButton,
-.deleteable:focus~.deleteButton,
 .deleteButton:focus-within,
-.deleteButton:hover {
+.deleteButton:hover,
+.deleteable:hover ~ .deleteButton,
+.deleteable:focus ~ .deleteButton {
   visibility: visible;
 }

--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -8,71 +8,141 @@
   --file-card--base-padding: var(--space-small);
 }
 
-.formatFile {
-  display: flex;
-  height: var(--file-card--height);
+.expanded {
+  display: grid;
+  grid-template-columns: auto max-content;
+  gap: var(--file-card--base-padding);
+  align-items: center;
   border: var(--border-base) solid var(--file-card--border-color);
   border-radius: var(--radius-base);
-  overflow: hidden;
   background-color: var(--file-card--background-color);
-  align-items: center;
-  outline-color: var(--color-focus);
+  padding-right: var(--space-small);
+  position: relative;
 }
 
-.imageBlock {
+.compact {
+  position: relative;
+}
+
+.wrapper {
+  display: grid;
+  grid-template-columns: max-content auto;
+  gap: var(--file-card--base-padding);
+  align-items: center;
+  border: none;
+  background-color: var(--color-transparent);
+  padding: 0;
+  text-align: left;
+}
+
+.large {
+  width: 168px;
+  height: 168px;
+}
+
+.default {
+  width: 56px;
+  height: 56px;
+}
+
+.thumbnail {
   display: flex;
   position: relative;
-  width: var(--file-card--height);
-  height: 100%;
   box-sizing: border-box;
   padding: 0;
-  background-color: var(--file-card--header-background-color);
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  align-items: center;
-  object-fit: cover;
+  overflow: hidden;
+  background-color: var(--color-surface--background);
   flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
 }
 
-.imageBlock::before {
+.compact .wrapper:focus {
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}
+
+.compact .thumbnail {
+  border-radius: var(--radius-base);
+}
+
+.expanded .wrapper{
+  outline: none;
+}
+
+.expanded .wrapper:focus::after {
   content: "";
   display: block;
   position: absolute;
   top: 0;
-  right: 0;
-  bottom: 0;
   left: 0;
-  background-color: var(--color-overlay);
-  mix-blend-mode: multiply;
+  width: 100%;
+  height: 100%;
+  box-shadow: var(--shadow-focus);
 }
 
-.icon {
-  margin: 0 auto;
+.expanded .thumbnail {
+  border-top-left-radius: var(--radius-base);
+  border-bottom-left-radius: var(--radius-base);
+  border-right: none;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.hoverable .thumbnail::after,
+.progress {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-overlay);
+  opacity: 0;
+  transition: all var(--timing-base);
+}
+
+.hoverable:hover .thumbnail::after,
+.hoverable:focus .thumbnail::after,
+.progress {
+  opacity: 1;
 }
 
 .progress {
   display: flex;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  padding: var(--file-card--base-padding);
   align-items: center;
+  padding: var(--file-card--base-padding);
 }
 
 .contentBlock {
-  flex-grow: 1;
-  padding: 0 var(--file-card--base-padding);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.contentBlock p {
+  margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.contentBlock p {
-  margin: 0;
+
+.compact .deleteButton {
+  position: absolute;
+  top: var(--space-smaller);
+  right: var(--space-smaller);
 }
 
-.actionBlock {
-  padding: 0 var(--file-card--base-padding) 0 0;
+.deleteable~.deleteButton {
+  visibility: hidden;
+}
+
+.deleteable:hover~.deleteButton,
+.deleteable:focus~.deleteButton,
+.deleteButton:focus-within,
+.deleteButton:hover {
+  visibility: visible;
 }

--- a/packages/components/src/FormatFile/FormatFile.css.d.ts
+++ b/packages/components/src/FormatFile/FormatFile.css.d.ts
@@ -3,7 +3,7 @@ declare const styles: {
   readonly "compact": string;
   readonly "wrapper": string;
   readonly "large": string;
-  readonly "default": string;
+  readonly "base": string;
   readonly "thumbnail": string;
   readonly "clickable": string;
   readonly "hoverable": string;

--- a/packages/components/src/FormatFile/FormatFile.css.d.ts
+++ b/packages/components/src/FormatFile/FormatFile.css.d.ts
@@ -1,10 +1,16 @@
 declare const styles: {
-  readonly "formatFile": string;
-  readonly "imageBlock": string;
-  readonly "icon": string;
+  readonly "expanded": string;
+  readonly "compact": string;
+  readonly "wrapper": string;
+  readonly "large": string;
+  readonly "default": string;
+  readonly "thumbnail": string;
+  readonly "clickable": string;
+  readonly "hoverable": string;
   readonly "progress": string;
   readonly "contentBlock": string;
-  readonly "actionBlock": string;
+  readonly "deleteButton": string;
+  readonly "deleteable": string;
 };
 export = styles;
 

--- a/packages/components/src/FormatFile/FormatFile.mdx
+++ b/packages/components/src/FormatFile/FormatFile.mdx
@@ -35,23 +35,30 @@ import { FormatFile } from "@jobber/components/FormatFile";
         name: "myballisbigandroundIamrollingitontheground.png",
         type: "image/png",
         size: 213402324,
-        progress: 0.3,
+        progress: 0.4,
         src: () => Promise.resolve("https://source.unsplash.com/250x250"),
       }}
-      onDelete={() => alert("🧨BALEETED!💥")}
+      display="compact"
+      onDelete={() => alert("Deleted")}
     />
     <FormatFile
       file={{
         key: "mosdef",
-        name: "tps_report.png",
+        name: "tps_report.pdf",
         type: "application/pdf",
         size: 2134023,
         progress: 1,
       }}
-      onDelete={() => alert("🧨BALEETED!💥")}
+      onDelete={() => alert("Deleted")}
     />
   </Content>
 </Playground>
+
+## Props
+
+<Props of={FormatFile} />
+
+---
 
 ## Design and Usage Guidelines
 
@@ -61,11 +68,77 @@ following:
 - FormatFile components should take up the full width of the parent container (1
   or 2 files per row).
 
-## Props
+### Display
 
-<Props of={FormatFile} />
+Format files can be displayed as either an expanded or compact format file.
 
----
+### Expanded
+
+Used to display a file alongside it's details.
+
+<Playground>
+  <Content>
+    <FormatFile
+      file={{
+        key: "abc",
+        name: "myballisbigandroundIamrollingitontheground.png",
+        type: "image/png",
+        size: 213402324,
+        progress: 0.5,
+        src: () => Promise.resolve("https://source.unsplash.com/250x250"),
+      }}
+      display="expanded"
+      onDelete={() => alert("Deleted")}
+    />
+    <FormatFile
+      file={{
+        key: "abc",
+        name: "image_of_something.png",
+        type: "image/png",
+        size: 213402324,
+        progress: 1,
+        src: () => Promise.resolve("https://source.unsplash.com/250x250"),
+      }}
+      display="expanded"
+      onDelete={() => alert("Deleted")}
+    />
+  </Content>
+</Playground>
+
+### Compact
+
+Used to display a cropped smaller version of a file or image.
+
+<Playground>
+  <Content>
+    <FormatFile
+      file={{
+        key: "abc",
+        name: "myballisbigandroundIamrollingitontheground.png",
+        type: "image/png",
+        size: 213402324,
+        progress: 0.5,
+        src: () => Promise.resolve("https://source.unsplash.com/250x250"),
+      }}
+      displaySize="large"
+      display="compact"
+      onDelete={() => alert("Deleted")}
+    />
+    <FormatFile
+      file={{
+        key: "abc",
+        name: "myballisbigandroundIamrollingitontheground.png",
+        type: "image/png",
+        size: 213402324,
+        progress: 1,
+        src: () => Promise.resolve("https://source.unsplash.com/250x250"),
+      }}
+      displaySize="large"
+      display="compact"
+      onDelete={() => alert("Deleted")}
+    />
+  </Content>
+</Playground>
 
 ## Related components
 

--- a/packages/components/src/FormatFile/FormatFile.test.tsx
+++ b/packages/components/src/FormatFile/FormatFile.test.tsx
@@ -12,12 +12,13 @@ it("renders a FormatFile", () => {
     type: "audio/ogg",
     size: 1024,
     progress: 1,
+    src: () => Promise.resolve("https://audio/somesound.ogg"),
   };
   const tree = renderer.create(<FormatFile file={testFile} />).toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-it("renders an image when provided as src", done => {
+it("renders an image when provided as src", async done => {
   const url = "not_actually_a_url";
   const testFile = {
     key: "234",
@@ -29,10 +30,15 @@ it("renders an image when provided as src", done => {
   };
 
   const { queryByTestId } = render(<FormatFile file={testFile} />);
-  const imageBlockDiv = queryByTestId("imageBlock");
+
+  await waitFor(() => {
+    expect(queryByTestId("internalThumbnailImage")).not.toBeUndefined();
+  });
+
+  const internalThumbnailImage = queryByTestId("internalThumbnailImage");
 
   waitFor(() => {
-    expect(imageBlockDiv).toHaveStyle(`background-image: url(${url})`);
+    expect(internalThumbnailImage).toBeInstanceOf(HTMLImageElement);
     done();
   });
 });
@@ -44,6 +50,7 @@ it("it should call the delete handler", async () => {
     type: "application/pdf",
     size: 1022,
     progress: 1,
+    src: () => Promise.resolve("https://nature/interesting-article.png"),
   };
   const deleteHandler = jest.fn();
   const { getByLabelText, getByText } = render(

--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -26,7 +26,7 @@ interface FormatFileProps {
    *
    * @default "default"
    */
-  readonly displaySize?: "default" | "large";
+  readonly displaySize?: "base" | "large";
 
   /**
    * Function to execute when format file is clicked
@@ -42,7 +42,7 @@ interface FormatFileProps {
 export function FormatFile({
   file,
   display = "expanded",
-  displaySize = "default",
+  displaySize = "base",
   onDelete,
   onClick,
 }: FormatFileProps) {

--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from "react";
-import filesize from "filesize";
-import { IconNames } from "@jobber/design";
+import React from "react";
+import classnames from "classnames";
+import getHumanReadableFileSize from "filesize";
 import styles from "./FormatFile.css";
-import { Button } from "../Button";
-import { Icon } from "../Icon";
-import { Typography } from "../Typography";
-import { ProgressBar } from "../ProgressBar";
+import { FormatFileDeleteButton } from "./FormatFileDeleteButton";
+import { InternalThumbnail } from "./InternalThumbnail";
 import { FileUpload } from "../InputFile";
+import { Text } from "../Text";
+import { ProgressBar } from "../ProgressBar";
 
 interface FormatFileProps {
   /**
@@ -15,56 +15,96 @@ interface FormatFileProps {
   readonly file: FileUpload;
 
   /**
+   * To display as either a file row or thumbnail
+   *
+   * @default "expanded"
+   */
+  readonly display?: "expanded" | "compact";
+
+  /**
+   * The base dimensions of the thumbnail
+   *
+   * @default "default"
+   */
+  readonly displaySize?: "default" | "large";
+
+  /**
+   * Function to execute when format file is clicked
+   */
+  onClick?(event: React.MouseEvent<HTMLDivElement | HTMLButtonElement>): void;
+
+  /**
    * onDelete callback - this function will be called when the delete action is triggered
    */
   onDelete?(): void;
 }
 
-export function FormatFile({ file, onDelete }: FormatFileProps) {
-  const [imageSource, setImageSource] = useState<string>();
+export function FormatFile({
+  file,
+  display = "expanded",
+  displaySize = "default",
+  onDelete,
+  onClick,
+}: FormatFileProps) {
   const isComplete = file.progress >= 1;
-
-  const iconName = getIconNameFromType(file.type);
   const fileSize = getHumanReadableFileSize(file.size);
+  const wrapperClassNames = classnames(styles[display], {
+    [styles[displaySize]]: display === "compact",
+  });
 
-  if (!imageSource && file.type.startsWith("image/") && file.src) {
-    file.src().then(src => setImageSource(src));
-  }
+  const DetailsContainer = isComplete && onClick ? "button" : "div";
 
-  const style = imageSource ? { backgroundImage: `url(${imageSource})` } : {};
+  const detailsClassNames = classnames(styles.wrapper, {
+    [styles[displaySize]]: display === "compact",
+    [styles.hoverable]: isHoverable({ display, isComplete, onClick, onDelete }),
+    [styles.clickable]: onClick,
+    [styles.deleteable]: display === "compact",
+  });
+
+  const thumbnailContainerClassNames = classnames(
+    styles.thumbnail,
+    styles[displaySize],
+  );
 
   return (
-    <div className={styles.formatFile}>
-      <div className={styles.imageBlock} style={style} data-testid="imageBlock">
-        {!imageSource && (
-          <div className={styles.icon}>
-            <Icon name={iconName} />
+    <div className={wrapperClassNames}>
+      <DetailsContainer
+        className={detailsClassNames}
+        onClick={isComplete ? onClick : undefined}
+        tabIndex={0}
+        aria-busy={!isComplete}
+      >
+        <div className={thumbnailContainerClassNames}>
+          <InternalThumbnail
+            name={file.name}
+            hideName={display === "compact"}
+            file={file}
+            size={displaySize}
+          />
+
+          {!isComplete && (
+            <div className={styles.progress}>
+              <ProgressBar
+                size="small"
+                currentStep={file.progress * 100}
+                totalSteps={100}
+              />
+            </div>
+          )}
+        </div>
+
+        {display === "expanded" && (
+          <div className={styles.contentBlock}>
+            <Text size="large">{file.name}</Text>
+            <Text size="small">{fileSize}</Text>
           </div>
         )}
-        {!isComplete && (
-          <div className={styles.progress}>
-            <ProgressBar
-              size="small"
-              currentStep={file.progress * 100}
-              totalSteps={100}
-            />
-          </div>
-        )}
-      </div>
-      <div className={styles.contentBlock}>
-        <Typography element="span">{file.name}</Typography>
-        <Typography element="p" size="small" textColor="greyBlueDark">
-          {fileSize}
-        </Typography>
-      </div>
+      </DetailsContainer>
       {isComplete && onDelete && (
-        <div className={styles.actionBlock}>
-          <Button
-            onClick={onDelete}
-            type="tertiary"
-            variation="destructive"
-            icon="trash"
-            ariaLabel="Delete"
+        <div className={styles.deleteButton}>
+          <FormatFileDeleteButton
+            size={display === "expanded" ? "large" : displaySize}
+            onDelete={onDelete}
           />
         </div>
       )}
@@ -72,20 +112,18 @@ export function FormatFile({ file, onDelete }: FormatFileProps) {
   );
 }
 
-function getHumanReadableFileSize(sizeInBytes: number): string {
-  return filesize(sizeInBytes);
-}
-
-function getIconNameFromType(mimeType: string): IconNames {
-  if (mimeType.startsWith("image/")) return "camera";
-  if (mimeType.startsWith("video/")) return "video";
-
-  switch (mimeType) {
-    case "application/pdf":
-      return "pdf";
-    case "application/vnd.ms-excel":
-      return "excel";
-    default:
-      return "file";
+function isHoverable({
+  display,
+  isComplete,
+  onClick,
+  onDelete,
+}: Pick<FormatFileProps, "display" | "onClick" | "onDelete"> & {
+  isComplete: boolean;
+}): boolean {
+  if (display === "compact") {
+    return Boolean(isComplete && (onClick || onDelete));
+  } else if (display === "expanded") {
+    return Boolean(isComplete && onClick);
   }
+  return false;
 }

--- a/packages/components/src/FormatFile/FormatFileDeleteButton.tsx
+++ b/packages/components/src/FormatFile/FormatFileDeleteButton.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from "react";
+import { Button } from "../Button";
+import { ConfirmationModal } from "../ConfirmationModal";
+
+interface DeleteButtonProps {
+  size?: "default" | "large";
+  onDelete?: () => void;
+}
+
+export function FormatFileDeleteButton({ size, onDelete }: DeleteButtonProps) {
+  const buttonSize = size === "default" ? "small" : "base";
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        onClick={() => setDeleteConfirmationOpen(true)}
+        variation="destructive"
+        type="tertiary"
+        icon="trash"
+        ariaLabel="Delete Thumbnail"
+        size={buttonSize}
+      />
+      <ConfirmationModal
+        title="Confirm Deletion"
+        message={`Are you sure you want to delete this file?`}
+        confirmLabel="Delete"
+        variation="destructive"
+        open={deleteConfirmationOpen}
+        onConfirm={() => onDelete?.()}
+        onRequestClose={() => setDeleteConfirmationOpen(false)}
+      />
+    </>
+  );
+}

--- a/packages/components/src/FormatFile/FormatFileDeleteButton.tsx
+++ b/packages/components/src/FormatFile/FormatFileDeleteButton.tsx
@@ -3,12 +3,12 @@ import { Button } from "../Button";
 import { ConfirmationModal } from "../ConfirmationModal";
 
 interface DeleteButtonProps {
-  size?: "default" | "large";
+  size?: "base" | "large";
   onDelete?: () => void;
 }
 
 export function FormatFileDeleteButton({ size, onDelete }: DeleteButtonProps) {
-  const buttonSize = size === "default" ? "small" : "base";
+  const buttonSize = size === "base" ? "small" : "base";
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
 
   return (

--- a/packages/components/src/FormatFile/InternalThumbnail.css
+++ b/packages/components/src/FormatFile/InternalThumbnail.css
@@ -1,0 +1,58 @@
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.loading {
+  display: none;
+}
+
+.content {
+  display: flex;
+  width: inherit;
+  height: inherit;
+  align-items: center;
+  justify-content: center;
+}
+
+.content::after {
+  content: "";
+  display: block;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  border: var(--border-base);
+  border-radius: var(--radius-base);
+  background: linear-gradient(
+    270deg,
+    rgb(244, 244, 244) 38.46%,
+    rgba(244, 244, 244, 0) 100%
+  );
+}
+
+.content.default::after {
+  width: var(--space-base);
+  height: var(--space-base);
+}
+
+.content.large::after {
+  width: var(--space-large);
+  height: var(--space-large);
+}
+
+.fileName {
+  position: absolute;
+}
+
+.default .fileName {
+  bottom: var(--space-smaller);
+  left: var(--space-smaller);
+  font-size: calc(var(--base-unit) * 0.625);
+}
+
+.large .fileName {
+  bottom: var(--space-small);
+  left: var(--space-small);
+  font-size: var(--typography--fontSize-small);
+}

--- a/packages/components/src/FormatFile/InternalThumbnail.css
+++ b/packages/components/src/FormatFile/InternalThumbnail.css
@@ -31,7 +31,7 @@
   );
 }
 
-.content.default::after {
+.content.base::after {
   width: var(--space-base);
   height: var(--space-base);
 }
@@ -45,7 +45,7 @@
   position: absolute;
 }
 
-.default .fileName {
+.base .fileName {
   bottom: var(--space-smaller);
   left: var(--space-smaller);
   font-size: calc(var(--base-unit) * 0.625);

--- a/packages/components/src/FormatFile/InternalThumbnail.css.d.ts
+++ b/packages/components/src/FormatFile/InternalThumbnail.css.d.ts
@@ -1,0 +1,10 @@
+declare const styles: {
+  readonly "image": string;
+  readonly "loading": string;
+  readonly "content": string;
+  readonly "default": string;
+  readonly "large": string;
+  readonly "fileName": string;
+};
+export = styles;
+

--- a/packages/components/src/FormatFile/InternalThumbnail.css.d.ts
+++ b/packages/components/src/FormatFile/InternalThumbnail.css.d.ts
@@ -2,7 +2,7 @@ declare const styles: {
   readonly "image": string;
   readonly "loading": string;
   readonly "content": string;
-  readonly "default": string;
+  readonly "base": string;
   readonly "large": string;
   readonly "fileName": string;
 };

--- a/packages/components/src/FormatFile/InternalThumbnail.tsx
+++ b/packages/components/src/FormatFile/InternalThumbnail.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import classNames from "classnames";
+import styles from "./InternalThumbnail.css";
+import { Icon, IconNames } from "../Icon";
+import { FileUpload } from "../InputFile";
+import { Typography } from "../Typography";
+
+interface InternalThumbnailProps {
+  readonly name?: string;
+  readonly hideName?: boolean;
+  readonly size: "default" | "large";
+  readonly file: FileUpload;
+}
+
+export function InternalThumbnail({
+  name,
+  hideName = false,
+  size,
+  file,
+}: InternalThumbnailProps) {
+  const [imageSource, setImageSource] = useState<string>();
+  const [imageLoaded, setImageLoaded] = useState<boolean>(false);
+  const iconName = getIconNameFromType(file.type);
+
+  if (!imageSource && file.type.startsWith("image/")) {
+    file.src().then(src => setImageSource(src));
+  }
+  const image = (
+    <img
+      src={imageSource}
+      onLoad={() => {
+        setImageLoaded(true);
+      }}
+      className={classNames(styles.image, { [styles.loading]: !imageLoaded })}
+      alt={name}
+    />
+  );
+  if (imageLoaded) {
+    return image;
+  }
+
+  return (
+    <div className={classNames(styles.content, styles[size])}>
+      {imageSource && image}
+      <Icon name={iconName} color="greyBlue" />
+      <div className={classNames(styles.fileName)}>
+        {hideName && (
+          <Typography element="span" textColor="text">
+            {name}
+          </Typography>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function getIconNameFromType(mimeType: string): IconNames {
+  if (mimeType.startsWith("image/")) return "camera";
+  if (mimeType.startsWith("video/")) return "video";
+
+  switch (mimeType) {
+    case "application/pdf":
+      return "pdf";
+    case "application/vnd.ms-excel":
+      return "excel";
+    default:
+      return "file";
+  }
+}

--- a/packages/components/src/FormatFile/InternalThumbnail.tsx
+++ b/packages/components/src/FormatFile/InternalThumbnail.tsx
@@ -8,7 +8,7 @@ import { Typography } from "../Typography";
 interface InternalThumbnailProps {
   readonly name?: string;
   readonly hideName?: boolean;
-  readonly size: "default" | "large";
+  readonly size: "base" | "large";
   readonly file: FileUpload;
 }
 

--- a/packages/components/src/FormatFile/InternalThumbnail.tsx
+++ b/packages/components/src/FormatFile/InternalThumbnail.tsx
@@ -33,6 +33,7 @@ export function InternalThumbnail({
       }}
       className={classNames(styles.image, { [styles.loading]: !imageLoaded })}
       alt={name}
+      data-testid="internalThumbnailImage"
     />
   );
   if (imageLoaded) {

--- a/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
+++ b/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
@@ -3,78 +3,70 @@
 exports[`renders a FormatFile 1`] = `
 <div
   className="expanded"
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
 >
   <div
-    className="imageBlock"
-    data-testid="imageBlock"
-    onClick={[Function]}
-    style={Object {}}
+    aria-busy={false}
+    className="wrapper"
+    tabIndex={0}
   >
     <div
-      className="icon"
+      className="thumbnail default"
     >
-      <svg
-        className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
-        data-testid="file"
-        viewBox="0 0 1024 1024"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className="content default"
       >
-        <path
-          className="_2e1AAW5-LqZd1rLcmAUuzN"
-          d="M597.333 384c0-23.564-19.102-42.667-42.667-42.667h-128c-23.564 0-42.667 19.103-42.667 42.667v256c0 23.565 19.103 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-64h85.333c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-85.333v-64h85.333c23.565 0 42.667-19.103 42.667-42.667z"
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="file"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className="_2e1AAW5-LqZd1rLcmAUuzN"
+            d="M597.333 384c0-23.564-19.102-42.667-42.667-42.667h-128c-23.564 0-42.667 19.103-42.667 42.667v256c0 23.565 19.103 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-64h85.333c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-85.333v-64h85.333c23.565 0 42.667-19.103 42.667-42.667z"
+          />
+          <path
+            className="_2e1AAW5-LqZd1rLcmAUuzN"
+            d="M256 85.333c-47.128 0-85.333 38.205-85.333 85.333v682.667c0 47.13 38.205 85.333 85.333 85.333h512c47.13 0 85.333-38.204 85.333-85.333v-536.994c0-22.632-8.99-44.337-24.994-60.34l-145.673-145.673c-16.004-16.003-37.709-24.994-60.339-24.994h-366.327zM256 853.333v-682.667h366.327l145.673 145.673v536.994h-512z"
+          />
+        </svg>
+        <div
+          className="fileName"
         />
-        <path
-          className="_2e1AAW5-LqZd1rLcmAUuzN"
-          d="M256 85.333c-47.128 0-85.333 38.205-85.333 85.333v682.667c0 47.13 38.205 85.333 85.333 85.333h512c47.13 0 85.333-38.204 85.333-85.333v-536.994c0-22.632-8.99-44.337-24.994-60.34l-145.673-145.673c-16.004-16.003-37.709-24.994-60.339-24.994h-366.327zM256 853.333v-682.667h366.327l145.673 145.673v536.994h-512z"
-        />
-      </svg>
+      </div>
     </div>
-  </div>
-  <div
-    className="contentBlock"
-  >
-    <span
-      className="base regular"
+    <div
+      className="contentBlock"
     >
-      Funky Corn
-    </span>
-    <p
-      className="base regular small greyBlueDark"
-    >
-      1 KB
-    </p>
+      <p
+        className="base regular large text"
+      >
+        Funky Corn
+      </p>
+      <p
+        className="base regular small text"
+      >
+        1 KB
+      </p>
+    </div>
   </div>
 </div>
 `;
 
 exports[`when the format file is a thumbnail when the thumbnail is default sized renders a FormatFile as a default sized thumbnail 1`] = `
 <div
-  className="thumbnail thumbnailDefault"
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
+  className="compact default"
 >
   <div
-    className="imageBlock imageBlockCompact imageBlockOverlayCompact"
-    data-testid="imageBlock"
-    onClick={[Function]}
-    style={
-      Object {
-        "height": "inherit",
-        "width": "inherit",
-      }
-    }
+    aria-busy={false}
+    className="wrapper default deleteable"
+    tabIndex={0}
   >
     <div
-      className="fileContentWrapper"
+      className="thumbnail default"
     >
       <div
-        className="icon"
+        className="content default"
       >
         <svg
           className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -87,15 +79,15 @@ exports[`when the format file is a thumbnail when the thumbnail is default sized
             d="M367.703 170.667c-32.322 0-61.87 18.261-76.325 47.171l-19.081 38.162h-101.631c-47.128 0-85.333 38.205-85.333 85.333v426.667c0 47.13 38.205 85.333 85.333 85.333h682.667c47.13 0 85.333-38.204 85.333-85.333v-426.667c0-47.128-38.204-85.333-85.333-85.333h-101.632l-19.081-38.162c-14.455-28.91-44.002-47.171-76.322-47.171h-288.596zM325.036 341.333l42.667-85.333h288.596l42.667 85.333h154.368v426.667h-682.667v-426.667h154.369zM682.667 554.667c0-94.255-76.412-170.667-170.667-170.667-94.257 0-170.667 76.412-170.667 170.667s76.41 170.667 170.667 170.667c94.255 0 170.667-76.412 170.667-170.667zM597.333 554.667c0 47.13-38.204 85.333-85.333 85.333s-85.333-38.204-85.333-85.333c0-47.13 38.204-85.333 85.333-85.333s85.333 38.204 85.333 85.333z"
           />
         </svg>
-      </div>
-      <div
-        className="thumbnailFilenameSmall"
-      >
-        <span
-          className="base regular"
+        <div
+          className="fileName"
         >
-          Pink Dolphin
-        </span>
+          <span
+            className="base regular text"
+          >
+            Pink Dolphin
+          </span>
+        </div>
       </div>
     </div>
   </div>
@@ -104,28 +96,18 @@ exports[`when the format file is a thumbnail when the thumbnail is default sized
 
 exports[`when the format file is a thumbnail when the thumbnail is large sized renders a FormatFile as a larget sized thumbnail 1`] = `
 <div
-  className="thumbnail thumbnailLarge"
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
+  className="compact large"
 >
   <div
-    className="imageBlock imageBlockCompact imageBlockOverlayCompact"
-    data-testid="imageBlock"
-    onClick={[Function]}
-    style={
-      Object {
-        "height": "inherit",
-        "width": "inherit",
-      }
-    }
+    aria-busy={false}
+    className="wrapper large deleteable"
+    tabIndex={0}
   >
     <div
-      className="fileContentWrapper fileContentWrapperLarge"
+      className="thumbnail large"
     >
       <div
-        className="icon"
+        className="content large"
       >
         <svg
           className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -138,15 +120,15 @@ exports[`when the format file is a thumbnail when the thumbnail is large sized r
             d="M367.703 170.667c-32.322 0-61.87 18.261-76.325 47.171l-19.081 38.162h-101.631c-47.128 0-85.333 38.205-85.333 85.333v426.667c0 47.13 38.205 85.333 85.333 85.333h682.667c47.13 0 85.333-38.204 85.333-85.333v-426.667c0-47.128-38.204-85.333-85.333-85.333h-101.632l-19.081-38.162c-14.455-28.91-44.002-47.171-76.322-47.171h-288.596zM325.036 341.333l42.667-85.333h288.596l42.667 85.333h154.368v426.667h-682.667v-426.667h154.369zM682.667 554.667c0-94.255-76.412-170.667-170.667-170.667-94.257 0-170.667 76.412-170.667 170.667s76.41 170.667 170.667 170.667c94.255 0 170.667-76.412 170.667-170.667zM597.333 554.667c0 47.13-38.204 85.333-85.333 85.333s-85.333-38.204-85.333-85.333c0-47.13 38.204-85.333 85.333-85.333s85.333 38.204 85.333 85.333z"
           />
         </svg>
-      </div>
-      <div
-        className="thumbnailFilename"
-      >
-        <span
-          className="base regular"
+        <div
+          className="fileName"
         >
-          Pink Dolphin
-        </span>
+          <span
+            className="base regular text"
+          >
+            Pink Dolphin
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
+++ b/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
@@ -2,11 +2,16 @@
 
 exports[`renders a FormatFile 1`] = `
 <div
-  className="formatFile"
+  className="expanded"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <div
     className="imageBlock"
     data-testid="imageBlock"
+    onClick={[Function]}
     style={Object {}}
   >
     <div
@@ -19,11 +24,11 @@ exports[`renders a FormatFile 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          className=""
+          className="_2e1AAW5-LqZd1rLcmAUuzN"
           d="M597.333 384c0-23.564-19.102-42.667-42.667-42.667h-128c-23.564 0-42.667 19.103-42.667 42.667v256c0 23.565 19.103 42.667 42.667 42.667s42.667-19.102 42.667-42.667v-64h85.333c23.565 0 42.667-19.102 42.667-42.667s-19.102-42.667-42.667-42.667h-85.333v-64h85.333c23.565 0 42.667-19.103 42.667-42.667z"
         />
         <path
-          className=""
+          className="_2e1AAW5-LqZd1rLcmAUuzN"
           d="M256 85.333c-47.128 0-85.333 38.205-85.333 85.333v682.667c0 47.13 38.205 85.333 85.333 85.333h512c47.13 0 85.333-38.204 85.333-85.333v-536.994c0-22.632-8.99-44.337-24.994-60.34l-145.673-145.673c-16.004-16.003-37.709-24.994-60.339-24.994h-366.327zM256 853.333v-682.667h366.327l145.673 145.673v536.994h-512z"
         />
       </svg>
@@ -42,6 +47,108 @@ exports[`renders a FormatFile 1`] = `
     >
       1 KB
     </p>
+  </div>
+</div>
+`;
+
+exports[`when the format file is a thumbnail when the thumbnail is default sized renders a FormatFile as a default sized thumbnail 1`] = `
+<div
+  className="thumbnail thumbnailDefault"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="imageBlock imageBlockCompact imageBlockOverlayCompact"
+    data-testid="imageBlock"
+    onClick={[Function]}
+    style={
+      Object {
+        "height": "inherit",
+        "width": "inherit",
+      }
+    }
+  >
+    <div
+      className="fileContentWrapper"
+    >
+      <div
+        className="icon"
+      >
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="camera"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className="_2e1AAW5-LqZd1rLcmAUuzN"
+            d="M367.703 170.667c-32.322 0-61.87 18.261-76.325 47.171l-19.081 38.162h-101.631c-47.128 0-85.333 38.205-85.333 85.333v426.667c0 47.13 38.205 85.333 85.333 85.333h682.667c47.13 0 85.333-38.204 85.333-85.333v-426.667c0-47.128-38.204-85.333-85.333-85.333h-101.632l-19.081-38.162c-14.455-28.91-44.002-47.171-76.322-47.171h-288.596zM325.036 341.333l42.667-85.333h288.596l42.667 85.333h154.368v426.667h-682.667v-426.667h154.369zM682.667 554.667c0-94.255-76.412-170.667-170.667-170.667-94.257 0-170.667 76.412-170.667 170.667s76.41 170.667 170.667 170.667c94.255 0 170.667-76.412 170.667-170.667zM597.333 554.667c0 47.13-38.204 85.333-85.333 85.333s-85.333-38.204-85.333-85.333c0-47.13 38.204-85.333 85.333-85.333s85.333 38.204 85.333 85.333z"
+          />
+        </svg>
+      </div>
+      <div
+        className="thumbnailFilenameSmall"
+      >
+        <span
+          className="base regular"
+        >
+          Pink Dolphin
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`when the format file is a thumbnail when the thumbnail is large sized renders a FormatFile as a larget sized thumbnail 1`] = `
+<div
+  className="thumbnail thumbnailLarge"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="imageBlock imageBlockCompact imageBlockOverlayCompact"
+    data-testid="imageBlock"
+    onClick={[Function]}
+    style={
+      Object {
+        "height": "inherit",
+        "width": "inherit",
+      }
+    }
+  >
+    <div
+      className="fileContentWrapper fileContentWrapperLarge"
+    >
+      <div
+        className="icon"
+      >
+        <svg
+          className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
+          data-testid="camera"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className="_2e1AAW5-LqZd1rLcmAUuzN"
+            d="M367.703 170.667c-32.322 0-61.87 18.261-76.325 47.171l-19.081 38.162h-101.631c-47.128 0-85.333 38.205-85.333 85.333v426.667c0 47.13 38.205 85.333 85.333 85.333h682.667c47.13 0 85.333-38.204 85.333-85.333v-426.667c0-47.128-38.204-85.333-85.333-85.333h-101.632l-19.081-38.162c-14.455-28.91-44.002-47.171-76.322-47.171h-288.596zM325.036 341.333l42.667-85.333h288.596l42.667 85.333h154.368v426.667h-682.667v-426.667h154.369zM682.667 554.667c0-94.255-76.412-170.667-170.667-170.667-94.257 0-170.667 76.412-170.667 170.667s76.41 170.667 170.667 170.667c94.255 0 170.667-76.412 170.667-170.667zM597.333 554.667c0 47.13-38.204 85.333-85.333 85.333s-85.333-38.204-85.333-85.333c0-47.13 38.204-85.333 85.333-85.333s85.333 38.204 85.333 85.333z"
+          />
+        </svg>
+      </div>
+      <div
+        className="thumbnailFilename"
+      >
+        <span
+          className="base regular"
+        >
+          Pink Dolphin
+        </span>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
+++ b/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
@@ -10,10 +10,10 @@ exports[`renders a FormatFile 1`] = `
     tabIndex={0}
   >
     <div
-      className="thumbnail default"
+      className="thumbnail base"
     >
       <div
-        className="content default"
+        className="content base"
       >
         <svg
           className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"
@@ -55,18 +55,18 @@ exports[`renders a FormatFile 1`] = `
 
 exports[`when the format file is a thumbnail when the thumbnail is default sized renders a FormatFile as a default sized thumbnail 1`] = `
 <div
-  className="compact default"
+  className="compact base"
 >
   <div
     aria-busy={false}
-    className="wrapper default deleteable"
+    className="wrapper base deleteable"
     tabIndex={0}
   >
     <div
-      className="thumbnail default"
+      className="thumbnail base"
     >
       <div
-        className="content default"
+        className="content base"
       >
         <svg
           className="ZDlJU6tECg7ouG-b27gya _3ctOeOMP7zLhU37n25xoZC"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We needed the ability to view format files as thumbnails

## Changes

Added new props to allow format file to be displayed as a thumbnail

## Decision Justification

- we didn't add spacing to the component to allow for devs to set their own spacing

## Testing

In playground with a format file, set display to "compact".


## References

https://www.figma.com/file/b7LY6hVMwFOj5maidxPTMB/Design-System-Contribution-%5B-Thumbnail-%2B-Gallery-%5D?node-id=1420%3A19642

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
