### PR TITLE
feat(design): include semantic workflow colors for schedule [JOB-49083]

### DIFF
--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -18,13 +18,13 @@ overview of how we speak on behalf of the Jobber brand.
 
 Use **account** in reference to the SP's business' Jobber account.
 
-| ✅ **Do**                                        | ❌ **Don't**                                                        |
+| ✅ **Do**                                         | ❌ **Don't**                                                        |
 | ------------------------------------------------- | ------------------------------------------------------------------- |
 | Only the account owner can set up Jobber Payments | Your account can not set up Jobber Payments for this Jobber account |
 
 Use **profile** for individual users to reduce ambiguity.
 
-| **✅ Do**                                                 | **❌ Don't**                                                          |
+| **✅ Do**                                                  | **❌ Don't**                                                          |
 | ---------------------------------------------------------- | --------------------------------------------------------------------- |
 | Join Lawn Care Pro Co\. on Jobber by creating your profile | Join Lawn Care Pro Co\.'s account by creating your own Jobber account |
 
@@ -42,7 +42,7 @@ consistency with what appears on **Manage Team**.
 We call our Jobber subscribers **customers** and we call the people they serve
 **clients**.
 
-| **✅ Do**                                              | **❌ Don't**                                              |
+| **✅ Do**                                               | **❌ Don't**                                              |
 | ------------------------------------------------------- | --------------------------------------------------------- |
 | All selected invoices have been emailed to your clients | All selected invoices have been emailed to your customers |
 
@@ -50,7 +50,7 @@ Sometimes in product, the context makes sense to use **customer** as terms our
 integration partners use or as a blanket term for existing clients and new
 leads.
 
-| **✅ Do**                                           | **❌ Don't**                                           |
+| **✅ Do**                                            | **❌ Don't**                                           |
 | ---------------------------------------------------- | ------------------------------------------------------ |
 | Sync clients with active QuickBooks Online customers | Sync customers with active QuickBooks Online customers |
 
@@ -132,7 +132,7 @@ Avoid spatial terms to direct users as they can be misinterpreted or irrelevant
 depending on screen size, screen reader, and so on. Reference a call to action
 and the component directly when possible.
 
-| **✅ Do**                                                   | **❌ Don't**                                                       |
+| **✅ Do**                                                    | **❌ Don't**                                                       |
 | ------------------------------------------------------------ | ------------------------------------------------------------------ |
 | Finish linking your Google and Jobber accounts by logging in | Finish linking your Google and Jobber accounts by logging in below |
 | View the sample's details in the following list              | Click on the request below to view it's details                    |
@@ -175,7 +175,7 @@ Use **delete** when permanently erasing information available in Jobber. Always
 follow up with a confirmation dialog. Think of **delete** as the inverse of
 [**create**](#add--create--new).
 
-| **✅ Do**    | **❌ Don't**  |
+| **✅ Do**     | **❌ Don't**  |
 | ------------- | ------------- |
 | Delete Quote  | Remove Quote  |
 | Delete Client | Remove Client |
@@ -183,7 +183,7 @@ follow up with a confirmation dialog. Think of **delete** as the inverse of
 Use **remove** when hiding information from the current view but not permanently
 erasing it. Think of **remove** as the inverse of [**add**](#add--create--new).
 
-| **✅ Do**                        | **❌ Don't**                      |
+| **✅ Do**                         | **❌ Don't**                      |
 | --------------------------------- | --------------------------------- |
 | Remove users over your plan limit | Delete users over your plan limit |
 | Remove tax rate                   | Delete tax rate from group rate   |
@@ -197,14 +197,14 @@ Never use **destroy** unless Wreck-it Ralph is making a cameo.
 When discussing Jobber features, use **turn on** and **turn off** for
 controlling the availability of it on an account.
 
-| **✅ Do**              | **❌ Don't**           |
+| **✅ Do**               | **❌ Don't**           |
 | ----------------------- | ---------------------- |
 | Turn on Jobber Payments | Enable Jobber Payments |
 
 When referencing the apps in the App Marketplace, use **connect** and
 **disconnect** for controlling their availability.
 
-| **✅ Do**        | **❌ Don't**      |
+| **✅ Do**         | **❌ Don't**      |
 | ----------------- | ----------------- |
 | Connect Mailchimp | Turn on Mailchimp |
 
@@ -215,7 +215,7 @@ When referencing the apps in the App Marketplace, use **connect** and
 Use **export** and **import** when data is moving in or out of Jobber and is
 converted into a different format.
 
-| **✅ Do**    | **❌ Don't**    |
+| **✅ Do**     | **❌ Don't**    |
 | ------------- | --------------- |
 | Import CSV    | Upload CSV      |
 | Export Report | Download Report |
@@ -223,7 +223,7 @@ converted into a different format.
 Use **download** and **upload** when data is being transferred in or out of
 Jobber in the same format.
 
-| **✅ Do**           | **❌ Don't**       |
+| **✅ Do**            | **❌ Don't**       |
 | -------------------- | ------------------ |
 | Upload photo         | Import photo       |
 | Download attachments | Export attachments |
@@ -349,14 +349,14 @@ Use app when referring to the Jobber app itself, or the apps provided within the
 App Marketplace. Apps in the Marketplace can also just be referred to by their
 brand name.
 
-| **✅ Do**                                                     | **❌ Don't**                                                                  |
+| **✅ Do**                                                      | **❌ Don't**                                                                  |
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | Try the Jobber app                                             | Try the Jobber Mobile Application                                             |
 | Connect Mailchimp to your account to automate your marketing\. | Connect the Mailchimp integration to your account to automate your marketing. |
 
 Use integration when referring to how an app connects with Jobber.
 
-| **✅ Do**                                                                                                                      | **❌ Don't**                                                                                                            |
+| **✅ Do**                                                                                                                       | **❌ Don't**                                                                                                            |
 | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | The Mailchimp integration will be removed because the user who connected it to Jobber no longer has administrator permissions\. | The Mailchimp app will be removed because the user who connected it to Jobber no longer has administrator permissions\. |
 
@@ -377,7 +377,7 @@ items.
 Use **attachments** when referring to files as a grouping rather than singular
 or as a verb.
 
-| **✅ Do**                   | **❌ Don't**      |
+| **✅ Do**                    | **❌ Don't**      |
 | ---------------------------- | ----------------- |
 | Internal notes & attachments | Add an attachment |
 | Quote attachments            | Attach a file     |
@@ -390,7 +390,7 @@ or as a verb.
 Always refer to our service consumer portal as the customer's client hub. Stick
 to sentence case, as it is a general term, not branded.
 
-| **✅ Do**                                 | **❌ Don't**                               |
+| **✅ Do**                                  | **❌ Don't**                               |
 | ------------------------------------------ | ------------------------------------------ |
 | Changes will be visible in your client hub | Changes will be visible in your Client Hub |
 
@@ -415,7 +415,7 @@ Avoid using **learn more** as a link's label as it is poor for accessibility.
 Stick to descriptive labels that give more context of where the link is taking a
 user.
 
-| **✅ Do**                                                                                | **❌ Don't**                                                                              |
+| **✅ Do**                                                                                 | **❌ Don't**                                                                              |
 | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | Learn how disputes work and how to prevent them in our [Help Center](#concepts-and-items) | Want to know how disputes work and how to prevent them? [Learn more](#concepts-and-items) |
 
@@ -566,8 +566,9 @@ on using "valid".
 
 ### Multiplication
 
-Use the `×` symbol to indicate multiplication whenever possible, rather than an `x`.
+Use the `×` symbol to indicate multiplication whenever possible, rather than an
+`x`.
 
-| **✅ Do**     | **❌ Don't** |
-| ------------- | ----------- |
-| 12 × $48.00   | 12 x $48.00 |
+| **✅ Do**   | **❌ Don't** |
+| ----------- | ------------ |
+| 12 × $48.00 | 12 x $48.00  |

--- a/docs/content/voice-and-tone.mdx
+++ b/docs/content/voice-and-tone.mdx
@@ -30,7 +30,7 @@ do).
 Don't use a period in microcopy such as error messages, list items, or form
 instructions.
 
-| ✅ **Do**       | ❌ **Don't**      |
+| ✅ **Do**        | ❌ **Don't**      |
 | ---------------- | ----------------- |
 | Enter your email | Enter your email. |
 
@@ -40,7 +40,7 @@ Don’t use words that would mean nothing to a stranger on the street. We’re h
 to make our users’ lives simpler and less stressful, not to teach them about
 computer science.
 
-| ✅ **Do**                    | ❌ **Don't**                              |
+| ✅ **Do**                     | ❌ **Don't**                              |
 | ----------------------------- | ----------------------------------------- |
 | No search results for "Brian" | Could not detect match for string "Brian" |
 
@@ -49,13 +49,13 @@ computer science.
 Lead with the action so that the user understands the action they need to take,
 rather than leading with the item they must take action on.
 
-| ✅ **Do**                                         | ❌ **Don't**                                                |
+| ✅ **Do**                                          | ❌ **Don't**                                                |
 | -------------------------------------------------- | ----------------------------------------------------------- |
 | Turn on **show pricing** to give access to reports | **Show pricing** must be turned on in order to view reports |
 
 The user is the implied subject in most scenarios so there is no need to include
 an explicit subject such as "You must... ".
 
-| ✅ **Do**                                         | ❌ **Don't**                                                   |
+| ✅ **Do**                                          | ❌ **Don't**                                                   |
 | -------------------------------------------------- | -------------------------------------------------------------- |
 | Turn on **show pricing** to give access to reports | You need to turn on **show pricing** to give access to reports |

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -281,8 +281,8 @@ Determine what default keyboard appears on mobile web.
 
 ## Loading
 
-Add a loading state to content. Note that `loading={true}` is unimplemented
-for multiline input text, i.e., when `multiline={true}`.
+Add a loading state to content. Note that `loading={true}` is unimplemented for
+multiline input text, i.e., when `multiline={true}`.
 
 <Playground>
   <InputText

--- a/packages/components/src/Page/Page.mdx
+++ b/packages/components/src/Page/Page.mdx
@@ -42,19 +42,20 @@ of footer, it should exist after Page.
 
 #### Narrow
 
-Use a `narrow` Page when the content is optimized for a single column, such as a form design.
+Use a `narrow` Page when the content is optimized for a single column, such as a
+form design.
 
 #### Standard
 
-Use a `standard` Page for most "show" state layouts, as it allows for a mix of contents in a 
-multi-column layout while keeping things constrained so the user does not have to track too far left-to-right
-as they interact.
+Use a `standard` Page for most "show" state layouts, as it allows for a mix of
+contents in a multi-column layout while keeping things constrained so the user
+does not have to track too far left-to-right as they interact.
 
 #### Fill
 
-A `fill` Page should be used when the content is optimized for wider views, such as 
-responsive dashboards and data visualizations, data tables, calendars, or otherwise does 
-not benefit from horizontal constraints.
+A `fill` Page should be used when the content is optimized for wider views, such
+as responsive dashboards and data visualizations, data tables, calendars, or
+otherwise does not benefit from horizontal constraints.
 
 ## Props
 

--- a/packages/components/src/RecurringSelect/RecurringSelect.mdx
+++ b/packages/components/src/RecurringSelect/RecurringSelect.mdx
@@ -45,21 +45,24 @@ import { RecurringSelect } from "@jobber/components/RecurringSelect";
 
 ## Design and usage guidelines
 
-The RecurringSelect is a complex tool, so ensure the user will require the full suite of 
-recurrence options before reaching for it. For instances where you may only require 
-a simple recurrence option, such as "Every `n` weeks", you are likely better served using basic
-form inputs such as `InputNumber` or `Select` to give the user fewer options.
+The RecurringSelect is a complex tool, so ensure the user will require the full
+suite of recurrence options before reaching for it. For instances where you may
+only require a simple recurrence option, such as "Every `n` weeks", you are
+likely better served using basic form inputs such as `InputNumber` or `Select`
+to give the user fewer options.
 
-The visual calendar selections in the RecurringSelect will scale up or down to adapt to the 
-width of the RecurringSelect's container, allowing this pattern to be more prominent when used as a 
-primary interface, or work in a smaller column-based or mobile interface. Consider this as you
-design solutions that may require RecurringSelect.
+The visual calendar selections in the RecurringSelect will scale up or down to
+adapt to the width of the RecurringSelect's container, allowing this pattern to
+be more prominent when used as a primary interface, or work in a smaller
+column-based or mobile interface. Consider this as you design solutions that may
+require RecurringSelect.
 
 ### Disabled state
 
-When the RecurringSelect is set to disabled, all child components become disabled. As with
-any design, your first goal should be to _avoid_ creating a flow where the user 
-encounters a disabled state, so only use this approach if a disabled state cannot be avoided.
+When the RecurringSelect is set to disabled, all child components become
+disabled. As with any design, your first goal should be to _avoid_ creating a
+flow where the user encounters a disabled state, so only use this approach if a
+disabled state cannot be avoided.
 
 <Playground>
   {() => {
@@ -76,11 +79,12 @@ encounters a disabled state, so only use this approach if a disabled state canno
 
 The `RecurringSelect` component is entirely usable by keyboard.
 
-All selections can be done and undone with tabs and the space bar. The "visual" 
-calendar-style selectors are all built using radio or checkbox elements where necessary,
-ensuring that users of assistive tech have appropriate context as to the type of
-selection they are making.
+All selections can be done and undone with tabs and the space bar. The "visual"
+calendar-style selectors are all built using radio or checkbox elements where
+necessary, ensuring that users of assistive tech have appropriate context as to
+the type of selection they are making.
 
 ## Related Components
 
-To allow the user to select specific dates, use [Datepicker](/components/date-picker) or [InputDate](/components/input-date).
+To allow the user to select specific dates, use
+[Datepicker](/components/date-picker) or [InputDate](/components/input-date).

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -64,6 +64,9 @@
   --color-request: var(--color-indigo);
   --color-quote: var(--color-pink);
   --color-job: var(--color-yellowGreen);
+  --color-visit: var(--color-green);
+  --color-task: var(--color-navy);
+  --color-event: var(--color-yellow);
   --color-invoice: var(--color-purple);
   --color-payments: var(--color-orange);
 


### PR DESCRIPTION
## Motivations

We offer inconsistent usage for teams working in the scheduling space, where they can use semantic colors for jobs/requests but not for visits/tasks/events

## Changes

### Added

![image](https://user-images.githubusercontent.com/39704901/172945278-93657681-9539-4655-af1d-fd79453aa609.png)

- Task = Navy
- Event = Yellow
- Visit = Green

### Changed

A bunch of linter issues with mdx files were auto-fixed

## Testing

View the tokens in the [Design -> Color docs](https://add-semantic-colors-for-sche.atlantis.pages.dev/colors/#swatch-list)
![image](https://user-images.githubusercontent.com/39704901/172945266-9d771cce-692f-4923-8d7f-ebf63de8df26.png)

If you want, try using the colors in a component and observe that they update
![image](https://user-images.githubusercontent.com/39704901/172945156-03112fde-4afa-4e51-83ca-08a53f71de50.png)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
