### PR TITLE
feat(design): update base red and usages of critical onSurface [JOB-48592]

### DIFF
--- a/packages/components/src/Chips/InternalChipAffix.tsx
+++ b/packages/components/src/Chips/InternalChipAffix.tsx
@@ -47,7 +47,7 @@ export function InternalChipAffix({
 
   function getIconColor() {
     if (disabled && !active) return "disabled";
-    if (invalid && !disabled) return "criticalOnSurface";
+    if (invalid && !disabled) return "critical";
     if (active) return "white";
     return;
   }

--- a/packages/components/src/Chips/InternalChipButton.tsx
+++ b/packages/components/src/Chips/InternalChipButton.tsx
@@ -62,7 +62,7 @@ export function InternalChipButton({
 
   function getColor() {
     if (disabled) return "disabled";
-    if (invalid) return "criticalOnSurface";
+    if (invalid) return "critical";
     return "greyBlue";
   }
 

--- a/packages/components/src/Chips/tests/InternalChip.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChip.test.tsx
@@ -26,13 +26,13 @@ it("should fire the callback when it's clicked", () => {
 describe("Chip icon colors depending on state", () => {
   it("should be red when it's invalid", () => {
     expect(mockChip({ invalid: true })).toHaveStyle({
-      fill: "var(--color-critical--onSurface)",
+      fill: "var(--color-critical)",
     });
   });
 
   it("should be red when it's invalid and active", () => {
     expect(mockChip({ invalid: true, active: true })).toHaveStyle({
-      fill: "var(--color-critical--onSurface)",
+      fill: "var(--color-critical)",
     });
   });
 

--- a/packages/components/src/Chips/tests/InternalChipButton.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipButton.test.tsx
@@ -63,7 +63,7 @@ describe("Interaction", () => {
 describe("Chip icon colors depending on state", () => {
   it("should be red when it's invalid", () => {
     expect(mockChip({ invalid: true })).toHaveStyle({
-      fill: "var(--color-critical--onSurface)",
+      fill: "var(--color-critical)",
     });
   });
 

--- a/packages/components/src/Typography/css/TextColors.css
+++ b/packages/components/src/Typography/css/TextColors.css
@@ -51,7 +51,7 @@
 }
 
 .critical {
-  color: var(--color-critical--onSurface);
+  color: var(--color-critical);
 }
 
 .warning {

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -103,11 +103,11 @@
   --color-yellow--lightest: rgb(250, 246, 219);
   --color-yellow--dark: rgb(144, 127, 10);
 
-  --color-red: rgb(239, 87, 51);
-  --color-red--light: rgb(244, 137, 112);
-  --color-red--lighter: rgb(249, 188, 173);
-  --color-red--lightest: rgb(253, 230, 224);
-  --color-red--dark: rgb(155, 57, 33);
+  --color-red: rgb(201, 66, 33);
+  --color-red--light: rgb(233, 141, 119);
+  --color-red--lighter: rgb(255, 206, 194);
+  --color-red--lightest: rgb(255, 226, 219);
+  --color-red--dark: rgb(128, 25, 0);
 
   --color-grey: rgb(181, 181, 181);
   --color-grey--light: rgb(203, 203, 203);


### PR DESCRIPTION
## Motivations

We're updating our "base red" to be a bit less orange, and have a slightly higher contrast ratio on a white background. As a result, we can also move away from using `critical--onSurface` on white backgrounds, as that value is mainly intended to be used overtop `critical--surface`.

## Changes

- updated rgb values of base red palette 
- updated components using `critical--onSurface` when not overlaid over red

### Changed

- Base red [+ critical + destructive semantic values]
![image](https://user-images.githubusercontent.com/39704901/180270973-21f4a008-1b0a-406e-894c-9280bbf82c06.png)
![image](https://user-images.githubusercontent.com/39704901/180271017-b19cdd69-a597-4199-9b99-5f692123b3cb.png)
![image](https://user-images.githubusercontent.com/39704901/180271064-28af7622-957f-48d2-a8a6-5c94879d8848.png)

- Chip (when invalid)
![image](https://user-images.githubusercontent.com/39704901/180269310-f63a3bb4-8db1-4de0-8191-9fe9f969bc27.png)
- Button (destructive) 
![image](https://user-images.githubusercontent.com/39704901/180271241-564093dc-008d-4fc1-8b47-6f1ad7a12de4.png)
- Text (error)
![image](https://user-images.githubusercontent.com/39704901/180271458-2eb92d76-440a-4f54-a173-cbe6349a77e8.png)
- InputValidation
![image](https://user-images.githubusercontent.com/39704901/180271573-168f7d90-47cb-42a4-8293-9da36ed5930d.png)
- InputText (validation message)
![image](https://user-images.githubusercontent.com/39704901/180271643-2fc317fe-9fee-4992-9053-8c5c7970e32b.png)
- Card (accent = red)
![image](https://user-images.githubusercontent.com/39704901/180271828-0a56fb96-dbab-4b0d-9823-67bcf467db80.png)
- Icons (trash, userUnassigned, reminder, badInvoice)
![image](https://user-images.githubusercontent.com/39704901/180272164-55fbe82a-7998-49ac-8a55-59bbe12158c1.png)

## Testing

- View color docs, Button, Chip, Text, InputValidation... basically the things from the screenshots above

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
