### PR TITLE
fix(components): Clicking On FormatFile Triggers Form Submit

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -69,6 +69,7 @@ export function FormatFile({
   return (
     <div className={wrapperClassNames}>
       <DetailsContainer
+        type="button"
         className={detailsClassNames}
         onClick={isComplete ? onClick : undefined}
         tabIndex={0}

--- a/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
+++ b/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders a FormatFile 1`] = `
     aria-busy={false}
     className="wrapper"
     tabIndex={0}
+    type="button"
   >
     <div
       className="thumbnail base"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We noticed a bug where clicking on a gallery thumbnail would trigger a form submission if the gallery was wrapped in a form

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Explicitly add `type="button"` to `DetailsContainer` of `FormatFile`, since `<button>` will default to a submit type

## Testing

- [ ] Test in master first to compare changes

<details>
<summary>Change the first playground in Form.mdx to have a gallery</summary>

```
<Playground>
  {() => {
    const [{ isDirty, isValid }, setFormState] = useFormState();
    const [first, setFirst] = useState("");
    return (
      <Form
        onSubmit={() => alert("Submitted 🎉🎉🎉")}
        onStateChange={setFormState}
      >
        <Content>
          <InputText
            placeholder="First Name"
            name="firstName"
            value={first}
            onChange={setFirst}
            validations={{
              required: {
                value: true,
                message: "Tell us your name",
              },
              minLength: {
                value: 3,
                message: "Your name is to short.",
              },
            }}
          />
          <InputText
            placeholder="Last Name"
            name="lastName"
            validations={{
              required: {
                value: true,
                message: "Tell us your last name.",
              },
            }}
          />
          <Button
            label="Submit Form"
            submit={true}
            disabled={!isDirty || !isValid}
          />
          <Gallery
            files={[
              {
                key: "abc",
                name: "myballisbigandroundIamrollingitontheground.png",
                type: "image/png",
                size: 213402324,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
              {
                key: "def",
                name: "iamanimage.png",
                type: "image/png",
                size: 124525234,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
              {
                key: "efg",
                name: "upanddown.png",
                type: "image/png",
                size: 233411234,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
              {
                key: "jkl",
                name: "kramer.png",
                type: "image/png",
                size: 233411234,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
              {
                key: "mno",
                name: "boston.png",
                type: "image/png",
                size: 233411234,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
              {
                key: "pqr",
                name: "pizzaisgood.png",
                type: "image/png",
                size: 233411234,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
              {
                key: "pQ=",
                name: "avatar.png",
                type: "image/png",
                size: 233411234,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
              {
                key: "fGr",
                name: "whatevenisthat.png",
                type: "image/png",
                size: 233411234,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
              {
                key: "AM=",
                name: "stairs.png",
                type: "image/png",
                size: 233411234,
                progress: 1,
                src: "https://source.unsplash.com/250x250",
              },
            ]}
          />
        </Content>
      </Form>
    );
  }}
</Playground>
```

</details>

- [ ] Open the form component in atlantis, you should see a gallery in the first example thanks to the changes you should have made to the .mdx file
- [ ] Click one of the gallery files. In current master, this will cause the validations to trigger, and if you filled out the form, this will cause the form to submit. On this branch, none of that should happen

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
