### PR TITLE
fix(components): apply correct cursors on labels within FormField components

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`it should display headers when headers are passed in 1`] = `
   className="autocomplete"
 >
   <div
-    className="wrapper"
+    className="wrapper textCursor"
     style={
       Object {
         "--formField-maxLength": undefined,
@@ -42,7 +42,7 @@ exports[`renders an Autocomplete 1`] = `
   className="autocomplete"
 >
   <div
-    className="wrapper"
+    className="wrapper textCursor"
     style={
       Object {
         "--formField-maxLength": undefined,

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -198,6 +198,19 @@
   transition: all var(--timing-quick);
 }
 
+/**
+ * Cursor types
+ **/
+.textCursor,
+.textCursor .label {
+  cursor: text;
+}
+
+.selectCursor,
+.selectCursor .label {
+  cursor: select;
+}
+
 .miniLabel .label {
   font-size: calc(var(--base-unit) * 0.875);
 }

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -15,6 +15,8 @@ declare const styles: {
   readonly "select": string;
   readonly "label": string;
   readonly "postfix": string;
+  readonly "textCursor": string;
+  readonly "selectCursor": string;
   readonly "affixIcon": string;
   readonly "suffix": string;
   readonly "hasAction": string;

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -56,7 +56,12 @@ export function FormFieldWrapper({
       [styles.disabled]: disabled,
       [styles.inline]: inline,
       [styles.maxLength]: maxLength,
-      [styles.select]: type === "select",
+      [styles.textCursor]:
+        type &&
+        ["text", "password", "number", "time", "textarea", "email"].includes(
+          type,
+        ),
+      [styles.selectCursor]: type === "select",
     },
   );
 

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -9,7 +9,7 @@ it("renders an input type number", () => {
   const tree = renderer.create(<InputNumber value={123} />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
+      className="wrapper textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,

--- a/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
+++ b/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<InputPassword /> renders an input type password 1`] = `
 <div>
   <div
-    class="wrapper"
+    class="wrapper textCursor"
   >
     <div
       class="inputWrapper"

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -10,7 +10,7 @@ it("renders a regular input for text and numbers", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
+      className="wrapper textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,
@@ -49,7 +49,7 @@ it("renders a textarea", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper textarea"
+      className="wrapper textarea textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,
@@ -92,7 +92,7 @@ it("renders a textarea with 4 rows", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper textarea"
+      className="wrapper textarea textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,

--- a/packages/components/src/InputTime/InputTime.test.tsx
+++ b/packages/components/src/InputTime/InputTime.test.tsx
@@ -10,7 +10,7 @@ it("renders a InputTime", () => {
   const tree = renderer.create(<InputTime />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
+      className="wrapper textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,
@@ -45,7 +45,7 @@ it("renders an initial time when given 'defaultValue'", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
+      className="wrapper textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,
@@ -80,7 +80,7 @@ it("renders correctly in a readonly state", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
+      className="wrapper textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,
@@ -116,7 +116,7 @@ it("adds a error border when invalid", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper"
+      className="wrapper textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,
@@ -150,7 +150,7 @@ it("should set the value when given 'value' and 'onChange'", () => {
   const tree = renderer.create(<InputTime invalid />).toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <div
-      className="wrapper invalid"
+      className="wrapper invalid textCursor"
       style={
         Object {
           "--formField-maxLength": undefined,

--- a/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders a Select with many options 1`] = `
 <div
-  className="wrapper select"
+  className="wrapper selectCursor"
   style={
     Object {
       "--formField-maxLength": undefined,
@@ -56,7 +56,7 @@ exports[`renders a Select with many options 1`] = `
 
 exports[`renders a Select with no options 1`] = `
 <div
-  className="wrapper select"
+  className="wrapper selectCursor"
   style={
     Object {
       "--formField-maxLength": undefined,
@@ -97,7 +97,7 @@ exports[`renders a Select with no options 1`] = `
 
 exports[`renders a Select with one option 1`] = `
 <div
-  className="wrapper select"
+  className="wrapper selectCursor"
   style={
     Object {
       "--formField-maxLength": undefined,
@@ -142,7 +142,7 @@ exports[`renders a Select with one option 1`] = `
 
 exports[`renders correctly as large 1`] = `
 <div
-  className="wrapper large select"
+  className="wrapper large selectCursor"
   style={
     Object {
       "--formField-maxLength": undefined,
@@ -187,7 +187,7 @@ exports[`renders correctly as large 1`] = `
 
 exports[`renders correctly as small 1`] = `
 <div
-  className="wrapper small select"
+  className="wrapper small selectCursor"
   style={
     Object {
       "--formField-maxLength": undefined,
@@ -232,7 +232,7 @@ exports[`renders correctly as small 1`] = `
 
 exports[`renders correctly when disabled 1`] = `
 <div
-  className="wrapper disabled select"
+  className="wrapper disabled selectCursor"
   style={
     Object {
       "--formField-maxLength": undefined,
@@ -278,7 +278,7 @@ exports[`renders correctly when disabled 1`] = `
 
 exports[`renders correctly when invalid 1`] = `
 <div
-  className="wrapper invalid select"
+  className="wrapper invalid selectCursor"
   style={
     Object {
       "--formField-maxLength": undefined,


### PR DESCRIPTION
## Motivations

Labels within FormFields and some FormField types do not have pleasant cursor types to indicate what type of action would take place.

- [Autocomplete](https://atlantis.getjobber.com/components/autocomplete)
    - label does not have text cursor
- [InputEmail](https://atlantis.getjobber.com/components/input-email)
    - label does not have text cursor
- [InputNumber](https://atlantis.getjobber.com/components/input-number)
    - label does not have text cursor
- [InputPassword](https://atlantis.getjobber.com/components/input-password)
    - label does not have text cursor
- [InputText](https://atlantis.getjobber.com/components/input-text)
    - label does not have text cursor
- [InputTime](https://atlantis.getjobber.com/components/input-time)
    - has no cursor on the entire component
 - [Select](https://atlantis.getjobber.com/components/select)
    - has no cursor on the entire component    
 
## Changes

### Fixed

- FormFields of type `text`, `password`, `number`, `time`, `textarea`, `email` will all have text cursors even on their labels. This affects:
    - [Autocomplete](https://atlantis.getjobber.com/components/autocomplete)
    - [InputEmail](https://atlantis.getjobber.com/components/input-email)
    - [InputNumber](https://atlantis.getjobber.com/components/input-number)
    - [InputPassword](https://atlantis.getjobber.com/components/input-password)
    - [InputText](https://atlantis.getjobber.com/components/input-text)
    - [InputTime](https://atlantis.getjobber.com/components/input-time)
- FormFields of type `select` will all have text cursors even on their labels. This affects:
    - [Select](https://atlantis.getjobber.com/components/select)
    - Other components which inherit/use [Select](https://atlantis.getjobber.com/components/select), such as [RecurringSelect](https://atlantis.getjobber.com/patterns/recurringselect)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
