### PR TITLE
feat(hooks): allow totalCount to be optional -- (Minor) Feature Release

### DIFF
--- a/packages/hooks/src/useCollectionQuery/mdxUtils.ts
+++ b/packages/hooks/src/useCollectionQuery/mdxUtils.ts
@@ -16,7 +16,7 @@ export interface ListQueryType {
       };
       cursor: string;
     }>;
-    totalCount: number;
+    totalCount?: number;
   };
 }
 
@@ -34,7 +34,6 @@ export const LIST_QUERY = gql`
         }
         cursor
       }
-      totalCount
     }
   }
 `;

--- a/packages/hooks/src/useCollectionQuery/test-utilities/mocks.tsx
+++ b/packages/hooks/src/useCollectionQuery/test-utilities/mocks.tsx
@@ -1,7 +1,8 @@
+import { DocumentNode } from "@apollo/client";
 import { MockedProvider, MockedResponse } from "@apollo/react-testing";
 import React from "react";
 import { v1 as uuidv1 } from "uuid";
-import { LIST_QUERY, SUBSCRIPTION_QUERY } from "./queries";
+import { SUBSCRIPTION_QUERY } from "./queries";
 
 export function wrapper(mocks: MockedResponse[]) {
   function ApolloMockedProvider({
@@ -21,6 +22,39 @@ export function wrapper(mocks: MockedResponse[]) {
 
 let listQueryHasNextPage = true;
 export const listQueryResponseMock = jest.fn(id => {
+  return {
+    data: {
+      conversation: {
+        __typename: "Conversation",
+        smsMessages: {
+          __typename: "SMSMessageConnection",
+          edges: [
+            {
+              __typename: "SMSMessageEdge",
+              node: {
+                __typename: "SMSMessage",
+                id: id || uuidv1(),
+              },
+            },
+          ],
+          nodes: [
+            {
+              __typename: "SMSMessage",
+              id: id || uuidv1(),
+            },
+          ],
+          pageInfo: {
+            __typename: "PageInfo",
+            endCursor: "MZ",
+            hasNextPage: listQueryHasNextPage,
+          },
+        },
+      },
+    },
+  };
+});
+
+export const listQueryWithTotalCountResponseMock = jest.fn(id => {
   return {
     data: {
       conversation: {
@@ -70,15 +104,17 @@ export const subscriptionQueryMock = jest.fn(id => {
 });
 
 export function buildListRequestMock(
+  query: DocumentNode,
+  responseMock: jest.Mock,
   id?: string | undefined,
   searchTerm?: string | undefined,
 ) {
   return {
     request: {
-      query: LIST_QUERY,
+      query: query,
       variables: { searchTerm: searchTerm },
     },
-    result: () => listQueryResponseMock(id),
+    result: () => responseMock(id),
   };
 }
 
@@ -92,13 +128,17 @@ export function buildSubscriptionRequestMock(id?: string | undefined) {
   };
 }
 
-export function buildListRequestMockForNextPage(id?: string | undefined) {
+export function buildListRequestMockForNextPage(
+  query: DocumentNode,
+  responseMock: jest.Mock,
+  id?: string | undefined,
+) {
   return {
     request: {
-      query: LIST_QUERY,
+      query: query,
       variables: { cursor: "MZ" },
     },
-    result: () => listQueryResponseMock(id),
+    result: () => responseMock(id),
   };
 }
 

--- a/packages/hooks/src/useCollectionQuery/test-utilities/queries.ts
+++ b/packages/hooks/src/useCollectionQuery/test-utilities/queries.ts
@@ -18,6 +18,29 @@ export const LIST_QUERY = gql`
           endCursor
           hasNextPage
         }
+      }
+    }
+  }
+`;
+
+export const LIST_QUERY_WITH_TOTAL_COUNT = gql`
+  query ConversationMessages($cursor: string, $searchTerm: string) {
+    conversation(id: "MQ==") {
+      smsMessages(first: 1, after: $cursor, searchTerm: $searchTerm) {
+        edges {
+          node {
+            __typename
+            id
+          }
+        }
+        nodes {
+          __typename
+          id
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
         totalCount
       }
     }
@@ -45,7 +68,7 @@ export interface ListQueryType {
         endCursor: string;
         hasNextPage: boolean;
       };
-      totalCount: number;
+      totalCount?: number;
     };
   };
 }

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -70,7 +70,7 @@ interface Collection {
     hasNextPage: boolean;
     [otherProperties: string]: unknown;
   };
-  totalCount: number;
+  totalCount?: number;
   [otherProperties: string]: unknown;
 }
 
@@ -258,7 +258,7 @@ function fetchMoreUpdateQueryHandler<TQuery>(
 
   Object.assign(outputCollection, {
     pageInfo: cloneDeep(nextCollection.pageInfo),
-    totalCount: nextCollection.totalCount,
+    ...getTotalCount(nextCollection.totalCount),
   });
 
   return output;
@@ -298,10 +298,23 @@ function subscribeToMoreHandler<TQuery, TSubscription>(
 
   Object.assign(outputCollection, {
     pageInfo: cloneDeep(outputCollection.pageInfo),
-    totalCount: outputCollection.totalCount + 1,
+    ...getTotalCount(outputCollection.totalCount, 1),
   });
 
   return output;
+}
+
+interface TotalCountReturn {
+  totalCount?: number;
+}
+
+function getTotalCount(
+  totalCount: number | undefined,
+  additionalCount = 0,
+): TotalCountReturn {
+  return totalCount !== undefined
+    ? { totalCount: totalCount + additionalCount }
+    : {};
 }
 
 export function isAlreadyUpdated(outputCollection: Collection, newNode: Node) {


### PR DESCRIPTION
## Motivations

- Comms Experience is attempting to reduce the load times of conversation queries. TotalCount is expensive, so if we remove totalCount from the query we should experience some wins.

## Changes

- Make totalCount optional.
    - If totalCount is not supplied, do not return it. 

### Changed

- totalCount optionally returned

## Testing

In both JO and JM:

- [x] run `npm i @jobber/hooks@1.11.1-pre.59+4b93cd11` This will allow you to test these changes in JO or JM.
- [x] Remove totalCount from conversation queries:
- From JO: 
       - app/javascript/jobber/chat/components/ChatDrawer/Chat/Chat.graphql.ts
       - app/javascript/jobber/chat/components/ChatDrawer/NotificationList/NotificationList.graphql.ts
       - remove reference to totalCount within NotificationListWrapper around line 113
- From JM: 
       - src/features/SmsCommunication/views/Conversation/Conversation.graphql.ts
       - src/features/SmsCommunication/views/ConversationList/ConversationList.graphql.ts
- [x] Run `npm run gql:update`
- [x] Make sure herald is running to test notifications
- [ ] Test sending and receiving of sms when:
     - [x] In a conversation
     - [x] In a different conversation
     - [x] In the Message Center
     - [x] When the Message Center is closed
     - [x] Ensure Read badge is working correctly

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
