### PR TITLE
fix(components): add a border to thumbnail 

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -67,6 +67,7 @@
 }
 
 .compact .thumbnail {
+  border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Thumbnail component needs to have a border to match [figma](https://www.figma.com/file/b7LY6hVMwFOj5maidxPTMB/Design-System-Contribution-%5B-Thumbnail-%2B-Gallery-%5D?node-id=1420%3A19639) and so that they still look nice in the case of white backgrounds

### Fixed

- Add border on compact thumbnail component
![Screen Shot 2022-08-25 at 1 00 29 PM](https://user-images.githubusercontent.com/104797704/186726173-fec186ee-92bc-43d4-adb1-ccd6e794412e.png)
![Screen Shot 2022-08-25 at 1 03 43 PM](https://user-images.githubusercontent.com/104797704/186726471-290be7f2-427b-4eeb-9d11-f74c76f265b5.png)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
