### PR TITLE
chore(eslint) Removing `no-null` linter rule

### DIFF
--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInView.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInView.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 export function useInView<T extends Element>() {
-  const ref = useRef<T>(null); // eslint-disable-line no-null/no-null
+  const ref = useRef<T>(null);
   const [isInView, setIsInView] = useState(false);
 
   if (window.IntersectionObserver) {

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissible.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissible.ts
@@ -10,7 +10,7 @@ export function useInternalChipDismissible({
   onClick,
   onCustomAdd,
 }: InternalChipDismissibleProps) {
-  const ref = useRef<HTMLDivElement>(null); // eslint-disable-line no-null/no-null
+  const ref = useRef<HTMLDivElement>(null);
   const chipOptions = children.map(chip => chip.props);
   const visibleChipOptions = chipOptions.filter(chip =>
     selected.includes(chip.value),

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -45,7 +45,7 @@ export function useInternalChipDismissibleInput({
 
   const computed = {
     menuId,
-    inputRef: useRef<HTMLInputElement>(null), // eslint-disable-line no-null/no-null
+    inputRef: useRef<HTMLInputElement>(null),
     activeOption: allOptions[activeIndex],
     hasAvailableOptions: allOptions.length > 0,
     nextOptionIndex: activeIndex < maxOptionIndex ? activeIndex + 1 : 0,

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useScrollToActive.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useScrollToActive.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 
 export function useScrollToActive(index: number) {
-  const ref = useRef<HTMLDivElement>(null); // eslint-disable-line no-null/no-null
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!window.HTMLElement.prototype.scrollIntoView) return;

--- a/packages/components/src/Modal/useFocusTrap.ts
+++ b/packages/components/src/Modal/useFocusTrap.ts
@@ -12,7 +12,6 @@ export function useFocusTrap<T extends HTMLElement>(active: boolean) {
   // There's an ongoing issue with useRef return type clashing with an element's
   // ref prop type. TLDR: Use null because useRef doesn't expect undefined.
   // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/35572
-  // eslint-disable-next-line no-null/no-null
   const ref = useRef<T>(null);
 
   function handleKeyDown(event: KeyboardEvent) {

--- a/packages/components/src/Tooltip/useTooltipPositioning.ts
+++ b/packages/components/src/Tooltip/useTooltipPositioning.ts
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import { usePopper } from "react-popper";
 
 export function useTooltipPositioning() {
-  const shadowRef = useRef<HTMLSpanElement>(null); // eslint-disable-line no-null/no-null
+  const shadowRef = useRef<HTMLSpanElement>(null);
   const [positionElement, setTooltipRef] = useState<HTMLDivElement | null>();
   const [arrowElement, setArrowRef] = useState<HTMLDivElement | null>();
 

--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     "react",
     "prettier",
     "import",
-    "no-null",
     "jest",
   ],
   settings: {
@@ -51,7 +50,6 @@ module.exports = {
     "import/no-deprecated": "error",
     "import/newline-after-import": "error",
     "jest/no-jasmine-globals": "error",
-    "no-null/no-null": "error",
     "react/no-danger": "error",
     "prettier/prettier": [
       "error",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,7 +14,6 @@
     "eslint-import-resolver-typescript": "^1.1.1",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.17.0",
-    "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.14.3",
     "prettier": "^2.4.1"


### PR DESCRIPTION
## Motivations

There was a lot of discussion around the rule and we eventually decided to take it out. Because we're using tools and libraries that aren't as strict about `null` as this rule it means there's lots of cases where `null` is valid and necessary value to assign to a variable. An example of this is null fields in GraphQL. If a field is nullable and you want to test the null case your test data will necessarily have `null` in it. The rule meant that we were regularly adding exceptions or doing other type acrobatics to make the linter happy.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
