### PR TITLE
feat(components): MultiSelect component

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -46,6 +46,8 @@ interface BaseCheckboxProps {
   readonly description?: string;
 
   onChange?(newValue: boolean): void;
+
+  onFocus?(): void;
 }
 
 interface CheckboxLabelProps extends BaseCheckboxProps {
@@ -75,6 +77,7 @@ export function Checkbox({
   description,
   children,
   onChange,
+  onFocus,
 }: CheckboxProps) {
   const wrapperClassName = classnames(
     styles.wrapper,
@@ -100,6 +103,7 @@ export function Checkbox({
             value={value}
             name={name}
             disabled={disabled}
+            onFocus={onFocus}
           />
           <span className={styles.checkBox}>
             <Icon name={iconName} size="small" color="white" />

--- a/packages/components/src/MultiSelect/DropDownMenu.css
+++ b/packages/components/src/MultiSelect/DropDownMenu.css
@@ -1,0 +1,28 @@
+.dropDownMenuContainer {
+  display: flex;
+  position: absolute;
+  z-index: var(--elevation-menu);
+  width: 100%;
+  max-height: 300px;
+  box-shadow: var(--shadow-base);
+  padding-bottom: var(--space-smaller);
+  border: var(--border-base) solid var(--color-border);
+  border-radius: var(--radius-large);
+  overflow: auto;
+  background-color: var(--color-surface);
+  flex-direction: column;
+  scroll-behavior: smooth;
+}
+
+.option {
+  width: 100%;
+  padding: var(--space-small) var(--space-base) 0;
+  cursor: pointer;
+  transition: all var(--timing-base);
+}
+
+.option:focus,
+.option.active {
+  background-color: var(--color-surface--hover);
+  outline-color: var(--color-focus);
+}

--- a/packages/components/src/MultiSelect/DropDownMenu.css
+++ b/packages/components/src/MultiSelect/DropDownMenu.css
@@ -7,7 +7,6 @@
   box-shadow: var(--shadow-base);
   margin: 0;
   padding: 0;
-  padding-bottom: var(--space-smaller);
   border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-large);
   overflow: auto;
@@ -21,8 +20,9 @@
 }
 
 .option {
+  display: flex;
   width: 100%;
-  padding: var(--space-small) var(--space-base) 0;
+  padding: var(--space-small) var(--space-base);
   cursor: pointer;
   transition: all var(--timing-base);
 }

--- a/packages/components/src/MultiSelect/DropDownMenu.css
+++ b/packages/components/src/MultiSelect/DropDownMenu.css
@@ -5,6 +5,8 @@
   width: 100%;
   max-height: 300px;
   box-shadow: var(--shadow-base);
+  margin: 0;
+  padding: 0;
   padding-bottom: var(--space-smaller);
   border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-large);
@@ -12,6 +14,10 @@
   background-color: var(--color-surface);
   flex-direction: column;
   scroll-behavior: smooth;
+}
+
+.dropDownMenuContainer li {
+  list-style: none;
 }
 
 .option {

--- a/packages/components/src/MultiSelect/DropDownMenu.css
+++ b/packages/components/src/MultiSelect/DropDownMenu.css
@@ -3,7 +3,7 @@
   position: absolute;
   z-index: var(--elevation-menu);
   width: 100%;
-  max-height: 300px;
+  max-height: calc(var(--space-extravagant) * 5);
   box-shadow: var(--shadow-base);
   margin: 0;
   padding: 0;

--- a/packages/components/src/MultiSelect/DropDownMenu.css.d.ts
+++ b/packages/components/src/MultiSelect/DropDownMenu.css.d.ts
@@ -1,0 +1,7 @@
+declare const styles: {
+  readonly "dropDownMenuContainer": string;
+  readonly "option": string;
+  readonly "active": string;
+};
+export = styles;
+

--- a/packages/components/src/MultiSelect/DropDownMenu.tsx
+++ b/packages/components/src/MultiSelect/DropDownMenu.tsx
@@ -36,7 +36,7 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
 
   function handleOptionHover(event: MouseEvent<HTMLLIElement>, index: number) {
     event.preventDefault();
-    handleOptionFocus(index);
+    setHighlightedIndex(index);
   }
 
   function handleOptionFocus(index: number) {
@@ -116,7 +116,6 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
       data-testid="dropdown-menu"
       className={styles.dropDownMenuContainer}
       ref={menuDiv}
-      aria-multiselectable="true"
     >
       {options.map((option, index) => {
         const optionClass = classNames(styles.option, {

--- a/packages/components/src/MultiSelect/DropDownMenu.tsx
+++ b/packages/components/src/MultiSelect/DropDownMenu.tsx
@@ -1,4 +1,10 @@
-import React, { MouseEvent, MutableRefObject, useRef, useState } from "react";
+import React, {
+  MouseEvent,
+  MutableRefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import classNames from "classnames";
 import { useOnKeyDown } from "@jobber/hooks";
 import styles from "./DropDownMenu.css";
@@ -30,7 +36,16 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
 
   function handleOptionHover(event: MouseEvent<HTMLLIElement>, index: number) {
     event.preventDefault();
+    handleOptionFocus(index);
+  }
+
+  function handleOptionFocus(index: number) {
     setHighlightedIndex(index);
+
+    if (menuDiv.current) {
+      const option = menuDiv.current.children[index].querySelector("input");
+      option?.focus();
+    }
   }
 
   function scrollMenuIfItemNotInView(
@@ -60,28 +75,25 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
 
   function setupKeyListeners(key: string) {
     switch (key) {
-      case "Enter": {
+      case "Enter":
+      case " ": {
         if (highlightedIndex >= 0) {
           onOptionSelect && onOptionSelect(options[highlightedIndex]);
         }
         break;
       }
       case "ArrowDown": {
-        setHighlightedIndex(Math.min(options.length - 1, highlightedIndex + 1));
+        const newIndex = Math.min(options.length - 1, highlightedIndex + 1);
 
-        if (menuDiv.current) {
-          scrollMenuIfItemNotInView(menuDiv.current, "down");
-        }
-
+        handleOptionFocus(newIndex);
+        scrollMenuIfItemNotInView(menuDiv.current, "down");
         break;
       }
       case "ArrowUp": {
-        setHighlightedIndex(Math.max(0, highlightedIndex - 1));
+        const newIndex = Math.max(0, highlightedIndex - 1);
 
-        if (menuDiv.current) {
-          scrollMenuIfItemNotInView(menuDiv.current, "up");
-        }
-
+        handleOptionFocus(newIndex);
+        scrollMenuIfItemNotInView(menuDiv.current, "up");
         break;
       }
     }
@@ -89,9 +101,15 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
 
   useOnKeyDown(handleKeyboardShortcut(setupKeyListeners).callback, [
     "Enter",
+    " ",
     "ArrowDown",
     "ArrowUp",
   ]);
+
+  useEffect(() => {
+    // focus first option
+    handleOptionFocus(0);
+  }, [menuDiv]);
 
   return (
     <ul
@@ -112,7 +130,11 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
             onClick={e => handleOptionClick(e, option)}
             onMouseOver={e => handleOptionHover(e, index)}
           >
-            <Checkbox label={option.label} checked={option.checked} />
+            <Checkbox
+              label={option.label}
+              checked={option.checked}
+              onFocus={() => setHighlightedIndex(index)}
+            />
           </li>
         );
       })}

--- a/packages/components/src/MultiSelect/DropDownMenu.tsx
+++ b/packages/components/src/MultiSelect/DropDownMenu.tsx
@@ -1,0 +1,117 @@
+import React, { MouseEvent, useRef, useState } from "react";
+import classNames from "classnames";
+import { useOnKeyDown } from "@jobber/hooks";
+import styles from "./DropDownMenu.css";
+import { Option, Options } from "./types";
+import { handleKeyboardShortcut } from "./utils";
+import { Checkbox } from "../Checkbox";
+
+interface DropDownMenuProps {
+  /**
+   * List of options to be selected
+   * @default false
+   */
+  readonly options: Options;
+
+  /**
+   * Change handler.
+   */
+  onOptionSelect?(option: Option): void;
+}
+
+export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const menuDiv = useRef() as React.MutableRefObject<HTMLDivElement>;
+
+  function handleOptionClick(
+    event: MouseEvent<HTMLDivElement>,
+    option: Option,
+  ) {
+    event.preventDefault();
+    onOptionSelect && onOptionSelect(option);
+  }
+
+  function handleOptionHover(event: MouseEvent<HTMLDivElement>, index: number) {
+    event.preventDefault();
+    setHighlightedIndex(index);
+  }
+
+  function setupKeyListeners(key: string) {
+    function scrollMenuIfItemNotInView(
+      menuDivElement: HTMLDivElement,
+      direction: "up" | "down",
+    ) {
+      const itemDiv = menuDivElement.querySelector(
+        `:nth-child(${highlightedIndex + 1})`,
+      ) as HTMLButtonElement;
+
+      if (!itemDiv) return;
+
+      const menuTop = menuDivElement.getBoundingClientRect().top;
+      const {
+        top: itemTop,
+        height: itemHeight,
+        bottom: itemBottom,
+      } = itemDiv.getBoundingClientRect();
+      const itemTrueBottom = itemBottom + itemHeight;
+      const menuBottom = menuDivElement.getBoundingClientRect().bottom;
+      if (direction == "up" && itemTop - itemHeight < menuTop) {
+        menuDivElement.scrollTop -= itemHeight;
+      } else if (direction == "down" && itemTrueBottom > menuBottom) {
+        menuDivElement.scrollTop += itemHeight;
+      }
+    }
+
+    switch (key) {
+      case "Enter": {
+        onOptionSelect && onOptionSelect(options[highlightedIndex]);
+        break;
+      }
+      case "ArrowDown": {
+        setHighlightedIndex(Math.min(options.length - 1, highlightedIndex + 1));
+
+        if (menuDiv.current) {
+          scrollMenuIfItemNotInView(menuDiv.current, "down");
+        }
+
+        break;
+      }
+      case "ArrowUp": {
+        setHighlightedIndex(Math.max(0, highlightedIndex - 1));
+
+        if (menuDiv.current) {
+          scrollMenuIfItemNotInView(menuDiv.current, "up");
+        }
+
+        break;
+      }
+    }
+  }
+
+  useOnKeyDown(handleKeyboardShortcut(setupKeyListeners).callback, [
+    "Enter",
+    "ArrowDown",
+    "ArrowUp",
+  ]);
+
+  return (
+    <div className={styles.dropDownMenuContainer} ref={menuDiv}>
+      {options.map((option, index) => {
+        const optionClass = classNames(styles.option, {
+          [styles.active]: index === highlightedIndex,
+        });
+
+        return (
+          <div
+            key={`${index}-${option.label}`}
+            className={optionClass}
+            onClick={e => handleOptionClick(e, option)}
+            onMouseOver={e => handleOptionHover(e, index)}
+          >
+            <Checkbox label={option.label} checked={option.checked} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/components/src/MultiSelect/DropDownMenu.tsx
+++ b/packages/components/src/MultiSelect/DropDownMenu.tsx
@@ -97,7 +97,11 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
   ]);
 
   return (
-    <div className={styles.dropDownMenuContainer} ref={menuDiv}>
+    <div
+      data-testid="dropdown-menu"
+      className={styles.dropDownMenuContainer}
+      ref={menuDiv}
+    >
       {options.map((option, index) => {
         const optionClass = classNames(styles.option, {
           [styles.active]: index === highlightedIndex,

--- a/packages/components/src/MultiSelect/DropDownMenu.tsx
+++ b/packages/components/src/MultiSelect/DropDownMenu.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useRef, useState } from "react";
+import React, { MouseEvent, MutableRefObject, useRef, useState } from "react";
 import classNames from "classnames";
 import { useOnKeyDown } from "@jobber/hooks";
 import styles from "./DropDownMenu.css";
@@ -20,24 +20,21 @@ interface DropDownMenuProps {
 }
 
 export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const menuDiv = useRef() as React.MutableRefObject<HTMLDivElement>;
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const menuDiv = useRef() as MutableRefObject<HTMLUListElement>;
 
-  function handleOptionClick(
-    event: MouseEvent<HTMLDivElement>,
-    option: Option,
-  ) {
+  function handleOptionClick(event: MouseEvent<HTMLLIElement>, option: Option) {
     event.preventDefault();
     onOptionSelect && onOptionSelect(option);
   }
 
-  function handleOptionHover(event: MouseEvent<HTMLDivElement>, index: number) {
+  function handleOptionHover(event: MouseEvent<HTMLLIElement>, index: number) {
     event.preventDefault();
     setHighlightedIndex(index);
   }
 
   function scrollMenuIfItemNotInView(
-    menuDivElement: HTMLDivElement,
+    menuDivElement: HTMLUListElement,
     direction: "up" | "down",
   ) {
     const itemDiv = menuDivElement.querySelector(
@@ -97,10 +94,11 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
   ]);
 
   return (
-    <div
+    <ul
       data-testid="dropdown-menu"
       className={styles.dropDownMenuContainer}
       ref={menuDiv}
+      aria-multiselectable="true"
     >
       {options.map((option, index) => {
         const optionClass = classNames(styles.option, {
@@ -108,16 +106,16 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
         });
 
         return (
-          <div
+          <li
             key={`${index}-${option.label}`}
             className={optionClass}
             onClick={e => handleOptionClick(e, option)}
             onMouseOver={e => handleOptionHover(e, index)}
           >
             <Checkbox label={option.label} checked={option.checked} />
-          </div>
+          </li>
         );
       })}
-    </div>
+    </ul>
   );
 }

--- a/packages/components/src/MultiSelect/DropDownMenu.tsx
+++ b/packages/components/src/MultiSelect/DropDownMenu.tsx
@@ -36,35 +36,37 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
     setHighlightedIndex(index);
   }
 
-  function setupKeyListeners(key: string) {
-    function scrollMenuIfItemNotInView(
-      menuDivElement: HTMLDivElement,
-      direction: "up" | "down",
-    ) {
-      const itemDiv = menuDivElement.querySelector(
-        `:nth-child(${highlightedIndex + 1})`,
-      ) as HTMLButtonElement;
+  function scrollMenuIfItemNotInView(
+    menuDivElement: HTMLDivElement,
+    direction: "up" | "down",
+  ) {
+    const itemDiv = menuDivElement.querySelector(
+      `:nth-child(${highlightedIndex + 1})`,
+    ) as HTMLButtonElement;
 
-      if (!itemDiv) return;
+    if (!itemDiv) return;
 
-      const menuTop = menuDivElement.getBoundingClientRect().top;
-      const {
-        top: itemTop,
-        height: itemHeight,
-        bottom: itemBottom,
-      } = itemDiv.getBoundingClientRect();
-      const itemTrueBottom = itemBottom + itemHeight;
-      const menuBottom = menuDivElement.getBoundingClientRect().bottom;
-      if (direction == "up" && itemTop - itemHeight < menuTop) {
-        menuDivElement.scrollTop -= itemHeight;
-      } else if (direction == "down" && itemTrueBottom > menuBottom) {
-        menuDivElement.scrollTop += itemHeight;
-      }
+    const menuTop = menuDivElement.getBoundingClientRect().top;
+    const {
+      top: itemTop,
+      height: itemHeight,
+      bottom: itemBottom,
+    } = itemDiv.getBoundingClientRect();
+    const itemTrueBottom = itemBottom + itemHeight;
+    const menuBottom = menuDivElement.getBoundingClientRect().bottom;
+    if (direction == "up" && itemTop - itemHeight < menuTop) {
+      menuDivElement.scrollTop -= itemHeight;
+    } else if (direction == "down" && itemTrueBottom > menuBottom) {
+      menuDivElement.scrollTop += itemHeight;
     }
+  }
 
+  function setupKeyListeners(key: string) {
     switch (key) {
       case "Enter": {
-        onOptionSelect && onOptionSelect(options[highlightedIndex]);
+        if (highlightedIndex >= 0) {
+          onOptionSelect && onOptionSelect(options[highlightedIndex]);
+        }
         break;
       }
       case "ArrowDown": {

--- a/packages/components/src/MultiSelect/DropDownMenu.tsx
+++ b/packages/components/src/MultiSelect/DropDownMenu.tsx
@@ -1,6 +1,8 @@
 import React, {
+  Dispatch,
   MouseEvent,
   MutableRefObject,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -22,17 +24,23 @@ interface DropDownMenuProps {
   /**
    * Change handler.
    */
-  onOptionSelect?(option: Option): void;
+  setOptions: Dispatch<React.SetStateAction<Options>>;
 }
 
-export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
+export function DropDownMenu({ options, setOptions }: DropDownMenuProps) {
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const menuDiv = useRef() as MutableRefObject<HTMLUListElement>;
 
-  function handleOptionClick(event: MouseEvent<HTMLLIElement>, option: Option) {
-    event.preventDefault();
-    onOptionSelect && onOptionSelect(option);
-  }
+  const handleOptionClick = useCallback((clickedOption: Option) => {
+    setOptions(current =>
+      current.map(option => {
+        if (option.label == clickedOption.label) {
+          return { ...option, checked: !clickedOption.checked };
+        }
+        return option;
+      }),
+    );
+  }, []);
 
   function handleOptionHover(event: MouseEvent<HTMLLIElement>, index: number) {
     event.preventDefault();
@@ -78,7 +86,7 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
       case "Enter":
       case " ": {
         if (highlightedIndex >= 0) {
-          onOptionSelect && onOptionSelect(options[highlightedIndex]);
+          handleOptionClick(options[highlightedIndex]);
         }
         break;
       }
@@ -126,7 +134,11 @@ export function DropDownMenu({ options, onOptionSelect }: DropDownMenuProps) {
           <li
             key={`${index}-${option.label}`}
             className={optionClass}
-            onClick={e => handleOptionClick(e, option)}
+            onClick={event => {
+              event.stopPropagation();
+              event.preventDefault();
+              handleOptionClick(option);
+            }}
             onMouseOver={e => handleOptionHover(e, index)}
           >
             <Checkbox

--- a/packages/components/src/MultiSelect/MultiSelect.css
+++ b/packages/components/src/MultiSelect/MultiSelect.css
@@ -1,0 +1,13 @@
+.multiSelectContainer {
+  position: relative;
+  width: 100%;
+}
+
+.multiSelectContainer:hover,
+.multiSelectContainer input {
+  cursor: pointer;
+}
+
+.multiSelectContainer.active {
+  box-shadow: var(--shadow-focus);
+}

--- a/packages/components/src/MultiSelect/MultiSelect.css
+++ b/packages/components/src/MultiSelect/MultiSelect.css
@@ -31,6 +31,8 @@
   caret-color: transparent;
 }
 
+.multiSelect:focus,
 .multiSelect.active {
   box-shadow: var(--shadow-focus);
+  outline-color: transparent;
 }

--- a/packages/components/src/MultiSelect/MultiSelect.css
+++ b/packages/components/src/MultiSelect/MultiSelect.css
@@ -34,5 +34,5 @@
 .multiSelect:focus,
 .multiSelect.active {
   box-shadow: var(--shadow-focus);
-  outline-color: transparent;
+  outline: none;
 }

--- a/packages/components/src/MultiSelect/MultiSelect.css
+++ b/packages/components/src/MultiSelect/MultiSelect.css
@@ -5,18 +5,15 @@
 
 .multiSelect {
   display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
   padding-top: calc(var(--space-base) - var(--space-smallest));
   padding-bottom: calc(var(--space-base) - var(--space-smallest));
   padding-left: var(--space-base);
   padding-right: var(--space-base);
   border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
 }
 
 .multiSelect p {

--- a/packages/components/src/MultiSelect/MultiSelect.css
+++ b/packages/components/src/MultiSelect/MultiSelect.css
@@ -3,11 +3,34 @@
   width: 100%;
 }
 
-.multiSelectContainer:hover,
-.multiSelectContainer input {
-  cursor: pointer;
+.multiSelect {
+  display: flex;
+  padding-top: calc(var(--space-base) - var(--space-smallest));
+  padding-bottom: calc(var(--space-base) - var(--space-smallest));
+  padding-left: var(--space-base);
+  padding-right: var(--space-base);
+  border: var(--border-base) solid var(--color-border);
+  border-radius: var(--radius-base);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 }
 
-.multiSelectContainer.active {
+.multiSelect p {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.multiSelectContainer:hover,
+.multiSelectContainer.multiSelect {
+  cursor: pointer;
+  caret-color: transparent;
+}
+
+.multiSelect.active {
   box-shadow: var(--shadow-focus);
 }

--- a/packages/components/src/MultiSelect/MultiSelect.css.d.ts
+++ b/packages/components/src/MultiSelect/MultiSelect.css.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "multiSelectContainer": string;
+  readonly "multiSelect": string;
   readonly "active": string;
 };
 export = styles;

--- a/packages/components/src/MultiSelect/MultiSelect.css.d.ts
+++ b/packages/components/src/MultiSelect/MultiSelect.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "multiSelectContainer": string;
+  readonly "active": string;
+};
+export = styles;
+

--- a/packages/components/src/MultiSelect/MultiSelect.mdx
+++ b/packages/components/src/MultiSelect/MultiSelect.mdx
@@ -91,10 +91,17 @@ the onChange prop
 
 ## Accessibility
 
-- Users should be able to use their keyboard to navigate through the options and
-  check/uncheck them
-- The trigger contains a downward-pointing-arrow to hint that it can be
-  expanded.
+- The MultiSelect trigger element contains a downward-pointing-arrow to hint
+  that it can be expanded;
+- Users are able to focus the MultiSelect trigger element by using the Tab key;
+- Users should be able to display the options by using the Space or Enter/Return
+  keys;
+- Users should be able to navigate through the options by using Tab or
+  ArrowDown/ArrowUp keys and check/uncheck them by using Space or Enter/Return
+  keys;
+- Users can press the Escape key, click out of the component or click the
+  trigger again to close the menu;
+- Features and behavior are announced to the user when using a screen reader;
 
 ## Responsiveness
 

--- a/packages/components/src/MultiSelect/MultiSelect.mdx
+++ b/packages/components/src/MultiSelect/MultiSelect.mdx
@@ -22,26 +22,16 @@ import { MultiSelect } from "@jobber/components/MultiSelect";
   {() => {
     const [options, setOptions] = useState([
       { label: "Synced", checked: true },
-      { label: "Errors" },
+      { label: "Errors", checked: false },
       { label: "Warnings", checked: true },
       { label: "Ignored", checked: true },
     ]);
-    const handleChange = clickedOption => {
-      setOptions(current =>
-        current.map(option => {
-          if (option.label == clickedOption.label) {
-            return { ...option, checked: !clickedOption.checked };
-          }
-          return option;
-        })
-      );
-    };
     return (
       <MultiSelect
         defaultLabel="Status"
         allSelectedLabel="All Statuses"
         options={options}
-        onChange={handleChange}
+        onOptionsChange={setOptions}
       />
     );
   }}

--- a/packages/components/src/MultiSelect/MultiSelect.mdx
+++ b/packages/components/src/MultiSelect/MultiSelect.mdx
@@ -1,0 +1,127 @@
+---
+name: MultiSelect
+menu: Components
+route: /components/multi-select
+showDirectoryLink: true
+---
+
+import { Playground, Props } from "docz";
+import { MultiSelect } from ".";
+import { useState } from "react";
+
+# Multi Select
+
+The `MultiSelect` component gives our users the possibility to select multiple
+options from a menu.
+
+```ts
+import { MultiSelect } from "@jobber/components/MultiSelect";
+```
+
+<Playground>
+  {() => {
+    const [options, setOptions] = useState([
+      { label: "Synced", checked: true },
+      { label: "Errors" },
+      { label: "Warnings", checked: true },
+      { label: "Ignored", checked: true },
+    ]);
+    const handleChange = clickedOption => {
+      setOptions(current =>
+        current.map(option => {
+          if (option.label == clickedOption.label) {
+            return { ...option, checked: !clickedOption.checked };
+          }
+          return option;
+        })
+      );
+    };
+    return (
+      <MultiSelect
+        defaultLabel="Status"
+        allSelectedLabel="All Statuses"
+        options={options}
+        onChange={handleChange}
+      />
+    );
+  }}
+</Playground>
+
+<!--
+  INTERFACE: This is for the proposal stage of the component
+
+  Provide an example of what the component looks like in code. How would you use
+  it from another React component? This should consist primarily of code blocks.
+  This section can be deleted once the component is built, when the Playground
+  will demonstrate this at a higher fidelity.
+-->
+
+## Props
+
+<Props of={MultiSelect} />
+
+<!--
+  It is not necessary to provide an example of each prop. Use usage examples to
+  highlight key features of a component or particular considerations.
+
+  See `Button.mdx` for a good example of this.
+-->
+
+## Usage Guidelines
+
+The goal of the `MultiSelect` component is to allow a user to check multiple
+options within a list of items.
+
+A user can click on the element to expand it and display the multiple options.
+The element will display the selected options or the placeholder text if none
+are selected.
+
+Every time an option is checked or unchecked a behavior can be triggered using
+the onChange prop
+
+<!--
+  What is the design purpose of this component? How do its responsibilities
+  relate to other components? What should this component not be used for? What
+  are some related components in Atlantis? Try to describe this component not
+  in terms of what it looks like or what elements make it up, but what function
+  it performs or how it enables a user to perform tasks (e.g. “Buttons allow users
+  to initiate, complete, and reverse actions.” vs “Buttons are rectangular elements
+  that have a green background and white text”).
+-->
+
+## Accessibility
+
+- Users should be able to use their keyboard to navigate through the options and
+  check/uncheck them
+- The trigger contains a downward-pointing-arrow to hint that it can be
+  expanded.
+
+## Responsiveness
+
+On mobile devices the interaction behaviour would be the same as a mouse with
+touch/click. The component should adapt to different screen sizes the same as an
+html select would.
+
+<!--
+  How should the component behave on an iPhone 8? An iPad? A 1920x1080 monitor? How does the
+  component appear when the component itself is less than 375px wide? Less than 640px wide?
+  Less than 1200px wide? Greater than 1200px? Does it change when the device DPI is higher
+  or lower?
+-->
+
+## Mockup
+
+<iframe
+  style="border: 1px solid rgba(0, 0, 0, 0.1);"
+  width="800"
+  height="450"
+  src="https://www.figma.com/file/Dat89UMBtcroHoy2TFpqxA/QBO-Integration?node-id=318%3A75252"
+  allowfullscreen
+></iframe>
+
+<!--
+  Insert a Figma mockup from the [Design System Contribution template](https://www.figma.com/file/3BXCXXD9glMtj8RAHjXiQC/Design-System-Contribution-TEMPLATE?node-id=26%3A2)
+  that conveys the visual design of the component, with variants and state accounted for.
+  Consider progressive enhancement; might this rely on newer browser features that aren’t
+  widely supported yet?
+-->

--- a/packages/components/src/MultiSelect/MultiSelect.mdx
+++ b/packages/components/src/MultiSelect/MultiSelect.mdx
@@ -37,25 +37,9 @@ import { MultiSelect } from "@jobber/components/MultiSelect";
   }}
 </Playground>
 
-<!--
-  INTERFACE: This is for the proposal stage of the component
-
-  Provide an example of what the component looks like in code. How would you use
-  it from another React component? This should consist primarily of code blocks.
-  This section can be deleted once the component is built, when the Playground
-  will demonstrate this at a higher fidelity.
--->
-
 ## Props
 
 <Props of={MultiSelect} />
-
-<!--
-  It is not necessary to provide an example of each prop. Use usage examples to
-  highlight key features of a component or particular considerations.
-
-  See `Button.mdx` for a good example of this.
--->
 
 ## Usage Guidelines
 
@@ -68,16 +52,6 @@ are selected.
 
 Every time an option is checked or unchecked a behavior can be triggered using
 the onChange prop
-
-<!--
-  What is the design purpose of this component? How do its responsibilities
-  relate to other components? What should this component not be used for? What
-  are some related components in Atlantis? Try to describe this component not
-  in terms of what it looks like or what elements make it up, but what function
-  it performs or how it enables a user to perform tasks (e.g. “Buttons allow users
-  to initiate, complete, and reverse actions.” vs “Buttons are rectangular elements
-  that have a green background and white text”).
--->
 
 ## Accessibility
 
@@ -98,27 +72,3 @@ the onChange prop
 On mobile devices the interaction behaviour would be the same as a mouse with
 touch/click. The component should adapt to different screen sizes the same as an
 html select would.
-
-<!--
-  How should the component behave on an iPhone 8? An iPad? A 1920x1080 monitor? How does the
-  component appear when the component itself is less than 375px wide? Less than 640px wide?
-  Less than 1200px wide? Greater than 1200px? Does it change when the device DPI is higher
-  or lower?
--->
-
-## Mockup
-
-<iframe
-  style="border: 1px solid rgba(0, 0, 0, 0.1);"
-  width="800"
-  height="450"
-  src="https://www.figma.com/file/Dat89UMBtcroHoy2TFpqxA/QBO-Integration?node-id=318%3A75252"
-  allowfullscreen
-></iframe>
-
-<!--
-  Insert a Figma mockup from the [Design System Contribution template](https://www.figma.com/file/3BXCXXD9glMtj8RAHjXiQC/Design-System-Contribution-TEMPLATE?node-id=26%3A2)
-  that conveys the visual design of the component, with variants and state accounted for.
-  Consider progressive enhancement; might this rely on newer browser features that aren’t
-  widely supported yet?
--->

--- a/packages/components/src/MultiSelect/MultiSelect.test.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.test.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MultiSelect } from ".";
+
+afterEach(cleanup);
+
+const options = [
+  { label: "Synced", checked: true },
+  { label: "Errors" },
+  { label: "Warnings", checked: true },
+  { label: "Ignored", checked: true },
+];
+const changeHandler = jest.fn();
+const component = (
+  <MultiSelect
+    defaultLabel="Status"
+    allSelectedLabel="All Statuses"
+    options={options}
+    onChange={changeHandler}
+  />
+);
+
+describe("when rendering MultiSelect component", () => {
+  describe("when not all options are checked", () => {
+    beforeEach(() => {
+      render(component);
+    });
+
+    it("input should have checked options as the value", () => {
+      const multiSelectInput = screen.getByRole("textbox");
+
+      expect(multiSelectInput).toHaveValue("Synced, Warnings, Ignored");
+    });
+  });
+
+  describe("when all options are unchecked ", () => {
+    const allOptionsUnchecked = [
+      { label: "Synced", checked: false },
+      { label: "Errors", checked: false },
+      { label: "Warnings", checked: false },
+      { label: "Ignored", checked: false },
+    ];
+
+    beforeEach(() => {
+      render(
+        <MultiSelect
+          defaultLabel="Status"
+          allSelectedLabel="All Statuses"
+          options={allOptionsUnchecked}
+          onChange={changeHandler}
+        />,
+      );
+    });
+
+    it("input should have the provided defaultLabel as value", () => {
+      const multiSelectInput = screen.getByRole("textbox");
+
+      expect(multiSelectInput).toHaveValue("Status");
+    });
+  });
+
+  describe("when all options are checked ", () => {
+    const allOptionsChecked = [
+      { label: "Synced", checked: true },
+      { label: "Errors", checked: true },
+      { label: "Warnings", checked: true },
+      { label: "Ignored", checked: true },
+    ];
+
+    beforeEach(() => {
+      render(
+        <MultiSelect
+          defaultLabel="Status"
+          allSelectedLabel="All Statuses"
+          options={allOptionsChecked}
+          onChange={changeHandler}
+        />,
+      );
+    });
+
+    it("input should have the provided allSelectedLabel as value", () => {
+      const multiSelectInput = screen.getByRole("textbox");
+
+      expect(multiSelectInput).toHaveValue("All Statuses");
+    });
+  });
+});
+
+describe("when displaying the options", () => {
+  beforeEach(() => {
+    render(component);
+  });
+
+  it("should not display the menu", () => {
+    expect(screen.queryByTestId("dropdown-menu")).toBeNull();
+  });
+
+  describe("when clicking MultiSelect", () => {
+    it("should display the dropdown menu with the options", () => {
+      userEvent.click(screen.getByRole("textbox"));
+      const dropDownMenu = screen.getByTestId("dropdown-menu");
+
+      expect(dropDownMenu).not.toBeNull();
+      expect(within(dropDownMenu).getByText(/Synced/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Errors/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Warnings/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Ignored/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when pressing 'Escape' key", () => {
+    it("should hide the dropdown menu", () => {
+      userEvent.click(screen.getByRole("textbox"));
+
+      expect(screen.queryByTestId("dropdown-menu")).not.toBeNull();
+
+      fireEvent(
+        screen.getByRole("textbox"),
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: true,
+          cancelable: false,
+        }),
+      );
+
+      expect(screen.queryByTestId("dropdown-menu")).toBeNull();
+    });
+  });
+});
+
+describe("when selecting an option", () => {
+  beforeEach(() => {
+    render(component);
+  });
+
+  describe("when using mouse click event", () => {
+    it("should call the provided callback", () => {
+      userEvent.click(screen.getByRole("textbox"));
+      userEvent.click(screen.getAllByRole("checkbox")[0]);
+
+      expect(changeHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when using keyboard navigation", () => {
+    it("should call the provided callback", () => {
+      userEvent.click(screen.getByRole("textbox"));
+
+      fireEvent(
+        screen.getByTestId("dropdown-menu"),
+        new KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          bubbles: true,
+          cancelable: false,
+        }),
+      );
+      fireEvent(
+        screen.getByTestId("dropdown-menu"),
+        new KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          bubbles: true,
+          cancelable: false,
+        }),
+      );
+      fireEvent(
+        screen.getByTestId("dropdown-menu"),
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: false,
+        }),
+      );
+
+      expect(changeHandler).toHaveBeenCalledWith(options[1]);
+    });
+  });
+});

--- a/packages/components/src/MultiSelect/MultiSelect.test.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.test.tsx
@@ -93,7 +93,7 @@ describe("when rendering MultiSelect component", () => {
   });
 });
 
-describe("when displaying the options", () => {
+describe("when focusing multislect to display the options", () => {
   beforeEach(() => {
     render(component);
   });
@@ -105,6 +105,50 @@ describe("when displaying the options", () => {
   describe("when clicking MultiSelect", () => {
     it("should display the dropdown menu with the options", () => {
       userEvent.click(screen.getByTestId("multi-select"));
+      const dropDownMenu = screen.getByTestId("dropdown-menu");
+
+      expect(dropDownMenu).not.toBeNull();
+      expect(within(dropDownMenu).getByText(/Synced/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Errors/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Warnings/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Ignored/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when pressing Spacebar key", () => {
+    it("should display the dropdown menu with the options", () => {
+      userEvent.tab();
+      fireEvent(
+        screen.getByTestId("multi-select"),
+        new KeyboardEvent("keydown", {
+          key: " ",
+          bubbles: true,
+          cancelable: false,
+        }),
+      );
+
+      const dropDownMenu = screen.getByTestId("dropdown-menu");
+
+      expect(dropDownMenu).not.toBeNull();
+      expect(within(dropDownMenu).getByText(/Synced/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Errors/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Warnings/i)).toBeInTheDocument();
+      expect(within(dropDownMenu).getByText(/Ignored/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when pressing Enter key", () => {
+    it("should display the dropdown menu with the options", () => {
+      userEvent.tab();
+      fireEvent(
+        screen.getByTestId("multi-select"),
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: false,
+        }),
+      );
+
       const dropDownMenu = screen.getByTestId("dropdown-menu");
 
       expect(dropDownMenu).not.toBeNull();
@@ -155,14 +199,14 @@ describe("when selecting an option", () => {
   describe("when using mouse click event", () => {
     it("should call the provided callback", () => {
       userEvent.click(screen.getByTestId("multi-select"));
-      userEvent.click(screen.getAllByRole("checkbox")[0]);
+      userEvent.click(screen.getAllByRole("checkbox")[2]);
 
-      expect(changeHandler).toHaveBeenCalledTimes(1);
+      expect(changeHandler).toHaveBeenCalledWith(options[2]);
     });
   });
 
   describe("when using keyboard navigation", () => {
-    it("should call the provided callback", () => {
+    it("should call the provided callback when using arrows and Enter keys", () => {
       userEvent.click(screen.getByTestId("multi-select"));
 
       fireEvent(
@@ -177,6 +221,22 @@ describe("when selecting an option", () => {
         screen.getByTestId("dropdown-menu"),
         new KeyboardEvent("keydown", {
           key: "Enter",
+          bubbles: true,
+          cancelable: false,
+        }),
+      );
+
+      expect(changeHandler).toHaveBeenCalledWith(options[1]);
+    });
+
+    it("should call the provided callback when using tab and spacebar keys", () => {
+      userEvent.click(screen.getByTestId("multi-select"));
+
+      userEvent.tab();
+      fireEvent(
+        screen.getByTestId("dropdown-menu"),
+        new KeyboardEvent("keydown", {
+          key: " ",
           bubbles: true,
           cancelable: false,
         }),

--- a/packages/components/src/MultiSelect/MultiSelect.test.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.test.tsx
@@ -34,9 +34,9 @@ describe("when rendering MultiSelect component", () => {
     });
 
     it("input should have checked options as the value", () => {
-      const multiSelectInput = screen.getByRole("textbox");
+      const multiSelectInput = screen.getByTestId("multi-select");
 
-      expect(multiSelectInput).toHaveValue("Synced, Warnings, Ignored");
+      expect(multiSelectInput).toHaveTextContent("Synced, Warnings, Ignored");
     });
   });
 
@@ -60,9 +60,9 @@ describe("when rendering MultiSelect component", () => {
     });
 
     it("input should have the provided defaultLabel as value", () => {
-      const multiSelectInput = screen.getByRole("textbox");
+      const multiSelectInput = screen.getByTestId("multi-select");
 
-      expect(multiSelectInput).toHaveValue("Status");
+      expect(multiSelectInput).toHaveTextContent("Status");
     });
   });
 
@@ -86,9 +86,9 @@ describe("when rendering MultiSelect component", () => {
     });
 
     it("input should have the provided allSelectedLabel as value", () => {
-      const multiSelectInput = screen.getByRole("textbox");
+      const multiSelectInput = screen.getByTestId("multi-select");
 
-      expect(multiSelectInput).toHaveValue("All Statuses");
+      expect(multiSelectInput).toHaveTextContent("All Statuses");
     });
   });
 });
@@ -104,7 +104,7 @@ describe("when displaying the options", () => {
 
   describe("when clicking MultiSelect", () => {
     it("should display the dropdown menu with the options", () => {
-      userEvent.click(screen.getByRole("textbox"));
+      userEvent.click(screen.getByTestId("multi-select"));
       const dropDownMenu = screen.getByTestId("dropdown-menu");
 
       expect(dropDownMenu).not.toBeNull();
@@ -117,18 +117,30 @@ describe("when displaying the options", () => {
 
   describe("when pressing 'Escape' key", () => {
     it("should hide the dropdown menu", () => {
-      userEvent.click(screen.getByRole("textbox"));
+      userEvent.click(screen.getByTestId("multi-select"));
 
       expect(screen.queryByTestId("dropdown-menu")).not.toBeNull();
 
       fireEvent(
-        screen.getByRole("textbox"),
+        screen.getByTestId("multi-select"),
         new KeyboardEvent("keydown", {
           key: "Escape",
           bubbles: true,
           cancelable: false,
         }),
       );
+
+      expect(screen.queryByTestId("dropdown-menu")).toBeNull();
+    });
+  });
+
+  describe("when clicking out of the component", () => {
+    it("should hide the dropdown menu", () => {
+      userEvent.click(screen.getByTestId("multi-select"));
+
+      expect(screen.queryByTestId("dropdown-menu")).not.toBeNull();
+
+      userEvent.click(document.body);
 
       expect(screen.queryByTestId("dropdown-menu")).toBeNull();
     });
@@ -142,7 +154,7 @@ describe("when selecting an option", () => {
 
   describe("when using mouse click event", () => {
     it("should call the provided callback", () => {
-      userEvent.click(screen.getByRole("textbox"));
+      userEvent.click(screen.getByTestId("multi-select"));
       userEvent.click(screen.getAllByRole("checkbox")[0]);
 
       expect(changeHandler).toHaveBeenCalledTimes(1);
@@ -151,16 +163,8 @@ describe("when selecting an option", () => {
 
   describe("when using keyboard navigation", () => {
     it("should call the provided callback", () => {
-      userEvent.click(screen.getByRole("textbox"));
+      userEvent.click(screen.getByTestId("multi-select"));
 
-      fireEvent(
-        screen.getByTestId("dropdown-menu"),
-        new KeyboardEvent("keydown", {
-          key: "ArrowDown",
-          bubbles: true,
-          cancelable: false,
-        }),
-      );
       fireEvent(
         screen.getByTestId("dropdown-menu"),
         new KeyboardEvent("keydown", {

--- a/packages/components/src/MultiSelect/MultiSelect.test.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   cleanup,
   fireEvent,
@@ -11,26 +11,28 @@ import { MultiSelect } from ".";
 
 afterEach(cleanup);
 
-const options = [
-  { label: "Synced", checked: true },
-  { label: "Errors" },
-  { label: "Warnings", checked: true },
-  { label: "Ignored", checked: true },
-];
-const changeHandler = jest.fn();
-const component = (
-  <MultiSelect
-    defaultLabel="Status"
-    allSelectedLabel="All Statuses"
-    options={options}
-    onChange={changeHandler}
-  />
-);
+const Component = () => {
+  const [options, setOptions] = useState([
+    { label: "Synced", checked: true },
+    { label: "Errors", checked: false },
+    { label: "Warnings", checked: true },
+    { label: "Ignored", checked: true },
+  ]);
+
+  return (
+    <MultiSelect
+      defaultLabel="Status"
+      allSelectedLabel="All Statuses"
+      options={options}
+      onOptionsChange={setOptions}
+    />
+  );
+};
 
 describe("when rendering MultiSelect component", () => {
   describe("when not all options are checked", () => {
     beforeEach(() => {
-      render(component);
+      render(<Component />);
     });
 
     it("input should have checked options as the value", () => {
@@ -41,22 +43,26 @@ describe("when rendering MultiSelect component", () => {
   });
 
   describe("when all options are unchecked ", () => {
-    const allOptionsUnchecked = [
-      { label: "Synced", checked: false },
-      { label: "Errors", checked: false },
-      { label: "Warnings", checked: false },
-      { label: "Ignored", checked: false },
-    ];
+    const AllOptionsUnchecked = () => {
+      const [options, setOptions] = useState([
+        { label: "Synced", checked: false },
+        { label: "Errors", checked: false },
+        { label: "Warnings", checked: false },
+        { label: "Ignored", checked: false },
+      ]);
 
-    beforeEach(() => {
-      render(
+      return (
         <MultiSelect
           defaultLabel="Status"
           allSelectedLabel="All Statuses"
-          options={allOptionsUnchecked}
-          onChange={changeHandler}
-        />,
+          options={options}
+          onOptionsChange={setOptions}
+        />
       );
+    };
+
+    beforeEach(() => {
+      render(<AllOptionsUnchecked />);
     });
 
     it("input should have the provided defaultLabel as value", () => {
@@ -67,22 +73,26 @@ describe("when rendering MultiSelect component", () => {
   });
 
   describe("when all options are checked ", () => {
-    const allOptionsChecked = [
-      { label: "Synced", checked: true },
-      { label: "Errors", checked: true },
-      { label: "Warnings", checked: true },
-      { label: "Ignored", checked: true },
-    ];
+    const AllOptionsChecked = () => {
+      const [options, setOptions] = useState([
+        { label: "Synced", checked: true },
+        { label: "Errors", checked: true },
+        { label: "Warnings", checked: true },
+        { label: "Ignored", checked: true },
+      ]);
 
-    beforeEach(() => {
-      render(
+      return (
         <MultiSelect
           defaultLabel="Status"
           allSelectedLabel="All Statuses"
-          options={allOptionsChecked}
-          onChange={changeHandler}
-        />,
+          options={options}
+          onOptionsChange={setOptions}
+        />
       );
+    };
+
+    beforeEach(() => {
+      render(<AllOptionsChecked />);
     });
 
     it("input should have the provided allSelectedLabel as value", () => {
@@ -95,7 +105,7 @@ describe("when rendering MultiSelect component", () => {
 
 describe("when focusing multislect to display the options", () => {
   beforeEach(() => {
-    render(component);
+    render(<Component />);
   });
 
   it("should not display the menu", () => {
@@ -193,7 +203,7 @@ describe("when focusing multislect to display the options", () => {
 
 describe("when selecting an option", () => {
   beforeEach(() => {
-    render(component);
+    render(<Component />);
   });
 
   describe("when using mouse click event", () => {
@@ -201,7 +211,7 @@ describe("when selecting an option", () => {
       userEvent.click(screen.getByTestId("multi-select"));
       userEvent.click(screen.getAllByRole("checkbox")[2]);
 
-      expect(changeHandler).toHaveBeenCalledWith(options[2]);
+      expect(screen.getByLabelText("Warnings")).not.toBeChecked();
     });
   });
 
@@ -226,7 +236,7 @@ describe("when selecting an option", () => {
         }),
       );
 
-      expect(changeHandler).toHaveBeenCalledWith(options[1]);
+      expect(screen.getByLabelText("Errors")).toBeChecked();
     });
 
     it("should call the provided callback when using tab and spacebar keys", () => {
@@ -242,7 +252,7 @@ describe("when selecting an option", () => {
         }),
       );
 
-      expect(changeHandler).toHaveBeenCalledWith(options[1]);
+      expect(screen.getByLabelText("Errors")).toBeChecked();
     });
   });
 });

--- a/packages/components/src/MultiSelect/MultiSelect.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import classNames from "classnames";
+import { useOnKeyDown } from "@jobber/hooks";
+import styles from "./MultiSelect.css";
+import { DropDownMenu } from "./DropDownMenu";
+import { Option, Options } from "./types";
+import { handleKeyboardShortcut } from "./utils";
+import { InputText } from "../InputText";
+
+interface MultiSelectProps {
+  /**
+   * The label to be displayed by default when no options are selected
+   */
+  readonly defaultLabel: string;
+
+  /**
+   * The label to be displayed when all options are selected
+   */
+  readonly allSelectedLabel: string;
+
+  /**
+   * List of options to be checked
+   */
+  readonly options: Options;
+
+  /**
+   * Change handler
+   */
+  onChange?(option: Option): void;
+}
+
+export function MultiSelect({
+  defaultLabel,
+  allSelectedLabel,
+  options,
+  onChange,
+}: MultiSelectProps) {
+  const [label, setLabel] = React.useState(defaultLabel);
+  const [menuVisible, setMenuVisible] = React.useState(false);
+  const multiSelectContainerClass = classNames(styles.multiSelectContainer, {
+    [styles.active]: menuVisible,
+  });
+
+  function handleMenuVisibility() {
+    setMenuVisible(!menuVisible);
+  }
+
+  function setupKeyListeners(key: string) {
+    switch (key) {
+      case "Escape": {
+        setMenuVisible(false);
+        break;
+      }
+    }
+  }
+
+  useOnKeyDown(handleKeyboardShortcut(setupKeyListeners).callback, ["Escape"]);
+
+  React.useEffect(() => {
+    const selected = options.filter(option => option.checked);
+
+    if (selected.length === 0) {
+      setLabel(defaultLabel);
+    } else if (selected.length == options.length) {
+      setLabel(allSelectedLabel);
+    } else {
+      const selectedLabels: string[] = [];
+      selected.forEach(option => selectedLabels.push(option.label));
+      setLabel(selectedLabels.join(", "));
+    }
+  }, [options]);
+
+  return (
+    <div className={multiSelectContainerClass}>
+      <div onClick={handleMenuVisibility}>
+        <InputText
+          value={label}
+          suffix={{ icon: menuVisible ? "arrowUp" : "arrowDown" }}
+        />
+      </div>
+      {menuVisible && (
+        <DropDownMenu options={options} onOptionSelect={onChange} />
+      )}
+    </div>
+  );
+}

--- a/packages/components/src/MultiSelect/MultiSelect.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.tsx
@@ -31,9 +31,14 @@ interface MultiSelectProps {
   readonly options: Options;
 
   /**
+   * Text to be announced by screen readers
+   */
+  readonly ariaLabel?: string;
+
+  /**
    * Change handler
    */
-  onChange?(option: Option): void;
+  onChange(option: Option): void;
 }
 
 // eslint-disable-next-line max-statements
@@ -41,6 +46,7 @@ export function MultiSelect({
   defaultLabel,
   allSelectedLabel,
   options,
+  ariaLabel,
   onChange,
 }: MultiSelectProps) {
   const [label, setLabel] = useState(defaultLabel);
@@ -116,6 +122,7 @@ export function MultiSelect({
         tabIndex={0}
         ref={multiSelectRef}
         role="button"
+        aria-label={ariaLabel}
         aria-multiselectable
         aria-haspopup
       >

--- a/packages/components/src/MultiSelect/MultiSelect.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.tsx
@@ -116,6 +116,8 @@ export function MultiSelect({
         tabIndex={0}
         ref={multiSelectRef}
         role="button"
+        aria-multiselectable
+        aria-haspopup
       >
         <Text>{label}</Text>
         <Icon name="arrowDown" />

--- a/packages/components/src/MultiSelect/MultiSelect.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.tsx
@@ -31,11 +31,6 @@ interface MultiSelectProps {
   readonly options: Options;
 
   /**
-   * Text to be announced by screen readers
-   */
-  readonly ariaLabel?: string;
-
-  /**
    * Change handler
    */
   onOptionsChange: Dispatch<React.SetStateAction<Options>>;
@@ -46,7 +41,6 @@ export function MultiSelect({
   defaultLabel,
   allSelectedLabel,
   options,
-  ariaLabel,
   onOptionsChange,
 }: MultiSelectProps) {
   const [label, setLabel] = useState(defaultLabel);
@@ -122,7 +116,7 @@ export function MultiSelect({
         tabIndex={0}
         ref={multiSelectRef}
         role="button"
-        aria-label={ariaLabel}
+        aria-label={`${defaultLabel}: ${label}`}
         aria-multiselectable
         aria-haspopup
       >

--- a/packages/components/src/MultiSelect/MultiSelect.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.tsx
@@ -1,5 +1,5 @@
 import React, {
-  MouseEvent,
+  Dispatch,
   MutableRefObject,
   useEffect,
   useRef,
@@ -9,7 +9,7 @@ import classNames from "classnames";
 import { useOnKeyDown } from "@jobber/hooks";
 import styles from "./MultiSelect.css";
 import { DropDownMenu } from "./DropDownMenu";
-import { Option, Options } from "./types";
+import { Options } from "./types";
 import { handleKeyboardShortcut } from "./utils";
 import { Text } from "../Text";
 import { Icon } from "../Icon";
@@ -38,7 +38,7 @@ interface MultiSelectProps {
   /**
    * Change handler
    */
-  onChange(option: Option): void;
+  onOptionsChange: Dispatch<React.SetStateAction<Options>>;
 }
 
 // eslint-disable-next-line max-statements
@@ -47,7 +47,7 @@ export function MultiSelect({
   allSelectedLabel,
   options,
   ariaLabel,
-  onChange,
+  onOptionsChange,
 }: MultiSelectProps) {
   const [label, setLabel] = useState(defaultLabel);
   const [menuVisible, setMenuVisible] = useState(false);
@@ -130,7 +130,7 @@ export function MultiSelect({
         <Icon name="arrowDown" />
       </div>
       {menuVisible && (
-        <DropDownMenu options={options} onOptionSelect={onChange} />
+        <DropDownMenu options={options} setOptions={onOptionsChange} />
       )}
     </div>
   );

--- a/packages/components/src/MultiSelect/MultiSelect.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.tsx
@@ -36,6 +36,7 @@ interface MultiSelectProps {
   onChange?(option: Option): void;
 }
 
+// eslint-disable-next-line max-statements
 export function MultiSelect({
   defaultLabel,
   allSelectedLabel,
@@ -45,33 +46,34 @@ export function MultiSelect({
   const [label, setLabel] = useState(defaultLabel);
   const [menuVisible, setMenuVisible] = useState(false);
   const [focused, setFocused] = useState(false);
+  const multiSelectContainer = useRef() as MutableRefObject<HTMLDivElement>;
   const multiSelectRef = useRef() as MutableRefObject<HTMLDivElement>;
   const multiSelectClass = classNames(styles.multiSelect, {
     [styles.active]: menuVisible,
   });
 
   function handleMenuVisibility() {
-    setFocused(true);
+    multiSelectRef.current.focus();
     setMenuVisible(!menuVisible);
   }
 
   const handleClickOutside = (e: globalThis.MouseEvent) => {
-    if (!multiSelectRef?.current?.contains(e.target as Node)) {
-      setFocused(false);
+    if (!multiSelectContainer?.current?.contains(e.target as Node)) {
       setMenuVisible(false);
     }
   };
 
   function setupKeyListeners(key: string) {
     switch (key) {
-      case "Enter": {
-        if (!menuVisible && focused) {
-          setMenuVisible(true);
+      case "Enter":
+      case " ": {
+        if (focused) {
+          setMenuVisible(!menuVisible);
         }
         break;
       }
       case "Escape": {
-        setFocused(false);
+        multiSelectRef.current.focus();
         setMenuVisible(false);
         break;
       }
@@ -80,6 +82,7 @@ export function MultiSelect({
 
   useOnKeyDown(handleKeyboardShortcut(setupKeyListeners).callback, [
     "Enter",
+    " ",
     "Escape",
   ]);
 
@@ -103,13 +106,16 @@ export function MultiSelect({
   }, [options]);
 
   return (
-    <div ref={multiSelectRef} className={styles.multiSelectContainer}>
+    <div ref={multiSelectContainer} className={styles.multiSelectContainer}>
       <div
         data-testid="multi-select"
         className={multiSelectClass}
         onClick={handleMenuVisibility}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
+        tabIndex={0}
+        ref={multiSelectRef}
+        role="button"
       >
         <Text>{label}</Text>
         <Icon name="arrowDown" />

--- a/packages/components/src/MultiSelect/index.ts
+++ b/packages/components/src/MultiSelect/index.ts
@@ -1,0 +1,1 @@
+export { MultiSelect } from "./MultiSelect";

--- a/packages/components/src/MultiSelect/types.ts
+++ b/packages/components/src/MultiSelect/types.ts
@@ -1,0 +1,15 @@
+export interface Option {
+  /**
+   * Text to be displayed for the option
+   *
+   */
+  label: string;
+
+  /**
+   * When set to true the option is checked by default
+   *
+   */
+  checked?: boolean;
+}
+
+export type Options = Array<Option>;

--- a/packages/components/src/MultiSelect/types.ts
+++ b/packages/components/src/MultiSelect/types.ts
@@ -9,7 +9,7 @@ export interface Option {
    * When set to true the option is checked by default
    *
    */
-  checked?: boolean;
+  checked: boolean;
 }
 
 export type Options = Array<Option>;

--- a/packages/components/src/MultiSelect/utils.ts
+++ b/packages/components/src/MultiSelect/utils.ts
@@ -3,7 +3,6 @@ export function handleKeyboardShortcut(
 ) {
   function callback(event: KeyboardEvent) {
     const { metaKey, ctrlKey, key, target } = event;
-    if (!open) return;
 
     const shouldTriggerShortcut =
       target instanceof HTMLButtonElement ? metaKey || ctrlKey : true;

--- a/packages/components/src/MultiSelect/utils.ts
+++ b/packages/components/src/MultiSelect/utils.ts
@@ -1,0 +1,19 @@
+export function handleKeyboardShortcut(
+  setupKeyListeners: (key: string) => void,
+) {
+  function callback(event: KeyboardEvent) {
+    const { metaKey, ctrlKey, key, target } = event;
+    if (!open) return;
+
+    const shouldTriggerShortcut =
+      target instanceof HTMLButtonElement ? metaKey || ctrlKey : true;
+
+    if (!shouldTriggerShortcut) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    setupKeyListeners(key);
+  }
+
+  return { callback };
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Add new MultiSelect component to have the ability to select multiple options in a list

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

MultiSelect Component with the following features:
- Options displayed as a list of checkboxes;
- Custom default Label, Custom All options selected Label;
- The MultiSelect trigger element contains a downward-pointing-arrow to hint that it can be expanded;
- Users are able to focus the MultiSelect trigger element by using the Tab key;
- Users should be able to display the options by using the Space or Enter/Return keys;
- Users should be able to navigate through the options by using Tab or ArrowDown/ArrowUp keys and check/uncheck them by using Space or Enter/Return keys;
- Users can press the Escape key, click out of the component or click the trigger again to close the menu;
- Features and behavior are announced to the user when using a screen reader;

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
