### PR TITLE
fix(component) Adjust dropdown height in DataTable compoment

### DIFF
--- a/packages/components/src/DataTable/DataTable.tsx
+++ b/packages/components/src/DataTable/DataTable.tsx
@@ -7,7 +7,7 @@ import { createTableSettings } from "./createTableSettings";
 import styles from "./DataTable.css";
 import { Pagination } from "./Pagination";
 import { Header } from "./Header";
-import { PaginationType, Sorting } from "./types";
+import { PaginationType, SortingType } from "./types";
 import { Footer } from "./Footer";
 
 export interface DataTableProps<T> {
@@ -37,7 +37,7 @@ export interface DataTableProps<T> {
    * https://tanstack.com/table/v8/docs/api/features/sorting#table-options
    *
    */
-  sorting?: Sorting;
+  sorting?: SortingType;
 
   /**
    * This will force the table to have the specified hight

--- a/packages/components/src/DataTable/Header.tsx
+++ b/packages/components/src/DataTable/Header.tsx
@@ -2,13 +2,13 @@ import { Row, Table, flexRender } from "@tanstack/react-table";
 import classNames from "classnames";
 import React from "react";
 import styles from "./DataTable.css";
-import { Sorting } from "./types";
+import { SortingType } from "./types";
 import { Icon } from "../Icon";
 
 interface HeaderProps<T> {
   table: Table<T>;
   stickyHeader?: boolean;
-  sorting?: Sorting;
+  sorting?: SortingType;
   onRowClick?: (row: Row<T>) => void;
 }
 
@@ -45,17 +45,12 @@ export function Header<T extends object>({
                       header.column.columnDef.header,
                       header.getContext(),
                     )}
-                    {{
-                      asc: <Icon name="longArrowUp" color="green" />,
-                      desc: <Icon name="longArrowDown" color="green" />,
-                    }[header.column.getIsSorted() as string] ?? (
-                      <svg
-                        style={{
-                          width: "var(--space-large)",
-                          height: "var(--space-large)",
-                        }}
-                      />
-                    )}
+                    {
+                      {
+                        asc: <Icon name="longArrowUp" color="green" />,
+                        desc: <Icon name="longArrowDown" color="green" />,
+                      }[header.column.getIsSorted() as string]
+                    }
                   </div>
                 )}
               </th>

--- a/packages/components/src/DataTable/Pagination.tsx
+++ b/packages/components/src/DataTable/Pagination.tsx
@@ -39,6 +39,7 @@ export function Pagination<T extends object>({
             onChange={value => {
               table.setPageSize(Number(value));
             }}
+            size="small"
           >
             {itemsPerPageOptions.map(numOfPages => (
               <Option key={numOfPages} value={numOfPages}>

--- a/packages/components/src/DataTable/createTableSettings.ts
+++ b/packages/components/src/DataTable/createTableSettings.ts
@@ -6,12 +6,12 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
 } from "@tanstack/react-table";
-import { Pagination, Sorting } from "./types";
+import { PaginationType, SortingType } from "./types";
 
 export function createTableSettings<T>(
   data: T[],
   columns: ColumnDef<T>[],
-  options?: { pagination?: Pagination; sorting?: Sorting },
+  options?: { pagination?: PaginationType; sorting?: SortingType },
 ) {
   const { state: paginationState, ...restPaginationSettings } =
     getPaginationSettings(options?.pagination);
@@ -54,7 +54,7 @@ type PaginationSettings<T> = Pick<
 >;
 
 function getPaginationSettings<T>(
-  pagination?: Pagination,
+  pagination?: PaginationType,
 ): PaginationSettings<T> {
   const paginationSettings: PaginationSettings<T> = {};
 
@@ -90,7 +90,7 @@ type SortingSettings<T> = Pick<
   | "enableSortingRemoval"
 >;
 
-function getSortingSettings<T>(sorting?: Sorting): SortingSettings<T> {
+function getSortingSettings<T>(sorting?: SortingType): SortingSettings<T> {
   const sortingSettings: SortingSettings<T> = {};
 
   if (!sorting) return sortingSettings;

--- a/packages/components/src/DataTable/types.ts
+++ b/packages/components/src/DataTable/types.ts
@@ -92,4 +92,4 @@ export interface DefaultSorting {
   manualSorting: false;
 }
 
-export type Sorting = DefaultSorting | ManualSorting;
+export type SortingType = DefaultSorting | ManualSorting;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

The height of the dropdown box was a little taller than we planned for:

![image](https://user-images.githubusercontent.com/27180625/202513564-34557602-f510-4d48-93d6-2cc5ba765896.png)


## Changes

- Adjust items per page dropdown height in the footer;
- Remove svg placeholder from headers;


### Fixed


<img width="729" alt="image" src="https://user-images.githubusercontent.com/27180625/202513968-83da9af7-a258-4306-9b69-647cd265fd10.png">


[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
