### PR TITLE
fix(component) only add tooltip arrow background colour after rotation

### DIFF
--- a/packages/components/src/Tooltip/Tooltip.css
+++ b/packages/components/src/Tooltip/Tooltip.css
@@ -27,7 +27,7 @@
 .tooltip .arrow::after {
   width: var(--tooltip--arrow-size);
   height: var(--tooltip--arrow-size);
-  background-color: inherit;
+  background-color: transparent;
 }
 
 .tooltip .arrow::after {
@@ -35,6 +35,7 @@
   display: block;
   position: absolute;
   border: var(--border-base) solid var(--color-informative);
+  background-color: var(--color-informative--surface);
   transform: rotate(45deg);
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The tooltip arrow looked normal on white backgrounds. However, on non-white background it was possible to see white triangles on each side of it.

## Changes

* Initialized the tooltip arrow background colour as transparent
* Set arrow background colour to `var(--color-informative--surface)` after the tooltip arrow is rotated

### Fixed
#### Before
<img width="423" alt="Screenshot 2022-12-12 at 5 38 16 PM" src="https://user-images.githubusercontent.com/3407664/207198556-d87f4e53-6117-40a3-acf9-d7ebf6bedb2e.png">

#### After
<img width="450" alt="Screenshot 2022-12-12 at 5 33 56 PM" src="https://user-images.githubusercontent.com/3407664/207198558-1869057f-2b21-4b67-af57-5f493159fb23.png">

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
