### PR TITLE
feat(components): Add configurable column width to DataTable

### DIFF
--- a/packages/components/src/DataTable/Body.tsx
+++ b/packages/components/src/DataTable/Body.tsx
@@ -29,7 +29,14 @@ export function Body<T extends object>({ table, onRowClick }: BodyProps<T>) {
           >
             {row.getVisibleCells().map(cell => {
               return (
-                <td key={cell.id}>
+                <td
+                  key={cell.id}
+                  style={{
+                    width: cell.column.getSize(),
+                    minWidth: cell.column.columnDef.minSize,
+                    maxWidth: cell.column.columnDef.maxSize,
+                  }}
+                >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
               );

--- a/packages/components/src/DataTable/DataTable.mdx
+++ b/packages/components/src/DataTable/DataTable.mdx
@@ -662,6 +662,7 @@ import { DataTable } from "@jobber/components/DataTable";
         accessorKey: "name",
         header: "Name",
         footer: "Totals",
+        enableResizing: false,
       },
       {
         id: "points",
@@ -702,6 +703,99 @@ import { DataTable } from "@jobber/components/DataTable";
           </Typography>
         ),
         cell: info => <Typography align="end">{info.getValue()}</Typography>,
+      },
+    ]}
+  />
+</Playground>
+
+## Table with manual column sizing
+
+<Playground>
+  <DataTable
+    pagination={{ manualPagination: false, itemsPerPage: [10, 20, 30] }}
+    sorting={{ manualSorting: false }}
+    data={[
+      {
+        name: "Daenerys Stormborn of House Targaryen, the First of Her Name, Queen of the Andals and the First Men, Protector of the Seven Kingdoms, the Mother of Dragons, the Khaleesi of the Great Grass Sea, the Unburnt, the Breaker of Chains.",
+        points: "1,000,000",
+        chance: 5,
+        power: "50,000",
+      },
+      {
+        name: "Aegon “The Conqueror” Targaryen and Rhaenys Targaryen",
+        points: "2,000,000",
+        chance: 5,
+        power: "40,000",
+      },
+      {
+        name: "Jaehaerys “The Old King” Targaryen and Alysanne Targaryen",
+        points: "1,250,000",
+        chance: 8,
+        power: "20,000",
+      },
+    ]}
+    columns={[
+      {
+        id: "name",
+        accessorKey: "name",
+        header: "Name",
+        footer: "Totals",
+        enableResizing: false,
+        cell: info => (
+          <Typography numberOfLines={1}>{info.getValue()}</Typography>
+        ),
+        size: 538,
+        minSize: 438,
+        maxSize: 538,
+      },
+      {
+        id: "points",
+        accessorKey: "points",
+        header: () => (
+          <Typography align="end" fontWeight="bold">
+            Points
+          </Typography>
+        ),
+        footer: () => (
+          <Typography align="end" fontWeight="bold">
+            10,050,400
+          </Typography>
+        ),
+        cell: info => <Typography align="end">{info.getValue()}</Typography>,
+        size: 268,
+        minSize: 168,
+        maxSize: 268,
+      },
+      {
+        id: "chance",
+        accessorKey: "chance",
+        header: () => (
+          <Typography align="end" fontWeight="bold">
+            Chance (%)
+          </Typography>
+        ),
+        cell: info => <Typography align="end">{info.getValue()}</Typography>,
+        size: 268,
+        minSize: 168,
+        maxSize: 268,
+      },
+      {
+        id: "power",
+        accessorKey: "power",
+        header: () => (
+          <Typography align="end" fontWeight="bold">
+            Power
+          </Typography>
+        ),
+        footer: () => (
+          <Typography align="end" fontWeight="bold">
+            300,000
+          </Typography>
+        ),
+        cell: info => <Typography align="end">{info.getValue()}</Typography>,
+        size: 268,
+        minSize: 168,
+        maxSize: 268,
       },
     ]}
   />

--- a/packages/components/src/DataTable/DataTable.mdx
+++ b/packages/components/src/DataTable/DataTable.mdx
@@ -662,7 +662,6 @@ import { DataTable } from "@jobber/components/DataTable";
         accessorKey: "name",
         header: "Name",
         footer: "Totals",
-        enableResizing: false,
       },
       {
         id: "points",
@@ -740,7 +739,6 @@ import { DataTable } from "@jobber/components/DataTable";
         accessorKey: "name",
         header: "Name",
         footer: "Totals",
-        enableResizing: false,
         cell: info => (
           <Typography numberOfLines={1}>{info.getValue()}</Typography>
         ),

--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -4,6 +4,8 @@ import userEvent from "@testing-library/user-event";
 import * as jobberHooks from "@jobber/hooks";
 import { DataTable } from "./DataTable";
 import {
+  columSizeColumns,
+  columnSizeData,
   columns,
   data,
   royaltyReportColumns,
@@ -250,5 +252,27 @@ describe("when using the column footers", () => {
 
       expect(totalsRow).toBeDefined();
     });
+  });
+});
+
+describe("when using manual column sizing", () => {
+  beforeEach(() => {
+    render(<DataTable data={columnSizeData} columns={columSizeColumns} />);
+  });
+
+  it("applies the defined widths to headers", () => {
+    const firstHeader = screen.getAllByRole("columnheader")[0];
+
+    expect(firstHeader.style.width).toBe("538px");
+    expect(firstHeader.style["min-width"]).toBe("438px");
+    expect(firstHeader.style["max-width"]).toBe("538px");
+  });
+
+  it("applies the defined widths to cells", () => {
+    const firstCell = screen.getAllByRole("cell")[0];
+
+    expect(firstCell.style.width).toBe("538px");
+    expect(firstCell.style["min-width"]).toBe("438px");
+    expect(firstCell.style["max-width"]).toBe("538px");
   });
 });

--- a/packages/components/src/DataTable/Footer.tsx
+++ b/packages/components/src/DataTable/Footer.tsx
@@ -18,7 +18,14 @@ const DesktopView = <T extends object>({ table }: ViewProps<T>) => (
     {table.getFooterGroups().map(footerGroup => (
       <tr key={footerGroup.id}>
         {footerGroup.headers.map(header => (
-          <th key={header.id}>
+          <th
+            key={header.id}
+            style={{
+              width: header.getSize(),
+              minWidth: header.column.columnDef.minSize,
+              maxWidth: header.column.columnDef.maxSize,
+            }}
+          >
             {flexRender(header.column.columnDef.footer, header.getContext())}
           </th>
         ))}

--- a/packages/components/src/DataTable/Header.tsx
+++ b/packages/components/src/DataTable/Header.tsx
@@ -38,6 +38,11 @@ export function Header<T extends object>({
                 onClick={
                   sorting ? header.column.getToggleSortingHandler() : undefined
                 }
+                style={{
+                  width: header.getSize(),
+                  minWidth: header.column.columnDef.minSize,
+                  maxWidth: header.column.columnDef.maxSize,
+                }}
               >
                 {header.isPlaceholder ? null : (
                   <div>

--- a/packages/components/src/DataTable/test-utilities/mocks.ts
+++ b/packages/components/src/DataTable/test-utilities/mocks.ts
@@ -8,6 +8,13 @@ interface Data {
   isAlive: string;
 }
 
+interface RankingData {
+  name: string;
+  points: string;
+  chance: number;
+  power: string;
+}
+
 interface RoyaltyReportData {
   franchiseName: string;
   payment: string;
@@ -182,5 +189,69 @@ export const royaltyReportData: RoyaltyReportData[] = [
     payment: "1,250,000",
     royaltyRate: 8,
     royaltyAmount: "20,000",
+  },
+];
+
+export const columnSizeData: RankingData[] = [
+  {
+    name: "Daenerys Stormborn of House Targaryen, the First of Her Name, Queen of the Andals and the First Men, Protector of the Seven Kingdoms, the Mother of Dragons, the Khaleesi of the Great Grass Sea, the Unburnt, the Breaker of Chains.",
+    points: "1,000,000",
+    chance: 5,
+    power: "50,000",
+  },
+  {
+    name: "Aegon “The Conqueror” Targaryen and Rhaenys Targaryen",
+    points: "2,000,000",
+    chance: 5,
+    power: "40,000",
+  },
+  {
+    name: "Jaehaerys “The Old King” Targaryen and Alysanne Targaryen",
+    points: "1,250,000",
+    chance: 8,
+    power: "20,000",
+  },
+];
+
+export const columSizeColumns = [
+  {
+    id: "name",
+    accessorKey: "name",
+    header: "Name",
+    footer: "Totals",
+    enableResizing: false,
+    cell: (info: { getValue: () => unknown }) => info.getValue(),
+    size: 538,
+    minSize: 438,
+    maxSize: 538,
+  },
+  {
+    id: "points",
+    accessorKey: "points",
+    header: "Points",
+    footer: "10,050,400",
+    cell: (info: { getValue: () => unknown }) => info.getValue(),
+    size: 268,
+    minSize: 168,
+    maxSize: 268,
+  },
+  {
+    id: "chance",
+    accessorKey: "chance",
+    header: "Chance (%)",
+    cell: (info: { getValue: () => unknown }) => info.getValue(),
+    size: 268,
+    minSize: 168,
+    maxSize: 268,
+  },
+  {
+    id: "power",
+    accessorKey: "power",
+    header: "Power",
+    footer: "300,000",
+    cell: (info: { getValue: () => unknown }) => info.getValue(),
+    size: 268,
+    minSize: 168,
+    maxSize: 268,
   },
 ];


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To be able to adjust the column width manually in order to emphasize column data

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Configurable column width options in column prop (`size, minSize, maxSize`)

## Testing

- Add `size, minSize, maxSize` to a `column` object and test if this style is applied to the column element

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
