### PR TITLE
feat(components): Add DataTable test helpers

### DIFF
--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -1,28 +1,16 @@
 import React from "react";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import * as jobberHooks from "@jobber/hooks";
 import { DataTable } from "./DataTable";
 import {
   columSizeColumns,
   columnSizeData,
   columns,
   data,
+  mockContainerWidth,
   royaltyReportColumns,
   royaltyReportData,
 } from "./test-utilities";
-
-const mockContainerWidth = (exactWidth?: number) => {
-  jest.spyOn(jobberHooks, "useResizeObserver").mockReturnValue([
-    { current: null },
-    {
-      width: 1200,
-      height: 800,
-      exactWidth: exactWidth || 1200,
-      exactHeight: 800,
-    },
-  ]);
-};
 
 describe("when rendering a Basic Table", () => {
   beforeEach(() => {

--- a/packages/components/src/DataTable/index.ts
+++ b/packages/components/src/DataTable/index.ts
@@ -2,6 +2,8 @@ export { DataTable } from "./DataTable";
 
 export * from "./types";
 
+export * from "./test-utilities/helpers";
+
 export {
   Row,
   ColumnDef,

--- a/packages/components/src/DataTable/test-utilities/helpers.ts
+++ b/packages/components/src/DataTable/test-utilities/helpers.ts
@@ -1,0 +1,13 @@
+import * as jobberHooks from "@jobber/hooks";
+
+export const mockContainerWidth = (exactWidth?: number) => {
+  jest.spyOn(jobberHooks, "useResizeObserver").mockReturnValue([
+    { current: null },
+    {
+      width: 1200,
+      height: 800,
+      exactWidth: exactWidth || 1200,
+      exactHeight: 800,
+    },
+  ]);
+};

--- a/packages/components/src/DataTable/test-utilities/index.ts
+++ b/packages/components/src/DataTable/test-utilities/index.ts
@@ -1,1 +1,2 @@
 export * from "./mocks";
+export * from "./helpers";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Add `mockContainerWidth` function to enable DataTable Footer to be tested.
As `DataTable` footer uses the `useResizeObserver` hook, when a developer tries to jest mock this hook from `jobber/hooks` package in an external project, it doesn't work because the reference isn't the same as the DataTable one.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `mockContainerWidth` test utility helper function

## Testing

- You can use the `mockContainerWidth` function in a jest test in an external project by copying the DataTable folder under dist and pasting inside the project node_modules jobber dist folder.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
