### PR TITLE
build(design): Export Atlantis CSS vars to SCSS

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -27,6 +27,21 @@ fs.writeFile("./foundation.js", jsonContent, "utf8", function (err) {
   console.log("JSON file has been saved.");
 });
 
+const scssColors = getResolvedSCSSColors(resolvedCssVars);
+
+fs.writeFile(
+  "./foundation.scss",
+  scssColors.join("\n"),
+  "utf-8",
+  function (err) {
+    if (err) {
+      console.log("An error occured while writing SCSS to File.");
+      return console.log(err);
+    }
+    console.log("SCSS file has been saved.");
+  },
+);
+
 /**
  * Recursively resolve css custom properties.
  *
@@ -135,4 +150,15 @@ function getResolvedCSSVars(cssProperties) {
     acc[newKey] = jobberStyle(key);
     return acc;
   }, {});
+}
+
+function getResolvedSCSSColors(cssProperties) {
+  const allKeys = Object.keys(cssProperties);
+  return allKeys.reduce((acc, cssVar) => {
+    if (cssVar.includes("color")) {
+      return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]};`];
+    } else {
+      return acc;
+    }
+  }, []);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Export Atlantis' CSS variables to a SCSS.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- The build phase of jobberStyles.js where to also generate a SCSS files with our colors to be consumed.

## Testing
1. Open your cmd in the root of atlantis
2. `cd packages/design`
3. `npm run build`

You'll see that a `foundation.scss` file was generated along with other files.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
