### PR TITLE
fix(components): Fix radio button shrinking when label is too long

### DIFF
--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -27,6 +27,7 @@
   border-radius: 100%;
   background-color: var(--color-surface);
   transition: all var(--timing-base);
+  flex-shrink: 0;
 }
 
 .input:focus + .label:before {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

Radio buttons were shrinking when it has long label text

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

added the css prop `flex-shrink: 0` to the container

### Fixed

#### Before:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/27180625/211628631-418e38d0-b212-4a07-9e22-6c1dcbbd931a.png">

#### After: 

<img width="372" alt="image" src="https://user-images.githubusercontent.com/27180625/211629114-51ec49e1-364f-4a44-a080-b5ac780f53bb.png">

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
