### PR TITLE
refactor(components): update autocomplete false value in FormField 

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`it should display headers when headers are passed in 1`] = `
         placeholder_name
       </label>
       <input
-        autoComplete="autocomplete-off"
+        autoComplete="off"
         className="input"
         id="123e4567-e89b-12d3-a456-426655440035"
         onBlur={[Function]}
@@ -59,7 +59,7 @@ exports[`renders an Autocomplete 1`] = `
         placeholder_name
       </label>
       <input
-        autoComplete="autocomplete-off"
+        autoComplete="off"
         className="input"
         id="123e4567-e89b-12d3-a456-426655440001"
         onBlur={[Function]}

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -320,7 +320,7 @@ describe("FormField", () => {
           <FormField placeholder="foo" autocomplete={false} />,
         );
         const input = getByLabelText("foo");
-        expect(input).toHaveAttribute("autocomplete", "autocomplete-off");
+        expect(input).toHaveAttribute("autocomplete", "off");
       });
     });
   });

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -205,7 +205,7 @@ function setAutocomplete(
   if (autocompleteSetting === true) {
     return undefined;
   } else if (autocompleteSetting === false) {
-    return "autocomplete-off";
+    return "off";
   }
 
   return autocompleteSetting;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
- `FormField` was passing `autocomplete` as `autocomplete=“autocomplete-off”` when provided `false`, when it should be passing only `"off"`

### Changed
- when `autocompleteSetting === false`, simply return `"off"`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
