### PR TITLE
Bumping json5 dependency to 1.0.2 and 2.2.3 throughout Atlantis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
+        "json5": "^2.2.3",
         "lodash": "^4.17.19",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -10363,9 +10363,9 @@
           "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
         },
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -10999,7 +10999,7 @@
           "dev": true,
           "requires": {
             "@types/json5": "^0.0.29",
-            "json5": "^1.0.1",
+            "json5": "^1.0.2",
             "minimist": "^1.2.0",
             "strip-bom": "^3.0.0"
           },
@@ -24259,7 +24259,7 @@
         "fs-extra": "^8.1.0",
         "gatsby-core-utils": "^1.9.0",
         "gray-matter": "^4.0.2",
-        "json5": "^2.1.3",
+        "json5": "^2.2.3",
         "loader-utils": "^1.4.0",
         "lodash": "^4.17.20",
         "mdast-util-to-string": "^1.1.0",
@@ -29528,9 +29528,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
@@ -30173,13 +30173,13 @@
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
+        "json5": "^1.0.2"
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -39880,15 +39880,15 @@
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^1.0.2",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/packages/docz-tools/package-lock.json
+++ b/packages/docz-tools/package-lock.json
@@ -528,9 +528,9 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -542,7 +542,7 @@
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
+        "json5": "^1.0.2"
       }
     },
     "loose-envify": {

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -1072,10 +1072,10 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-			"requires": {
+			"version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "requires": {
 				"minimist": "^1.2.0"
 			},
 			"dependencies": {
@@ -1708,7 +1708,7 @@
 			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
 			"requires": {
 				"@types/json5": "^0.0.29",
-				"json5": "^1.0.1",
+				"json5": "^1.0.2",
 				"minimist": "^1.2.0",
 				"strip-bom": "^3.0.0"
 			},


### PR DESCRIPTION
## Motivations
- Addresses [CVE-2022-46175](https://github.com/advisories/GHSA-9c47-m6qq-7p4h)
- Instead of individually managing all the PRs opened by Dependabot, I've decided to address it in one go

## Changes
- Our sub-dependency `json5` is being used by other tools, so it was pulling in major version `1` and `2`
- This PR bumps both major versions to safety grounds, @ `2.2.3` and `1.0.2` respectively

### Changed

![Screenshot 2023-01-11 at 4 00 33 PM](https://user-images.githubusercontent.com/10535453/211936549-0021808e-0fd3-4cfc-98cc-279d27f86512.png)



### Security

- Addresses [CVE-2022-46175](https://github.com/advisories/GHSA-9c47-m6qq-7p4h)


## Testing

- Pending CI, hosted CloudFlare page and Atlantis' behavior should continue to work without observable differences 
