### PR TITLE
Bumping `loader-utils` to v1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30166,9 +30166,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",


### PR DESCRIPTION
## Motivations
- Addresses [CVE-2022-37599](https://github.com/advisories/GHSA-hhq3-ff78-jv3g)
- Instead of individually managing all the PRs opened by Dependabot, I've decided to address it in one go
- This single PR should take care of [the 4 PRs dependabot have created](https://github.com/GetJobber/atlantis/pulls?q=is%3Apr+is%3Aopen+loader-utils)

## Changes
- Bumping the required `loader-utils` to 1.4.2 will lift all sub-dependencies to use the same version as well

### Changed

![Screenshot 2023-01-16 at 8 19 43 PM](https://user-images.githubusercontent.com/10535453/212802933-42709e55-3116-49bb-a9f4-d73f98e65ab1.png)


### Security

- Addresses [CVE-2022-37599](https://github.com/advisories/GHSA-hhq3-ff78-jv3g)


## Testing

- Pending CI, hosted CloudFlare page and Atlantis' behavior should continue to work without observable differences 
