### PR TITLE
Bumping `engine.io` sub dependency version to 3.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21215,9 +21215,9 @@
       }
     },
     "engine.io": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.2.tgz",
-      "integrity": "sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.6.1.tgz",
+      "integrity": "sha512-dfs8EVg/i7QjFsXxn7cCRQ+Wai1G1TlEvHhdYEi80fxn5R1vZ2K661O6v/rezj1FP234SZ14r9CmJke99iYDGg==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -37732,7 +37732,7 @@
       "dev": true,
       "requires": {
         "debug": "~4.1.0",
-        "engine.io": "~3.4.0",
+        "engine.io": "~3.6.1",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.3.0",


### PR DESCRIPTION
## Motivations
- Addresses [CVE-2022-41940](https://github.com/advisories/GHSA-r7qp-cfhv-p84w)
- Doesn't appeared the bot have spotted an issue however, it looks like we are using a vulnerable version (3.4.2)
- This PR bumps it to safety, to v3.6.1

## Changes
- Bumping the required `engine.io` sub dependency and requirement to 3.6.1

### Changed

![Screenshot 2023-01-16 at 8 43 17 PM](https://user-images.githubusercontent.com/10535453/212805464-9d22a1fc-310f-4e17-bdb1-dbf65b7df86f.png)

### Security

- Addresses [CVE-2022-41940](https://github.com/advisories/GHSA-r7qp-cfhv-p84w)


## Testing

- Pending CI, hosted CloudFlare page and Atlantis' behavior should continue to work without observable differences 
