### PR TITLE
refactor(design): Adjust base typography scale

### DIFF
--- a/packages/components/src/Typography/css/Typography.css
+++ b/packages/components/src/Typography/css/Typography.css
@@ -3,14 +3,26 @@
     sans-serif;
   --typography--fontFamily-display: "Poppins", Helvetica, Arial, sans-serif;
 
-  --typography--fontSize-extravagant: calc(var(--base-unit) * 3); /* 48 */
-  --typography--fontSize-jumbo: calc(var(--base-unit) * 2.25); /* 36 */
-  --typography--fontSize-largest: calc(var(--base-unit) * 1.5); /* 24 */
-  --typography--fontSize-larger: calc(var(--base-unit) * 1.25); /* 20 */
-  --typography--fontSize-large: calc(var(--base-unit) * 1.125); /* 18 */
-  --typography--fontSize-base: calc(var(--base-unit) * 1); /* 16 */
-  --typography--fontSize-small: calc(var(--base-unit) * 0.875); /* 14 */
-  --typography--fontSize-smaller: calc(var(--base-unit) * 0.75); /* 12 */
+  --typography--fontSize-extravagant: calc(
+    var(--typography--fontSize-large) * 3
+  );
+  /* 48 */
+  --typography--fontSize-jumbo: calc(var(--typography--fontSize-large) * 2.25);
+  /* 36 */
+  --typography--fontSize-largest: calc(var(--typography--fontSize-large) * 1.5);
+  /* 24 */
+  --typography--fontSize-larger: calc(var(--typography--fontSize-large) * 1.25);
+  /* 20 */
+  --typography--fontSize-large: calc(var(--base-unit) * 1);
+  /* 16 */
+  --typography--fontSize-base: calc(var(--typography--fontSize-large) * 0.875);
+  /* 14 */
+  --typography--fontSize-small: calc(var(--typography--fontSize-large) * 0.75);
+  /* 12 */
+  --typography--fontSize-smaller: calc(
+    var(--typography--fontSize-large) * 0.625
+  );
+  /* 10 */
 
   --typography--lineHeight-large: 1.34;
   --typography--lineHeight-base: 1.25;
@@ -22,9 +34,18 @@
 
 @media (--handhelds) {
   :root {
-    --typography--fontSize-extravagant: calc(var(--base-unit) * 2.5); /* 40 */
-    --typography--fontSize-jumbo: calc(var(--base-unit) * 1.75); /* 28 */
-    --typography--fontSize-largest: calc(var(--base-unit) * 1.375); /* 22 */
+    --typography--fontSize-extravagant: calc(
+      var(--typography--fontSize-large) * 2.5
+    );
+    /* 40 */
+    --typography--fontSize-jumbo: calc(
+      var(--typography--fontSize-large) * 1.75
+    );
+    /* 28 */
+    --typography--fontSize-largest: calc(
+      var(--typography--fontSize-large) * 1.375
+    );
+    /* 22 */
   }
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->
## Motivations
Modify the typography scale to account for new typeface

## Changes

### Changed
- Typography scale from `smaller` to `large` inclusive, have been bumped down by 2px.
- scale is now calculated relative to `--typography--fontSize-large` instead of `--base-unit`

### Testing
- can compare typography size to the Figma; ex. Headings in the Figma match px size of new typography scale
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
