### PR TITLE
docs(design): Update Typography documentation to reflect new base font-size

### DIFF
--- a/packages/components/src/Typography/Typography.mdx
+++ b/packages/components/src/Typography/Typography.mdx
@@ -35,7 +35,14 @@ import { Typography } from "@jobber/components/Typography";
 ## Font size
 
 <Playground>
-  <Typography size="extravagant">Size prop changes the font size</Typography>
+  <Typography size="smaller">smaller</Typography>
+  <Typography size="small">small</Typography>
+  <Typography size="base">base</Typography>
+  <Typography size="large">large</Typography>
+  <Typography size="larger">larger</Typography>
+  <Typography size="largest">largest</Typography>
+  <Typography size="jumbo">jumbo</Typography>
+  <Typography size="extravagant">extravagant</Typography>
 </Playground>
 
 ## Font weight

--- a/packages/design/src/Typography.mdx
+++ b/packages/design/src/Typography.mdx
@@ -106,11 +106,11 @@ form inputs, labels, and more!
 
 ## Font sizes
 
-At the default zoom level, our base font size is equivalent to `14px`. Depending
-on the context in which your typography is being used, font size can be adjusted
-to be larger or smaller than the base font size.
+At the default zoom level, our base font-size is equivalent to `14px`. Depending
+on the context in which your typography is being used, font-size can be adjusted
+to be larger or smaller than the base font-size.
 
-Suggestions for when to use varying font sizes are discussed within the
+Suggestions for when to use varying font-sizes are discussed within the
 [Sizes](/packages-components-src-text-text#sizes) section of the Text component.
 
 ## Line-height

--- a/packages/design/src/Typography.mdx
+++ b/packages/design/src/Typography.mdx
@@ -114,8 +114,6 @@ Suggestions for when to use varying font-sizes are discussed in the
 [Heading](/packages-components-src-heading-heading) component, and within the
 [Sizes](/packages-components-src-text-text#sizes) section of the Text component.
 
-### Implementation
-
 export function Example({ of: size }) {
   const style = {
     fontSize: `var(--typography--fontSize-${size})`,
@@ -157,8 +155,6 @@ the user to more easily parse multiple lines of small text. As font-size
 increases into "display" sizes such as a level 1 `Heading`, the ratio of
 line-height to font-size decreases as the larger font-size is more readable and
 requires less line-to-line breathing room.
-
-### Implementation
 
 export function Visual({ of: size }) {
   const style = {

--- a/packages/design/src/Typography.mdx
+++ b/packages/design/src/Typography.mdx
@@ -106,11 +106,12 @@ form inputs, labels, and more!
 
 ## Font sizes
 
-Our base font-size is based on our [Spacing](/space) scale for a consistent
-sizing rhythm across Jobber. At its' default zoom level, the equivalent is
-`16px`. While this is higher than in some systems where `14` may be more common,
-Source Sans Pro is optically a bit smaller, particularly at the x-height, so we
-start with `16` and work our way up and down from there.
+At the default zoom level, our base font size is equivalent to `14px`. Depending
+on the context in which your typography is being used, font size can be adjusted
+to be larger or smaller than the base font size.
+
+Suggestions for when to use varying font sizes are discussed within the
+[Sizes](/packages-components-src-text-text#sizes) section of the Text component.
 
 ## Line-height
 

--- a/packages/design/src/Typography.mdx
+++ b/packages/design/src/Typography.mdx
@@ -114,6 +114,35 @@ Suggestions for when to use varying font-sizes are discussed in the
 [Heading](/packages-components-src-heading-heading) component, and within the
 [Sizes](/packages-components-src-text-text#sizes) section of the Text component.
 
+### Implementation
+
+export function Example({ of: size }) {
+  const style = {
+    fontSize: `var(--typography--fontSize-${size})`,
+  };
+  return <div style={style}>{size}</div>;
+}
+
+export function PixelSize({ of: size }) {
+  const element = document.createElement("div");
+  element.style.fontSize = `var(--typography--fontSize-${size})`;
+  document.body.appendChild(element);
+  const value = getComputedStyle(element).fontSize;
+  element.remove();
+  return value;
+}
+
+| Name                                 | Visual                       | Value                          |
+| :----------------------------------- | :--------------------------- | :----------------------------- |
+| `--typography--fontSize-smaller`     | <Example of="smaller" />     | <PixelSize of="smaller" />     |
+| `--typography--fontSize-small`       | <Example of="small" />       | <PixelSize of="small" />       |
+| `--typography--fontSize-base`        | <Example of="base" />        | <PixelSize of="base" />        |
+| `--typography--fontSize-large`       | <Example of="large" />       | <PixelSize of="large" />       |
+| `--typography--fontSize-larger`      | <Example of="larger" />      | <PixelSize of="larger" />      |
+| `--typography--fontSize-largest`     | <Example of="largest" />     | <PixelSize of="largest" />     |
+| `--typography--fontSize-jumbo`       | <Example of="jumbo" />       | <PixelSize of="jumbo" />       |
+| `--typography--fontSize-extravagant` | <Example of="extravagant" /> | <PixelSize of="extravagant" /> |
+
 ## Line-height
 
 Line-height, or
@@ -128,3 +157,38 @@ the user to more easily parse multiple lines of small text. As font-size
 increases into "display" sizes such as a level 1 `Heading`, the ratio of
 line-height to font-size decreases as the larger font-size is more readable and
 requires less line-to-line breathing room.
+
+### Implementation
+
+export function Visual({ of: size }) {
+  const style = {
+    lineHeight: `var(--typography--lineHeight-${size})`,
+  };
+  return (
+    <div style={style}>
+      Line-height, or leading, is the space between subsequent lines of type.
+      The line-heights in the Heading and Text components are optimized for each
+      variation's unique combination of...
+    </div>
+  );
+}
+
+export function Value({ of: size }) {
+  const element = document.createElement("div");
+  element.style.lineHeight = `var(--typography--lineHeight-${size})`;
+  document.body.appendChild(element);
+  const value =
+    parseFloat(getComputedStyle(element).lineHeight) /
+    parseFloat(getComputedStyle(element).fontSize);
+  element.remove();
+  return value;
+}
+
+| Name                                 | Visual                    | Value                    |
+| :----------------------------------- | :------------------------ | :----------------------- |
+| `--typography--lineHeight-large`     | <Visual of="large" />     | <Value of="large" />     |
+| `--typography--lineHeight-base`      | <Visual of="base" />      | <Value of="base" />      |
+| `--typography--lineHeight-tight`     | <Visual of="tight" />     | <Value of="tight" />     |
+| `--typography--lineHeight-tighter`   | <Visual of="tighter" />   | <Value of="tighter" />   |
+| `--typography--lineHeight-tightest`  | <Visual of="tightest" />  | <Value of="tightest" />  |
+| `--typography--lineHeight-miniscule` | <Visual of="miniscule" /> | <Value of="miniscule" /> |

--- a/packages/design/src/Typography.mdx
+++ b/packages/design/src/Typography.mdx
@@ -110,7 +110,8 @@ At the default zoom level, our base font-size is equivalent to `14px`. Depending
 on the context in which your typography is being used, font-size can be adjusted
 to be larger or smaller than the base font-size.
 
-Suggestions for when to use varying font-sizes are discussed within the
+Suggestions for when to use varying font-sizes are discussed in the
+[Heading](/packages-components-src-heading-heading) component, and within the
 [Sizes](/packages-components-src-text-text#sizes) section of the Text component.
 
 ## Line-height


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Documentation for `Typography` needs to be updated to reflect new `base` font-size.

## Changes
### Added
- Typography component is now exposed (with updated Playground displaying all sizes)
<img width="644" alt="Screenshot 2023-01-18 at 11 35 27 PM" src="https://user-images.githubusercontent.com/104797704/213477708-f2417326-9aa2-45d2-98fc-f8f0443e98e3.png">

- added typography and line height token tables to the Typography Design page
<img width="565" alt="Screenshot 2023-01-18 at 11 18 03 PM" src="https://user-images.githubusercontent.com/104797704/213477903-e88ca8f2-33bb-4d5a-b271-d5f7e059854f.png">
<img width="578" alt="Screenshot 2023-01-18 at 11 18 11 PM" src="https://user-images.githubusercontent.com/104797704/213477917-0c4f8241-643b-4b33-a60a-027bb7d02700.png">


### Changed
- Updated wording in [Font Sizes](http://localhost:3333/typography#font-sizes) section of Typography component

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
