### PR TITLE
refactor: Move all Typography token variables to design package

### DIFF
--- a/packages/components/src/Typography/css/Typography.css
+++ b/packages/components/src/Typography/css/Typography.css
@@ -1,14 +1,3 @@
-@media (--handhelds) {
-  :root {
-    --typography--fontSize-extravagant: calc(var(--base-unit) * 2.5);
-    /* 40 */
-    --typography--fontSize-jumbo: calc(var(--base-unit) * 1.75);
-    /* 28 */
-    --typography--fontSize-largest: calc(var(--base-unit) * 1.375);
-    /* 22 */
-  }
-}
-
 .base {
   margin: 0;
   padding: 0;

--- a/packages/components/src/Typography/css/Typography.css
+++ b/packages/components/src/Typography/css/Typography.css
@@ -1,30 +1,11 @@
-:root {
-  --typography--fontFamily-normal: "Source Sans Pro", Helvetica, Arial,
-    sans-serif;
-  --typography--fontFamily-display: "Poppins", Helvetica, Arial, sans-serif;
-
-  --typography--fontSize-extravagant: calc(var(--base-unit) * 3); /* 48 */
-  --typography--fontSize-jumbo: calc(var(--base-unit) * 2.25); /* 36 */
-  --typography--fontSize-largest: calc(var(--base-unit) * 1.5); /* 24 */
-  --typography--fontSize-larger: calc(var(--base-unit) * 1.25); /* 20 */
-  --typography--fontSize-large: calc(var(--base-unit) * 1.125); /* 18 */
-  --typography--fontSize-base: calc(var(--base-unit) * 1); /* 16 */
-  --typography--fontSize-small: calc(var(--base-unit) * 0.875); /* 14 */
-  --typography--fontSize-smaller: calc(var(--base-unit) * 0.75); /* 12 */
-
-  --typography--lineHeight-large: 1.34;
-  --typography--lineHeight-base: 1.25;
-  --typography--lineHeight-tight: 1.2;
-  --typography--lineHeight-tighter: 1.143;
-  --typography--lineHeight-tightest: 1.12;
-  --typography--lineHeight-miniscule: 1.08;
-}
-
 @media (--handhelds) {
   :root {
-    --typography--fontSize-extravagant: calc(var(--base-unit) * 2.5); /* 40 */
-    --typography--fontSize-jumbo: calc(var(--base-unit) * 1.75); /* 28 */
-    --typography--fontSize-largest: calc(var(--base-unit) * 1.375); /* 22 */
+    --typography--fontSize-extravagant: calc(var(--base-unit) * 2.5);
+    /* 40 */
+    --typography--fontSize-jumbo: calc(var(--base-unit) * 1.75);
+    /* 28 */
+    --typography--fontSize-largest: calc(var(--base-unit) * 1.375);
+    /* 22 */
   }
 }
 

--- a/packages/design/src/typography.css
+++ b/packages/design/src/typography.css
@@ -1,4 +1,32 @@
 :root {
   --typography--letterSpacing-base: 0;
   --typography--letterSpacing-loose: calc(var(--base-unit) / 40);
+
+  --typography--fontFamily-normal: "Source Sans Pro", Helvetica, Arial,
+    sans-serif;
+  --typography--fontFamily-display: "Poppins", Helvetica, Arial, sans-serif;
+
+  --typography--fontSize-extravagant: calc(var(--base-unit) * 3);
+  /* 48 */
+  --typography--fontSize-jumbo: calc(var(--base-unit) * 2.25);
+  /* 36 */
+  --typography--fontSize-largest: calc(var(--base-unit) * 1.5);
+  /* 24 */
+  --typography--fontSize-larger: calc(var(--base-unit) * 1.25);
+  /* 20 */
+  --typography--fontSize-large: calc(var(--base-unit) * 1.125);
+  /* 18 */
+  --typography--fontSize-base: calc(var(--base-unit) * 1);
+  /* 16 */
+  --typography--fontSize-small: calc(var(--base-unit) * 0.875);
+  /* 14 */
+  --typography--fontSize-smaller: calc(var(--base-unit) * 0.75);
+  /* 12 */
+
+  --typography--lineHeight-large: 1.34;
+  --typography--lineHeight-base: 1.25;
+  --typography--lineHeight-tight: 1.2;
+  --typography--lineHeight-tighter: 1.143;
+  --typography--lineHeight-tightest: 1.12;
+  --typography--lineHeight-miniscule: 1.08;
 }

--- a/packages/design/src/typography.css
+++ b/packages/design/src/typography.css
@@ -30,3 +30,14 @@
   --typography--lineHeight-tightest: 1.12;
   --typography--lineHeight-miniscule: 1.08;
 }
+
+@media (--handhelds) {
+  :root {
+    --typography--fontSize-extravagant: calc(var(--base-unit) * 2.5);
+    /* 40 */
+    --typography--fontSize-jumbo: calc(var(--base-unit) * 1.75);
+    /* 28 */
+    --typography--fontSize-largest: calc(var(--base-unit) * 1.375);
+    /* 22 */
+  }
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To allow font tokens to be easily shared / used

### Added

- New typography tokens to design package

### Removed

- typography tokens definitions from Typography component styles

## Testing

<!-- How to test your changes. -->
- Test if all places using Typography still have the same styles using values from typography tokens.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
