### PR TITLE
Bump loader-utils of docz to v1.4.2

### DIFF
--- a/packages/docz-tools/package-lock.json
+++ b/packages/docz-tools/package-lock.json
@@ -536,9 +536,9 @@
       }
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",


### PR DESCRIPTION
## Motivations
- Sorry I missed the ~~one~~ few that bumps docz earlier, this one addresses [CVE-2022-37599](https://github.com/advisories/GHSA-hhq3-ff78-jv3g) for `docz-tools` in favor of #936 as it seemed unnecessary complex for a minor version bump
- Instead of letting Dependabot do the work, I've decided to address it in one simpler PR

## Changes
- Bumping the required `loader-utils` to 1.4.2 for docz

### Before
![Screenshot 2023-01-18 at 9 04 36 PM](https://user-images.githubusercontent.com/10535453/213354532-b672d1f3-f4d1-4957-a3f6-f5b47bf76df9.png)


### After
![Screenshot 2023-01-18 at 9 17 30 PM](https://user-images.githubusercontent.com/10535453/213354545-fb280820-d7ad-4a59-b9b0-0dab06f6f9d4.png)



### Security

- Addresses [CVE-2022-37599](https://github.com/advisories/GHSA-hhq3-ff78-jv3g)


## Testing

- Pending CI, hosted CloudFlare page and Atlantis' behavior should continue to work without observable differences 
