### PR TITLE
refactor(components): Update typography for Popover and ColorSwatches

### DIFF
--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -26,7 +26,7 @@
   box-shadow: var(--shadow-base);
   border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
-  font-size: var(--base-unit);
+  font-size: var(--typography--fontSize-base);
   line-height: normal;
   background: var(--color-surface);
 }

--- a/packages/docx/src/ColorSwatches/ColorSwatches.css
+++ b/packages/docx/src/ColorSwatches/ColorSwatches.css
@@ -6,7 +6,7 @@
   font-size: var(--typography--fontSize-larger);
   font-weight: 800;
   line-height: var(--typography--lineHeight-tight);
-  text-transform: uppercase;
+  text-transform: capitalize;
 }
 
 .swatchGroup {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Prepping for updated font families and styling guidelines

## Changes

- Nothing visual at this point

### Changed

- updated casing of internal component
- updated CSS property for Popover font-size

## Testing

- go to ColorSwatch docs and verify group titles are title-case instead of uppercase ("Interactive" in this example)
![image](https://user-images.githubusercontent.com/39704901/213772716-b46560e9-0638-4787-991b-3bab1861739f.png)
- go to Popover and verify text inside Popover uses `base` fontSize
![image](https://user-images.githubusercontent.com/39704901/213772875-b0af0b26-238a-41e3-9ca1-fe35ea34bde8.png)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
