### PR TITLE
refactor(design): Re-add typography scale

### DIFF
--- a/packages/design/src/typography.css
+++ b/packages/design/src/typography.css
@@ -6,22 +6,26 @@
   --typography--fontFamily-display: "Jobber Pro", "Poppins", Helvetica, Arial,
     sans-serif;
 
-  --typography--fontSize-extravagant: calc(var(--base-unit) * 3);
+  --typography--fontSize-extravagant: calc(
+    var(--typography--fontSize-large) * 3
+  );
   /* 48 */
-  --typography--fontSize-jumbo: calc(var(--base-unit) * 2.25);
+  --typography--fontSize-jumbo: calc(var(--typography--fontSize-large) * 2.25);
   /* 36 */
-  --typography--fontSize-largest: calc(var(--base-unit) * 1.5);
+  --typography--fontSize-largest: calc(var(--typography--fontSize-large) * 1.5);
   /* 24 */
-  --typography--fontSize-larger: calc(var(--base-unit) * 1.25);
+  --typography--fontSize-larger: calc(var(--typography--fontSize-large) * 1.25);
   /* 20 */
-  --typography--fontSize-large: calc(var(--base-unit) * 1.125);
-  /* 18 */
-  --typography--fontSize-base: calc(var(--base-unit) * 1);
+  --typography--fontSize-large: calc(var(--base-unit) * 1);
   /* 16 */
-  --typography--fontSize-small: calc(var(--base-unit) * 0.875);
+  --typography--fontSize-base: calc(var(--typography--fontSize-large) * 0.875);
   /* 14 */
-  --typography--fontSize-smaller: calc(var(--base-unit) * 0.75);
+  --typography--fontSize-small: calc(var(--typography--fontSize-large) * 0.75);
   /* 12 */
+  --typography--fontSize-smaller: calc(
+    var(--typography--fontSize-large) * 0.625
+  );
+  /* 10 */
 
   --typography--lineHeight-large: 1.34;
   --typography--lineHeight-base: 1.25;
@@ -33,11 +37,17 @@
 
 @media (--handhelds) {
   :root {
-    --typography--fontSize-extravagant: calc(var(--base-unit) * 2.5);
+    --typography--fontSize-extravagant: calc(
+      var(--typography--fontSize-large) * 2.5
+    );
     /* 40 */
-    --typography--fontSize-jumbo: calc(var(--base-unit) * 1.75);
+    --typography--fontSize-jumbo: calc(
+      var(--typography--fontSize-large) * 1.75
+    );
     /* 28 */
-    --typography--fontSize-largest: calc(var(--base-unit) * 1.375);
+    --typography--fontSize-largest: calc(
+      var(--typography--fontSize-large) * 1.375
+    );
     /* 22 */
   }
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Work to adjust the Typography scale was originally done in [this PR](https://github.com/GetJobber/atlantis/pull/976), but was overwritten by changes to move the scale to a different file.  This PR is to correct that and re-add the new typography scale.

## Changes


### Changed
- Typography scale from smaller to large inclusive, have been bumped down by 2px
- scale is now calculated relative to `--typography--fontSize-large` instead of `--base-unit`


## Note:
There is strange behaviour on loading within the two tables; for the purpose of getting this scale back into the feature branch, this will be addressed in a future PR

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
