### PR TITLE
feat(components): Update drawer, modal and card headings

### DIFF
--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -4,7 +4,7 @@ import { XOR } from "ts-xor";
 import styles from "./Card.css";
 import colors from "./colors.css";
 import { CardClickable } from "./CardClickable";
-import { Typography } from "../Typography";
+import { Heading } from "../Heading";
 
 interface CardProps {
   /**
@@ -57,15 +57,7 @@ export function Card({
     <>
       {title && (
         <div className={styles.header}>
-          <Typography
-            element="h3"
-            size="large"
-            textCase="uppercase"
-            fontWeight="extraBold"
-            textColor="heading"
-          >
-            {title}
-          </Typography>
+          <Heading level={3}>{title}</Heading>
         </div>
       )}
       {children}

--- a/packages/components/src/Card/tests/Card.test.tsx
+++ b/packages/components/src/Card/tests/Card.test.tsx
@@ -38,7 +38,7 @@ it("renders a card", () => {
         className="header"
       >
         <h3
-          className="base extraBold large uppercase heading"
+          className="base extraBold larger heading"
         >
           The Undiscovered Country
         </h3>

--- a/packages/components/src/ConfirmationModal/tests/__snapshots__/snapshot-ConfirmationModal.test.tsx.snap
+++ b/packages/components/src/ConfirmationModal/tests/__snapshots__/snapshot-ConfirmationModal.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`renders a simple ConfirmationModal 1`] = `
       data-testid="modal-header"
     >
       <h3
-        className="base extraBold large uppercase"
+        className="base extraBold larger heading"
       >
         Should we?
       </h3>

--- a/packages/components/src/Drawer/Drawer.css
+++ b/packages/components/src/Drawer/Drawer.css
@@ -41,7 +41,7 @@
 
 .header {
   display: flex;
-  padding: var(--drawer--base-padding);
+  padding: var(--space-small) var(--drawer--base-padding);
   background-color: var(--color-surface--background);
   justify-content: space-between;
   align-items: center;

--- a/packages/components/src/Drawer/Drawer.tsx
+++ b/packages/components/src/Drawer/Drawer.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from "react";
 import classnames from "classnames";
 import styles from "./Drawer.css";
-import { Typography } from "../Typography";
+import { Heading } from "../Heading";
 import { ButtonDismiss } from "../ButtonDismiss";
 
 interface DrawerProps {
@@ -57,14 +57,7 @@ interface HeaderProps {
 function Header({ title, onRequestClose }: HeaderProps) {
   return (
     <div className={styles.header} data-testid="drawer-header">
-      <Typography
-        element="h3"
-        size="large"
-        textCase="uppercase"
-        fontWeight="extraBold"
-      >
-        {title}
-      </Typography>
+      <Heading level={3}>{title}</Heading>
       <ButtonDismiss
         onClick={onRequestClose}
         ariaLabel={`Close ${title || "drawer"}`}

--- a/packages/components/src/Heading/Heading.test.tsx
+++ b/packages/components/src/Heading/Heading.test.tsx
@@ -34,7 +34,7 @@ it("renders a Heading 3", () => {
     .toJSON();
   expect(tree).toMatchInlineSnapshot(`
     <h3
-      className="base bold larger heading"
+      className="base extraBold larger heading"
     >
       Dis be a Heading 3
     </h3>

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -30,7 +30,7 @@ export function Heading({ level = 5, children }: HeadingProps) {
     3: {
       element: "h3",
       size: "larger",
-      fontWeight: "bold",
+      fontWeight: "extraBold",
       textColor: "heading",
     },
     4: {

--- a/packages/components/src/Markdown/__snapshots__/Markdown.test.tsx.snap
+++ b/packages/components/src/Markdown/__snapshots__/Markdown.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`renders Level 3 Heading Component 1`] = `
   className="padded base"
 >
   <h3
-    className="base bold larger heading"
+    className="base extraBold larger heading"
   >
     Heading 3
   </h3>

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -6,7 +6,7 @@ import { useOnKeyDown, useRefocusOnActivator } from "@jobber/hooks";
 import styles from "./Modal.css";
 import sizes from "./Sizes.css";
 import { useFocusTrap } from "./useFocusTrap";
-import { Typography } from "../Typography";
+import { Heading } from "../Heading";
 import { Button, ButtonProps } from "../Button";
 import { ButtonDismiss } from "../ButtonDismiss";
 
@@ -106,14 +106,7 @@ interface HeaderProps {
 function Header({ title, dismissible, onRequestClose }: HeaderProps) {
   return (
     <div className={styles.header} data-testid="modal-header">
-      <Typography
-        element="h3"
-        size="large"
-        textCase="uppercase"
-        fontWeight="extraBold"
-      >
-        {title}
-      </Typography>
+      <Heading level={3}>{title}</Heading>
 
       {dismissible && (
         <ButtonDismiss onClick={onRequestClose} ariaLabel="Close modal" />

--- a/packages/components/src/Modal/__snapshots__/ModalSnapshots.test.tsx.snap
+++ b/packages/components/src/Modal/__snapshots__/ModalSnapshots.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Button Variations modal shows with primary learning button 1`] = `
       data-testid="modal-header"
     >
       <h3
-        className="base extraBold large uppercase"
+        className="base extraBold larger heading"
       >
         Teaching Modal
       </h3>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Update to match new designs with Jobber Pro and Inter

## Changes

### Changed

- Drawer, Modal, and Card now consume Heading level 3
- Padding on Drawer adjusted to match Figma
- Heading level 3 now uses Jobber Pro

## Testing

- Go to Drawer, Modal and Card locally
- Can also checkout ConfirmationModal

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
