### PR TITLE
refactor(components): Update FormatFile filename size

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -96,7 +96,7 @@ export function FormatFile({
 
         {display === "expanded" && (
           <div className={styles.contentBlock}>
-            <Text size="large">{file.name}</Text>
+            <Text size="base">{file.name}</Text>
             <Text size="small">{fileSize}</Text>
           </div>
         )}

--- a/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
+++ b/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`renders a FormatFile 1`] = `
       className="contentBlock"
     >
       <p
-        className="base regular large text"
+        className="base regular base text"
       >
         Funky Corn
       </p>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Match new style for FormatFile component because the typography has been updated

## Changes
Updated `font-size` of the filename

Before:
![Screenshot 2023-01-23 at 11 14 14 AM](https://user-images.githubusercontent.com/104797704/214090930-d5da31c1-5869-4bbb-870b-612ebc416f64.png)

After:
![Screenshot 2023-01-23 at 11 14 19 AM](https://user-images.githubusercontent.com/104797704/214090950-3b2ccdea-3a84-48d1-b1af-99a6aa23df58.png)

### Changed
- `font-size` from `large` to `base` to match Figma
- updated snapshot tests

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
