### PR TITLE
fix(docs): Round the decimals on line height

### DIFF
--- a/packages/design/src/Typography.mdx
+++ b/packages/design/src/Typography.mdx
@@ -178,7 +178,7 @@ export function Value({ of: size }) {
     parseFloat(getComputedStyle(element).lineHeight) /
     parseFloat(getComputedStyle(element).fontSize);
   element.remove();
-  return value;
+  return parseFloat(value.toFixed(3));
 }
 
 | Name                                 | Visual                    | Value                    |


### PR DESCRIPTION
## Motivations
Just rounded the line height value to have a maximum of 3 decimals.

## Changes

Rounded the value



---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
