### PR TITLE
refactor(components): Increase sidenav component list from small to base

### DIFF
--- a/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
+++ b/packages/docz-tools/src/gatsby-theme-docz/components/Navigation/Navigation.module.css
@@ -62,7 +62,7 @@
   /* align-items: baseline; */
   padding: var(--space-smaller) 0;
   font-family: var(--typography--fontFamily-normal);
-  font-size: var(--typography--fontSize-small);
+  font-size: var(--typography--fontSize-base);
   font-weight: normal;
   text-transform: none;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Within each dropdown in the side nav, each component bullet was size `small` but new typography means they should be `base` instead

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed
Before:
![Screenshot 2023-01-23 at 4 13 20 PM](https://user-images.githubusercontent.com/104797704/214151294-c70121d7-8d09-4615-af9c-85c6bbc28d5a.png)

After:
![Screenshot 2023-01-23 at 4 10 40 PM](https://user-images.githubusercontent.com/104797704/214151142-9fa66008-6b0e-4f79-b168-6c4d49d0571a.png)


## Testing
- look at sidebar locally and inspect to be sure it's now `14px`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
