### PR TITLE
Cleanup: Update validation link for banner

### DIFF
--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -133,7 +133,8 @@ Use error banners when:
 
 Errors should explain what happened, and summarize how many issues need to be
 addressed in a concise manner. Detailed information about each error is the role
-of the [input validation](input-validation) component.
+of the [input text validation message](input-text/#validation-message) component
+or, if unavailable, [input validation](input-validation).
 
 For more guidance on wording, check out the
 [Product Vocabulary](../guides/product-vocabulary).

--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -133,7 +133,7 @@ Use error banners when:
 
 Errors should explain what happened, and summarize how many issues need to be
 addressed in a concise manner. Detailed information about each error is the role
-of the [input text validation message](input-text/#validation-message) component
+of the [InputText validation message](input-text/#validation-message) component
 or, if unavailable, [input validation](input-validation).
 
 For more guidance on wording, check out the


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Changes

The validation link seems to be broken in production but works locally. So I think I'd have to change it further to work but IDK?

Anyway I thought I would push people to the more common validation page first regardless.



[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
