### PR TITLE
build(design): Export spacing tokens to SCSS

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -27,7 +27,7 @@ fs.writeFile("./foundation.js", jsonContent, "utf8", function (err) {
   console.log("JSON file has been saved.");
 });
 
-const scssColors = getResolvedSCSSColors(resolvedCssVars);
+const scssColors = getResolvedSCSSVariables(resolvedCssVars);
 
 fs.writeFile(
   "./foundation.scss",
@@ -152,11 +152,16 @@ function getResolvedCSSVars(cssProperties) {
   }, {});
 }
 
-function getResolvedSCSSColors(cssProperties) {
+function getResolvedSCSSVariables(cssProperties) {
   const allKeys = Object.keys(cssProperties);
   return allKeys.reduce((acc, cssVar) => {
     if (cssVar.includes("color")) {
       return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]};`];
+    } else if (cssVar.includes("space")) {
+      const calcRegexResult = regexExpressions.calculations.exec(
+        customProperties["--" + cssVar],
+      );
+      return [...acc, `$${cssVar}: ${handleCalc(calcRegexResult)}px;`];
     } else {
       return acc;
     }


### PR DESCRIPTION

## Motivations

Follow-up of #959 , now exporting the spacing variables to the `foundation.scss` file.

## Changes
- Added the resolved spacing variables to the `foundation.scss` file


## Testing

You can build the file by running:
1. `cd packages/design`
2. `npm run build:foundation`

The Spacing tokens should be at the end of `foundation.scss`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
