### PR TITLE
build(design): Export border and radius tokens to SCSS

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -162,6 +162,8 @@ function getResolvedSCSSVariables(cssProperties) {
         customProperties["--" + cssVar],
       );
       return [...acc, `$${cssVar}: ${handleCalc(calcRegexResult)}px;`];
+    } else if (cssVar.includes("border")) {
+      return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]}px;`];
     } else {
       return acc;
     }

--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -154,7 +154,11 @@ function getResolvedCSSVars(cssProperties) {
 
 function getResolvedSCSSVariables(cssProperties) {
   const allKeys = Object.keys(cssProperties);
+  const sizeVariables = ["border", "radius"];
+
   return allKeys.reduce((acc, cssVar) => {
+    const isSizeVariable = sizeVariables.some(v => cssVar.includes(v));
+
     if (cssVar.includes("color")) {
       return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]};`];
     } else if (cssVar.includes("space")) {
@@ -162,8 +166,9 @@ function getResolvedSCSSVariables(cssProperties) {
         customProperties["--" + cssVar],
       );
       return [...acc, `$${cssVar}: ${handleCalc(calcRegexResult)}px;`];
-    } else if (cssVar.includes("border")) {
-      return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]}px;`];
+    } else if (isSizeVariable) {
+      const suffix = customProperties["--" + cssVar].includes("%") ? "%" : "px";
+      return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]}${suffix};`];
     } else {
       return acc;
     }


### PR DESCRIPTION
## Motivations
Follow-up of #959, now exporting the `border` and `radius` variables to the `foundation.scss` file.

## Changes
- Added the resolved `border` and `radius` variables to the `foundation.scss` file

## Testing

You can build the file by running:
1. `cd packages/design`
2. `npm run build:foundation`

The `border` and `radius` tokens should be in `foundation.scss`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
