### PR TITLE
build(design): Export timing and elevation tokens

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -155,7 +155,7 @@ function getResolvedCSSVars(cssProperties) {
 function getResolvedSCSSVariables(cssProperties) {
   const allKeys = Object.keys(cssProperties);
   return allKeys.reduce((acc, cssVar) => {
-    if (cssVar.includes("color")) {
+    if (cssVar.includes("color") || cssVar.includes("timing")) {
       return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]};`];
     } else if (cssVar.includes("space")) {
       const calcRegexResult = regexExpressions.calculations.exec(

--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -154,8 +154,12 @@ function getResolvedCSSVars(cssProperties) {
 
 function getResolvedSCSSVariables(cssProperties) {
   const allKeys = Object.keys(cssProperties);
+  const simpleVariables = ["color", "timing", "elevation"];
+
   return allKeys.reduce((acc, cssVar) => {
-    if (cssVar.includes("color") || cssVar.includes("timing")) {
+    const isSimpleVariable = simpleVariables.some(v => cssVar.includes(v));
+
+    if (isSimpleVariable) {
       return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]};`];
     } else if (cssVar.includes("space")) {
       const calcRegexResult = regexExpressions.calculations.exec(


### PR DESCRIPTION
## Motivations

Follow-up of #959 , now exporting the timing and elevation variables to the `foundation.scss` file.

## Changes
- Added the resolved timing and elevation variables to the `foundation.scss` file


## Testing

You can build the file by running:
1. `cd packages/design`
2. `npm run build:foundation`

The timing and elevation tokens should in the file `foundation.scss`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
