### PR TITLE
docs: update guides and capitalization [JOB-61191]

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -130,14 +130,14 @@ component once your proposal is approved.
 7. Once approved a maintainer will land the proposal in `master` and you can
    proceed to implementation
 
-### Implement a Proposal
+### Implement a proposal
 
 All components should start with a proposal. One of our
 [Guiding Principles](#guiding-principles) is to start all components with
 documentation. Once your proposal has been approved, proceed to contribute code
 to Atlantis to make it a reality!
 
-#### Contributing Code
+#### Contributing code
 
 The process for contributing code is fairly simple.
 
@@ -147,7 +147,7 @@ The process for contributing code is fairly simple.
    referencing the Issue that you are trying to solve.
 4. Once approved a maintainer will land the proposal in `master`
 
-#### Opening a Pull Request
+#### Opening a pull request
 
 Atlantis uses Conventional Commits to track versions. Pull request titles should
 follow the following format.
@@ -163,7 +163,7 @@ To request a review from Atlantis maintainers, use
 [Github's review tool](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review)
 and request from review from `GetJobber/Atlantis`.
 
-## Guiding Principles
+## Guiding principles
 
 ### Documentation first
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,14 +41,14 @@ To start the [docz](https://www.docz.site/) development server:
 npm start
 ```
 
-### Monorepo Notes
+### Monorepo notes
 
-#### Installing Dependencies
+#### Installing dependencies
 
 When installing dependencies, unless they are required for the documentation
 viewer, they should be within the package you are working within.
 
-#### Cross Linking
+#### Cross-linking
 
 If you are making a change in one package that will be needed in another you
 will need to make the needed change and run a `npm run lerna:bootstrap` before
@@ -81,7 +81,7 @@ standards, these packages will be useful:
 - [EsLint configuration](/packages/eslint-config)
 - [StyleLint configuration](/packages/stylelint-config)
 
-## Generating a Component
+## Generating a component
 
 Running the following command will prompt you for a component name and generate
 a starting point consisting of a component, tests, styling, etc to help you get
@@ -139,7 +139,7 @@ npm run lint:css
 npm run lint:ts
 ```
 
-## Repo Structure
+## Repo structure
 
 The `atlantis` repo is a monorepo consisting of a few different packages all
 living in the `./packages/` directory.
@@ -185,14 +185,14 @@ publish whenever a pull request is merged.
 <code>npm run release:unpublished-package</code>
 </details>
 
-### Pre-Release
+### Pre-release
 
 ```sh
 npx lerna version --allow-branch <branch-for-pre-release> --conventional-prerelease --preid pre
 npm run publish:prerelease
 ```
 
-### What has Changed
+### What has changed
 
 ```sh
 lerna changed

--- a/docs/content/formatting.mdx
+++ b/docs/content/formatting.mdx
@@ -14,16 +14,16 @@ weekday headers).
 
 This means in general, capitalize only the first letter of the content unless
 there is a proper noun (such as a person's name) involved. This applies to
-headings and titles, as well as cases like card headers and menu options.
+headings and titles, as well as card headers and menu options.
 
-Jobber features, such as jobs, quotes, and invoices, are not proper nouns and
+Jobber features such as jobs, quotes, and invoices are not proper nouns and
 should not be capitalized.
 
 ### Names
 
-Respect user input for names, and do not force capitalization. Names like
-“LaGrange”, “DeAndre”, and “dos Santos”, for example, all carry meaning, and we
-should not impose a standardized structure that omits these nuances.
+Respect user input for names and do not force capitalization. For example, names
+like “LaGrange”, “DeAndre”, and “dos Santos” all carry meaning, and we should
+not impose a standardized structure that omits these nuances.
 
 ### Buttons
 

--- a/docs/content/formatting.mdx
+++ b/docs/content/formatting.mdx
@@ -6,7 +6,35 @@ route: /content/formatting
 
 # Formatting
 
-## Guidelines
+## Capitalization
+
+Use sentence-case for almost all typographic content, with the exception of
+instances where all-caps is a stylistic decision (i.e. MON WED TUE as calendar
+weekday headers).
+
+This means in general, capitalize only the first letter of the content unless
+there is a proper noun (such as a person's name) involved. This applies to
+headings and titles, as well as cases like card headers and menu options.
+
+Jobber features, such as jobs, quotes, and invoices, are not proper nouns and
+should not be capitalized.
+
+### Names
+
+Respect user input for names, and do not force capitalization. Names like
+“LaGrange”, “DeAndre”, and “dos Santos”, for example, all carry meaning, and we
+should not impose a standardized structure that omits these nuances.
+
+### Buttons
+
+Button labels should be title-cased. This means in general, capitalize all words
+with the exception of:
+
+- articles (a, an, the)
+- coordinating conjunctions (but, for)
+- prepositions (at, by, to, etc.)
+
+## Date and time
 
 Where applicable, respect the time and date formats as set in the account's
 settings.

--- a/docs/content/formatting.mdx
+++ b/docs/content/formatting.mdx
@@ -34,6 +34,8 @@ with the exception of:
 - coordinating conjunctions (but, for)
 - prepositions (at, by, to, etc.)
 
+---
+
 ## Punctuation
 
 ### Periods
@@ -63,6 +65,10 @@ Use the `×` symbol to indicate multiplication whenever possible, rather than an
 | **✅ Do**   | **❌ Don't** |
 | ----------- | ------------ |
 | 12 × $48.00 | 12 x $48.00  |
+
+<br />
+
+---
 
 ## Date and time
 

--- a/docs/content/formatting.mdx
+++ b/docs/content/formatting.mdx
@@ -34,6 +34,36 @@ with the exception of:
 - coordinating conjunctions (but, for)
 - prepositions (at, by, to, etc.)
 
+## Punctuation
+
+### Periods
+
+Don't use a period in microcopy such as error messages, list items, or form
+instructions.
+
+| ✅ **Do**        | ❌ **Don't**      |
+| ---------------- | ----------------- |
+| Enter your email | Enter your email. |
+
+### Ampersands
+
+Use an ampersand (&) for titles and in labels of “compound” actions to keep
+things short and snappy.
+
+| ✅ **Do**          | ❌ **Don't**         |
+| ------------------ | -------------------- |
+| Review & Send      | Review and Send      |
+| Approve & Schedule | Approve and Schedule |
+
+### Multiplication
+
+Use the `×` symbol to indicate multiplication whenever possible, rather than an
+`x`.
+
+| **✅ Do**   | **❌ Don't** |
+| ----------- | ------------ |
+| 12 × $48.00 | 12 x $48.00  |
+
 ## Date and time
 
 Where applicable, respect the time and date formats as set in the account's

--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -561,14 +561,3 @@ on using "valid".
 | Enter a valid expiration year | The expiration year is invalid, please try again |
 
 <br />
-
-## Symbols and punctuation
-
-### Multiplication
-
-Use the `×` symbol to indicate multiplication whenever possible, rather than an
-`x`.
-
-| **✅ Do**   | **❌ Don't** |
-| ----------- | ------------ |
-| 12 × $48.00 | 12 x $48.00  |

--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -4,7 +4,7 @@ menu: Content
 route: /content/product-vocabulary
 ---
 
-# Product Vocabulary
+# Product vocabulary
 
 When and how to use words for our in-product experience. Refer to the
 [Voice and Tone Guidelines](https://jobber.atlassian.net/l/c/8vMbiEG1) for an
@@ -12,7 +12,7 @@ overview of how we speak on behalf of the Jobber brand.
 
 ---
 
-## People and Us
+## People and us
 
 ### account / profile
 
@@ -326,7 +326,7 @@ instead.
 
 <br />
 
-## Concepts and Items
+## Concepts and items
 
 In general, none of these should be capitalized unless explicitly stated or when
 used in a page title.
@@ -497,7 +497,7 @@ TBD
 
 <br />
 
-## General Phrasing
+## General phrasing
 
 ### please
 
@@ -562,7 +562,7 @@ on using "valid".
 
 <br />
 
-## Symbols and Punctuation
+## Symbols and punctuation
 
 ### Multiplication
 

--- a/docs/content/voice-and-tone.mdx
+++ b/docs/content/voice-and-tone.mdx
@@ -27,12 +27,23 @@ do).
 
 ### Punctuation
 
+#### Periods
+
 Don't use a period in microcopy such as error messages, list items, or form
 instructions.
 
 | ✅ **Do**        | ❌ **Don't**      |
 | ---------------- | ----------------- |
 | Enter your email | Enter your email. |
+
+#### Ampersands
+
+Use an ampersand (&) for titles and in labels of “compound” actions.
+
+| ✅ **Do**          | ❌ **Don't**         |
+| ------------------ | -------------------- |
+| Review & Send      | Review and Send      |
+| Approve & Schedule | Approve and Schedule |
 
 ### Don't be technical
 

--- a/docs/content/voice-and-tone.mdx
+++ b/docs/content/voice-and-tone.mdx
@@ -25,26 +25,6 @@ do).
 
 ## Guidelines
 
-### Punctuation
-
-#### Periods
-
-Don't use a period in microcopy such as error messages, list items, or form
-instructions.
-
-| ✅ **Do**        | ❌ **Don't**      |
-| ---------------- | ----------------- |
-| Enter your email | Enter your email. |
-
-#### Ampersands
-
-Use an ampersand (&) for titles and in labels of “compound” actions.
-
-| ✅ **Do**          | ❌ **Don't**         |
-| ------------------ | -------------------- |
-| Review & Send      | Review and Send      |
-| Approve & Schedule | Approve and Schedule |
-
 ### Don't be technical
 
 Don’t use words that would mean nothing to a stranger on the street. We’re here

--- a/docs/proposals/Disclosure/README.md
+++ b/docs/proposals/Disclosure/README.md
@@ -26,7 +26,7 @@ users may care about, should they choose to learn more about it.
         clickable/interactable
       - title has a `<summary>` of its content
 
-## Content Guidelines
+## Content guidelines
 
 - **Title** should be informative and label the type of content grouped in the
   body content in it

--- a/packages/components/src/Autocomplete/Autocomplete.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.mdx
@@ -63,14 +63,7 @@ import { Autocomplete } from "@jobber/components/Autocomplete";
 
 ---
 
-<!--
-  It is not necessary to provide an example of each prop. Use usage examples to
-  highlight key features of a component or particular considerations.
-
-  See `Button.mdx` for a good example of this.
--->
-
-## With Details
+## With details
 
 You can add a description to an option, which will appear below the option's
 label. You can also add a detail to an option which shows on the option's the
@@ -178,7 +171,7 @@ An autocomplete can provide section headings to break up the options.
   }}
 </Playground>
 
-## Kitchensink
+## Kitchen sink
 
 This autocomplete uses section headings, details, descriptions and option
 separators.
@@ -251,7 +244,7 @@ separators.
   }}
 </Playground>
 
-## Setting Value
+## Setting a value
 
 You can supply a value to `Autocomplete` in the form of an active `Option`.
 
@@ -300,7 +293,7 @@ You can supply a value to `Autocomplete` in the form of an active `Option`.
   }}
 </Playground>
 
-## Async Requests for Options
+## Async requests for options
 
 The `getOptions` method expected to be async so you can do any desired requests
 using either promises or `await` in `getOptions`.

--- a/packages/components/src/Avatar/Avatar.mdx
+++ b/packages/components/src/Avatar/Avatar.mdx
@@ -31,7 +31,7 @@ import { Avatar } from "@jobber/components/Avatar";
   />
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 - Avatars are available in 3 sizes:
   - `base`: Used by default.

--- a/packages/components/src/Banner/Banner.mdx
+++ b/packages/components/src/Banner/Banner.mdx
@@ -158,7 +158,7 @@ to resolve or troubleshoot the issue if possible.
   </Banner>
 </Playground>
 
-## Content Guidelines
+## Content guidelines
 
 Content in banner should:
 

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -39,7 +39,7 @@ import { Button } from "@jobber/components/Button";
 
 ---
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The right button to use depends on:
 
@@ -222,7 +222,35 @@ elements such as a Modal header.
   </Content>
 </Playground>
 
-## Disabled
+## Content guidelines
+
+Button labels should be title-cased. This means in general, capitalize all words
+with the exception of:
+
+- articles (a, an, the)
+- coordinating conjunctions (but, for)
+- prepositions (at, by, to, etc.)
+
+| ✅ Do        | ❌ Don't     |
+| ------------ | ------------ |
+| Go to Visits | Go To Visits |
+| Save Job     | SAVE JOB     |
+
+### & vs and
+
+If you have a Button with "compound" actions such as "Review & Send" or "Approve
+& Schedule", use an ampersand (&) for brevity and to reduce the likelihood that
+your label will wrap. A non-breaking space should be used between the ampersand
+and the second word so that the ampersand wraps with the second word.
+
+| ✅ Do              | ❌ Don't             |
+| ------------------ | -------------------- |
+| Review & Send      | Review and Send      |
+| Approve & Schedule | Approve and Schedule |
+
+## States and variants
+
+### Disabled
 
 As a best practice, do not design with disabled button states. This has negative
 impacts on accessibility as well as an increase in complexity for users to
@@ -235,7 +263,7 @@ how you disable a button.
   <Button label="Do the Thing" disabled />
 </Playground>
 
-## Sizes
+### Sizes
 
 Buttons comes in three sizes. `Base` is the default and should be used for
 almost every use case.
@@ -257,7 +285,7 @@ Only use `large` for extremely spacious interfaces such as a login form, and
   </Content>
 </Playground>
 
-## Icons
+### Icons
 
 You can use icons inside buttons. They can stand-alone, or appear before, after,
 or on top of the button label. They can also be added before or after the label.
@@ -276,7 +304,7 @@ present to describe the button.
   />
 </Playground>
 
-## Loading
+### Loading
 
 A way to communicate to the user that a background action is being performed.
 
@@ -296,7 +324,7 @@ A way to communicate to the user that a background action is being performed.
   <Button label="Canceling..." variation="subtle" loading={true} />
 </Playground>
 
-## Client Side Routing
+## Client-side routing
 
 A `Button` can be used for client side routing as well. When using a Button to
 handle the client side routing, use the `to` prop. Notice when you click below
@@ -326,7 +354,7 @@ that the url will change to the appropriate route.
   }}
 </Playground>
 
-## Form Submit
+## Form submit
 
 Passing the `submit` prop will allow a `Button` to submit a
 [Form](/components/form). Since submitting a form is a specific action, only

--- a/packages/components/src/Button/Button.mdx
+++ b/packages/components/src/Button/Button.mdx
@@ -46,10 +46,10 @@ The right button to use depends on:
 - the type of action your user is attempting to complete
 - the hierarchy of the interface the button lives in
 
-### Work actions
+### Work
 
-Use Work Actions buttons to enable user interactions in the goal of completing
-work in Jobber.
+Use work buttons to enable user interactions in the goal of completing work in
+Jobber.
 
 #### Primary
 
@@ -81,15 +81,15 @@ editing, revealing details, or navigating within the view.
   <Button label="Do the Thing" type="tertiary" />
 </Playground>
 
-### Learning Actions
+### Learning
 
-Use the Learning Actions buttons to enable user interactions in the goal of
-learning about Jobber, whether for marketing or coaching purposes.
+Use the Learning buttons to enable user interactions in the goal of learning
+about Jobber, whether for marketing or coaching purposes.
 
-#### Primary, Secondary, Tertiary
+#### Primary, secondary, tertiary
 
-The usage pattern for Learning Actions should follow the same logic as Work
-Actions for all three levels.
+The usage pattern for Learning should follow the same logic as Work actions for
+all three levels.
 
 <Playground>
   <Content>
@@ -122,24 +122,24 @@ Actions for all three levels.
   </Content>
 </Playground>
 
-### Destructive Actions
+### Destructive
 
 Destructive actions remove something from Jobber.
 
 #### Primary
 
-A Primary destructive action will permanently destroy an object carrying
+A primary destructive action will permanently destroy an object carrying
 significant data, such as a job, quote, or client. This destructive action
 should be contained in a [ConfirmationModal](/components/confirmation-modal)
 triggered by clicking a secondary or tertiary destructive button.
 
-#### Secondary or Tertiary
+#### Secondary or tertiary
 
-A Secondary or tertiary destructive action will either...
+A secondary or tertiary destructive action will either...
 
 - destroy an item on an object that can be quickly restored, such as a line item
   on a job
-- trigger a dialog to confirm a Primary destructive action
+- trigger a dialog to confirm a primary destructive action
 
 <Playground>
   <Content>
@@ -155,10 +155,7 @@ A Secondary or tertiary destructive action will either...
   </Content>
 </Playground>
 
-### Subtle Actions
-
-> Subtle actions replace a previous concept of "cancel" actions which has been
-> deprecated.
+### Subtle
 
 Use a subtle button when you want the visual appearance to be more, well...
 _subtle._ This variation of button uses subdued color, allowing it to sit
@@ -167,7 +164,7 @@ comfortably alongside more prominent content.
 Think of icon actions in a navigation bar, buttons to dismiss a modal, or opting
 out of completing an action they have triggered.
 
-#### Primary, Secondary, and Tertiary
+#### Primary, secondary, and tertiary
 
 A key distinction between subtle buttons and the other variations is that the
 primary/secondary/tertiary scale is styled differently, but conceptual hierarchy

--- a/packages/components/src/ButtonDismiss/ButtonDismiss.mdx
+++ b/packages/components/src/ButtonDismiss/ButtonDismiss.mdx
@@ -33,7 +33,7 @@ import { ButtonDismiss } from "@jobber/components/ButtonDismiss";
   to answer common questions and considerations about component usage.
 -->
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 When contributing to, or consuming the ButtonDismiss component, consider the
 following:

--- a/packages/components/src/Card/Card.mdx
+++ b/packages/components/src/Card/Card.mdx
@@ -41,7 +41,7 @@ import { Card } from "@jobber/components/Card";
   </Card>
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 A card is useful for grouping content because of it's distinct visual
 boundaries. However, similar to the idea that "making everything stand out means
@@ -57,7 +57,17 @@ removed, and it may be worth re-assessing the hierarchy of your interface.
 
 ---
 
-## Usage
+## Content guidelines
+
+Card titles should be sentence-cased.
+
+| ✅ Do                   | ❌ Don't                |
+| ----------------------- | ----------------------- |
+| Client property details | Client Property Details |
+| Assigned team           | ASSIGNED TEAM           |
+| Required deposit        | Required Deposit        |
+
+## Variations
 
 ### Clickable with URL
 
@@ -72,7 +82,7 @@ removed, and it may be worth re-assessing the hierarchy of your interface.
   </Card>
 </Playground>
 
-### Clickable with External URL
+### Clickable with external URL
 
 <Playground>
   <Card url="https://atlantis.getjobber.com/" external={true}>

--- a/packages/components/src/Card/Card.mdx
+++ b/packages/components/src/Card/Card.mdx
@@ -23,7 +23,7 @@ import { Card } from "@jobber/components/Card";
 ```
 
 <Playground>
-  <Card title="Banana">
+  <Card title="Banana varieties">
     <Content>
       <Heading level={4}>Burro</Heading>
       <Text>
@@ -74,7 +74,7 @@ Card titles should be sentence-cased.
 <Playground>
   <Card url="#">
     <Content>
-      <Heading level={4}>View All</Heading>
+      <Heading level={4}>View all</Heading>
       <Text>
         See how our 20+ features can help you organize, impress, and grow.
       </Text>
@@ -87,7 +87,7 @@ Card titles should be sentence-cased.
 <Playground>
   <Card url="https://atlantis.getjobber.com/" external={true}>
     <Content>
-      <Heading level={4}>View All</Heading>
+      <Heading level={4}>View all</Heading>
       <Text>
         See how our 20+ features can help you organize, impress, and grow.
       </Text>
@@ -105,7 +105,7 @@ Card titles should be sentence-cased.
     }}
   >
     <Content>
-      <Heading level={4}>View All</Heading>
+      <Heading level={4}>View all</Heading>
       <Text>
         See how our 20+ features can help you organize, impress, and grow.
       </Text>

--- a/packages/components/src/Checkbox/Checkbox.mdx
+++ b/packages/components/src/Checkbox/Checkbox.mdx
@@ -36,7 +36,7 @@ import { Checkbox } from "@jobber/components/Checkbox";
   }}
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 A checkbox is a familiar pattern for users who need to choose from a set of
 options, or opt in to a single choice.

--- a/packages/components/src/Chips/Chips.mdx
+++ b/packages/components/src/Chips/Chips.mdx
@@ -25,7 +25,7 @@ group while preserving vertical space in the interface.
 import { Chip, Chips } from "@jobber/components/Chips";
 ```
 
-## Usage Guidelines
+## Usage guidelines
 
 The `<Chip>` will allow users to make selections in scenarios where vertical
 space is at a premium. It has three high-level usages: single-select,
@@ -170,7 +170,7 @@ which they can also remove once added.
 
 <Props of={Chip} />
 
-## Content Guidelines
+## Content guidelines
 
 Chip labels should be 1–2 words at most. If any of the options in the group may
 have longer labels, consider Checkbox or Radio as necessary for your selection
@@ -192,7 +192,7 @@ The Chips itself will take up as much space as its' container allows, and the
 Chips will flow left-to-right. Chips may re-flow into new rows, or scroll out of
 view in a single row, depending on your use case.
 
-## Related Components
+## Related components
 
 - [Radio](/components/radio-group) should be used to allow the user to select
   "one-of-many" items (single-select) and the labels for the items are longer

--- a/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.mdx
@@ -46,7 +46,7 @@ import {
   }}
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 ConfirmationModals should be used to confirm or cancel an action the user is
 performing.

--- a/packages/components/src/Content/Content.mdx
+++ b/packages/components/src/Content/Content.mdx
@@ -52,7 +52,7 @@ import { Content } from "@jobber/components/Content";
   </Content>
 </Playground>
 
-## Design Usage & Guidelines
+## Design & usage guidelines
 
 Content should be used whenever you have a container with mixed content that
 requires consistent spacing between the elements.

--- a/packages/components/src/Countdown/Countdown.mdx
+++ b/packages/components/src/Countdown/Countdown.mdx
@@ -65,7 +65,7 @@ Consider the context of the countdown and whether the user will have enough
 context to interpret appropriately without labeled units when making the
 decision on whether to show or hide the units.
 
-## On Complete
+## onComplete
 
 `onComplete` is a callback that will fire once the countdown to the specified
 time has been completed.

--- a/packages/components/src/DataDump/DataDump.mdx
+++ b/packages/components/src/DataDump/DataDump.mdx
@@ -29,7 +29,7 @@ import { DataDump } from "@jobber/components/DataDump";
   to answer common questions and considerations about component usage.
 -->
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 `DataDump` should not be used in a production environment to show information to
 users.

--- a/packages/components/src/DataTable/DataTable.mdx
+++ b/packages/components/src/DataTable/DataTable.mdx
@@ -1023,7 +1023,7 @@ content?
   />
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The `DataTable` component is a great solution if you are looking to display data
 in a tabular way while giving your user the ability to sort, paginate or filter

--- a/packages/components/src/DataTable/DataTable.mdx
+++ b/packages/components/src/DataTable/DataTable.mdx
@@ -34,7 +34,7 @@ pagination with an external API or on the client side.
 import { DataTable } from "@jobber/components/DataTable";
 ```
 
-## Basic Table
+## Basic table
 
 <Playground>
   <DataTable
@@ -101,7 +101,7 @@ import { DataTable } from "@jobber/components/DataTable";
 
 <Props of={DataTable} />
 
-## Table with Actions
+## Table with actions
 
 <Playground>
   <DataTable
@@ -202,7 +202,7 @@ import { DataTable } from "@jobber/components/DataTable";
   />
 </Playground>
 
-## Client-Side Pagination, Sorting, Clickable Rows, and Fixed Height with Sticky Header
+## Client-side pagination, sorting, clickable rows, and fixed height with sticky header
 
 <Playground>
   <DataTable
@@ -336,7 +336,7 @@ import { DataTable } from "@jobber/components/DataTable";
   />
 </Playground>
 
-## Disable Sorting of a Specific Column
+## Disable sorting of a specific column
 
 <Playground>
   <DataTable
@@ -471,7 +471,7 @@ import { DataTable } from "@jobber/components/DataTable";
   />
 </Playground>
 
-## Horizontal Scrolling, Pinning First Column, Custom Cell, Custom Header
+## Horizontal scrolling, pinning first column, custom cell, custom header
 
 <Playground>
   <div style={{ maxWidth: 390 }}>
@@ -552,7 +552,7 @@ import { DataTable } from "@jobber/components/DataTable";
   </div>
 </Playground>
 
-## Manual Sorting
+## Manual sorting
 
 <Playground>
   {() => {
@@ -661,7 +661,7 @@ import { DataTable } from "@jobber/components/DataTable";
   }}
 </Playground>
 
-## Manual Pagination
+## Manual pagination
 
 <Playground>
   {() => {

--- a/packages/components/src/DatePicker/DatePicker.mdx
+++ b/packages/components/src/DatePicker/DatePicker.mdx
@@ -78,7 +78,7 @@ volume of UI elements to process at once.
   }}
 </Playground>
 
-## Custom Activator
+## Custom activator
 
 If you want to use a different activator to display the `DatePicker` you can
 pass a `React` component as the `activator`.

--- a/packages/components/src/DatePicker/DatePicker.mdx
+++ b/packages/components/src/DatePicker/DatePicker.mdx
@@ -41,7 +41,7 @@ import { DatePicker } from "@jobber/components/DatePicker";
 
 <Props of={DatePicker} />
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 Use Datepicker when you are looking to provide the user with a highly visual
 interface for intuitive date selections.
@@ -141,7 +141,7 @@ format "Choose {date} (button)". For example, "Choose December 1st, 2021
 
 If using a custom activator, ensure that the activator is keyboard-operable.
 
-## Related Components
+## Related components
 
 - If you are looking to use the `DatePicker` in a `Form`, consider the
   [InputDate](/components/input-date) component.

--- a/packages/components/src/DescriptionList/DescriptionList.mdx
+++ b/packages/components/src/DescriptionList/DescriptionList.mdx
@@ -34,7 +34,7 @@ import { DescriptionList } from "@jobber/components/DescriptionList";
 
 <Props of={DescriptionList} />
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The Description List is a great solution when you have a small list of
 information with a 1:1 label-to-data relationship. For example, the issued and

--- a/packages/components/src/DescriptionList/DescriptionList.mdx
+++ b/packages/components/src/DescriptionList/DescriptionList.mdx
@@ -42,7 +42,7 @@ due dates on an invoice, or the job type, billing type and duration of a job.
 
 ---
 
-## Passing an Element
+## Passing a custom element
 
 You are able to pass a react element in as the second term of the data tuple.
 

--- a/packages/components/src/Disclosure/Disclosure.mdx
+++ b/packages/components/src/Disclosure/Disclosure.mdx
@@ -32,7 +32,7 @@ care about, should they choose to learn more about it.
 
 <Props of={Disclosure} />
 
-## Usage Guidelines
+## Usage guidelines
 
 Use `Disclosure`for progressive... _disclosure..._ of elements that aren't
 essential for the user to view all at once. You may want to put content inside
@@ -48,7 +48,7 @@ task, do not put the selection controls in a `Disclosure`, but if there is an
 optional setting that a user _may_ want to change but is not required to, a
 `Disclosure` would do the trick nicely.
 
-## Content Guidelines
+## Content guidelines
 
 - **Title** should be informative and label the type of content grouped in the
   body content in it

--- a/packages/components/src/Divider/Divider.mdx
+++ b/packages/components/src/Divider/Divider.mdx
@@ -31,7 +31,7 @@ import { Divider } from "@jobber/components/Divider";
   </Content>
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The `Divider` component comes with no spacing around it. This means that it
 should be used within a [`Content`](/components/content) component.
@@ -40,7 +40,7 @@ should be used within a [`Content`](/components/content) component.
 
 <Props of={Divider} />
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 ### Size
 
@@ -89,7 +89,7 @@ Use a vertical divider when the content to be divided runs horizontally.
   </div>
 </Playground>
 
-## Related Components
+## Related components
 
 - To segment different groups of content, use [Card.](/components/card)
 - For guidance on borders in general, see our [Borders guide.](/borders)

--- a/packages/components/src/Divider/Divider.mdx
+++ b/packages/components/src/Divider/Divider.mdx
@@ -31,16 +31,16 @@ import { Divider } from "@jobber/components/Divider";
   </Content>
 </Playground>
 
-## Design & usage guidelines
-
-The `Divider` component comes with no spacing around it. This means that it
-should be used within a [`Content`](/components/content) component.
-
 ## Props
 
 <Props of={Divider} />
 
+---
+
 ## Design & usage guidelines
+
+The `Divider` component comes with no spacing around it. This means that it
+should be used within a [`Content`](/components/content) component.
 
 ### Size
 

--- a/packages/components/src/Drawer/Drawer.mdx
+++ b/packages/components/src/Drawer/Drawer.mdx
@@ -71,7 +71,7 @@ to indicate to assistive technology that the content within the Drawer is:
 For drawer toggle elements, use `aria-controls` attribute on the trigger and an
 `id` for the drawer element.
 
-## Related Components
+## Related components
 
 Drawer is similar in some regards to Card and Modal.
 

--- a/packages/components/src/Drawer/Drawer.mdx
+++ b/packages/components/src/Drawer/Drawer.mdx
@@ -82,7 +82,7 @@ For an experience where the user can only interact with one "mode" of content
 For an inline grouping of content that is relevant within the main view and
 non-dismissible, use [Card.](https://atlantis.getjobber.com/components/modal)
 
-### Drawer Grid (Experimental)
+### DrawerGrid (Experimental)
 
 A `DrawerGrid` wraps the content and the drawer component. It allows the content
 to fill the available space when a user toggles the drawer.

--- a/packages/components/src/Emphasis/Emphasis.mdx
+++ b/packages/components/src/Emphasis/Emphasis.mdx
@@ -25,7 +25,7 @@ import { Emphasis } from "@jobber/components/Emphasis";
   </Text>
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 ### Bold
 

--- a/packages/components/src/Form/Form.mdx
+++ b/packages/components/src/Form/Form.mdx
@@ -113,7 +113,7 @@ practice to use the [`useFormState`](/hooks/useFormState) hook with the
   }}
 </Playground>
 
-## Triggering Submission
+## Triggering submission
 
 Submission of a `Form` can be done outside of the `Form` itself by using the
 `validate` function that is exposed.

--- a/packages/components/src/FormField/FormField.mdx
+++ b/packages/components/src/FormField/FormField.mdx
@@ -89,7 +89,7 @@ import { FormField } from "@jobber/components/FormField";
   <FormField name="Error" placeholder="Error" invalid={true} />
 </Playground>
 
-### Read only
+### Read-only
 
 <Playground>
   <FormField

--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -41,7 +41,7 @@ import { strFormatDate } from "@jobber/components/FormatDate";
   <Text>{strFormatDate(new Date())}</Text>
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 Use FormatDate to ensure that a date is represented as expected.
 

--- a/packages/components/src/FormatDate/FormatDate.mdx
+++ b/packages/components/src/FormatDate/FormatDate.mdx
@@ -18,8 +18,6 @@ import { Text } from "../Text";
 In Jobber a FormatDate is used to ensure that the date is displayed in the
 expected format. No text styling is applied, this simply formats the date.
 
-## Simple Example
-
 ```ts
 import { FormatDate } from "@jobber/components/FormatDate";
 ```
@@ -27,6 +25,12 @@ import { FormatDate } from "@jobber/components/FormatDate";
 <Playground>
   <FormatDate date={new CivilDate(2020, 2, 26)} />
 </Playground>
+
+## Props
+
+<Props of={FormatDate} />
+
+---
 
 ## Getting a string version
 
@@ -54,7 +58,3 @@ If the formatted date is intended to be part of a heading, wrap FormatDate in a
 component.
 
 If you require a string instead of a component use strFormatDate.
-
-## Props
-
-<Props of={FormatDate} />

--- a/packages/components/src/FormatFile/FormatFile.mdx
+++ b/packages/components/src/FormatFile/FormatFile.mdx
@@ -60,7 +60,7 @@ import { FormatFile } from "@jobber/components/FormatFile";
 
 ---
 
-## Design and Usage Guidelines
+## Design & usage guidelines
 
 When contributing to, or consuming the `InputFile` component, consider the
 following:

--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.mdx
@@ -18,11 +18,15 @@ A FormatRelateDateTime displays the date and time using relative wording or
 approximate values. Note. This component only represents current date and dates
 in the past. No future dating.
 
-## Simple Example
-
 ```ts
 import { FormatRelativeDateTime } from "@jobber/components/FormatRelativeDateTime";
 ```
+
+## Props
+
+<Props of={FormatRelativeDateTime} />
+
+---
 
 ## Rules
 
@@ -43,7 +47,3 @@ format is Month Day, Year
 <Playground>
   <FormatRelativeDateTime date={new CivilDateTime(2020, 2, 26, 14, 29, 39)} />
 </Playground>
-
-## Props
-
-<Props of={FormatRelativeDateTime} />

--- a/packages/components/src/FormatTime/FormatTime.mdx
+++ b/packages/components/src/FormatTime/FormatTime.mdx
@@ -17,8 +17,6 @@ import { FormatTime } from ".";
 In Jobber a FormatTime is used to ensure that time is displayed in the expected
 format. No text styling is applied, this simply formats the text.
 
-## Simple Example
-
 ```ts
 import { FormatTime } from "@jobber/components/FormatTime";
 ```
@@ -35,7 +33,7 @@ import { FormatTime } from "@jobber/components/FormatTime";
 
 ---
 
-## Specify Format
+## Specify format
 
 <Playground>
   <FormatTime time={new CivilTime(2, 35)} use24HourClock={true} />

--- a/packages/components/src/Gallery/Gallery.mdx
+++ b/packages/components/src/Gallery/Gallery.mdx
@@ -100,7 +100,7 @@ import { Gallery } from "@jobber/components/Gallery";
 
 <Props of={Gallery} />
 
-## Usage Guidelines
+## Usage guidelines
 
 The `<Gallery>` will layout a set of thumbnails as a group and allows the user
 to tap/click to see them larger
@@ -212,7 +212,7 @@ maximum
   />
 </Playground>
 
-## Content Guidelines
+## Content guidelines
 
 The Gallery was created to present images, specifically thumbnails, to the user.
 The Gallery can display as many images as the designs call for, but if the

--- a/packages/components/src/Heading/Heading.mdx
+++ b/packages/components/src/Heading/Heading.mdx
@@ -106,7 +106,8 @@ of content.
 ## Content guidelines
 
 The only content that should be used in a `Heading` is text. Use sentence-case
-for headings.
+for headings. The exception is `Heading 6`, which is capitalized as a stylistic
+reference to "eyebrow" typgraphic patterns.
 
 | ✅ Do                       | ❌ Don't                    |
 | --------------------------- | --------------------------- |

--- a/packages/components/src/Heading/Heading.mdx
+++ b/packages/components/src/Heading/Heading.mdx
@@ -21,7 +21,7 @@ import { Heading } from "@jobber/components/Heading";
   <Heading level={2}>Subtitle</Heading>
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 ### Heading 1
 
@@ -102,6 +102,17 @@ of content.
 <Props of={Heading} />
 
 ---
+
+## Content guidelines
+
+The only content that should be used in a `Heading` is text. Use sentence-case
+for headings.
+
+| ✅ Do                       | ❌ Don't                    |
+| --------------------------- | --------------------------- |
+| Job #21 for Nathaniel Lewis | Job #21 For Nathaniel Lewis |
+| Save job and...             | Save Job And...             |
+| Push notification settings  | Push Notification Settings  |
 
 ## Related components
 

--- a/packages/components/src/Heading/Heading.mdx
+++ b/packages/components/src/Heading/Heading.mdx
@@ -107,7 +107,8 @@ of content.
 
 The only content that should be used in a `Heading` is text. Use sentence-case
 for headings. The exception is `Heading 6`, which is capitalized as a stylistic
-reference to "eyebrow" typgraphic patterns.
+reference to the
+[eyebrow typgraphic pattern.](https://app.uxcel.com/lessons/basics-ii-588#eyebrow-headline-8095)
 
 | ✅ Do                       | ❌ Don't                    |
 | --------------------------- | --------------------------- |

--- a/packages/components/src/Icon/Icon.mdx
+++ b/packages/components/src/Icon/Icon.mdx
@@ -23,7 +23,7 @@ Use icons as intended. Provided icons have a specific meaning. To avoid
 confusing users, each icon should be used in accordance with its meaning and
 recommended usage.
 
-## Design Guidelines
+## Design guidelines
 
 ### Icon sizes
 

--- a/packages/components/src/InlineLabel/InlineLabel.mdx
+++ b/packages/components/src/InlineLabel/InlineLabel.mdx
@@ -24,7 +24,7 @@ import { InlineLabel } from "@jobber/components/InlineLabel";
   <InlineLabel>Draft</InlineLabel>
 </Playground>
 
-## Design Usage & Guidelines
+## Design & usage guidelines
 
 Inline labels can be used fairly broadly, but the application of
 [color](#colors) should be handled with intent. Use of colour along with a

--- a/packages/components/src/InputAvatar/InputAvatar.mdx
+++ b/packages/components/src/InputAvatar/InputAvatar.mdx
@@ -46,7 +46,7 @@ import { InputAvatar } from "@jobber/components/InputAvatar";
   }}
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 An InputAvatar should be used to allow users to change their Avatar.
 

--- a/packages/components/src/InputDate/InputDate.mdx
+++ b/packages/components/src/InputDate/InputDate.mdx
@@ -53,12 +53,12 @@ ranges.
 
 <Props of={InputDate} />
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The `<InputDate>` should be used in most cases where the user needs to select a
 date.
 
-## Content Guidelines
+## Content guidelines
 
 The InputDate should only be used to display and submit date values. For other
 input usage, see [Related Components](#related-components).
@@ -87,7 +87,7 @@ The FormField for InputDate will take up the full available width of its parent.
 If used in an [InputGroup](/components/input-group), it will take up the
 available amount of space left by any other inputs in the group.
 
-## Related Components
+## Related components
 
 - If you do not need an accompanying form field, you can use the
   [Datepicker](/components/Datepicker) on its own

--- a/packages/components/src/InputEmail/InputEmail.mdx
+++ b/packages/components/src/InputEmail/InputEmail.mdx
@@ -24,7 +24,7 @@ import { InputEmail } from "@jobber/components/InputEmail";
 
 <Props of={InputEmail} />
 
-## Usage Guidelines
+## Usage guidelines
 
 Use the `<InputEmail>` when you expect the user to input an email address.
 

--- a/packages/components/src/InputFile/InputFile.mdx
+++ b/packages/components/src/InputFile/InputFile.mdx
@@ -51,7 +51,7 @@ import { InputFile, updateFiles } from "@jobber/components/InputFile";
   }}
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 When contributing to, or consuming the `InputFile` component, consider the
 following:

--- a/packages/components/src/InputFile/InputFile.mdx
+++ b/packages/components/src/InputFile/InputFile.mdx
@@ -90,7 +90,7 @@ interface UploadParams {
 }
 ```
 
-## updateFiles Helper
+## updateFiles helper
 
 `InputFile` also exports a `updateFiles` method. This method allows for easily
 updating an array of `FileUpload`s based on their `key` as uploads progress.
@@ -107,7 +107,7 @@ updating an array of `FileUpload`s based on their `key` as uploads progress.
 export function updateFiles(updatedFile: FileUpload, files: FileUpload[]);
 ```
 
-## Only Allow Images
+## Only allow images
 
 Using the `allowedTypes` prop you can choose to allow all files types or only
 images. To upload multiple images you can use the `multiple` prop;
@@ -127,7 +127,7 @@ export function fetchUploadParams() {
   </Content>
 </Playground>
 
-## Variations & Size
+## Variations & size
 
 InputFile supports two variations (`dropzone` & `button`) each with two sizes
 (`small` & `base`). Both variations of InputFile allow for drag and drop however

--- a/packages/components/src/InputGroup/InputGroup.mdx
+++ b/packages/components/src/InputGroup/InputGroup.mdx
@@ -36,7 +36,7 @@ event) they are great candidates for an InputGroup.
 
 ---
 
-## Nested Example
+## Nested example
 
 The default layout is for fields to flow in a vertical direction, one above the
 next. Use the `flowDirection` prop to specify when you want fields to flow in a

--- a/packages/components/src/InputNumber/InputNumber.mdx
+++ b/packages/components/src/InputNumber/InputNumber.mdx
@@ -27,7 +27,7 @@ import { InputNumber } from "@jobber/components/InputNumber";
   <InputNumber defaultValue={7} max={11} min={0} placeholder="Number" />
 </Playground>
 
-## Design Usage & Guidelines
+## Design & usage guidelines
 
 This is best suited for input data that benefits from being modified in
 increments, such as quantity, price, or days (ie 2 days -> 3 days).

--- a/packages/components/src/InputNumber/InputNumber.mdx
+++ b/packages/components/src/InputNumber/InputNumber.mdx
@@ -72,7 +72,7 @@ no value to the user by offering an incrementer.
   />
 </Playground>
 
-### Read only
+### Read-only
 
 <Playground>
   <InputNumber
@@ -132,7 +132,7 @@ For more information about available `validations`, see the
   </Text>
 </Playground>
 
-## Focus & Blur
+## Focus & blur
 
 <Playground>
   {() => {

--- a/packages/components/src/InputPassword/InputPassword.mdx
+++ b/packages/components/src/InputPassword/InputPassword.mdx
@@ -24,7 +24,7 @@ import { InputPassword } from "@jobber/components/InputPassword";
   <InputPassword defaultValue="password" placeholder="Password" />
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 Use InputPassword for authentication flows where the user is required to enter a
 password.

--- a/packages/components/src/InputPassword/InputPassword.mdx
+++ b/packages/components/src/InputPassword/InputPassword.mdx
@@ -56,7 +56,7 @@ character-masking, consider using
   <InputPassword defaultValue="password" placeholder="Password" hasVisibility />
 </Playground>
 
-## With Error
+## With error
 
 For more information about available `validations`, see the
 [InputText](/components/input-text/#validation-message) docs.

--- a/packages/components/src/InputText/InputText.mdx
+++ b/packages/components/src/InputText/InputText.mdx
@@ -62,7 +62,7 @@ three. Note that `loading={true}` is unimplemented for multiline input text.
   />
 </Playground>
 
-## Multiline with Minimum and Maximum
+## Multiline with minimum and maximum
 
 This is to allow flexibility in the displayed textarea size as the user types.
 The textarea will start at a specified minimum and grow to a specified maximum.
@@ -75,7 +75,7 @@ The textarea will start at a specified minimum and grow to a specified maximum.
   />
 </Playground>
 
-## Prefix/Suffix
+## Prefix/suffix
 
 Use a prefix or suffix when additional visual cues about an input's function may
 be helpful.
@@ -169,7 +169,7 @@ This includes, but is not limited to:
   />
 </Playground>
 
-### Read only
+### Read-only
 
 <Playground>
   <InputText

--- a/packages/components/src/InputTime/InputTime.mdx
+++ b/packages/components/src/InputTime/InputTime.mdx
@@ -44,7 +44,7 @@ import { InputTime } "@jobber/components/InputTime";
   <InputTime defaultValue={new CivilTime(3, 52)} disabled={true} />
 </Playground>
 
-### Read only
+### Read-only
 
 <Playground>
   <InputTime defaultValue={new CivilTime(5, 23)} readonly={true} />

--- a/packages/components/src/LightBox/LightBox.mdx
+++ b/packages/components/src/LightBox/LightBox.mdx
@@ -57,7 +57,7 @@ import { LightBox } from "@jobber/components/LightBox";
   }}
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 A lightbox's primary goal is to allow users to see a higher resolution view of
 images contained within the page they're viewing. The application of a lightbox

--- a/packages/components/src/List/List.mdx
+++ b/packages/components/src/List/List.mdx
@@ -53,13 +53,13 @@ import { List } from "@jobber/components/List";
 
 <Props of={List} />
 
-## List item props
+## ListItem props
 
 <Props of={ListItem} />
 
 ---
 
-## Sectioned List Items
+## Sectioned ListItems
 
 This groups the component in specific sections.
 

--- a/packages/components/src/Menu/Menu.mdx
+++ b/packages/components/src/Menu/Menu.mdx
@@ -80,7 +80,7 @@ Jobber features, such as jobs, quotes, and invoices, are not proper nouns and
 | Collect signature                | COLLECT SIGNATURE                |
 | Assign Jasmine Williams to visit | Assign jasmine williams to visit |
 
-## Custom Activator
+## Custom activator
 
 <Playground>
   <Menu

--- a/packages/components/src/Menu/Menu.mdx
+++ b/packages/components/src/Menu/Menu.mdx
@@ -17,7 +17,7 @@ import { Menu } from ".";
 
 A toggleable menu that holds a list of actions. Where `InputSelect` is used to
 select an item from a list `Menu` is used to display a dismissible menu of
-actions the user can preform.
+actions the user can perform.
 
 ```ts
 import { Menu } from "@jobber/components/Menu";
@@ -41,7 +41,7 @@ import { Menu } from "@jobber/components/Menu";
         header: "Send as...",
         actions: [
           {
-            label: "Text Message",
+            label: "Text message",
             icon: "sms",
             onClick: () => {
               alert("📱");
@@ -65,7 +65,20 @@ import { Menu } from "@jobber/components/Menu";
 
 <Props of={Menu} />
 
----
+## Content guidelines
+
+Menu action labels should be sentence-cased. This means in general, capitalize
+only the first letter of the label unless there is a proper noun (such as a
+person's name) in the label.
+
+Jobber features, such as jobs, quotes, and invoices, are not proper nouns and
+[should not be capitalized.](/content/product-vocabulary#concepts-and-items)
+
+| ✅ Do                            | ❌ Don't                         |
+| -------------------------------- | -------------------------------- |
+| Send as text message             | Send As Text Message             |
+| Collect signature                | COLLECT SIGNATURE                |
+| Assign Jasmine Williams to visit | Assign jasmine williams to visit |
 
 ## Custom Activator
 

--- a/packages/components/src/MultiSelect/MultiSelect.mdx
+++ b/packages/components/src/MultiSelect/MultiSelect.mdx
@@ -42,7 +42,7 @@ import { MultiSelect } from "@jobber/components/MultiSelect";
 
 <Props of={MultiSelect} />
 
-## Usage Guidelines
+## Usage guidelines
 
 The goal of the `MultiSelect` component is to allow a user to check multiple
 options within a list of items.

--- a/packages/components/src/Page/Page.mdx
+++ b/packages/components/src/Page/Page.mdx
@@ -63,7 +63,7 @@ otherwise does not benefit from horizontal constraints.
 
 ---
 
-## Page with Actions
+## Page with qctions
 
 <Playground>
   <Page
@@ -112,7 +112,7 @@ otherwise does not benefit from horizontal constraints.
 
 ---
 
-## Page with Subtitle
+## Page with subtitle
 
 Use a subtitle when you need to supplement a page title.
 

--- a/packages/components/src/Page/Page.mdx
+++ b/packages/components/src/Page/Page.mdx
@@ -63,7 +63,7 @@ otherwise does not benefit from horizontal constraints.
 
 ---
 
-## Page with qctions
+## Page with actions
 
 <Playground>
   <Page

--- a/packages/components/src/Popover/Popover.mdx
+++ b/packages/components/src/Popover/Popover.mdx
@@ -54,7 +54,7 @@ import { Popover } from "@jobber/components/Popover";
 
 <Props of={Popover} />
 
-## Usage Guidelines
+## Usage guidelines
 
 Some scenarios for Popover include the following:
 
@@ -118,7 +118,7 @@ go.
   A "functional" Popover hasn't been implemented in a componentized fashion yet.
 </Banner>
 
-### Related Components
+### Related components
 
 To add a menu button that presents multiple actions to the user, use
 [Menu](https://atlantis.getjobber.com/components/menu).
@@ -131,7 +131,7 @@ To add an inline informational element that the user can dismiss, consider if
 [Banner](https://atlantis.getjobber.com/components/banner) is the right fit for
 your use case.
 
-## Content Guidelines
+## Content guidelines
 
 - Popover text content should be concise and clear. Try not to go over three
   lines so the user can get back to what they were doing!

--- a/packages/components/src/ProgressBar/ProgressBar.mdx
+++ b/packages/components/src/ProgressBar/ProgressBar.mdx
@@ -48,7 +48,7 @@ An example where you might be better served using a spinner:
 
 ---
 
-## Example with State
+## Example with state
 
 <Playground>
   {() => {

--- a/packages/components/src/ProgressBar/ProgressBar.mdx
+++ b/packages/components/src/ProgressBar/ProgressBar.mdx
@@ -24,7 +24,7 @@ import { ProgressBar } from "@jobber/components/ProgressBar";
   <ProgressBar currentStep={3} totalSteps={4} />
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The progress bar should be used to show "definite" progress; we know exactly how
 close the process is to completion. For "indefinite" progress, where we may not

--- a/packages/components/src/RadioGroup/RadioGroup.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.mdx
@@ -39,15 +39,15 @@ import { RadioGroup } from "@jobber/components/RadioGroup";
   }}
 </Playground>
 
-## RadioGroup Props
+## RadioGroup props
 
 <Props of={RadioGroup} />
 
-## RadioOption Props
+## RadioOption props
 
 <Props of={RadioOption} />
 
-## Disabled Options
+## Disabled
 
 `RadioOptions` can be disabled by passing in the disabled prop. Disabling an
 option will prevent a user from being able to select the option.
@@ -108,7 +108,7 @@ A `description` can be used to further describe the label of the `RadioOption`.
   }}
 </Playground>
 
-## Render RadioOption with Children
+## Render RadioOption with children
 
 If the `RadioGroup` is being used to select something other then text, you can
 render the `RadioOptions` with `children`.

--- a/packages/components/src/RecurringSelect/RecurringSelect.mdx
+++ b/packages/components/src/RecurringSelect/RecurringSelect.mdx
@@ -84,7 +84,7 @@ calendar-style selectors are all built using radio or checkbox elements where
 necessary, ensuring that users of assistive tech have appropriate context as to
 the type of selection they are making.
 
-## Related Components
+## Related components
 
 To allow the user to select specific dates, use
 [Datepicker](/components/date-picker) or [InputDate](/components/input-date).

--- a/packages/components/src/Select/Select.mdx
+++ b/packages/components/src/Select/Select.mdx
@@ -82,7 +82,7 @@ import { Select, Option } from "@jobber/components/Select";
   </Select>
 </Playground>
 
-## Initial Value
+## Initial value
 
 <Playground>
   <Select defaultValue="yoink">
@@ -108,6 +108,6 @@ import { Select, Option } from "@jobber/components/Select";
 
 An `Option` defines a value selectable by a `<Select>`.
 
-## Option Props
+## Option props
 
 <Props of={Option} />

--- a/packages/components/src/Spinner/Spinner.mdx
+++ b/packages/components/src/Spinner/Spinner.mdx
@@ -28,7 +28,7 @@ import { Spinner } from "@jobber/components/Spinner";
 
 ---
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 Use Spinner to indicate loading of content where the actual amount of loading
 time or progress is unknown.
@@ -69,7 +69,7 @@ The following built-in properties help `Spinner` convey its' role effectively:
 
 ---
 
-## Related Components
+## Related components
 
 If the amount of progress or loading time is known, use
 [ProgressBar](https://atlantis.getjobber.com/components/progress-bar) to give

--- a/packages/components/src/StatusLabel/StatusLabel.mdx
+++ b/packages/components/src/StatusLabel/StatusLabel.mdx
@@ -26,7 +26,7 @@ import { StatusLabel } from "@jobber/components/StatusLabel";
 
 <Props of={StatusLabel} />
 
-## Usage Guidelines
+## Usage guidelines
 
 StatusLabel is a more opinionated version of
 [InlineLabel](/components/inline-label) and offers only 5 possible status
@@ -80,12 +80,12 @@ right, use the `end` alignment.
   </div>
 </Playground>
 
-## Related Components
+## Related components
 
 - [InlineLabel](/components/inline-label) should be replaced with StatusLabel
   where possible to provide a more intentional communication of status to users
 
-## Content Guidelines
+## Content guidelines
 
 StatusLabel does not accept any child content. It presents only a text-based
 label describing the status, and a visual color indicator to reinforce the

--- a/packages/components/src/Switch/Switch.mdx
+++ b/packages/components/src/Switch/Switch.mdx
@@ -30,7 +30,7 @@ import { Switch } from "@jobber/components/Switch";
 
 ---
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The switch is a useful component for manipulating settings with binary
 (true/false, yes/no, on/off) conditions. For this reason its' label is limited

--- a/packages/components/src/Table/Table.mdx
+++ b/packages/components/src/Table/Table.mdx
@@ -101,7 +101,7 @@ Table components do not currently accept options.
 
 ---
 
-## Cell Types
+## Cell types
 
 ### Cell
 

--- a/packages/components/src/Table/Table.mdx
+++ b/packages/components/src/Table/Table.mdx
@@ -77,7 +77,7 @@ import {
   </Table>
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The Table component is a great solution when you need to allow the user to
 compare data across items. It's a tried-and-true means of data visualization

--- a/packages/components/src/Tabs/Tabs.mdx
+++ b/packages/components/src/Tabs/Tabs.mdx
@@ -43,7 +43,7 @@ import { Tabs, Tab } from "@jobber/components/Tabs";
 
 <Props of={Tab} />
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 Use Tabs when you need to group related sub-groups of content and the user only
 needs to access one sub-group at a time.
@@ -51,7 +51,7 @@ needs to access one sub-group at a time.
 Do not use Tabs as a means of navigating the view or in lieu of a Table of
 Contents.
 
-## Related Components
+## Related components
 
 To show multiple groupings of content at once, use [Card](card).
 

--- a/packages/components/src/Toast/Toast.mdx
+++ b/packages/components/src/Toast/Toast.mdx
@@ -39,7 +39,7 @@ import { showToast } from "@jobber/components/Toast";
   />
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 When contributing to or consuming the Toast component, consider the following:
 
@@ -51,7 +51,7 @@ When contributing to or consuming the Toast component, consider the following:
 - Don't use `Dismiss` or `Cancel` as an action label.
   - Examples of action labels: `Undo`, `View`, `Refresh`.
 
-## Related Components
+## Related components
 
 For more persistent feedback (such as displaying errors), communicating a
 background process that is ongoing, or for feedback that has a longer reading

--- a/packages/components/src/Tooltip/Tooltip.mdx
+++ b/packages/components/src/Tooltip/Tooltip.mdx
@@ -33,7 +33,7 @@ import { Tooltip } from "@jobber/components/Tooltip";
   </Tooltip>
 </Playground>
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 When contributing to, or consuming the `Tooltip` component, consider the
 following:
@@ -55,7 +55,7 @@ following:
 - `Tooltip` content should consist of only text
 - `Tooltip` text content should not exceed 3 lines
 
-### Related Components
+### Related components
 
 - To introduce a novel change to the interface, highlight new functionality, or
   offer a temporary, dismissible "attached" element to part of the UI, use

--- a/packages/design/src/Colors.mdx
+++ b/packages/design/src/Colors.mdx
@@ -26,7 +26,7 @@ Color should never be the single means of conveying information in an interface.
 Use labels, iconography, or hints for assistive technology alongside color to
 ensure your content can be understood by everyone.
 
-## Usage Guidelines
+## Usage guidelines
 
 ### Typography
 
@@ -290,6 +290,6 @@ caution, it’s _bright!_
 <br />
 <br />
 
-## Swatch List
+## Swatch list
 
 <ColorSwatches colors={colors.customProperties} />

--- a/packages/generators/templates/component/{{name}}.{{mdx}}
+++ b/packages/generators/templates/component/{{name}}.{{mdx}}
@@ -38,7 +38,7 @@ import { {{ name }} } from "@jobber/components/{{ name }}";
   See `Button.mdx` for a good example of this.
 -->
 
-## Usage Guidelines
+## Usage guidelines
 
 The `<{{name}}>` will... _Add a brief description of the component_
 
@@ -52,7 +52,7 @@ The `<{{name}}>` will... _Add a brief description of the component_
   that have a green background and white text”).
 -->
 
-## Content Guidelines
+## Content guidelines
 
 <!--
   What type of content does this component present (documents, text, images, other components)?


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

As our casing for titles changes from UPPERCASE to
- sentence-case for headings
- titlecase for button labels

Our content guidance should be updated to reflect this, and our documentation should follow the same patterns we describe.

## Changes

### Added

- new capitalization section to our content docs
- capitalization guidelines to components like Heading and Button

### Changed

- updated casing of common section headings (Content guidelines, Design & usage guidelines, etc)
- casing of headers in main repo README and contributing guides

## Testing

View the associated docs pages and confirm guidelines exist and section headings follow appropriate casing

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
