### PR TITLE
build(design): Export shadow tokens to SCSS

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -171,8 +171,33 @@ function getResolvedSCSSVariables(cssProperties) {
     } else if (isSizeVariable) {
       const suffix = customProperties["--" + cssVar].includes("%") ? "%" : "px";
       return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]}${suffix};`];
+    } else if (cssVar.includes("shadow")) {
+      const resolvedShadowProperty = resolveShadow(
+        customProperties["--" + cssVar],
+      );
+
+      return [...acc, `$${cssVar}: ${resolvedShadowProperty};`];
     } else {
       return acc;
     }
   }, []);
+}
+
+function resolveShadow(shadowValue) {
+  const splittedValue = shadowValue.split(" ").filter(n => n);
+
+  return splittedValue
+    .map(value => {
+      const varRegexResult = regexExpressions.cssVars.exec(value);
+
+      if (varRegexResult) {
+        const result = jobberStyle(varRegexResult[1]);
+        const suffix = typeof result === "string" ? "" : "px";
+
+        return `${result}${suffix}`;
+      }
+
+      return value;
+    })
+    .join(" ");
 }


### PR DESCRIPTION
## Motivations

Follow-up of #959, now exporting the shadow variables to the `foundation.scss` file.

## Changes
- Added the resolved shadow variables to the `foundation.scss` file
- Shadow tokens are a little bit different because they can have multiple CSS variables inside the value, that's why I created a separated function and mapped the values to identify all CSS variables to translate to actual values.

## Testing

You can build the file by running:
1. `cd packages/design`
2. `npm run build:foundation`

The shadow tokens should be in the file `foundation.scss`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
