### PR TITLE
build(design): Export Typography tokens

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -155,15 +155,24 @@ function getResolvedCSSVars(cssProperties) {
 function getResolvedSCSSVariables(cssProperties) {
   const allKeys = Object.keys(cssProperties);
   const sizeVariables = ["border", "radius"];
-  const simpleVariables = ["color", "timing", "elevation"];
+  const simpleVariables = [
+    "color",
+    "timing",
+    "elevation",
+    "lineHeight",
+    "fontFamily",
+    "letterSpacing-base",
+  ];
+  const calcVariables = ["space", "letterSpacing-loose", "fontSize"];
 
   return allKeys.reduce((acc, cssVar) => {
     const isSizeVariable = sizeVariables.some(v => cssVar.includes(v));
     const isSimpleVariable = simpleVariables.some(v => cssVar.includes(v));
+    const isCalcVariable = calcVariables.some(v => cssVar.includes(v));
 
     if (isSimpleVariable) {
       return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]};`];
-    } else if (cssVar.includes("space")) {
+    } else if (isCalcVariable) {
       const calcRegexResult = regexExpressions.calculations.exec(
         customProperties["--" + cssVar],
       );


### PR DESCRIPTION
## Motivations

Follow-up of #959, now exporting the typography variables to the `foundation.scss` file.

## Changes
- Added the resolved typography variables to the `foundation.scss` file

## Testing

You can build the file by running:
1. `cd packages/design`
2. `npm run build:foundation`

The typography tokens should be in the file `foundation.scss`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
