### PR TITLE
refactor(design): Cleanup function to export SCSS tokens

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -156,33 +156,7 @@ function getResolvedSCSSVariables(cssProperties) {
   const allKeys = Object.keys(cssProperties);
 
   return allKeys.reduce((acc, cssVar) => {
-    const customPropertyValue = customProperties["--" + cssVar];
-    const variableType = getVariableType(cssVar);
-    let propertyValue = "";
-
-    switch (variableType) {
-      case "simple":
-        propertyValue = `${resolvedCssVars[cssVar]}`;
-        break;
-      case "calc":
-        {
-          const calcRegexResult =
-            regexExpressions.calculations.exec(customPropertyValue);
-          propertyValue = `${handleCalc(calcRegexResult)}px`;
-        }
-        break;
-      case "size":
-        {
-          const suffix = customPropertyValue.includes("%") ? "%" : "px";
-          propertyValue = `${resolvedCssVars[cssVar]}${suffix}`;
-        }
-        break;
-      case "shadow":
-        propertyValue = `${resolveShadow(customPropertyValue)}`;
-        break;
-      default:
-        propertyValue = "";
-    }
+    const propertyValue = getPropertyValue(cssVar);
 
     if (propertyValue) {
       return [...acc, `$${cssVar}: ${propertyValue};`];
@@ -232,4 +206,27 @@ function getVariableType(cssVar) {
   if (isSizeVariables) return "size";
   if (isCalcVariables) return "calc";
   if (isShadowVariable) return "shadow";
+}
+
+function getPropertyValue(cssVar) {
+  const customPropertyValue = customProperties["--" + cssVar];
+  const variableType = getVariableType(cssVar);
+
+  switch (variableType) {
+    case "simple":
+      return `${resolvedCssVars[cssVar]}`;
+    case "calc": {
+      const calcRegexResult =
+        regexExpressions.calculations.exec(customPropertyValue);
+      return `${handleCalc(calcRegexResult)}px`;
+    }
+    case "size": {
+      const suffix = customPropertyValue.includes("%") ? "%" : "px";
+      return `${resolvedCssVars[cssVar]}${suffix}`;
+    }
+    case "shadow":
+      return `${resolveShadow(customPropertyValue)}`;
+    default:
+      return "";
+  }
 }

--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -154,41 +154,41 @@ function getResolvedCSSVars(cssProperties) {
 
 function getResolvedSCSSVariables(cssProperties) {
   const allKeys = Object.keys(cssProperties);
-  const sizeVariables = ["border", "radius"];
-  const simpleVariables = [
-    "color",
-    "timing",
-    "elevation",
-    "lineHeight",
-    "fontFamily",
-    "letterSpacing-base",
-  ];
-  const calcVariables = ["space", "letterSpacing-loose", "fontSize"];
 
   return allKeys.reduce((acc, cssVar) => {
-    const isSizeVariable = sizeVariables.some(v => cssVar.includes(v));
-    const isSimpleVariable = simpleVariables.some(v => cssVar.includes(v));
-    const isCalcVariable = calcVariables.some(v => cssVar.includes(v));
+    const customPropertyValue = customProperties["--" + cssVar];
+    const variableType = getVariableType(cssVar);
+    let propertyValue = "";
 
-    if (isSimpleVariable) {
-      return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]};`];
-    } else if (isCalcVariable) {
-      const calcRegexResult = regexExpressions.calculations.exec(
-        customProperties["--" + cssVar],
-      );
-      return [...acc, `$${cssVar}: ${handleCalc(calcRegexResult)}px;`];
-    } else if (isSizeVariable) {
-      const suffix = customProperties["--" + cssVar].includes("%") ? "%" : "px";
-      return [...acc, `$${cssVar}: ${resolvedCssVars[cssVar]}${suffix};`];
-    } else if (cssVar.includes("shadow")) {
-      const resolvedShadowProperty = resolveShadow(
-        customProperties["--" + cssVar],
-      );
-
-      return [...acc, `$${cssVar}: ${resolvedShadowProperty};`];
-    } else {
-      return acc;
+    switch (variableType) {
+      case "simple":
+        propertyValue = `${resolvedCssVars[cssVar]}`;
+        break;
+      case "calc":
+        {
+          const calcRegexResult =
+            regexExpressions.calculations.exec(customPropertyValue);
+          propertyValue = `${handleCalc(calcRegexResult)}px`;
+        }
+        break;
+      case "size":
+        {
+          const suffix = customPropertyValue.includes("%") ? "%" : "px";
+          propertyValue = `${resolvedCssVars[cssVar]}${suffix}`;
+        }
+        break;
+      case "shadow":
+        propertyValue = `${resolveShadow(customPropertyValue)}`;
+        break;
+      default:
+        propertyValue = "";
     }
+
+    if (propertyValue) {
+      return [...acc, `$${cssVar}: ${propertyValue};`];
+    }
+
+    return acc;
   }, []);
 }
 
@@ -209,4 +209,27 @@ function resolveShadow(shadowValue) {
       return value;
     })
     .join(" ");
+}
+
+function getVariableType(cssVar) {
+  const includesInArray = v => cssVar.includes(v);
+
+  const isSizeVariables = ["border", "radius"].some(includesInArray);
+  const isSimpleVariables = [
+    "color",
+    "timing",
+    "elevation",
+    "lineHeight",
+    "fontFamily",
+    "letterSpacing-base",
+  ].some(includesInArray);
+  const isCalcVariables = ["space", "letterSpacing-loose", "fontSize"].some(
+    includesInArray,
+  );
+  const isShadowVariable = cssVar.includes("shadow");
+
+  if (isSizeVariables) return "size";
+  if (isSimpleVariables) return "simple";
+  if (isCalcVariables) return "calc";
+  if (isShadowVariable) return "shadow";
 }

--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -228,8 +228,8 @@ function getVariableType(cssVar) {
   );
   const isShadowVariable = cssVar.includes("shadow");
 
-  if (isSizeVariables) return "size";
   if (isSimpleVariables) return "simple";
+  if (isSizeVariables) return "size";
   if (isCalcVariables) return "calc";
   if (isShadowVariable) return "shadow";
 }


### PR DESCRIPTION
## Motivations
Refactor the function that exports the design tokens to SCSS.

## Changes
- Just clean up and refactor.

## Testing
You can build the file by running:
1. `cd packages/design`
2. `npm run build:foundation`

The exported tokens should be the same as `master`


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
