### PR TITLE
fix(components): Remove default value for prop size in ConfirmationModal

### DIFF
--- a/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
@@ -175,7 +175,7 @@ export const ConfirmationModal = forwardRef(function ConfirmationModalInternal(
     onCancel,
     onRequestClose,
     variation = "work",
-    size = "small",
+    size = undefined,
     children,
   }: ConfirmationModalProps,
   ref: Ref<ConfirmationModalRef>,

--- a/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
@@ -175,7 +175,7 @@ export const ConfirmationModal = forwardRef(function ConfirmationModalInternal(
     onCancel,
     onRequestClose,
     variation = "work",
-    size = undefined,
+    size,
     children,
   }: ConfirmationModalProps,
   ref: Ref<ConfirmationModalRef>,

--- a/packages/components/src/ConfirmationModal/tests/__snapshots__/snapshot-ConfirmationModal.test.tsx.snap
+++ b/packages/components/src/ConfirmationModal/tests/__snapshots__/snapshot-ConfirmationModal.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`renders a simple ConfirmationModal 1`] = `
     }
   />
   <div
-    className="modal small"
+    className="modal"
     style={
       Object {
         "opacity": 0,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
In the [PR](https://github.com/GetJobber/atlantis/pull/969) that added additional functionality to the `ConfirmationModal` we assign the default `size` property to the `small` value. This led to only 2 sizes being available for the modal size: `small` and `large`. 

We want to ensure that if `size` property is not supplied, none of the styles for the size modal will be applied, meaning that it will be the default size.

## Changes
Remove the default value for the `size` prop in the `ConfirmationModal` component.

### Added
n/a

### Changed
The `small` size prop was a default value. Now, `size` doesn't have default value.


### Deprecated
n/a
### Removed
n/a
- <!-- now removed features -->

### Fixed
n/a
- <!-- for any bug fixes -->

### Security
n/a
- <!-- in case of vulnerabilities -->

## Testing
Go to the Confirmation modal and open it. Should open the modal.
If you provide `small` or `large` size value - the size of the modal should change correspondingly.  

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
