### PR TITLE
fix(components): Make CSS selector more specific on SortIcon to not affect other icons [JOB-61694]

### DIFF
--- a/packages/components/src/DataTable/SortIcon.css
+++ b/packages/components/src/DataTable/SortIcon.css
@@ -1,14 +1,14 @@
 .sortIcon {
   padding-right: var(--space-small);
 }
-path {
+.sortIcon path {
   fill: var(--color-greyBlue);
 }
 
-path.active {
+.sortIcon path.active {
   fill: var(--color-blue);
 }
 
-path.inactive {
+.sortIcon path.inactive {
   fill: var(--color-greyBlue--lighter);
 }


### PR DESCRIPTION
## Motivations
CSS Selector was affecting other icons (truck, for example) and filling them with grey blue.

### Fixed
- SortIcon CSS selectors


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
