### PR TITLE
Bumping `@sideway/formula` to safety version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14553,9 +14553,9 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
       "dev": true
     },
     "@sideway/pinpoint": {


### PR DESCRIPTION
### Security

- Mirroring #1028, but without the weird removal of dev flags
- As per https://github.com/advisories/GHSA-c2jc-4fpr-4vhg, this addresses [CVE-2023-25166](https://nvd.nist.gov/vuln/detail/CVE-2023-25166)