### PR TITLE
docs(components): convert first component storybook bundle

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.stories.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.stories.mdx
@@ -1,0 +1,343 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Button } from "@jobber/components/Button";
+import { Autocomplete } from "@jobber/components/Autocomplete";
+import { useState } from "react";
+import cloneDeep from "lodash/cloneDeep";
+
+<Meta title="Components/Autocomplete" component={Autocomplete} />
+
+# Autocomplete
+
+An autocomplete allows a user to quickly pick a preset value from a larger list
+of possible options.
+
+If the number of available options is smaller consider a [Select](select)
+instead.
+
+```ts
+import { Autocomplete } from "@jobber/components/Autocomplete";
+```
+
+<Canvas>
+  <Story name="Autocomplete">
+    {() => {
+      const options = [
+        { value: 1, label: "Nostromo" },
+        { value: 2, label: "Rodger Young" },
+        { value: 3, label: "Serenity" },
+        { value: 4, label: "Sleeper Service" },
+        { value: 5, label: "Enterprise" },
+        { value: 6, label: "Enterprise-D" },
+      ];
+      const [value, setValue] = useState();
+      return (
+        <Autocomplete
+          value={value}
+          initialOptions={[]}
+          onChange={setValue}
+          getOptions={getOptions}
+          placeholder="Search for something"
+        />
+      );
+      function getOptions(text) {
+        if (text === "") {
+          return options;
+        }
+        const filterRegex = new RegExp(text, "i");
+        return options.filter(option => option.label.match(filterRegex));
+      }
+    }}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Autocomplete} story="Autocomplete" />
+
+---
+
+## With details
+
+You can add a description to an option, which will appear below the option's
+label. You can also add a detail to an option which shows on the option's the
+bottom right. Both of these are optional per option.
+
+<Canvas>
+  <Story name="With details">
+    {() => {
+      const options = [
+        {
+          value: 1,
+          label: "Sulaco",
+          description: "They mostly come at night, mostly.",
+          details: "LV-426",
+        },
+        { value: 2, label: "Nostromo", details: "LV-426" },
+        { value: 3, label: "Serenity", description: "I aim to misbehave." },
+        { value: 4, label: "Sleeper Service" },
+        { value: 5, label: "Enterprise" },
+        {
+          value: 6,
+          label: "Enterprise-D",
+          description: "Tea, earl grey, hot.",
+          details: "NCC-1701D",
+        },
+      ];
+      const [value, setValue] = useState();
+      return (
+        <Autocomplete
+          value={value}
+          initialOptions={options}
+          onChange={setValue}
+          getOptions={getOptions}
+          placeholder="Search for something"
+        />
+      );
+      function getOptions(text) {
+        if (text === "") {
+          return options;
+        }
+        const filterRegex = new RegExp(text, "i");
+        return options.filter(option =>
+          option.heading ? true : option.label.match(filterRegex)
+        );
+      }
+    }}
+  </Story>
+</Canvas>
+
+## Section headings
+
+An autocomplete can provide section headings to break up the options.
+
+<Canvas>
+  <Story name="Section headings">
+    {() => {
+      const options = [
+        {
+          label: "Ships",
+          options: [
+            { value: 1, label: "Sulaco" },
+            { value: 2, label: "Nostromo" },
+            { value: 3, label: "Serenity" },
+            { value: 4, label: "Sleeper Service" },
+            { value: 5, label: "Enterprise" },
+            { value: 6, label: "Enterprise-D" },
+          ],
+        },
+        {
+          label: "Planets",
+          options: [
+            { value: 7, label: "Endor" },
+            { value: 8, label: "Vulcan" },
+            { value: 9, label: "Bespin" },
+            { value: 10, label: "Tatooine" },
+          ],
+        },
+      ];
+      const [value, setValue] = useState();
+      return (
+        <Autocomplete
+          value={value}
+          separators={true}
+          initialOptions={options}
+          onChange={setValue}
+          getOptions={getOptions}
+          placeholder="Search for something"
+        />
+      );
+      function getOptions(text) {
+        const workingOptions = cloneDeep(options);
+        return filterOptions(text, workingOptions);
+      }
+      /**
+       * This is an example of a synchronous filter function.
+       * In reality an api should return this pre-formatted structure.
+       */
+      function filterOptions(text, options = []) {
+        return options.filter(option => {
+          if (option.options) {
+            option.options = filterOptions(text, option.options);
+            return true;
+          }
+          const filterRegex = new RegExp(text, "i");
+          return option.label.match(filterRegex);
+        });
+      }
+    }}
+  </Story>
+</Canvas>
+
+## Kitchen sink
+
+This autocomplete uses section headings, details, descriptions and option
+separators.
+
+<Canvas>
+  <Story name="Kitchen sink">
+    {() => {
+      const options = [
+        {
+          label: "Ships",
+          options: [
+            {
+              value: 1,
+              label: "Sulaco",
+              description: "They mostly come at night, mostly.",
+              details: "LV-426",
+            },
+            { value: 2, label: "Nostromo", details: "LV-426" },
+            { value: 3, label: "Serenity", description: "I aim to misbehave." },
+            { value: 4, label: "Sleeper Service" },
+            { value: 5, label: "Enterprise" },
+            {
+              value: 6,
+              label: "Enterprise-D",
+              description: "Tea, earl grey, hot.",
+              details: "NCC-1701D",
+            },
+          ],
+        },
+        {
+          label: "Planets",
+          options: [
+            { value: 7, label: "Endor" },
+            { value: 8, label: "Vulcan" },
+            { value: 9, label: "Bespin" },
+            { value: 10, label: "Tatooine" },
+            { value: 11, label: "Enterprise" },
+            { value: 12, label: "Ariel" },
+          ],
+        },
+      ];
+      const [value, setValue] = useState();
+      return (
+        <Autocomplete
+          value={value}
+          initialOptions={options}
+          onChange={setValue}
+          getOptions={getOptions}
+          size={"small"}
+          placeholder="Search for something"
+        />
+      );
+      function getOptions(text) {
+        const workingOptions = cloneDeep(options);
+        return filterOptions(text, workingOptions);
+      }
+      /**
+       * This is an example of a synchronous filter function.
+       * In reality an api should return this pre-formatted structure.
+       */
+      function filterOptions(text, options = []) {
+        return options.filter(option => {
+          if (option.options) {
+            option.options = filterOptions(text, option.options);
+            return true;
+          }
+          const filterRegex = new RegExp(text, "i");
+          return option.label.match(filterRegex);
+        });
+      }
+    }}
+  </Story>
+</Canvas>
+
+## Setting a value
+
+You can supply a value to `Autocomplete` in the form of an active `Option`.
+
+<Canvas>
+  <Story name="Setting a value">
+    {() => {
+      const options = [
+        { value: 1, label: "Nostromo" },
+        { value: 2, label: "Rodger Young" },
+        { value: 3, label: "Serenity" },
+        { value: 4, label: "Sleeper Service" },
+        { value: 5, label: "Enterprise" },
+        { value: 6, label: "Enterprise-D" },
+      ];
+      const [value, setValue] = useState();
+      return (
+        <>
+          <pre>{JSON.stringify(value, undefined, 2)}</pre>
+          <Autocomplete
+            value={value}
+            initialOptions={[]}
+            onChange={setValue}
+            getOptions={getOptions}
+            placeholder="Search for something"
+          />
+          <Button
+            label="Choose the Enterprise"
+            onClick={() => {
+              setValue(options[4]);
+            }}
+          />
+          <Button
+            label="Reset"
+            onClick={() => {
+              setValue();
+            }}
+          />
+        </>
+      );
+      function getOptions(text) {
+        if (text === "") {
+          return options;
+        }
+        const filterRegex = new RegExp(text, "i");
+        return options.filter(option => option.label.match(filterRegex));
+      }
+    }}
+  </Story>
+</Canvas>
+
+## Async requests for options
+
+The `getOptions` method expected to be async so you can do any desired requests
+using either promises or `await` in `getOptions`.
+
+<Canvas>
+  <Story name="Async request for options">
+    {() => {
+      const options = [
+        { value: 1, label: "Nostromo" },
+        { value: 2, label: "Rodger Young" },
+        { value: 3, label: "Serenity" },
+        { value: 4, label: "Sleeper Service" },
+        { value: 5, label: "Enterprise" },
+        { value: 6, label: "Enterprise-D" },
+      ];
+      const [value, setValue] = useState();
+      return (
+        <Autocomplete
+          value={value}
+          initialOptions={[]}
+          onChange={setValue}
+          getOptions={getOptions}
+          placeholder="Search for something"
+        />
+      );
+      async function getOptions(text) {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            if (text === "") {
+              resolve(options);
+            }
+            const filterRegex = new RegExp(text, "i");
+            resolve(options.filter(option => option.label.match(filterRegex)));
+          }, 300);
+        });
+      }
+    }}
+  </Story>
+</Canvas>
+
+## Related components
+
+- If you want to present a list of predefined options without text input, use a
+  [Select](select) instead.
+- If autocompleted results are not required for the text input, use
+  [InputText](input-text) instead.

--- a/packages/components/src/Avatar/Avatar.stories.mdx
+++ b/packages/components/src/Avatar/Avatar.stories.mdx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Tooltip } from "@jobber/components/Tooltip";
+import { Avatar } from "@jobber/components/Avatar";
+
+<Meta title="Components/Avatar" component={Avatar} />
+
+# Avatar
+
+An avatar will be used to display an visual identifier for an individual user.
+
+```ts
+import { Avatar } from "@jobber/components/Avatar";
+```
+
+<Canvas>
+  <Story name="Avatar">
+    {() => {
+      return (
+        <Avatar
+          imageUrl="https://images.unsplash.com/photo-1533858539156-90ea20bafd17?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+          name="The Jobbler"
+          size="large"
+          initials="JBLR"
+          color="var(--color-indigo)"
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Design & usage guidelines
+
+- Avatars are available in 3 sizes:
+  - `base`: Used by default.
+  - `large`: Use when the avatar is the focal point.
+  - `small`: Use on higher-density/compact pages or components.
+- If an avatar is displayed without a name label, display a tooltip.
+- Initials and background color should have sufficient color contrast to meet
+  AA.
+
+## Props
+
+<Props of={Avatar} />
+
+## Color
+
+The concept of `color` with an Avatar is currently not used in Jobber.
+
+Use `color` to indicate the background and the border color of an avatar
+component.
+
+When using `color`, make sure that the color is consistent for a user throughout
+the application. The color that is represented for an avatar should be the same
+color that represents a user in other parts of the application, such as the
+calendar.
+
+<Canvas>
+  <Story name="Color">
+    {() => {
+      const [color, setColor] = useState("#7db00e");
+      const style = {
+        display: "inline-block",
+        marginRight: "5px",
+        verticalAlign: "middle",
+      };
+      return (
+        <>
+          <label htmlFor="color-picker">Select A Color</label>
+          <br />
+          <input
+            type="color"
+            id="color-picker"
+            value={color}
+            onChange={e => setColor(e.target.value)}
+          />
+          <hr />
+          <div style={style}>
+            <Avatar initials="JBLR" color={color} />
+          </div>
+          <div style={style}>
+            <Avatar
+              imageUrl="https://images.unsplash.com/photo-1533858539156-90ea20bafd17?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+              color={color}
+            />
+          </div>
+          <div style={style}>
+            <Avatar size="large" color={color} />
+          </div>
+          <div style={style}>
+            <Avatar
+              imageUrl="https://images.unsplash.com/photo-1533858539156-90ea20bafd17?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+              size="large"
+              color={color}
+            />
+          </div>
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Usage with Tooltip
+
+If an avatar is displayed without a name label, display a tooltip.
+
+<Canvas>
+  <Story name="Usage with Tooltip">
+    {() => {
+      const [name] = useState("The Jobbler");
+      return (
+        <Tooltip message={name}>
+          <Avatar size="large" initials="JBLR" />
+        </Tooltip>
+      );
+    }}
+  </Story>
+</Canvas>
+
+##### Avatar image credit
+
+[Gabrielle Henderson on Unplash](https://unsplash.com/photos/noSpEJztSMc)

--- a/packages/components/src/Disclosure/Disclosure.stories.mdx
+++ b/packages/components/src/Disclosure/Disclosure.stories.mdx
@@ -1,0 +1,118 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Content } from "@jobber/components/Content";
+import { Text } from "@jobber/components/Text";
+import { Disclosure } from "@jobber/components/Disclosure";
+
+<Meta title="Components/Disclosure" component={Disclosure} />
+
+# Disclosure
+
+```ts
+import { Disclosure } from "@jobber/components/Disclosure";
+```
+
+The `<Disclosure>` will reveal and hide additional information that the user may
+care about, should they choose to learn more about it.
+
+<Canvas>
+  <Story name="Disclosure">
+    {() => {
+      return (
+        <Disclosure title="Advanced instructions">
+          <Content>
+            <Text>
+              Here is some helpful information to level up your business:
+            </Text>
+            <Text>
+              For every 2 team members you add, your profits will triple.
+            </Text>
+          </Content>
+        </Disclosure>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Disclosure} />
+
+## Usage guidelines
+
+Use `Disclosure`for progressive... _disclosure..._ of elements that aren't
+essential for the user to view all at once. You may want to put content inside
+of a `Disclosure` to...
+
+- reduce distractions or avoid overwhelming the user
+- hide non-critical controls or options in a form
+
+`Disclosure` should only be used to contain content or controls that aren't
+required for the user to complete the primary objective of a given view. For
+example, if a user has to make a selection between two options to complete a
+task, do not put the selection controls in a `Disclosure`, but if there is an
+optional setting that a user _may_ want to change but is not required to, a
+`Disclosure` would do the trick nicely.
+
+## Content guidelines
+
+- **Title** should be informative and label the type of content grouped in the
+  body content in it
+  - uses `<Heading level={4}>` component
+- **Content** should be actionable and clear. May contain:
+  - good ol’ plain text
+  - accepts any React component as a child
+  - except: `<Page>`, `<Table>`
+
+## Accessibility
+
+- Users should be able to use their keyboard and toggle the component's
+  open/close state
+- Headings are permitted in `<summary>` elements to provide in-page navigational
+  assistance
+- Include aria-expanded attribute on the trigger to communicate to assistive
+  technology
+- Include aria-controls attribute ties on the trigger to the content it controls
+  using the id of the collapsible container
+- The trigger contains a downward-pointing-arrow to hint that it can be
+  expanded. when the disclosure item is in expanded state, this is rotated 180
+  degrees to point upwards
+- The icon will be given an `aria-hidden="true"` attribute to hide it from
+  assistive technologies, as well as `focusable="false"` to address an
+  inconsistency in IE and older versions of Edge
+
+## Responsiveness
+
+- This component should handle both click and touch, as well as keyboard inputs
+- This component should fill the width of its container
+- If the component is less than `375px` wide, the title will wrap and should not
+  be truncated
+- Text increases/decreases when user zooms in/out
+
+## Notes
+
+### Trade-offs, considerations, and things we want to remember
+
+- We may, in the future, setup an onchange handler that receives
+  expanded/collapsed events. For example so other parts of a page, SPA or not,
+  can subscribe to this and react accordingly.
+- While this is roughly based on a legacy Jobber implementation of an accordion,
+  we haven't fleshed out exactly how Disclosure will behave and look if used in
+  an accordion fashion
+- **Assumption**: `<Heading level=4>` should solve most use cases for this
+  component. We did consider the possibility of opening this up to other levels
+  but for a simpler end-user experience are not making the heading level
+  configurable from the component API at this time.
+
+### Similar components in other design systems
+
+https://reakit.io/docs/disclosure/
+
+https://reach.tech/disclosure/
+
+https://chakra-ui.com/usedisclosure
+
+https://github.com/accessible-ui/disclosure
+
+https://developer.apple.com/design/human-interface-guidelines/macos/buttons/disclosure-controls/
+
+https://polaris.shopify.com/components/behavior/collapsible

--- a/packages/components/src/Drawer/Drawer.stories.mdx
+++ b/packages/components/src/Drawer/Drawer.stories.mdx
@@ -1,0 +1,106 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { useState } from "react";
+import { Drawer, DrawerGrid } from "@jobber/components/Drawer";
+import { Content } from "@jobber/components/Content";
+import { Button } from "@jobber/components/Button";
+import { Text } from "@jobber/components/Text";
+import { Page } from "@jobber/components/Page";
+
+<Meta title="Components/Drawer" component={Drawer} />
+
+# Drawer
+
+Drawers are temporary sidebars that allow users to view supplementary content.
+Users can interact with the main content while the drawer is visible.
+
+```ts
+import { Drawer } from "@jobber/components/Drawer";
+```
+
+<Canvas>
+  <Story name="Drawer">
+    {() => {
+      const [drawerOpen, setDrawerOpen] = useState(true);
+      return (
+        <DrawerGrid>
+          <Page title="Page" width="fill" intro="">
+            <Content>
+              <Button
+                label="Toggle Drawer"
+                ariaControls="drawer-element"
+                onClick={() => setDrawerOpen(!drawerOpen)}
+              />
+              <Text>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+                in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+                nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+                sunt in culpa qui officia deserunt mollit anim id est laborum.
+              </Text>
+            </Content>
+          </Page>
+          <Drawer
+            id="drawer-element"
+            title="Drawer"
+            open={drawerOpen}
+            onRequestClose={() => setDrawerOpen(!drawerOpen)}
+          >
+            <Content>
+              <Text>
+                Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+                accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+                quae ab illo inventore veritatis et quasi architecto beatae
+                vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia
+                voluptas sit aspernatur aut odit aut fugit, sed quia
+                consequuntur magni dolores eos qui ratione voluptatem sequi
+                nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor
+                sit amet, consectetur, adipisci velit, sed quia non numquam eius
+                modi tempora incidunt ut labore et dolore magnam aliquam quaerat
+                voluptatem. Ut enim ad minima veniam, quis nostrum
+                exercitationem ullam corporis suscipit laboriosam, nisi ut
+                aliquid ex ea commodi consequatur? Quis autem vel eum iure
+                reprehenderit qui in ea voluptate velit esse quam nihil
+                molestiae consequatur, vel illum qui dolorem eum fugiat quo
+                voluptas nulla pariatur?
+              </Text>
+            </Content>
+          </Drawer>
+        </DrawerGrid>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Drawer} story="Drawer" />
+
+## Accessibility
+
+Drawer is built using an
+[`aside` element](https://www.w3.org/TR/html52/sections.html#the-aside-element)
+to indicate to assistive technology that the content within the Drawer is:
+
+> tangentially related to the content of the parenting sectioning content, and
+> which could be considered separate from that content. (W3 Org)
+
+For drawer toggle elements, use `aria-controls` attribute on the trigger and an
+`id` for the drawer element.
+
+## Related components
+
+Drawer is similar in some regards to Card and Modal.
+
+For an experience where the user can only interact with one "mode" of content
+(the main view _or_ the contents of the component) use
+[Modal.](https://atlantis.getjobber.com/components/modal)
+
+For an inline grouping of content that is relevant within the main view and
+non-dismissible, use [Card.](https://atlantis.getjobber.com/components/modal)
+
+### DrawerGrid (Experimental)
+
+A `DrawerGrid` wraps the content and the drawer component. It allows the content
+to fill the available space when a user toggles the drawer.

--- a/packages/components/src/Emphasis/Emphasis.stories.mdx
+++ b/packages/components/src/Emphasis/Emphasis.stories.mdx
@@ -1,0 +1,85 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Emphasis } from "@jobber/components/Emphasis";
+import { Heading } from "@jobber/components/Heading";
+import { Text } from "@jobber/components/Text";
+
+<Meta title="Components/Emphasis" component={Emphasis} />
+
+# Emphasis
+
+Use this component to emphasize certain content of a Heading or Text component.
+There are variations on Emphasis, each with their own use case and meaning.
+
+```ts
+import { Emphasis } from "@jobber/components/Emphasis";
+```
+
+<Canvas>
+  <Story name="Emphasis">
+    {() => {
+      return (
+        <Text>
+          To <Emphasis variation="bold">boldly</Emphasis> go…
+        </Text>
+      );
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={Emphasis} story="Emphasis" />
+
+## Design & usage guidelines
+
+### Bold
+
+Used to call attention to a piece of text. Bold should indicate that its
+contents have
+[strong importance, seriousness, or urgency.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)
+
+<Canvas>
+  <Story name="Bold">
+    {() => {
+      return (
+        <Text>
+          <Emphasis variation="bold">Save $240</Emphasis> when you choose our
+          Annual Plan
+        </Text>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Italic
+
+Italic emphasis should be used when there is stress emphasis on a word (or
+words) which modifies the meaning of the sentence itself.
+
+<Canvas>
+  <Story name="Italic">
+    {() => {
+      return (
+        <Text>
+          Simon’s here to show <Emphasis variation="italic">you</Emphasis> how
+          Jobber works.
+        </Text>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Highlight
+
+Used to call attention to a specific value prop on a heading. Highlight should
+only be used on page titles and subtitle, and is similar in meaning to Bold.
+
+<Canvas>
+  <Story name="Highlight">
+    {() => {
+      return (
+        <Heading level={1}>
+          Get paid <Emphasis variation="highlight">faster</Emphasis>
+        </Heading>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/components/src/InputValidation/InputValidation.stories.mdx
+++ b/packages/components/src/InputValidation/InputValidation.stories.mdx
@@ -1,0 +1,68 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { useState } from "react";
+import { Banner } from "@jobber/components/Banner";
+import { Text } from "@jobber/components/Text";
+import { InputText } from "@jobber/components/InputText";
+import { InputValidation } from "@jobber/components/InputValidation";
+
+<Meta title="Components/InputValidation" component={InputValidation} />
+
+# Input Validation
+
+<Banner type="warning">
+  90% of validation for inputs will be handled out-of-the-box by the{" "}
+  <a href="/components/input-text/#validation-message">
+    input component's validation
+  </a>
+  . Check that you cannot use the built-in validation before using this component.
+</Banner>
+
+`InputValidation` allows you to show the validation messages in cases where an
+[input's built-in validation](/components/input-text/#validation-message) is not
+available, such as in `inline` usage.
+
+For more information about `validations` using any of the `Input` components,
+see the [InputText](/components/input-text/#validation-message) documentation.
+
+```ts
+import { InputValidation } from "@jobber/components/InputValidation";
+```
+
+<Canvas>
+  <Story name="InputValidation">
+    {() => {
+      const [validationMessages, setValidationMessages] = useState(undefined);
+      return (
+        <div>
+          <Text>
+            My name is
+            <InputText
+              validations={{
+                required: {
+                  value: true,
+                  message: "Please tell me your name",
+                },
+                pattern: {
+                  value: /Jeff/,
+                  message: "Have you considered a better name, like Jeff?",
+                },
+              }}
+              onValidation={setValidationMessages}
+              name="myName"
+              size="small"
+              inline={true}
+              maxLength={4}
+            />
+          </Text>
+          {validationMessages && (
+            <InputValidation message={validationMessages} />
+          )}
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={InputValidation} story="InputValidation" />

--- a/packages/components/src/Menu/Menu.stories.mdx
+++ b/packages/components/src/Menu/Menu.stories.mdx
@@ -1,0 +1,124 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { createRef, useState } from "react";
+import { Button } from "@jobber/components/Button";
+import { Menu } from "@jobber/components/Menu";
+
+<Meta title="Components/Menu" component={Menu} />
+
+# Menu
+
+A toggleable menu that holds a list of actions. Where `InputSelect` is used to
+select an item from a list `Menu` is used to display a dismissible menu of
+actions the user can perform.
+
+```ts
+import { Menu } from "@jobber/components/Menu";
+```
+
+<Canvas>
+  <Story name="Menu">
+    {() => {
+      return (
+        <Menu
+          items={[
+            {
+              actions: [
+                {
+                  label: "Edit",
+                  icon: "edit",
+                  onClick: () => {
+                    alert("✏️");
+                  },
+                },
+              ],
+            },
+            {
+              header: "Send as...",
+              actions: [
+                {
+                  label: "Text message",
+                  icon: "sms",
+                  onClick: () => {
+                    alert("📱");
+                  },
+                },
+                {
+                  label: "Email",
+                  icon: "email",
+                  onClick: () => {
+                    alert("📨");
+                  },
+                },
+              ],
+            },
+          ]}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Menu} story="Menu" />
+
+## Content guidelines
+
+Menu action labels should be sentence-cased. This means in general, capitalize
+only the first letter of the label unless there is a proper noun (such as a
+person's name) in the label.
+
+Jobber features, such as jobs, quotes, and invoices, are not proper nouns and
+[should not be capitalized.](/content/product-vocabulary#concepts-and-items)
+
+| ✅ Do                            | ❌ Don't                         |
+| -------------------------------- | -------------------------------- |
+| Send as text message             | Send As Text Message             |
+| Collect signature                | COLLECT SIGNATURE                |
+| Assign Jasmine Williams to visit | Assign jasmine williams to visit |
+
+## Custom activator
+
+<Canvas>
+  <Story name="Custom activator">
+    {() => {
+      return (
+        <Menu
+          activator={<Button label="My Fancy Menu" />}
+          items={[
+            {
+              actions: [
+                {
+                  label: "Edit",
+                  icon: "edit",
+                  onClick: () => {
+                    alert("✏️");
+                  },
+                },
+              ],
+            },
+            {
+              header: "Send as...",
+              actions: [
+                {
+                  label: "Text Message",
+                  icon: "sms",
+                  onClick: () => {
+                    alert("📱");
+                  },
+                },
+                {
+                  label: "Email",
+                  icon: "email",
+                  onClick: () => {
+                    alert("📨");
+                  },
+                },
+              ],
+            },
+          ]}
+        />
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/components/src/RadioGroup/RadioGroup.stories.mdx
+++ b/packages/components/src/RadioGroup/RadioGroup.stories.mdx
@@ -1,0 +1,150 @@
+import { Content } from "@jobber/components/Content";
+import { Text } from "@jobber/components/Text";
+import { Checkbox } from "@jobber/components/Checkbox";
+import { Divider } from "@jobber/components/Divider";
+import { Avatar } from "@jobber/components/Avatar";
+import { useState } from "react";
+import { RadioGroup } from "@jobber/components/RadioGroup";
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+
+<Meta title="Components/RadioGroup" component={RadioGroup} />
+
+# Radio Group
+
+RadioGroup will allow users to choose a single selection from one of a list of
+provided options.
+
+```ts
+import { RadioGroup } from "@jobber/components/RadioGroup";
+```
+
+<Canvas>
+  <Story name="RadioGroup">
+    {() => {
+      const [company, setCompany] = useState("apple");
+      return (
+        <RadioGroup onChange={setCompany} value={company} ariaLabel="Companies">
+          <RadioOption value="apple" label="Apple" />
+          <RadioOption value="google" label="Google" />
+          <RadioOption value="microsoft" label="Microsoft" />
+        </RadioGroup>
+      );
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={RadioGroup} story="RadioGroup" />
+
+## RadioOption props
+
+<Props of={RadioOption} />
+
+## Disabled
+
+`RadioOptions` can be disabled by passing in the disabled prop. Disabling an
+option will prevent a user from being able to select the option.
+
+<Canvas>
+  <Story name="Disabled">
+    {() => {
+      const [company, setCompany] = useState("apple");
+      const [checked, setChecked] = useState(true);
+      return (
+        <Content spacing="large">
+          <RadioGroup
+            onChange={setCompany}
+            value={company}
+            ariaLabel="Companies"
+          >
+            <RadioOption value="apple" label="Apple" />
+            <RadioOption value="google" label="Google" />
+            <RadioOption value="amazon" label="Amazon" disabled={true} />
+            <RadioOption
+              value="microsoft"
+              label="Microsoft"
+              disabled={!checked}
+            />
+          </RadioGroup>
+          <Divider />
+          <Checkbox
+            checked={checked}
+            label="Allow Microsoft"
+            onChange={setChecked}
+          />
+        </Content>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Description
+
+A `description` can be used to further describe the label of the `RadioOption`.
+
+<Canvas>
+  <Story name="Description">
+    {() => {
+      const [company, setCompany] = useState("apple");
+      return (
+        <RadioGroup onChange={setCompany} value={company} ariaLabel="Companies">
+          <RadioOption
+            value="apple"
+            label="Apple"
+            description="A delicious fruit that fends off doctors"
+          />
+          <RadioOption
+            value="amazon"
+            label="Amazon"
+            description="The worlds largest rainforest"
+          />
+          <RadioOption
+            value="google"
+            label="Google"
+            description="A search engine"
+          />
+        </RadioGroup>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Render RadioOption with children
+
+If the `RadioGroup` is being used to select something other then text, you can
+render the `RadioOptions` with `children`.
+
+**Note:** When using `children`, `label` and `description` are not allowed due
+to the fact that they would collide with the `children` prop.
+
+**Note:** When using `children` it is the responsibility of the child to supply
+the proper accessible labels. If you are using children that do not contain
+text, an `aria-label` should be provided.
+
+<Canvas>
+  <Story name="RadioOption with children">
+    {() => {
+      const [company, setPhoto] = useState("JBR");
+      const users = [
+        { name: "Jobber", initials: "JBR" },
+        { name: "User 1", initials: "U1" },
+        { name: "User 2", initials: "U2" },
+        { name: "User 3", initials: "U3" },
+        { name: "User 4", initials: "U4" },
+      ];
+      return (
+        <>
+          <Content>
+            <Text>Select a user</Text>
+            <RadioGroup onChange={setPhoto} value={company} ariaLabel="Users">
+              {users.map(user => (
+                <RadioOption value={user.name}>
+                  <Avatar initials={user.initials} name={user.name} />
+                </RadioOption>
+              ))}
+            </RadioGroup>
+          </Content>
+        </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/components/src/Tabs/Tabs.stories.mdx
+++ b/packages/components/src/Tabs/Tabs.stories.mdx
@@ -1,0 +1,67 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Tabs, Tab } from "@jobber/components/Tabs";
+
+<Meta title="Components/Tabs" component={Tabs} />
+
+# Tabs
+
+Tabs are used to alternate amongst related views within the same context.
+
+```ts
+import { Tabs, Tab } from "@jobber/components/Tabs";
+```
+
+<Canvas>
+  <Story name="Tabs">
+    {() => {
+      return (
+        <Tabs>
+          <Tab label="Eggs">
+            🍳 Some eggs are laid by female animals of many different species,
+            including birds, reptiles, amphibians, mammals, and fish, and have
+            been eaten by humans for thousands of years.
+          </Tab>
+          <Tab label="Cheese">
+            🧀 Cheese is a dairy product derived from milk that is produced in a
+            wide range of flavors, textures, and forms by coagulation of the
+            milk protein casein.
+          </Tab>
+          <Tab label="Berries">
+            🍓 A berry is a small, pulpy, and often edible fruit. Typically,
+            berries are juicy, rounded, brightly colored, sweet, sour or tart,
+            and do not have a stone or pit.
+          </Tab>
+        </Tabs>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Tab} story="Tabs" />
+
+## Design & usage guidelines
+
+Use Tabs when you need to group related sub-groups of content and the user only
+needs to access one sub-group at a time.
+
+Do not use Tabs as a means of navigating the view or in lieu of a Table of
+Contents.
+
+## Related components
+
+To show multiple groupings of content at once, use [Card](card).
+
+To allow the user to select one-of-many options in a form, use
+[RadioGroup](radio-group) or [Select](select).
+
+## Accessibility
+
+Tabs have known accessibility concerns, including:
+
+- the user cannot navigate between Tabs using the arrow keys
+  - this breaks a universal expectation for tabbed interfaces
+- the user cannot keyboard-navigate directly from the selected Tab into the
+  selected Tab content
+  - initial keypress of `tab` key or `command+option+right` focuses next Tab


### PR DESCRIPTION
## Motivations
Convert the first bundle of components to Storybook.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
Storybook pages for:
- RadioGroup
- Disclosure
- Tabs
- InputValidation
- Drawer
- Menu
- Emphasis
- Avatar
- Autocomplete

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
