### PR TITLE
docs: add timesheets to product vocabulary

### DIFF
--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -491,6 +491,16 @@ space is limited.
 
 <br />
 
+### timesheets
+
+**Timesheets** is a single word in Jobber.
+
+| **✅ Do**          | **❌ Don't**        |
+| ------------------ | ------------------- |
+| Approve timesheets | Approve time sheets |
+
+<br />
+
 ### track / log / record
 
 TBD


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

@lorborb recently helped us get aligned on a direction to consistently present "timesheets" as "timesheets" and not "time sheets". This documents that decision for future questions about the "right" spelling.

## Changes

### Added

- Timesheets guidance to our product vocabulary

## Testing

Go to the [product vocabulary docs](https://add-timesheets-guidance-to-p.atlantis.pages.dev/content/product-vocabulary#timesheets) and make sure the timesheets section is there

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
