### PR TITLE
docs: Make docz gatsby work with stories again

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -16,7 +16,7 @@ export default {
   menu: ["Atlantis", "Patterns", "Components", "Hooks", "Design"],
   files: [
     "./docs/**/*.{md,mdx}",
-    ...packages.map(pckg => `./packages/${pckg}/src/**/*.{md,mdx}`),
+    ...packages.map(pckg => `./packages/${pckg}/src/**/!(*.stories).{md,mdx}`),
     ...packages.map(pckg => `./packages/${pckg}/README.{md,mdx}`),
     ...packages.map(pckg => `./packages/${pckg}/CHANGELOG.md`),
   ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,5 +8,12 @@ module.exports = {
         modules: ["@jobber/docz-tools"],
       },
     },
+    {
+      resolve: "gatsby-theme-docz",
+      options: {
+        files: "**/!(*.stories)*.{md,mdx}",
+        ignore: ["*.stories.mdx"],
+      },
+    },
   ],
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -87,7 +87,7 @@ exports.onCreateWebpackConfig = ({
     });
 
     config.module.rules.push({
-      test: /.*\.(?<!stories\.)(?:md|mdx)$/,
+      test: /.*\.(?:md|mdx)$/,
       use: path.resolve("../null-markdown-loader.js"),
     });
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,6 +74,11 @@ exports.onCreateWebpackConfig = ({
     cssRule,
   ];
 
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    mdxUtils: path.resolve(__dirname, "../.storybook/components"),
+  };
+
   // Situationally disable serverside rendering.
   if (stage.includes("html")) {
     config.module.rules.push({
@@ -82,8 +87,13 @@ exports.onCreateWebpackConfig = ({
     });
 
     config.module.rules.push({
-      test: /.*\.(?:md|mdx)$/,
+      test: /.*\.(?<!stories\.)(?:md|mdx)$/,
       use: path.resolve("../null-markdown-loader.js"),
+    });
+
+    config.module.rules.push({
+      test: /storybook-addon-designs\/blocks/,
+      use: loaders.null(),
     });
   }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

For some reason, gatsby within docz doesn't want to ignore stories files so this makes sure it has the necessary pieces (more like disable) to work.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

The `npm start` `npm run build` and `npm run storybook` should all build fine without stopping in an error

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
