### PR TITLE
fix: Override iOS default styling for disabled input

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -60,12 +60,6 @@
   box-shadow: var(--shadow-focus);
 }
 
-/* override iOS default styling for disabled input */
-.wrapper input:disabled {
-  -webkit-text-fill-color: var(--field--value-color);
-  opacity: 1;
-}
-
 .miniLabel {
   --field--label-elevation: calc(var(--field--base-elevation) - 1);
   --field--placeholder-color: var(--color-text--secondary);
@@ -88,6 +82,12 @@
   --field--value-color: var(--color-disabled);
   --field--background-color: var(--color-surface--background);
   --field--border-color: var(--color-disabled--secondary);
+}
+
+/* override iOS default styling for disabled input */
+.disabled :disabled {
+  -webkit-text-fill-color: var(--field--value-color);
+  opacity: 1;
 }
 
 .small {

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -60,6 +60,12 @@
   box-shadow: var(--shadow-focus);
 }
 
+/* override iOS default styling for disabled input */
+.wrapper input:disabled {
+  -webkit-text-fill-color: var(--field--value-color);
+  opacity: 1;
+}
+
 .miniLabel {
   --field--label-elevation: calc(var(--field--base-elevation) - 1);
   --field--placeholder-color: var(--color-text--secondary);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

iOS safari text inputs have their own styling for disabled, this PR should override it to look like Atlantis and not iOS.

### Before
<img width="405" alt="image" src="https://user-images.githubusercontent.com/15986172/220712473-0ac0bcfb-90a6-49f8-a520-c37355cc535b.png">

### After
<img width="403" alt="image" src="https://user-images.githubusercontent.com/15986172/220712294-53077497-2ed2-4c80-acd1-733f96cc2f56.png">


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Styling for disabled input

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- View on iPhone
- View on Desktop
- It should look exactly the same

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
