### PR TITLE
docs: Update spelling of Timesheets

### DIFF
--- a/docs/content/product-vocabulary.mdx
+++ b/docs/content/product-vocabulary.mdx
@@ -71,7 +71,7 @@ Never use **users** to refer to an individual directly.
 | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
 | Feedback from people like you will help us shape the future of this feature. | The feedback we receive from users like you will help shape the future of this feature. |
 
-Use **team member** or team when referring to assignments, time sheets and other
+Use **team member** or team when referring to assignments, timesheets and other
 work specific areas.
 
 | **✅ Do**                                          | **❌ Don't**                                |


### PR DESCRIPTION
## Motivations

Timesheets was misspelled

### Changed

'time sheets' to 'timesheets'

### Fixed

Spelling error

## Testing

Check to see if 'timesheets' is spelled without a space

---

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
