### PR TITLE
docs(components): Update Packages section

### DIFF
--- a/packages/components/src/readme.stories.mdx
+++ b/packages/components/src/readme.stories.mdx
@@ -1,8 +1,8 @@
 import { Description, Meta } from "@storybook/addon-docs";
-import Readme from "./README.mdx";
+import Readme from "../README.md";
 
 <Meta
-  title="Packages/Design"
+  title="Packages/Components"
   parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/packages/eslint-config/readme.stories.mdx
+++ b/packages/eslint-config/readme.stories.mdx
@@ -1,8 +1,8 @@
 import { Description, Meta } from "@storybook/addon-docs";
-import Readme from "./README.mdx";
+import Readme from "./README.md";
 
 <Meta
-  title="Packages/Design"
+  title="Packages/Eslint Config"
   parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/packages/hooks/readme.stories.mdx
+++ b/packages/hooks/readme.stories.mdx
@@ -13,4 +13,4 @@ Shared hooks for components in Atlantis.
 
 ## Installing
 
-`npm install hooks @jobber/hooks`
+`npm install @jobber/hooks`

--- a/packages/hooks/readme.stories.mdx
+++ b/packages/hooks/readme.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta } from "@storybook/addon-docs";
+import Readme from "./README.mdx";
+
+<Meta title="Packages/Hooks" />
+
+# Atlantis Hooks
+
+Shared hooks for components in Atlantis.
+
+## Hooks
+
+- [useResizeObserver](../?path=/docs/hooks-useresizeobserver--use-resize-observer)
+
+## Installing
+
+`npm install hooks @jobber/hooks`

--- a/packages/stylelint-config/readme.stories.mdx
+++ b/packages/stylelint-config/readme.stories.mdx
@@ -6,4 +6,4 @@ import { Meta } from "@storybook/addon-docs";
 
 ## Installing
 
-`npm install stylelint @jobber/stylelint-config`
+`npm install @jobber/stylelint-config`

--- a/packages/stylelint-config/readme.stories.mdx
+++ b/packages/stylelint-config/readme.stories.mdx
@@ -1,0 +1,9 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="Packages/Stylelint Config" />
+
+# Stylelint Config
+
+## Installing
+
+`npm install stylelint @jobber/stylelint-config`


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added


Packages:
- Components
- Eslint Config
- Hooks
- Stylelint Config

Note: Docz Tools is not being added and Formatters doesn't contain any content

### Changed

Updated the way these `README`'s get loaded in Storybook -> by loading from the original `README` instead of duplicating a file, **except** for these instances:
- _Hooks_: Decided to copy the `README` contents in the `stories.mdx` file because it contains a link to `useResizeObserver`.  I can't change that link directly in the original `README` right now, as it would change the link in docz hosted Atlantis web. 
- _Stylelint Config_: For an unknown reason, auto-formatting on save was not working when trying to pull contents directly from the original `README`. This was stopping the file from loading in Storybook so chose to just copy original `README` into the `stories.mdx` file.

## Notes

Once we remove docz, this will be removed in cleanup
![Screenshot 2023-02-24 at 2 19 39 PM](https://user-images.githubusercontent.com/104797704/221271778-b9c0a3f3-5822-4cda-9300-e537943fc50e.png)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)

