### PR TITLE
docs: add table styling + bring back content guides for button

### DIFF
--- a/.storybook/assets/css/preview.css
+++ b/.storybook/assets/css/preview.css
@@ -3,12 +3,7 @@
   outline: none;
 }
 
-:global(h6.sbdocs-h6) {
-  color: var(--color-heading);
-}
-
-a,
-:global(.sbdocs.sbdocs-a) {
+a {
   color: var(--color-interactive);
   font-family: inherit;
   font-size: inherit;
@@ -16,4 +11,31 @@ a,
 
 a:hover {
   color: var(--color-interactive--hover);
+}
+
+:global(.sbdocs-table) {
+  width: 100%;
+}
+
+:global(h6.sbdocs-h6) {
+  color: var(--color-heading);
+}
+
+:global(.sbdocs-table th) {
+  width: 50%;
+  background-color: var(--color-surface--background);
+}
+
+:global(.sbdocs.sbdocs-a) {
+  color: var(--color-interactive);
+  font-family: inherit;
+  font-size: inherit;
+}
+
+:global(.sbdocs.sbdocs-content) {
+  max-width: calc(var(--base-unit) * 48);
+}
+
+:global(.sbdocs.sbdocs-table tr:nth-of-type(2n)) {
+  background-color: transparent;
 }

--- a/packages/components/src/Button/Button.stories.mdx
+++ b/packages/components/src/Button/Button.stories.mdx
@@ -36,17 +36,17 @@ title prop. -->
 
 <ArgsTable of={Button} story="Button" />
 
-## Design & Usage Guidelines
+## Design & usage guidelines
 
 The right button to use depends on:
 
 - the type of action your user is attempting to complete
 - the hierarchy of the interface the button lives in
 
-### Work actions
+### Work buttons
 
-Use Work Actions buttons to enable user interactions with the goal of completing
-work in Jobber.
+Use "work" buttons to enable user interactions with the goal of completing work
+in Jobber.
 
 #### Primary
 
@@ -82,10 +82,10 @@ editing, revealing details, or navigating within the view.
   <Button label="Do the thing" type="tertiary" />
 </Canvas>
 
-### Learning Actions
+### Learning
 
-Use the Learning Actions buttons to enable user interactions in the goal of
-learning about Jobber, whether for marketing or coaching purposes.
+Use "learning" buttons to enable user interactions in the goal of learning about
+Jobber, whether for marketing or coaching purposes.
 
 #### Primary, Secondary, Tertiary
 
@@ -123,9 +123,9 @@ Actions for all three levels.
   </Content>
 </Canvas>
 
-### Destructive Actions
+### Destructive
 
-Destructive actions remove something from Jobber.
+"Destructive" actions remove something from Jobber.
 
 #### Primary
 
@@ -157,12 +157,9 @@ A Secondary or tertiary destructive action will either...
   </Content>
 </Canvas>
 
-### Subtle Actions
+### Subtle
 
-> Subtle actions replace a previous concept of "cancel" actions which has been
-> deprecated.
-
-Use a subtle button when you want the visual appearance to be more, well...
+Use a "subtle" button when you want the visual appearance to be more, well...
 _subtle._ This variation of button uses subdued color, allowing it to sit
 comfortably alongside more prominent content.
 
@@ -325,7 +322,7 @@ A way to communicate to the user that a background action is being performed.
   <Button label="Canceling..." variation="subtle" loading={true} />
 </Canvas>
 
-## Client Side Routing
+## Client-side routing
 
 A `Button` can be used for client-side routing as well. When using a Button to
 handle the client-side routing, use the `to` prop. Notice when you click below
@@ -351,7 +348,7 @@ that the URL will change to the appropriate route.
   </Router>
 </Canvas>
 
-## Form Submit
+## Form submit
 
 Passing the `submit` prop will allow a `Button` to submit a
 [Form](../?path=/docs/components-form--form). Since submitting a form is a

--- a/packages/components/src/Button/Button.stories.mdx
+++ b/packages/components/src/Button/Button.stories.mdx
@@ -224,6 +224,32 @@ background, allowing it to be _extra_ subtle when placed overtop
   </Content>
 </Canvas>
 
+## Content guidelines
+
+Button labels should be title-cased. This means in general, capitalize all words
+with the exception of:
+
+- articles (a, an, the)
+- coordinating conjunctions (but, for)
+- prepositions (at, by, to, etc.)
+
+| ✅ Do        | ❌ Don't     |
+| ------------ | ------------ |
+| Go to Visits | Go To Visits |
+| Save Job     | SAVE JOB     |
+
+### & vs and
+
+If you have a Button with "compound" actions such as "Review & Send" or "Approve
+& Schedule", use an ampersand (&) for brevity and to reduce the likelihood that
+your label will wrap. A non-breaking space should be used between the ampersand
+and the second word so that the ampersand wraps with the second word.
+
+| ✅ Do              | ❌ Don't             |
+| ------------------ | -------------------- |
+| Review & Send      | Review and Send      |
+| Approve & Schedule | Approve and Schedule |
+
 ## Disabled
 
 As a best practice, do not design with disabled button states. This has negative


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The content guidelines for Button were deleted in the move to Storybook. In bringing them back, I also wanted to address feedback around Storybook's default table display which we use primarily for "Do/Don't" examples and highlighting token values. This is really hard to read!

![image](https://user-images.githubusercontent.com/39704901/221933024-622179ff-f687-491a-ba7d-7ff3a98ead32.png)


## Changes

### Changed

- Storybook's tables how have even-width columns for the first two columns
- Storybook docs body content max-width has been reduced to 768px for shorter line lengths

### Fixed

- Button has content guidelines once again

## Testing

View docs for Button, Product Vocabulary, Spacing, etc.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
