### PR TITLE
docs(components): put all Heading level examples in main story

### DIFF
--- a/packages/components/src/Heading/Heading.stories.mdx
+++ b/packages/components/src/Heading/Heading.stories.mdx
@@ -12,12 +12,17 @@ interface. Reserved for short, important text or numbers.
 import { Heading } from "@jobber/components/Heading";
 ```
 
-<Canvas>
-  <Story name="Heading" args={{ level: 2 }}>
+<Canvas isColumn>
+  <Story name="Heading" args={{ level: 1 }}>
     {args => {
-      return <Heading {...args}>Subtitle</Heading>;
+      return <Heading {...args}>This is a heading</Heading>;
     }}
   </Story>
+  <Heading level={2}>This is a heading</Heading>
+  <Heading level={3}>This is a heading</Heading>
+  <Heading level={4}>This is a heading</Heading>
+  <Heading level={5}>This is a heading</Heading>
+  <Heading level={6}>This is a heading</Heading>
 </Canvas>
 
 <ArgsTable of={Heading} story="Heading" />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- While the example story in Heading is configurable with the controls, a typography component should showcase more variations upfront before having the reader dive into specific docs.

## Changes

### Added

- all level examples to the initial story. the first example is still configurable via controls.

## Testing

- view Heading docs

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
