### PR TITLE
refactor: Fix typing issue on card header

### DIFF
--- a/packages/components/src/Card/CardHeader.tsx
+++ b/packages/components/src/Card/CardHeader.tsx
@@ -15,7 +15,7 @@ export function CardHeader({
 }: Pick<CardProps, "title" | "header">) {
   const heading = title || header;
 
-  if (React.isValidElement(heading)) return <>{header}</>;
+  if (React.isValidElement(heading)) return <>{heading}</>;
   if (heading) {
     const titleString = typeof heading === "string" ? heading : heading.title;
 

--- a/packages/components/src/Card/CardHeader.tsx
+++ b/packages/components/src/Card/CardHeader.tsx
@@ -13,24 +13,16 @@ export function CardHeader({
   title,
   header,
 }: Pick<CardProps, "title" | "header">) {
-  if (title || typeof header === "string") {
-    return (
-      <div className={styles.header}>
-        {<Heading level={3}>{title || header}</Heading>}
-      </div>
-    );
-  }
+  const heading = title || header;
 
-  // header is a custom component
-  if (React.isValidElement(header)) {
-    return header;
-  }
-  // header is an action
-  if (header?.action) {
+  if (React.isValidElement(heading)) return header;
+  if (heading) {
+    const titleString = typeof heading === "string" ? heading : heading.title;
+
     return (
       <div className={styles.header}>
-        {header?.title && <Heading level={3}>{header?.title}</Heading>}
-        {renderHeaderAction(header.action)}
+        {titleString && <Heading level={3}>{titleString}</Heading>}
+        {typeof heading === "object" && renderHeaderAction(heading?.action)}
       </div>
     );
   }
@@ -38,8 +30,8 @@ export function CardHeader({
   return <></>;
 }
 
-function renderHeaderAction(action: ActionProps) {
-  if (action.type === Button) {
+function renderHeaderAction(action?: ActionProps) {
+  if (action?.type === Button) {
     const props: ButtonProps = {
       type: "tertiary",
       ...action.props,
@@ -48,8 +40,9 @@ function renderHeaderAction(action: ActionProps) {
     return action && <Button {...props} />;
   }
 
-  if (action.type === Menu) {
+  if (action?.type === Menu) {
     return action && <Menu {...(action.props as MenuProps)} />;
   }
+
   return <></>;
 }

--- a/packages/components/src/Card/CardHeader.tsx
+++ b/packages/components/src/Card/CardHeader.tsx
@@ -15,7 +15,7 @@ export function CardHeader({
 }: Pick<CardProps, "title" | "header">) {
   const heading = title || header;
 
-  if (React.isValidElement(heading)) return header;
+  if (React.isValidElement(heading)) return <>{header}</>;
   if (heading) {
     const titleString = typeof heading === "string" ? heading : heading.title;
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

It will throw a compile error on React 18 
![image](https://user-images.githubusercontent.com/15986172/222561121-19f9d788-ca85-4eee-80a1-df8d1c79cef6.png)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Logic around determining the card header content
- Fix a bug where if you put `header={{ title: "Banana" }}` it won't show a card title until you add an action

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
