### PR TITLE
docs: add rule about targeting html elements [JOB-61707]

### DIFF
--- a/docs/guides/frontend-style.stories.mdx
+++ b/docs/guides/frontend-style.stories.mdx
@@ -280,3 +280,32 @@ in a custom property in your file to avoid magic numbers.
   width: 280px;
 }
 ```
+
+### Targeting native HTML selectors
+
+Use a classname to select DOM elements for styling whenever possible.
+
+Scope CSS selectors that target native HTML elements with a classname if you
+cannot add a classname to the element directly. This keeps the styling
+encapsulated to the component and prevents styling from "leaking out" of the
+React component and into the rest of the project.
+
+#### ✅ Do
+
+```css
+a.myDestructiveComponent {
+  color: var(--color-destructive);
+}
+
+// this will only select `<a>` elements with the `myDestructiveComponent` classname
+```
+
+#### ❌ Don't
+
+```css
+a {
+  color: var(--color-destructive);
+}
+
+// this will select every `<a>` element in the project
+```


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Mitigate future issues like the SVG styling "leak" that @rodrigoeidelvein recently fixed

## Changes

### Added

- rules around CSS selectors to frontend styleguide

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
