### PR TITLE
fix(components): Fix progress bar alignment on FormatFile [JOB-63249]

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -115,6 +115,7 @@
 .progress {
   display: flex;
   align-items: center;
+  box-sizing: border-box;
   padding: var(--file-card--base-padding);
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
- alignment of the progress bar was off center in FormatFile

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
Before:
![image](https://user-images.githubusercontent.com/104797704/223312142-bd622b1b-c7e4-4f32-8957-08c981d45a03.png)

After:
<img width="403" alt="Screenshot 2023-03-06 at 10 18 20 PM" src="https://user-images.githubusercontent.com/104797704/223312273-10c547fa-9020-4852-b7a3-48499bf2397f.png">


### Fixed

 <!-- for any bug fixes -->
- Applying `box-sizing: border-box;` to the progress bar fixes the issue



---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
