### PR TITLE
feat(components): only show the navigation buttons on Lightbox when there is more than 1 image

### DIFF
--- a/packages/components/src/LightBox/LightBox.stories.mdx
+++ b/packages/components/src/LightBox/LightBox.stories.mdx
@@ -19,17 +19,18 @@ import { LightBox } from "@jobber/components/LightBox";
 
 export const images = [
   {
-    title: "😃 Happy Face",
-    url: "https://i.imgur.com/6Jcfgnp.jpg",
-    caption: "This is a happy face",
+    title: "Victoria, BC, Canada",
+    url: "https://images.unsplash.com/photo-1597201278257-3687be27d954?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+    caption:
+      "This was the view of Bushart Gardens in Victoria, BC, Canada in July from a hill.",
   },
   {
-    title: "😮",
-    url: "https://i.imgur.com/OsLxYkT.jpg",
+    title: "A house",
+    url: "https://images.unsplash.com/photo-1592595896616-c37162298647?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
     caption: "Suprised face",
   },
   {
-    url: "https://i.imgur.com/uigfzs5.jpg",
+    url: "https://images.unsplash.com/photo-1532302780319-95689ab9d79a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
   },
 ];
 
@@ -39,7 +40,7 @@ export const images = [
       const [open, isOpen] = useState(false);
       return (
         <>
-          <Button label="😈 Click me!" onClick={() => isOpen(true)} />
+          <Button label="Click me!" onClick={() => isOpen(true)} />
           <LightBox
             {...args}
             open={open}
@@ -77,24 +78,10 @@ analytics).
       const [open, isOpen] = useState(false);
       return (
         <>
-          <Button label="😈 Click me!" onClick={() => isOpen(true)} />
+          <Button label="Click me!" onClick={() => isOpen(true)} />
           <LightBox
             open={open}
-            images={[
-              {
-                title: "😃 Happy Face",
-                url: "https://i.imgur.com/6Jcfgnp.jpg",
-                caption: "This is a happy face",
-              },
-              {
-                title: "😮",
-                url: "https://i.imgur.com/OsLxYkT.jpg",
-                caption: "Suprised face",
-              },
-              {
-                url: "https://i.imgur.com/uigfzs5.jpg",
-              },
-            ]}
+            images={images}
             onRequestClose={options => {
               console.log(
                 "The user was saw this image last - ",

--- a/packages/components/src/LightBox/LightBox.stories.mdx
+++ b/packages/components/src/LightBox/LightBox.stories.mdx
@@ -27,7 +27,7 @@ export const images = [
   {
     title: "A house",
     url: "https://images.unsplash.com/photo-1592595896616-c37162298647?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
-    caption: "Suprised face",
+    caption: "House with a garden.",
   },
   {
     url: "https://images.unsplash.com/photo-1532302780319-95689ab9d79a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",

--- a/packages/components/src/LightBox/LightBox.tsx
+++ b/packages/components/src/LightBox/LightBox.tsx
@@ -152,8 +152,13 @@ export function LightBox({
               />
             </AnimatePresence>
           </div>
-          <PreviousButton onClick={debouncedHandlePrevious} />
-          <NextButton onClick={debouncedHandleNext} />
+
+          {images.length > 1 ? (
+            <>
+              <PreviousButton onClick={debouncedHandlePrevious} />
+              <NextButton onClick={debouncedHandleNext} />
+            </>
+          ) : null}
 
           <div className={styles.toolbar}>
             {images[currentImageIndex].caption}

--- a/packages/components/src/LightBox/LightBox.tsx
+++ b/packages/components/src/LightBox/LightBox.tsx
@@ -153,12 +153,12 @@ export function LightBox({
             </AnimatePresence>
           </div>
 
-          {images.length > 1 ? (
+          {images.length > 1 && (
             <>
               <PreviousButton onClick={debouncedHandlePrevious} />
               <NextButton onClick={debouncedHandleNext} />
             </>
-          ) : null}
+          )}
 
           <div className={styles.toolbar}>
             {images[currentImageIndex].caption}

--- a/packages/components/src/LightBox/__snapshots__/LightBoxSnapshots.test.tsx.snap
+++ b/packages/components/src/LightBox/__snapshots__/LightBoxSnapshots.test.tsx.snap
@@ -47,54 +47,6 @@ exports[`Images renders an image 1`] = `
       />
     </div>
     <div
-      class="prev"
-    >
-      <button
-        aria-label="Previous image"
-        class="button large onlyIcon subtle secondary"
-        type="button"
-      >
-        <svg
-          class="ZDlJU6tECg7ouG-b27gya _2SoAwA0A8G1BGDNjtkt-lt"
-          data-testid="arrowLeft"
-          viewBox="0 0 1024 1024"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            class=""
-            d="M649.534 671.644c8.315 8.341 12.466 19.27 12.445 30.19-0.021 10.887-4.181 21.768-12.479 30.071-8.298 8.307-19.172 12.466-30.049 12.488-10.929 0.021-21.862-4.143-30.199-12.488l-213.722-213.542c-8.339-8.345-12.509-19.283-12.509-30.221s4.17-21.875 12.509-30.221l213.539-213.543c8.341-8.344 19.274-12.507 30.203-12.487 10.878 0.019 21.751 4.181 30.049 12.487s12.458 19.185 12.479 30.071c0.017 10.922-4.13 21.849-12.445 30.189l-183.159 183.502 183.338 183.501z"
-          />
-        </svg>
-        <span
-          class="base extraBold large base"
-        />
-      </button>
-    </div>
-    <div
-      class="next"
-    >
-      <button
-        aria-label="Next image"
-        class="button large onlyIcon subtle secondary"
-        type="button"
-      >
-        <svg
-          class="ZDlJU6tECg7ouG-b27gya _2SoAwA0A8G1BGDNjtkt-lt"
-          data-testid="arrowRight"
-          viewBox="0 0 1024 1024"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            class=""
-            d="M375.467 671.644c-8.317 8.341-12.465 19.27-12.445 30.19 0.019 10.887 4.179 21.768 12.478 30.071 8.299 8.307 19.172 12.466 30.050 12.488 10.929 0.021 21.862-4.143 30.199-12.488l213.722-213.542c8.341-8.345 12.509-19.283 12.509-30.221s-4.168-21.875-12.509-30.221l-213.538-213.543c-8.341-8.344-19.274-12.507-30.202-12.487-10.879 0.019-21.75 4.181-30.050 12.487s-12.459 19.185-12.478 30.071c-0.019 10.922 4.129 21.849 12.445 30.189l183.158 183.502-183.338 183.501z"
-          />
-        </svg>
-        <span
-          class="base extraBold large base"
-        />
-      </button>
-    </div>
-    <div
       class="toolbar"
     >
       Dis be a caption 🎉


### PR DESCRIPTION


## Motivations
Don't show the navigation buttons when there is only one image in the Lightbox, avoids confusion to the user.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
