### PR TITLE
refactor(components): replace render with create root

### DIFF
--- a/packages/components/src/Toast/Toast.test.tsx
+++ b/packages/components/src/Toast/Toast.test.tsx
@@ -26,7 +26,7 @@ beforeEach(() => jest.useFakeTimers());
 
 afterEach(() => {
   cleanup();
-  jest.clearAllTimers();
+  jest.runAllTimers();
 });
 
 const successMessage =
@@ -35,70 +35,44 @@ const infoMessage = "Bland Toast";
 const errorMessage = "Errorful should last inbetween min-max";
 
 it("creates the placeholder div on showToast call", () => {
-  const { getByText, queryByText, getByLabelText } = render(<MockToast />);
+  const { getByText } = render(<MockToast />);
 
   fireEvent.click(getByText("No Variation"));
 
   expect(getByText(infoMessage)).toBeInstanceOf(HTMLSpanElement);
-
-  fireEvent.click(getByLabelText("Hide Notification"));
-  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("renders a Slice of Toast when the 'showToast' method is called", () => {
-  const { getByText, getByLabelText, queryByText } = render(<MockToast />);
+  const { getByText } = render(<MockToast />);
   fireEvent.click(getByText("Success"));
   expect(getByText(successMessage)).toBeInstanceOf(HTMLSpanElement);
-
-  fireEvent.click(getByLabelText("Hide Notification"));
-  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("shows a the checkmark icon for success toast", () => {
-  const { getByText, getByTestId, getByLabelText, queryByText } = render(
-    <MockToast />,
-  );
+  const { getByText, getByTestId } = render(<MockToast />);
   fireEvent.click(getByText("Success"));
   expect(getByTestId("checkmark")).toBeInstanceOf(SVGElement);
-
-  fireEvent.click(getByLabelText("Hide Notification"));
-  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("renders an knot icon variation: 'info' is set", () => {
-  const { getByText, getByTestId, getByLabelText, queryByText } = render(
-    <MockToast />,
-  );
+  const { getByText, getByTestId } = render(<MockToast />);
   fireEvent.click(getByText("No Variation"));
   expect(getByTestId("knot")).toBeInstanceOf(SVGElement);
-
-  fireEvent.click(getByLabelText("Hide Notification"));
-  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("renders an alert icon variation: 'error' is set", () => {
-  const { getByText, getByTestId, getByLabelText, queryByText } = render(
-    <MockToast />,
-  );
+  const { getByText, getByTestId } = render(<MockToast />);
   fireEvent.click(getByText("Error"));
   expect(getByTestId("alert")).toBeInstanceOf(SVGElement);
-
-  fireEvent.click(getByLabelText("Hide Notification"));
-  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("fires an action callback when the action button is clicked", () => {
   const mockAction = jest.fn();
-  const { getByText, getByLabelText, queryByText } = render(
-    <MockToast mockAction={mockAction} />,
-  );
+  const { getByText } = render(<MockToast mockAction={mockAction} />);
 
   fireEvent.click(getByText("No Variation"));
   fireEvent.click(getByText("Do The Action"));
   expect(mockAction).toHaveBeenCalledTimes(1);
-
-  fireEvent.click(getByLabelText("Hide Notification"));
-  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("sets a timer and clears the Slice after a certain amount of time", async done => {

--- a/packages/components/src/Toast/Toast.test.tsx
+++ b/packages/components/src/Toast/Toast.test.tsx
@@ -27,7 +27,6 @@ beforeEach(() => jest.useFakeTimers());
 afterEach(() => {
   cleanup();
   jest.clearAllTimers();
-  document.body.innerHTML = ``;
 });
 
 const successMessage =
@@ -36,49 +35,70 @@ const infoMessage = "Bland Toast";
 const errorMessage = "Errorful should last inbetween min-max";
 
 it("creates the placeholder div on showToast call", () => {
-  const { getByText } = render(<MockToast />);
-  expect(document.querySelector(`#atlantis-toast-element`)).not.toBeInstanceOf(
-    HTMLDivElement,
-  );
+  const { getByText, queryByText, getByLabelText } = render(<MockToast />);
 
   fireEvent.click(getByText("No Variation"));
 
-  expect(document.querySelector(`#atlantis-toast-element`)).toBeInstanceOf(
-    HTMLDivElement,
-  );
+  expect(getByText(infoMessage)).toBeInstanceOf(HTMLSpanElement);
+
+  fireEvent.click(getByLabelText("Hide Notification"));
+  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("renders a Slice of Toast when the 'showToast' method is called", () => {
-  const { getByText } = render(<MockToast />);
+  const { getByText, getByLabelText, queryByText } = render(<MockToast />);
   fireEvent.click(getByText("Success"));
   expect(getByText(successMessage)).toBeInstanceOf(HTMLSpanElement);
+
+  fireEvent.click(getByLabelText("Hide Notification"));
+  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("shows a the checkmark icon for success toast", () => {
-  const { getByText, getByTestId } = render(<MockToast />);
+  const { getByText, getByTestId, getByLabelText, queryByText } = render(
+    <MockToast />,
+  );
   fireEvent.click(getByText("Success"));
   expect(getByTestId("checkmark")).toBeInstanceOf(SVGElement);
+
+  fireEvent.click(getByLabelText("Hide Notification"));
+  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("renders an knot icon variation: 'info' is set", () => {
-  const { getByText, getByTestId } = render(<MockToast />);
+  const { getByText, getByTestId, getByLabelText, queryByText } = render(
+    <MockToast />,
+  );
   fireEvent.click(getByText("No Variation"));
   expect(getByTestId("knot")).toBeInstanceOf(SVGElement);
+
+  fireEvent.click(getByLabelText("Hide Notification"));
+  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("renders an alert icon variation: 'error' is set", () => {
-  const { getByText, getByTestId } = render(<MockToast />);
+  const { getByText, getByTestId, getByLabelText, queryByText } = render(
+    <MockToast />,
+  );
   fireEvent.click(getByText("Error"));
   expect(getByTestId("alert")).toBeInstanceOf(SVGElement);
+
+  fireEvent.click(getByLabelText("Hide Notification"));
+  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("fires an action callback when the action button is clicked", () => {
   const mockAction = jest.fn();
-  const { getByText } = render(<MockToast mockAction={mockAction} />);
+  const { getByText, getByLabelText, queryByText } = render(
+    <MockToast mockAction={mockAction} />,
+  );
 
   fireEvent.click(getByText("No Variation"));
   fireEvent.click(getByText("Do The Action"));
   expect(mockAction).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(getByLabelText("Hide Notification"));
+  expect(queryByText(infoMessage)).toBeNull();
 });
 
 it("sets a timer and clears the Slice after a certain amount of time", async done => {

--- a/packages/components/src/Toast/Toast.test.tsx
+++ b/packages/components/src/Toast/Toast.test.tsx
@@ -34,18 +34,17 @@ const successMessage =
 const infoMessage = "Bland Toast";
 const errorMessage = "Errorful should last inbetween min-max";
 
-it("creates the placeholder div on showToast call", () => {
-  const { getByText } = render(<MockToast />);
-
-  fireEvent.click(getByText("No Variation"));
-
-  expect(getByText(infoMessage)).toBeInstanceOf(HTMLSpanElement);
+it("creates the toasts target div", () => {
+  render(<MockToast />);
+  expect(document.querySelector("#atlantis-toast-element")).toBeInTheDocument();
 });
 
 it("renders a Slice of Toast when the 'showToast' method is called", () => {
-  const { getByText } = render(<MockToast />);
+  const { getByText, queryByText } = render(<MockToast />);
+  expect(queryByText(successMessage)).not.toBeInTheDocument();
+
   fireEvent.click(getByText("Success"));
-  expect(getByText(successMessage)).toBeInstanceOf(HTMLSpanElement);
+  expect(getByText(successMessage)).toBeInTheDocument();
 });
 
 it("shows a the checkmark icon for success toast", () => {

--- a/packages/components/src/Toast/showToast.tsx
+++ b/packages/components/src/Toast/showToast.tsx
@@ -7,26 +7,27 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { render } from "react-dom";
+// eslint-disable-next-line import/no-internal-modules
+import { createRoot } from "react-dom/client";
 import { Toast, ToastProps, ToastRef } from "./Toast";
 import styles from "./Toast.css";
 
-export function showToast(props: ToastProps) {
-  createDocumentToast(props);
+const targetId = "atlantis-toast-element";
+let target = document.querySelector(`#${targetId}`);
+
+if (!target) {
+  target = document.createElement("div");
+  target.id = targetId;
+  target.classList.add(styles.wrapper);
+  document.body.appendChild(target);
 }
 
-function createDocumentToast(props: ToastProps) {
-  const targetId = "atlantis-toast-element";
-  let target = document.querySelector(`#${targetId}`);
+// https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const root = createRoot(target!);
 
-  if (!target) {
-    target = document.createElement("div");
-    target.id = targetId;
-    target.classList.add(styles.wrapper);
-    document.body.appendChild(target);
-  }
-
-  render(<ToasterOven {...props} />, target);
+export function showToast(props: ToastProps) {
+  root.render(<ToasterOven {...props} />);
 }
 
 const ToastContainer = forwardRef(ToastInternal);

--- a/packages/components/src/Toast/showToast.tsx
+++ b/packages/components/src/Toast/showToast.tsx
@@ -7,6 +7,8 @@ import React, {
   useRef,
   useState,
 } from "react";
+// According to react, it's imported within the package
+// https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
 // eslint-disable-next-line import/no-internal-modules
 import { createRoot } from "react-dom/client";
 import { Toast, ToastProps, ToastRef } from "./Toast";
@@ -22,9 +24,7 @@ if (!target) {
   document.body.appendChild(target);
 }
 
-// https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const root = createRoot(target!);
+const root = createRoot(target);
 
 export function showToast(props: ToastProps) {
   root.render(<ToasterOven {...props} />);


### PR DESCRIPTION
## Motivations
Get rid of the React warning below by replacing `ReactDOM.render` with `createRoot`.

## Changes
- Replaced `ReactDOM.render` with `createRoot` on `showToast`
- Fixed tests by closing the toasts at the end of the tests.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
