### PR TITLE
fix: use update instead of forceUpdate on popper

### DIFF
--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -47,11 +47,13 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
   const {
     styles: popperStyles,
     attributes,
-    forceUpdate,
+    update,
     setPositionedElementRef,
   } = useRepositionMenu(attachTo);
 
-  useEffect(() => forceUpdate?.(), [allOptions]);
+  useEffect(() => {
+    if (menuOpen && update) update();
+  }, [allOptions]);
 
   useEffect(() => {
     handleDebouncedSearch();


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

`forceUpdate` from popper was too forceful that it'll crash the whole page and throw an error around `flushSync` when you use dismissible chips. This PR should make it less forceful while still keeping the same functionality.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- replaced `forceUpdate` to `update` in dismissible chips component
  - The reason why we needed to update is to reposition the options when you've selected enough chips that it goes into multiple lines. This is so that it doesn't cover the other selected chips.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Selecting many chips and going into multiple lines should reposition the options and not cover the selected chips.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
