### PR TITLE
refactor(components): use Atlantis timing in Spinner

### DIFF
--- a/packages/components/src/Spinner/Spinner.css
+++ b/packages/components/src/Spinner/Spinner.css
@@ -7,7 +7,7 @@
   border-width: calc(var(--space-small) * 0.75);
   border-radius: var(--radius-circle);
   background-color: var(--color-blue--lightest);
-  animation-duration: var(--timing-quick);
+  animation-duration: calc(var(--timing-slowest) * 2);
   animation-iteration-count: infinite;
   animation-name: animationSpin;
   animation-timing-function: linear;

--- a/packages/components/src/Spinner/Spinner.css
+++ b/packages/components/src/Spinner/Spinner.css
@@ -7,7 +7,7 @@
   border-width: calc(var(--space-small) * 0.75);
   border-radius: var(--radius-circle);
   background-color: var(--color-blue--lightest);
-  animation-duration: 1s;
+  animation-duration: var(--timing-quick);
   animation-iteration-count: infinite;
   animation-name: animationSpin;
   animation-timing-function: linear;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We have timing values for animation and one of them matches our duration used in Spinner

## Changes

### Changed

- replaced raw value with equivalent Atlantis timing value

## Testing

- Verify Spinner still spins at expected speed

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
