### PR TITLE
feat: add new InputDuration component (v1)

### DIFF
--- a/packages/components/src/InputDuration/InputDuration.css
+++ b/packages/components/src/InputDuration/InputDuration.css
@@ -1,0 +1,20 @@
+.container {
+  position: relative;
+}
+
+.textWrapper {
+  position: absolute;
+  top: 14px;
+  font-size: 16px;
+  left: 17px;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.maskText {
+  opacity: 0;
+}
+
+.description {
+  margin-top: 6px;
+}

--- a/packages/components/src/InputDuration/InputDuration.css
+++ b/packages/components/src/InputDuration/InputDuration.css
@@ -5,8 +5,8 @@
 .textWrapper {
   position: absolute;
   top: 14px;
-  font-size: 16px;
   left: 17px;
+  font-size: 16px;
   z-index: 2;
   pointer-events: none;
 }

--- a/packages/components/src/InputDuration/InputDuration.css.d.ts
+++ b/packages/components/src/InputDuration/InputDuration.css.d.ts
@@ -1,0 +1,8 @@
+declare const styles: {
+  readonly "container": string;
+  readonly "textWrapper": string;
+  readonly "maskText": string;
+  readonly "description": string;
+};
+export = styles;
+

--- a/packages/components/src/InputDuration/InputDuration.stories.mdx
+++ b/packages/components/src/InputDuration/InputDuration.stories.mdx
@@ -6,6 +6,7 @@ import { InputDuration } from "@jobber/components/InputDuration";
 # InputDuration
 
 Input text with duration (24h time format) used in forms that needs to set a time duration.
+There's a validation to support only numbers and no more than 59 minutes.
 
 ```ts
 import { InputDuration } from "@jobber/components/InputDuration";

--- a/packages/components/src/InputDuration/InputDuration.stories.mdx
+++ b/packages/components/src/InputDuration/InputDuration.stories.mdx
@@ -6,7 +6,8 @@ import { InputDuration } from "@jobber/components/InputDuration";
 # InputDuration
 
 Input text with duration (24h time format) used in forms that needs to set a time duration.
-There's a validation to support only numbers and no more than 59 minutes.
+
+There's a validation to support `only numbers` and no more than `59 minutes`.
 
 ```ts
 import { InputDuration } from "@jobber/components/InputDuration";

--- a/packages/components/src/InputDuration/InputDuration.stories.mdx
+++ b/packages/components/src/InputDuration/InputDuration.stories.mdx
@@ -1,0 +1,26 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { InputDuration } from "@jobber/components/InputDuration";
+
+<Meta title="Components/InputDuration" component={InputDuration} />
+
+# InputDuration
+
+Input text with duration (24h time format) used in forms that needs to set a time duration.
+
+```ts
+import { InputDuration } from "@jobber/components/InputDuration";
+```
+
+<Canvas>
+  <Story
+    name="InputDuration"
+    args={{
+      defaultValue: "10:10",
+      description: "Description of the field"
+    }}
+  >
+    {args => <InputDuration {...args} />}
+  </Story>
+</Canvas>
+
+<ArgsTable of={InputDuration} story="InputDuration" />

--- a/packages/components/src/InputDuration/InputDuration.test.tsx
+++ b/packages/components/src/InputDuration/InputDuration.test.tsx
@@ -20,7 +20,9 @@ it("renders a InputDuration", () => {
             <label
               class="label"
               for="123e4567-e89b-12d3-a456-426655440001"
-            />
+            >
+              Duration
+            </label>
             <input
               class="input"
               id="123e4567-e89b-12d3-a456-426655440001"
@@ -52,7 +54,7 @@ it("renders an initial time when given 'defaultValue'", () => {
         style="position: relative;"
       >
         <div
-          class="wrapper"
+          class="wrapper miniLabel"
         >
           <div
             class="inputWrapper"
@@ -60,7 +62,9 @@ it("renders an initial time when given 'defaultValue'", () => {
             <label
               class="label"
               for="123e4567-e89b-12d3-a456-426655440003"
-            />
+            >
+              Duration
+            </label>
             <input
               class="input"
               id="123e4567-e89b-12d3-a456-426655440003"

--- a/packages/components/src/InputDuration/InputDuration.test.tsx
+++ b/packages/components/src/InputDuration/InputDuration.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { InputDuration } from ".";
+
+afterEach(cleanup);
+
+it("renders a InputDuration", () => {
+  const { container } = render(<InputDuration onChange={jest.fn()} />);
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        style="position: relative;"
+      >
+        <div
+          class="wrapper"
+        >
+          <div
+            class="inputWrapper"
+          >
+            <label
+              class="label"
+              for="123e4567-e89b-12d3-a456-426655440001"
+            />
+            <input
+              class="input"
+              id="123e4567-e89b-12d3-a456-426655440001"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          style="position: absolute; top: 14px; font-size: 16px; left: 17px; z-index: 2; pointer-events: none;"
+        >
+          <span
+            style="opacity: 0;"
+          />
+        </div>
+      </div>
+    </div>
+  `);
+});
+
+it("renders an initial time when given 'defaultValue'", () => {
+  const { container } = render(
+    <InputDuration defaultValue={"10:55"} onChange={jest.fn()} />,
+  );
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        style="position: relative;"
+      >
+        <div
+          class="wrapper"
+        >
+          <div
+            class="inputWrapper"
+          >
+            <label
+              class="label"
+              for="123e4567-e89b-12d3-a456-426655440003"
+            />
+            <input
+              class="input"
+              id="123e4567-e89b-12d3-a456-426655440003"
+              type="text"
+              value="10:55"
+            />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          style="position: absolute; top: 14px; font-size: 16px; left: 17px; z-index: 2; pointer-events: none;"
+        >
+          <span
+            style="opacity: 0;"
+          >
+            10:55
+          </span>
+        </div>
+      </div>
+    </div>
+  `);
+});
+
+it("should call the onChange function when the component is modified", () => {
+  const newValue = "05:32";
+
+  const changeHandler = jest.fn();
+
+  const { container } = render(<InputDuration onChange={changeHandler} />);
+
+  const input = container.querySelector("input");
+
+  expect(input).toBeDefined();
+
+  input &&
+    fireEvent.change(input, {
+      target: { value: newValue },
+    });
+
+  expect(changeHandler).toHaveBeenCalledWith(newValue);
+});

--- a/packages/components/src/InputDuration/InputDuration.test.tsx
+++ b/packages/components/src/InputDuration/InputDuration.test.tsx
@@ -9,7 +9,7 @@ it("renders a InputDuration", () => {
   expect(container).toMatchInlineSnapshot(`
     <div>
       <div
-        style="position: relative;"
+        class="container"
       >
         <div
           class="wrapper"
@@ -33,10 +33,10 @@ it("renders a InputDuration", () => {
         </div>
         <div
           aria-hidden="true"
-          style="position: absolute; top: 14px; font-size: 16px; left: 17px; z-index: 2; pointer-events: none;"
+          class="textWrapper"
         >
           <span
-            style="opacity: 0;"
+            class="maskText"
           />
         </div>
       </div>
@@ -51,7 +51,7 @@ it("renders an initial time when given 'defaultValue'", () => {
   expect(container).toMatchInlineSnapshot(`
     <div>
       <div
-        style="position: relative;"
+        class="container"
       >
         <div
           class="wrapper miniLabel"
@@ -75,10 +75,10 @@ it("renders an initial time when given 'defaultValue'", () => {
         </div>
         <div
           aria-hidden="true"
-          style="position: absolute; top: 14px; font-size: 16px; left: 17px; z-index: 2; pointer-events: none;"
+          class="textWrapper"
         >
           <span
-            style="opacity: 0;"
+            class="maskText"
           >
             10:55
           </span>

--- a/packages/components/src/InputDuration/InputDuration.tsx
+++ b/packages/components/src/InputDuration/InputDuration.tsx
@@ -49,13 +49,23 @@ export function InputDuration({
   );
 
   function handleChange(value: string) {
+    const regex = /^[1-9]\d*$/;
+    const match = regex.exec(value);
+    console.log("match", match);
+
     const pattern = mask.split("");
     const specialChars = pattern.filter(char => char !== delimiter);
     const cleanVal = value
       .split("")
       .filter(char => !specialChars.includes(char));
 
-    if (parseInt(cleanVal[2], 10) > 5) {
+    /**
+     * Validation to check any not number or number > 59 (for minutes)
+     *  */
+    if (
+      parseInt(cleanVal[2], 10) > 5 ||
+      cleanVal.filter(i => isNaN(parseInt(i, 10))).length > 0
+    ) {
       return;
     }
 

--- a/packages/components/src/InputDuration/InputDuration.tsx
+++ b/packages/components/src/InputDuration/InputDuration.tsx
@@ -49,10 +49,6 @@ export function InputDuration({
   );
 
   function handleChange(value: string) {
-    const regex = /^[1-9]\d*$/;
-    const match = regex.exec(value);
-    console.log("match", match);
-
     const pattern = mask.split("");
     const specialChars = pattern.filter(char => char !== delimiter);
     const cleanVal = value

--- a/packages/components/src/InputDuration/InputDuration.tsx
+++ b/packages/components/src/InputDuration/InputDuration.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { InputText } from "../InputText";
+import { Typography } from "../Typography";
+
+interface InputDurationProps {
+  readonly defaultValue?: string;
+  readonly onChange: (value: string) => void;
+  readonly description?: string;
+}
+
+const mask = "**:**";
+const delimiter = "*";
+
+export function InputDuration({
+  defaultValue,
+  onChange,
+  description,
+}: InputDurationProps) {
+  const [maskedVal, setMaskedVal] = useState(defaultValue);
+  return (
+    <div style={{ position: "relative" }}>
+      <InputText
+        defaultValue={defaultValue}
+        value={maskedVal}
+        onChange={handleChange}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: "14px",
+          fontSize: "16px",
+          left: "17px",
+          zIndex: 2,
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
+      >
+        <span style={{ opacity: 0 }}>{maskedVal}</span>
+      </div>
+      {description && (
+        <div style={{ marginTop: 6 }}>
+          <Typography size="small" textColor="textSecondary">
+            {description}
+          </Typography>
+        </div>
+      )}
+    </div>
+  );
+
+  function handleChange(value: string) {
+    const pattern = mask.split("");
+    const specialChars = pattern.filter(char => char !== delimiter);
+    const cleanVal = value
+      .split("")
+      .filter(char => !specialChars.includes(char));
+
+    if (parseInt(cleanVal[2], 10) > 5) {
+      return;
+    }
+
+    const maskedValue = pattern.reduce((result, item) => {
+      if (!cleanVal.length) return result;
+      if (specialChars.includes(item)) {
+        return result + item;
+      } else if (item === delimiter) {
+        return result + cleanVal.shift();
+      } else {
+        return result;
+      }
+    }, "");
+    setMaskedVal(maskedValue);
+    onChange && onChange(maskedValue);
+  }
+}

--- a/packages/components/src/InputDuration/InputDuration.tsx
+++ b/packages/components/src/InputDuration/InputDuration.tsx
@@ -23,6 +23,7 @@ export function InputDuration({
         defaultValue={defaultValue}
         value={maskedVal}
         onChange={handleChange}
+        placeholder="Duration"
       />
       <div
         style={{

--- a/packages/components/src/InputDuration/InputDuration.tsx
+++ b/packages/components/src/InputDuration/InputDuration.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import styles from "./InputDuration.css";
 import { InputText } from "../InputText";
 import { Typography } from "../Typography";
 
@@ -18,28 +19,18 @@ export function InputDuration({
 }: InputDurationProps) {
   const [maskedVal, setMaskedVal] = useState(defaultValue);
   return (
-    <div style={{ position: "relative" }}>
+    <div className={styles.container}>
       <InputText
         defaultValue={defaultValue}
         value={maskedVal}
         onChange={handleChange}
         placeholder="Duration"
       />
-      <div
-        style={{
-          position: "absolute",
-          top: "14px",
-          fontSize: "16px",
-          left: "17px",
-          zIndex: 2,
-          pointerEvents: "none",
-        }}
-        aria-hidden="true"
-      >
-        <span style={{ opacity: 0 }}>{maskedVal}</span>
+      <div className={styles.textWrapper} aria-hidden="true">
+        <span className={styles.maskText}>{maskedVal}</span>
       </div>
       {description && (
-        <div style={{ marginTop: 6 }}>
+        <div className={styles.description}>
           <Typography size="small" textColor="textSecondary">
             {description}
           </Typography>

--- a/packages/components/src/InputDuration/index.ts
+++ b/packages/components/src/InputDuration/index.ts
@@ -1,0 +1,1 @@
+export { InputDuration } from "./InputDuration";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

@GetJobber/workday needs a specific input time field to be able to manage duration using 24h time format.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

-  New component `InputDuration` based on [this old PR by @darryltec ](https://github.com/GetJobber/atlantis/pull/789)

### QA

Run this branch locally and after `npm install` , just run `npm run start`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
