### PR TITLE
fix(design):  preserve responsive behaviour in larger fontSizes [JOB-64729]

### DIFF
--- a/packages/design/src/typography.css
+++ b/packages/design/src/typography.css
@@ -35,7 +35,7 @@
   --typography--lineHeight-miniscule: 1.08;
 }
 
-@media (--handhelds) {
+@media (max-width: 639px) {
   :root {
     --typography--fontSize-extravagant: calc(
       var(--typography--fontSize-large) * 2.5


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Responsive behaviour within Heading components was broken.

## Changes

### Changed

- Custom media query value was reliant on in-project configuration outside of Atlantis to work

### Fixed

- Font sizes `extravagant`, `jumbo`, and `largest` are responsive outside of the Atlantis repository

**Before:**
![image](https://user-images.githubusercontent.com/39704901/225464748-7e0924a2-fba8-4f1f-99b7-bb018d67090a.png)
![image](https://user-images.githubusercontent.com/39704901/225464475-d80e6696-a9da-4127-9d36-a87d03f23f7e.png)

**After:**
![image](https://user-images.githubusercontent.com/39704901/225464710-dbd411e2-b75d-42e3-be54-2ce4950f5d58.png)
![image](https://user-images.githubusercontent.com/39704901/225464663-90ad0afd-8986-4ff6-864b-a108e5ee9ecb.png)

## Testing

```
npm i @jobber/components@3.5.6-pre.0+03511639
npm i @jobber/design@0.29.4-pre.49+03511639
```

Or in Jobber, pull down `update-atlantis-headings-to-fix-responsiveness` for testing

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
