### PR TITLE
fix(components): Add description field to InputTime props [JOB-61719]

### DIFF
--- a/packages/components/src/InputTime/InputTimeProps.tsx
+++ b/packages/components/src/InputTime/InputTimeProps.tsx
@@ -5,6 +5,7 @@ export interface InputTimeProps
   extends Pick<
       CommonFormFieldProps,
       | "align"
+      | "description"
       | "disabled"
       | "invalid"
       | "inline"


### PR DESCRIPTION
## Motivations

We need a description to provide additional context for InputTime fields (in our case, the date)

## Changes

Add `description` as a valid prop to `InputTime`

## Testing

Set a description on `InputTime` and it should be visible.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
