### PR TITLE
docs(components): update casing of sample buttons to follow guidelines

### DIFF
--- a/packages/components/src/Button/Button.stories.mdx
+++ b/packages/components/src/Button/Button.stories.mdx
@@ -59,7 +59,7 @@ doesn't get added on the sidebar. We're adding a table of contents sidebar on
 each page that links to headings instead of stories -->
 
 <Canvas>
-  <Button label="Do the thing" />
+  <Button label="Do the Thing" />
 </Canvas>
 
 #### Secondary
@@ -70,7 +70,7 @@ A secondary button should be used when...
   action
 
 <Canvas>
-  <Button label="Do the thing" type="secondary" />
+  <Button label="Do the Thing" type="secondary" />
 </Canvas>
 
 #### Tertiary
@@ -79,7 +79,7 @@ A tertiary button should be used to complete actions within the view such as
 editing, revealing details, or navigating within the view.
 
 <Canvas>
-  <Button label="Do the thing" type="tertiary" />
+  <Button label="Do the Thing" type="tertiary" />
 </Canvas>
 
 ### Learning
@@ -257,7 +257,7 @@ With that said, if you _can't_ design a flow without a disabled state, this is
 how you disable a button.
 
 <Canvas>
-  <Button label="Do the thing" disabled />
+  <Button label="Do the Thing" disabled />
 </Canvas>
 
 ## Sizes


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Our example buttons did not all follow their own content rules

## Changes

### Changed

- casing of sample button docs

## Testing

View Buttons in storybook

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
