### PR TITLE
fix(components): define and standardize lineheight in FormField

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -27,6 +27,7 @@
   --field--padding-right: var(--space-base);
 
   --field--value-color: var(--color-heading);
+  --field--value-lineHeight: calc(var(--base-unit) * 1.25);
 
   --field--border-color: var(--color-border);
   --field--background-color: var(--color-surface);
@@ -151,7 +152,7 @@
   color: inherit;
   font-family: inherit;
   font-size: inherit;
-  line-height: calc(var(--base-unit) * 1.25);
+  line-height: var(--field--value-lineHeight);
   text-align: var(--field--textAlign);
   background: transparent;
   appearance: none;
@@ -196,7 +197,7 @@
   padding-right: var(--field--padding-right);
   overflow: hidden;
   color: var(--field--placeholder-color);
-  line-height: calc(var(--base-unit) * 1.25);
+  line-height: var(--field--value-lineHeight);
   text-align: var(--field--textAlign);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -272,10 +273,11 @@
 
 .affixLabel {
   display: flex;
-  align-items: center;
-  flex: 0 0 auto;
   margin: 0 calc((var(--field--padding-left) - var(--space-smallest)) * -1) 0 0;
   padding: 0 0 0 var(--field--padding-left);
+  line-height: var(--field--value-lineHeight);
+  align-items: center;
+  flex: 0 0 auto;
 }
 
 .affixLabel.suffix {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Because there's no defined lineheight on the fieldffix labels, but there is one on the `input` element, the fieldaffix labels are vulnerable to external stylesheets "leaking in" and causing unsightly inconsistencies when components using FormField are consumed by another project.

![image](https://user-images.githubusercontent.com/39704901/226067016-7d1f2e21-2f46-4b50-970e-618628d0c9e1.png)

## Changes

### Changed

- Added a CSS custom prop to the input and used wherever line-height was already being defined, then added it on the fieldaffix where there was no definition. I'm also open to the idea of using `inherit` on the fieldaffix level, or other suggestions for a cleaner way to solve this! 🤷 

### Fixed

- FormField and assorted consumers will no longer have misaligned baselines when the application has a global stylesheet with a different default.

## Testing

- Set a line-height on the body of the application and see that the FormField alignment stays as expected
- Run a pre-release into Jobber and observe that affixes and values line up as expected

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
