### PR TITLE
build(deps): Update react-hook-form to v7.43.7 [JOB-65458]

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -5496,9 +5496,9 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-hook-form": {
-      "version": "6.15.8",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
-      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg=="
+      "version": "7.43.7",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.7.tgz",
+      "integrity": "sha512-38yehQkQQ5uufaPKFScs7jhLE8n3+LG9H/BZfFAiBL2+7piDmw/BrdNJV4irzMaPnWZGhmGLHVICHXNVGIuXZg=="
     },
     "react-is": {
       "version": "16.8.6",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,7 +39,7 @@
     "react-countdown": "^2.3.2",
     "react-datepicker": "^4.10.0",
     "react-dropzone": "^11.0.2",
-    "react-hook-form": "^6.15.8",
+    "react-hook-form": "^7.43.7",
     "react-markdown": "^8.0.3",
     "react-popper": "^2.2.5",
     "react-router-dom": "^5.3.4",

--- a/packages/components/src/Form/Form.test.tsx
+++ b/packages/components/src/Form/Form.test.tsx
@@ -42,7 +42,7 @@ test("renders an error message when field is invalid", async () => {
   );
 });
 
-test("fires onStateChage when component renders", async () => {
+test("fires onStateChange when component renders", async () => {
   const stateChangeHandler = jest.fn();
   render(<MockForm onSubmit={jest.fn()} onStateChange={stateChangeHandler} />);
 
@@ -50,12 +50,12 @@ test("fires onStateChage when component renders", async () => {
     expect(stateChangeHandler).toHaveBeenCalled();
     expect(stateChangeHandler).toHaveBeenCalledWith({
       isDirty: false,
-      isValid: true,
+      isValid: false,
     });
   });
 });
 
-test("onStateChage updates state when form is valid", async () => {
+test("onStateChange updates state when form is valid", async () => {
   const stateChangeHandler = jest.fn();
   const { getByLabelText } = render(
     <MockForm onSubmit={jest.fn()} onStateChange={stateChangeHandler} />,

--- a/packages/components/src/Form/Form.tsx
+++ b/packages/components/src/Form/Form.tsx
@@ -5,7 +5,12 @@ import React, {
   useEffect,
   useImperativeHandle,
 } from "react";
-import { ErrorOption, FormProvider, useForm } from "react-hook-form";
+import {
+  FieldErrors,
+  FieldValues,
+  FormProvider,
+  useForm,
+} from "react-hook-form";
 
 export interface FormRef {
   submit(): void;
@@ -28,10 +33,9 @@ export const Form = forwardRef(function InternalForm(
 ) {
   const methods = useForm({ mode: "onTouched" });
   const {
-    errors,
     trigger,
     handleSubmit,
-    formState: { isDirty, isValid },
+    formState: { isDirty, isValid, errors },
   } = methods;
 
   useEffect(
@@ -81,7 +85,7 @@ export const Form = forwardRef(function InternalForm(
     onSubmit && onSubmit();
   }
 
-  function errorHandler(errs: ErrorOption) {
+  function errorHandler(errs: FieldErrors<FieldValues>) {
     const firstErrName = Object.keys(errs)[0];
     const element = document.querySelector(
       `[name="${firstErrName}"]`,

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -189,7 +189,7 @@ describe("FormField", () => {
     });
 
     describe("without validation errors", () => {
-      it("should trigger onValidation with undefined", () => {
+      it("should trigger onValidation with an empty string", () => {
         const validationHandler = jest.fn();
 
         render(

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -201,7 +201,7 @@ describe("FormField", () => {
         );
 
         expect(validationHandler).toHaveBeenCalled();
-        expect(validationHandler).toHaveBeenCalledWith(undefined);
+        expect(validationHandler).toHaveBeenCalledWith("");
       });
     });
 

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -14,6 +14,7 @@ import styles from "./FormField.css";
 import { FormFieldWrapper } from "./FormFieldWrapper";
 import { FormFieldPostFix } from "./FormFieldPostFix";
 
+// eslint-disable-next-line max-statements
 export function FormField(props: FormFieldProps) {
   const {
     actionsRef,
@@ -42,10 +43,14 @@ export function FormField(props: FormFieldProps) {
     onValidation,
   } = props;
 
-  const { control, errors, setValue, watch } =
-    useFormContext() != undefined
-      ? useFormContext()
-      : useForm({ mode: "onTouched" });
+  const {
+    control,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useFormContext() != undefined
+    ? useFormContext()
+    : useForm({ mode: "onTouched" });
 
   const [identifier] = useState(uuidv1());
   const [descriptionIdentifier] = useState(`descriptionUUID--${uuidv1()}`);
@@ -70,7 +75,10 @@ export function FormField(props: FormFieldProps) {
     },
   }));
 
-  const error = errors[controlledName] && errors[controlledName].message;
+  const message = errors[controlledName]?.message;
+
+  const error = getErrorMessage();
+
   useEffect(() => handleValidation(), [error]);
 
   return (
@@ -80,10 +88,12 @@ export function FormField(props: FormFieldProps) {
       rules={{ ...validations }}
       defaultValue={value ?? defaultValue ?? ""}
       render={({
-        onChange: onControllerChange,
-        onBlur: onControllerBlur,
-        name: controllerName,
-        ...rest
+        field: {
+          onChange: onControllerChange,
+          onBlur: onControllerBlur,
+          name: controllerName,
+          ...rest
+        },
       }) => {
         const fieldProps = {
           ...rest,
@@ -193,6 +203,14 @@ export function FormField(props: FormFieldProps) {
       }}
     />
   );
+
+  function getErrorMessage() {
+    if (typeof message === "string") {
+      return message;
+    }
+
+    return "";
+  }
 
   function handleValidation() {
     onValidation && onValidation(error);

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -63,7 +63,7 @@ test("it should call the validation with undefined as a success", () => {
     />,
   );
 
-  expect(validationHandler).toHaveBeenCalledWith(undefined);
+  expect(validationHandler).toHaveBeenCalledWith("");
 });
 
 test("it should call the validation with a range error", async () => {
@@ -163,7 +163,7 @@ test("validation passes if number is correct", async () => {
   input.blur();
 
   await waitFor(() => {
-    expect(validationHandler).toHaveBeenCalledWith(undefined);
+    expect(validationHandler).toHaveBeenCalledWith("");
   });
 });
 

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -50,7 +50,7 @@ test("it should call the handler with a number value", () => {
   expect(changeHandler).toHaveBeenCalledWith(newValue);
 });
 
-test("it should call the validation with undefined as a success", () => {
+test("it should call the validation with empty string as a success", () => {
   const validationHandler = jest.fn();
 
   render(

--- a/packages/hooks/src/useFormState/useFormState.ts
+++ b/packages/hooks/src/useFormState/useFormState.ts
@@ -3,7 +3,7 @@ import { useState } from "react";
 export function useFormState() {
   const [formState, setFormState] = useState({
     isDirty: false,
-    isValid: true,
+    isValid: false,
   });
 
   return [formState, setFormState] as const;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`react-hook-form` can now be upgraded to latest because Atlantis is on R18

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
`react-hook-form` upgraded from `6.15.8` => `7.43.7`


### Changed

 <!-- changes in existing functionality -->
- `errors` has been moved into `formState` object


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
