### PR TITLE
build(deps): Revert "Update react-hook-form to v7.43.7" [JOB-65564]

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -5496,9 +5496,9 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-hook-form": {
-      "version": "7.43.7",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.7.tgz",
-      "integrity": "sha512-38yehQkQQ5uufaPKFScs7jhLE8n3+LG9H/BZfFAiBL2+7piDmw/BrdNJV4irzMaPnWZGhmGLHVICHXNVGIuXZg=="
+      "version": "6.15.8",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
+      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg=="
     },
     "react-is": {
       "version": "16.8.6",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,7 +39,7 @@
     "react-countdown": "^2.3.2",
     "react-datepicker": "^4.10.0",
     "react-dropzone": "^11.0.2",
-    "react-hook-form": "^7.43.7",
+    "react-hook-form": "^6.15.8",
     "react-markdown": "^8.0.3",
     "react-popper": "^2.2.5",
     "react-router-dom": "^5.3.4",

--- a/packages/components/src/Form/Form.test.tsx
+++ b/packages/components/src/Form/Form.test.tsx
@@ -42,7 +42,7 @@ test("renders an error message when field is invalid", async () => {
   );
 });
 
-test("fires onStateChange when component renders", async () => {
+test("fires onStateChage when component renders", async () => {
   const stateChangeHandler = jest.fn();
   render(<MockForm onSubmit={jest.fn()} onStateChange={stateChangeHandler} />);
 
@@ -50,12 +50,12 @@ test("fires onStateChange when component renders", async () => {
     expect(stateChangeHandler).toHaveBeenCalled();
     expect(stateChangeHandler).toHaveBeenCalledWith({
       isDirty: false,
-      isValid: false,
+      isValid: true,
     });
   });
 });
 
-test("onStateChange updates state when form is valid", async () => {
+test("onStateChage updates state when form is valid", async () => {
   const stateChangeHandler = jest.fn();
   const { getByLabelText } = render(
     <MockForm onSubmit={jest.fn()} onStateChange={stateChangeHandler} />,

--- a/packages/components/src/Form/Form.tsx
+++ b/packages/components/src/Form/Form.tsx
@@ -5,12 +5,7 @@ import React, {
   useEffect,
   useImperativeHandle,
 } from "react";
-import {
-  FieldErrors,
-  FieldValues,
-  FormProvider,
-  useForm,
-} from "react-hook-form";
+import { ErrorOption, FormProvider, useForm } from "react-hook-form";
 
 export interface FormRef {
   submit(): void;
@@ -33,9 +28,10 @@ export const Form = forwardRef(function InternalForm(
 ) {
   const methods = useForm({ mode: "onTouched" });
   const {
+    errors,
     trigger,
     handleSubmit,
-    formState: { isDirty, isValid, errors },
+    formState: { isDirty, isValid },
   } = methods;
 
   useEffect(
@@ -85,7 +81,7 @@ export const Form = forwardRef(function InternalForm(
     onSubmit && onSubmit();
   }
 
-  function errorHandler(errs: FieldErrors<FieldValues>) {
+  function errorHandler(errs: ErrorOption) {
     const firstErrName = Object.keys(errs)[0];
     const element = document.querySelector(
       `[name="${firstErrName}"]`,

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -189,7 +189,7 @@ describe("FormField", () => {
     });
 
     describe("without validation errors", () => {
-      it("should trigger onValidation with an empty string", () => {
+      it("should trigger onValidation with undefined", () => {
         const validationHandler = jest.fn();
 
         render(
@@ -201,7 +201,7 @@ describe("FormField", () => {
         );
 
         expect(validationHandler).toHaveBeenCalled();
-        expect(validationHandler).toHaveBeenCalledWith("");
+        expect(validationHandler).toHaveBeenCalledWith(undefined);
       });
     });
 

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -14,7 +14,6 @@ import styles from "./FormField.css";
 import { FormFieldWrapper } from "./FormFieldWrapper";
 import { FormFieldPostFix } from "./FormFieldPostFix";
 
-// eslint-disable-next-line max-statements
 export function FormField(props: FormFieldProps) {
   const {
     actionsRef,
@@ -43,14 +42,10 @@ export function FormField(props: FormFieldProps) {
     onValidation,
   } = props;
 
-  const {
-    control,
-    formState: { errors },
-    setValue,
-    watch,
-  } = useFormContext() != undefined
-    ? useFormContext()
-    : useForm({ mode: "onTouched" });
+  const { control, errors, setValue, watch } =
+    useFormContext() != undefined
+      ? useFormContext()
+      : useForm({ mode: "onTouched" });
 
   const [identifier] = useState(uuidv1());
   const [descriptionIdentifier] = useState(`descriptionUUID--${uuidv1()}`);
@@ -75,10 +70,7 @@ export function FormField(props: FormFieldProps) {
     },
   }));
 
-  const message = errors[controlledName]?.message;
-
-  const error = getErrorMessage();
-
+  const error = errors[controlledName] && errors[controlledName].message;
   useEffect(() => handleValidation(), [error]);
 
   return (
@@ -88,12 +80,10 @@ export function FormField(props: FormFieldProps) {
       rules={{ ...validations }}
       defaultValue={value ?? defaultValue ?? ""}
       render={({
-        field: {
-          onChange: onControllerChange,
-          onBlur: onControllerBlur,
-          name: controllerName,
-          ...rest
-        },
+        onChange: onControllerChange,
+        onBlur: onControllerBlur,
+        name: controllerName,
+        ...rest
       }) => {
         const fieldProps = {
           ...rest,
@@ -203,14 +193,6 @@ export function FormField(props: FormFieldProps) {
       }}
     />
   );
-
-  function getErrorMessage() {
-    if (typeof message === "string") {
-      return message;
-    }
-
-    return "";
-  }
 
   function handleValidation() {
     onValidation && onValidation(error);

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -50,7 +50,7 @@ test("it should call the handler with a number value", () => {
   expect(changeHandler).toHaveBeenCalledWith(newValue);
 });
 
-test("it should call the validation with empty string as a success", () => {
+test("it should call the validation with undefined as a success", () => {
   const validationHandler = jest.fn();
 
   render(
@@ -63,7 +63,7 @@ test("it should call the validation with empty string as a success", () => {
     />,
   );
 
-  expect(validationHandler).toHaveBeenCalledWith("");
+  expect(validationHandler).toHaveBeenCalledWith(undefined);
 });
 
 test("it should call the validation with a range error", async () => {
@@ -163,7 +163,7 @@ test("validation passes if number is correct", async () => {
   input.blur();
 
   await waitFor(() => {
-    expect(validationHandler).toHaveBeenCalledWith("");
+    expect(validationHandler).toHaveBeenCalledWith(undefined);
   });
 });
 

--- a/packages/hooks/src/useFormState/useFormState.ts
+++ b/packages/hooks/src/useFormState/useFormState.ts
@@ -3,7 +3,7 @@ import { useState } from "react";
 export function useFormState() {
   const [formState, setFormState] = useState({
     isDirty: false,
-    isValid: false,
+    isValid: true,
   });
 
   return [formState, setFormState] as const;


### PR DESCRIPTION
Reverts GetJobber/atlantis#1140

Reverting the `react-hook-form` upgrade because when bringing latest `@jobber/components` into JO, typescript compile issues were a blocker.

We will upgrade `react-hook-form` once again, when JO has upgraded `typescript`.
