### PR TITLE
fix(components): Fix Typescript warnings on components

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -4,7 +4,7 @@ module.exports = {
   "*.{js,jsx,ts,tsx}": [
     "eslint --format=codeframe --fix",
     "git add",
-    "jest --bail --findRelatedTests",
+    "jest --bail --findRelatedTests --passWithNoTests",
   ],
   "*.css": ["stylelint --fix --allow-empty-input", "git add"],
   "*.{md,mdx}": ["prettier --write", "git add"],

--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -51,6 +51,7 @@ export default {
     "react-popper",
     "react-datepicker",
     "react-dropzone",
+    "react-dom/client",
     "axios",
     "filesize",
     "color",
@@ -64,5 +65,6 @@ export default {
     "@jobber/design",
     "@jobber/formatters",
     "@jobber/hooks",
+    "@tanstack/react-table",
   ],
 };

--- a/packages/components/src/DatePicker/DatePickerActivator.tsx
+++ b/packages/components/src/DatePicker/DatePickerActivator.tsx
@@ -50,6 +50,8 @@ function InternalActivator(
       return cloneElement(activator, {
         ...newActivatorProps,
         ...(isAComponent && { fullWidth: fullWidth }),
+        // @ts-expect-error - Issue with react types not including `ref` in
+        // cloneElement. https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40888
         ref,
       });
     } else {

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -93,7 +93,7 @@ export function ListItem({
   const Wrapper = url ? "a" : "button";
 
   const buttonProps = {
-    ...(Wrapper === "button" && { role: "button", type: "button" }),
+    ...(Wrapper === "button" && { role: "button", type: "button" as const }),
   };
 
   return (


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Used to throw these warnings

![image](https://user-images.githubusercontent.com/15986172/227968769-7342f5fb-2b14-4a8d-90b9-13dce831d612.png)

Now it's not

![image](https://user-images.githubusercontent.com/15986172/227968958-5304b65b-fdc1-4fd5-864f-0d70b9b84d1d.png)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Fix warnings on date picker and list item
- Marked tanstack and react-dom/client as external
- Skip pre-commit hook on tests if nothing was found

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
