### PR TITLE
refactor(components): Remove redundant button prop types

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -78,7 +78,7 @@ interface SubmitButtonProps {
 type ButtonFunctionality = XOR<
   SubmitButtonProps,
   XOR<ButtonLinkProps, ButtonAnchorProps>
-  >;
+>;
 
 /**This type ensures the button is identifiable to users*/
 type ButtonIdentification = XOR<ButtonIconProps, ButtonLabelProps>;

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -71,6 +71,7 @@ interface SubmitButtonProps {
    */
   submit: true;
   readonly type?: "primary";
+  readonly variation?: "work";
 }
 
 /** This type ensures the button defines only one purpose */

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -71,7 +71,10 @@ interface SubmitButtonProps {
    */
   submit: true;
   readonly type?: "primary";
-  readonly variation?: "work";
+  readonly variation?: Extract<
+    BaseActionProps["variation"],
+    "work" | "destructive"
+  >;
 }
 
 /** This type ensures the button defines only one purpose */

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -19,7 +19,6 @@ interface ButtonFoundationProps {
   readonly ariaHaspopup?: boolean;
   readonly ariaExpanded?: boolean;
   readonly disabled?: boolean;
-  readonly external?: boolean;
   readonly fullWidth?: boolean;
   readonly icon?: IconNames;
   readonly iconOnRight?: boolean;
@@ -27,67 +26,65 @@ interface ButtonFoundationProps {
   readonly label?: string;
   readonly loading?: boolean;
   readonly size?: "small" | "base" | "large";
-  onClick?(
-    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
-  ): void;
   onMouseDown?(
     event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
   ): void;
 }
 
-interface ButtonIconProps extends ButtonFoundationProps {
+interface ButtonIconProps {
   readonly icon: IconNames;
   readonly ariaLabel: string;
 }
-
 interface ButtonLabelProps extends ButtonFoundationProps {
   readonly label: string;
 }
 
-interface ButtonAnchorProps extends ButtonFoundationProps {
+interface BaseActionProps {
+  readonly variation?: "work" | "learning" | "subtle" | "destructive";
+  readonly type?: "primary" | "secondary" | "tertiary";
+  onClick?(
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ): void;
+}
+
+interface ButtonAnchorProps extends BaseActionProps {
   /**
    * Used to create an 'href' on an anchor tag.
    */
   readonly url?: string;
+  /**
+   * Used to open a new tab instead of change the location of the current tab
+   */
+  readonly external?: boolean;
 }
 
-interface ButtonLinkProps extends ButtonFoundationProps {
+interface ButtonLinkProps extends BaseActionProps {
   /**
    * Used for client side routing. Only use when inside a routed component.
    */
   readonly to?: string;
 }
 
-interface BaseActionProps extends ButtonFoundationProps {
-  readonly variation?: "work" | "learning" | "subtle" | "destructive";
-  readonly type?: "primary" | "secondary" | "tertiary";
-}
-
-interface DestructiveActionProps extends ButtonFoundationProps {
-  readonly variation: "destructive";
-  readonly type?: "primary" | "secondary" | "tertiary";
-}
-
-interface SubmitActionProps
-  extends Omit<ButtonFoundationProps, "external" | "onClick"> {
-  readonly type?: "primary";
-  readonly submit: boolean;
-}
-
-interface SubmitButtonProps
-  extends Omit<ButtonFoundationProps, "external" | "onClick"> {
+interface SubmitButtonProps {
   /**
    * Allows the button to submit a form
    */
-  submit: boolean;
+  submit: true;
+  readonly type?: "primary";
 }
 
-export type ButtonProps = XOR<
-  BaseActionProps,
-  XOR<DestructiveActionProps, SubmitActionProps>
-> &
-  XOR<SubmitButtonProps, XOR<ButtonLinkProps, ButtonAnchorProps>> &
-  XOR<ButtonIconProps, ButtonLabelProps>;
+/** This type ensures the button defines only one purpose */
+type ButtonFunctionality = XOR<
+  SubmitButtonProps,
+  XOR<ButtonLinkProps, ButtonAnchorProps>
+  >;
+
+/**This type ensures the button is identifiable to users*/
+type ButtonIdentification = XOR<ButtonIconProps, ButtonLabelProps>;
+
+export type ButtonProps = ButtonFoundationProps &
+  ButtonFunctionality &
+  ButtonIdentification;
 
 export function Button(props: ButtonProps) {
   const {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Simplify reading the button prop type so developers can more easily read the type to understand what it is trying to achieve.

## Changes

Removed unneeded inheritance in the sub types.
Removed unused destructive type
Separated type to give descriptive names

## Testing

Paste this code into the button file. All the objects added to the workingButtons array should be valid 
All the buttons in the badButtons array should have a typescript error
The label or aria label should give some explanation.
Do this on master and in the branch. Behaviour should be mostly the same except for the last bad button preventing the `external` flag existing on with the `to` property.
```
const workingButtons: ButtonProps[] = [];
workingButtons.push({
  label: "Button that doesn't do anything",
  //should we make it so onClick, submit, to, or url is required?
});

workingButtons.push({
  label: "nav button",
  to: "",
});

workingButtons.push({
  icon: "search",
  ariaLabel: "submit button must be primary",
  type: "primary",
  submit: true,
});

workingButtons.push({
  label: "url button",
  url: "",
});

workingButtons.push({
  label: "external url button",
  url: "",
  external: true,
});

workingButtons.push({
  label: "Destruction",
  onClick: () => {},
});

//new submit can be destructive
workingButtons.push({
  label: "Button can't submit and destructively",
  submit: true,
  variation: "destructive",
});

//done so there isn't an error on workingButtons not being used
console.log(workingButtons);

const badButtons: ButtonProps[] = [];
badButtons.push({
  label: "Button can't submit and onclick",
  onClick: () => {},
  submit: true,
});


workingButtons.push({
  icon: "search",
  ariaLabel: "submit button can't have variations",
  type: "primary",
  variation: "learning",
  submit: true,
});

badButtons.push({
  label: "Button can't submit and to",
  submit: true,
  to: "",
});

badButtons.push({
  label: "Button can't url and to",
  url: "",
  to: "",
});

badButtons.push({
  icon: "search",
  //needs a aria label
  type: "primary",
  submit: true,
});

badButtons.push({
  icon: "search",
  ariaLabel: "submit button can't have a variation other than work",
  type: "primary",
  variation: "learning",
  submit: true,
});


// This is new rule enforcement
badButtons.push({
  label: "nav can't go to external links",
  to: "",
  external: true,
});

//done so there isn't an error on badButtons not being used
console.log(badButtons);
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
