### PR TITLE
refactor(components): Fix TS warning on InputFile

### DIFF
--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -230,8 +230,7 @@ export function InputFile({
     } = await getUploadParams(file);
 
     const fileUpload = {
-      ...getFileUpload(file, key),
-      uploadUrl: url,
+      ...getFileUpload(file, key, url),
     };
     onUploadStart && onUploadStart({ ...fileUpload });
 
@@ -313,7 +312,7 @@ function getLabels(
   return { buttonLabel, hintText };
 }
 
-function getFileUpload(file: File, key: string): FileUpload {
+function getFileUpload(file: File, key: string, url: string): FileUpload {
   return {
     key: key,
     name: file.name,
@@ -321,6 +320,7 @@ function getFileUpload(file: File, key: string): FileUpload {
     size: file.size,
     progress: 0,
     src: getSrc,
+    uploadUrl: url,
   };
 
   function getSrc() {


### PR DESCRIPTION
## Motivations

Typescript was warning about the usage of `getFileUpload` because it was not returning `uploadUrl`.

## Changes

Changed `getFileUpload` to return `uploadUrl`.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
