### PR TITLE
fix: Use chip label instead of value on aria-label [JOB-66426]

### DIFF
--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
@@ -33,7 +33,7 @@ export function InternalChipDismissible(props: InternalChipDismissibleProps) {
           {...chip}
           onKeyDown={handleChipKeyDown(chip.value)}
           onClick={handleChipClick(chip.value)}
-          ariaLabel={`${chip.value}. Press delete or backspace to remove ${chip.value}`}
+          ariaLabel={`${chip.label}. Press delete or backspace to remove ${chip.label}`}
           tabIndex={0}
           suffix={
             <InternalChipButton


### PR DESCRIPTION
## Motivations

In order to improve accessibility on dismissible chips, we are changing the `ariaLabel` to use the chip `label` instead of the `value` to represent what the user is actually reading instead of the value of the chip that can be an ID.

## Changes

- Changed dismissible chip to use `label` instead of `value`

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
