### PR TITLE
feat(components): Skeleton loader for image thumbnails

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.test.tsx
+++ b/packages/components/src/FormatFile/FormatFile.test.tsx
@@ -33,6 +33,26 @@ it("renders an image when provided as src", async () => {
   expect(await findByRole("img")).toBeInTheDocument();
 });
 
+it("renders a skeleton loader when provided an image", async () => {
+  jest.useFakeTimers();
+  const url = "not_actually_a_url";
+  const testFile = {
+    key: "234",
+    name: "Onion",
+    type: "image/png",
+    size: 102432,
+    progress: 1,
+    src: () =>
+      new Promise<string>(resolve => setTimeout(() => resolve(url), 3000)),
+  };
+
+  const { getByTestId } = render(<FormatFile file={testFile} />);
+  expect(getByTestId("internalThumbnailImageLoader")).toBeInTheDocument();
+
+  jest.runAllTimers();
+  jest.useRealTimers();
+});
+
 it("should call the delete handler", async () => {
   const testFile = {
     key: "234",

--- a/packages/components/src/FormatFile/InternalThumbnail.css
+++ b/packages/components/src/FormatFile/InternalThumbnail.css
@@ -1,13 +1,3 @@
-.image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.loading {
-  display: none;
-}
-
 .content {
   display: grid;
   grid-template-columns: auto;

--- a/packages/components/src/FormatFile/InternalThumbnail.css.d.ts
+++ b/packages/components/src/FormatFile/InternalThumbnail.css.d.ts
@@ -1,6 +1,4 @@
 declare const styles: {
-  readonly "image": string;
-  readonly "loading": string;
   readonly "content": string;
   readonly "hasName": string;
   readonly "large": string;

--- a/packages/components/src/FormatFile/InternalThumbnail.tsx
+++ b/packages/components/src/FormatFile/InternalThumbnail.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import classNames from "classnames";
 import styles from "./InternalThumbnail.css";
+import { InternalThumbnailImage } from "./InternalThumbnailImage";
 import { Icon, IconNames } from "../Icon";
 import { FileUpload } from "../InputFile";
 import { Typography } from "../Typography";
@@ -16,28 +17,12 @@ export function InternalThumbnail({
   size,
   file,
 }: InternalThumbnailProps) {
-  const { name, type, src } = file;
-  const [imageSource, setImageSource] = useState<string>();
-  const [imageLoaded, setImageLoaded] = useState<boolean>(false);
+  const { name, type } = file;
   const iconName = getIconNameFromType(type);
   const hasName = Boolean(name) && compact;
 
-  if (!imageSource && type.startsWith("image/")) {
-    src().then(url => setImageSource(url));
-  }
-
-  const image = (
-    <img
-      src={imageSource}
-      onLoad={handleImageLoad}
-      className={classNames(styles.image, { [styles.loading]: !imageLoaded })}
-      alt={name}
-      data-testid="internalThumbnailImage"
-    />
-  );
-
-  if (imageLoaded) {
-    return image;
+  if (type.startsWith("image/")) {
+    return <InternalThumbnailImage file={file} />;
   }
 
   return (
@@ -46,8 +31,6 @@ export function InternalThumbnail({
         [styles.hasName]: hasName,
       })}
     >
-      {imageSource && image}
-
       <Icon name={iconName} color="greyBlue" size={size} />
 
       {hasName && (
@@ -59,10 +42,6 @@ export function InternalThumbnail({
       )}
     </div>
   );
-
-  function handleImageLoad() {
-    setImageLoaded(true);
-  }
 }
 
 function getIconNameFromType(mimeType: string): IconNames {

--- a/packages/components/src/FormatFile/InternalThumbnailImage.css
+++ b/packages/components/src/FormatFile/InternalThumbnailImage.css
@@ -1,0 +1,46 @@
+.glimmer {
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-grey--lightest);
+  background-image: linear-gradient(
+    90deg,
+    var(--color-grey--lightest) 0px,
+    var(--color-white) var(--space-larger),
+    var(--color-grey--lightest) var(--space-extravagant)
+  );
+  background-repeat: no-repeat;
+  background-size: var(--space-extravagant) 100%;
+  animation: glimmer 1s infinite linear;
+}
+
+@keyframes glimmer {
+  0%,
+  20% {
+    background-position: calc(var(--space-extravagant) * -1);
+  }
+
+  100% {
+    background-position: calc(100% + var(--space-extravagant));
+  }
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  animation: fadeIn 200ms ease;
+}
+
+.loading {
+  display: none;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}

--- a/packages/components/src/FormatFile/InternalThumbnailImage.css
+++ b/packages/components/src/FormatFile/InternalThumbnailImage.css
@@ -31,7 +31,7 @@
   animation: fadeIn 200ms ease;
 }
 
-.loading {
+.hidden {
   display: none;
 }
 

--- a/packages/components/src/FormatFile/InternalThumbnailImage.css.d.ts
+++ b/packages/components/src/FormatFile/InternalThumbnailImage.css.d.ts
@@ -2,7 +2,7 @@ declare const styles: {
   readonly "glimmer": string;
   readonly "image": string;
   readonly "fadeIn": string;
-  readonly "loading": string;
+  readonly "hidden": string;
 };
 export = styles;
 

--- a/packages/components/src/FormatFile/InternalThumbnailImage.css.d.ts
+++ b/packages/components/src/FormatFile/InternalThumbnailImage.css.d.ts
@@ -1,0 +1,8 @@
+declare const styles: {
+  readonly "glimmer": string;
+  readonly "image": string;
+  readonly "fadeIn": string;
+  readonly "loading": string;
+};
+export = styles;
+

--- a/packages/components/src/FormatFile/InternalThumbnailImage.tsx
+++ b/packages/components/src/FormatFile/InternalThumbnailImage.tsx
@@ -13,7 +13,7 @@ export function InternalThumbnailImage({ file }: InternalThumbnailImageProps) {
   const [imageLoaded, setImageLoaded] = useState<boolean>(false);
 
   if (!imageSource) {
-    src().then(url => setTimeout(() => setImageSource(url), 3000));
+    src().then(url => setImageSource(url));
   }
 
   return (
@@ -25,7 +25,7 @@ export function InternalThumbnailImage({ file }: InternalThumbnailImageProps) {
         onLoad={handleImageLoad}
         alt={name}
         data-testid="internalThumbnailImage"
-        className={classNames(styles.image, { [styles.loading]: !imageLoaded })}
+        className={classNames(styles.image, { [styles.hidden]: !imageLoaded })}
       />
     </>
   );

--- a/packages/components/src/FormatFile/InternalThumbnailImage.tsx
+++ b/packages/components/src/FormatFile/InternalThumbnailImage.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import classNames from "classnames";
+import styles from "./InternalThumbnailImage.css";
+import { FileUpload } from "../InputFile";
+
+interface InternalThumbnailImageProps {
+  readonly file: FileUpload;
+}
+
+export function InternalThumbnailImage({ file }: InternalThumbnailImageProps) {
+  const { name, src } = file;
+  const [imageSource, setImageSource] = useState<string>();
+  const [imageLoaded, setImageLoaded] = useState<boolean>(false);
+
+  if (!imageSource) {
+    src().then(url => setTimeout(() => setImageSource(url), 3000));
+  }
+
+  return (
+    <>
+      {!imageLoaded && <div className={styles.glimmer} />}
+
+      <img
+        src={imageSource}
+        onLoad={handleImageLoad}
+        alt={name}
+        data-testid="internalThumbnailImage"
+        className={classNames(styles.image, { [styles.loading]: !imageLoaded })}
+      />
+    </>
+  );
+
+  function handleImageLoad() {
+    setImageLoaded(true);
+  }
+}

--- a/packages/components/src/FormatFile/InternalThumbnailImage.tsx
+++ b/packages/components/src/FormatFile/InternalThumbnailImage.tsx
@@ -18,7 +18,12 @@ export function InternalThumbnailImage({ file }: InternalThumbnailImageProps) {
 
   return (
     <>
-      {!imageLoaded && <div className={styles.glimmer} />}
+      {!imageLoaded && (
+        <div
+          className={styles.glimmer}
+          data-testid="internalThumbnailImageLoader"
+        />
+      )}
 
       <img
         src={imageSource}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

It's less than ideal to flash icon thumbnails when the image is loading. Especially if it's the big one.

### Before

https://user-images.githubusercontent.com/15986172/230926848-1dbb06ed-6cda-47c9-9429-9800b57bbb12.mp4

### After

https://user-images.githubusercontent.com/15986172/230926887-c74b47b2-9c94-48b4-8405-0068cbee16fd.mp4


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Skeleton loader for image thumbnails

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Open `FormatFile.stories.mdx`
- Do this changes which simulates slow image loading

```diff
diff --git a/packages/components/src/FormatFile/FormatFile.stories.mdx b/packages/components/src/FormatFile/FormatFile.stories.mdx
index bbbf7656..3fc10c3e 100644
--- a/packages/components/src/FormatFile/FormatFile.stories.mdx
+++ b/packages/components/src/FormatFile/FormatFile.stories.mdx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { FormatFile } from ".";
 import { Content } from "../Content";
@@ -15,26 +16,73 @@ icon will be displayed depending on what is provided.
 A delete callback function can be passed in and will be called when the user
 actions the delete button.

-```ts
-import { FormatFile } from "@jobber/components/FormatFile";
-```
+export const imageFileOne = {
+  key: "abc",
+  name: "myballisbigandroundIamrollingitontheground.png",
+  type: "image/png",
+  size: 213402324,
+  progress: 1,
+  src: () =>
+    new Promise(resolve =>
+      setTimeout(() => resolve("https://source.unsplash.com/250x350"), 3000),
+    ),
+};
+
+export const imageFileTwo = {
+  name: "Second File",
+  type: "image/png",
+  size: 3,
+  key: "b",
+  uploadUrl: "",
+  progress: 1,
+  src: () =>
+    new Promise(resolve =>
+      setTimeout(() => resolve("https://source.unsplash.com/450x350"), 3000),
+    ),
+};
+
+export const fileThree = {
+  name: "Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptate atque veritatis qui fuga adipisci accusamus ex optio perferendis incidunt quae.",
+  type: "application/pdf",
+  size: 3,
+  key: "c",
+  uploadUrl: "",
+  progress: 1,
+  src: () => Promise.resolve(""),
+};
+
+export const fileFour = {
+  name: "",
+  type: "application/pdf",
+  size: 3,
+  key: "d",
+  uploadUrl: "",
+  progress: 1,
+  src: () => Promise.resolve(""),
+};

 <Canvas>
   <Story
     name="FormatFile"
     args={{
-      file: {
-        key: "abc",
-        name: "myballisbigandroundIamrollingitontheground.png",
-        type: "image/png",
-        size: 213402324,
-        progress: 1,
-        src: () => Promise.resolve("https://source.unsplash.com/250x250"),
-      },
+      file: imageFileOne,
       onDelete: () => alert("Deleted"),
+      display: "compact",
+      displaySize: "large",
     }}
   >
-    {args => <FormatFile {...args} />}
+    {args => {
+      const [file, setFile] = useState(args.file);
+      return (
+        <>
+          <button onClick={() => setFile(imageFileOne)}>image file one</button>
+          <button onClick={() => setFile(imageFileTwo)}>image file two</button>
+          <button onClick={() => setFile(fileThree)}>file three</button>
+          <button onClick={() => setFile(fileFour)}>file four</button>
+          <FormatFile {...args} file={file} />
+        </>
+      );
+    }}
   </Story>
 </Canvas>
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)

JOB-53679