### PR TITLE
fix(components): Fix label z-index and autofill style on Inputs [JOB-63282]

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -62,7 +62,6 @@
 }
 
 .miniLabel {
-  --field--label-elevation: calc(var(--field--base-elevation) + 1);
   --field--placeholder-color: var(--color-text--secondary);
   --field--placeholder-offset: var(--space-smallest);
   --field--placeholder-transform: 0;


### PR DESCRIPTION
## Motivations

When autofilling an Atlantis input using the browser's default behavior, the label disappeared and the input's background was set to blue.

## Changes

- Removed the reassigned of the CSS variable `--field--base-elevation` inside `miniLabel`
- Added the styling to remove the autofill background style ([SO answer](https://stackoverflow.com/a/14205976))

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Input's autofill behavior

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
