### PR TITLE
fix: Update positioning of Autocomplete Menu

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import debounce from "lodash/debounce";
 import { XOR } from "ts-xor";
 import styles from "./Autocomplete.css";
@@ -77,6 +77,7 @@ export function Autocomplete({
   const [options, setOptions] = useState(initialOptions);
   const [menuVisible, setMenuVisible] = useState(false);
   const [inputText, setInputText] = useState(value?.label ?? "");
+  const autocompleteRef = useRef(null);
 
   const delayedSearch = debounce(updateSearch, debounceRate);
 
@@ -90,7 +91,7 @@ export function Autocomplete({
   }, [value]);
 
   return (
-    <div className={styles.autocomplete}>
+    <div className={styles.autocomplete} ref={autocompleteRef}>
       <InputText
         autocomplete={false}
         size={size}
@@ -103,6 +104,7 @@ export function Autocomplete({
       />
       {menuVisible && (
         <Menu
+          attachTo={autocompleteRef}
           visible={true}
           options={options}
           selectedOption={value}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

It gets cut off in the storybook because it's rendered within a parent with an `overflow: hidden`. Best practice around floating elements like a menu is always to throw it to the body.

### Before
![image](https://user-images.githubusercontent.com/15986172/232512044-f0a863c6-99a1-49cc-a86f-2772a98d3f8b.png)


## After
![image](https://user-images.githubusercontent.com/15986172/232511889-3c2ef68e-c388-4efd-a110-df0011a1863f.png)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Portal Autocomplete Menu to the body
- Replaced positioning logic of Autocomplete Menu

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
