### PR TITLE
feat(design): Add opacity tokens to Atlantis web

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -89,8 +89,7 @@ function jobberStyle(styling) {
 }
 
 function isFloatValue(value) {
-  const isFloat = parseFloat(value);
-  return value == isFloat;
+  return value == parseFloat(value);
 }
 
 function handleCalc(calcRegexResult) {

--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -82,8 +82,15 @@ function jobberStyle(styling) {
   } else if (varRegexResult) {
     return jobberStyle(varRegexResult[1]);
   } else {
-    return isSpacingValue(styleValue) ? parseFloat(styleValue) : styleValue;
+    return isSpacingValue(styleValue) || isFloatValue(styleValue)
+      ? parseFloat(styleValue)
+      : styleValue;
   }
+}
+
+function isFloatValue(value) {
+  const isFloat = parseFloat(value);
+  return value == isFloat;
 }
 
 function handleCalc(calcRegexResult) {

--- a/packages/design/src/foundation.css
+++ b/packages/design/src/foundation.css
@@ -4,6 +4,7 @@
 @import "./spacing.css";
 @import "./shadows.css";
 @import "./timings.css";
+@import "./opacity.css";
 @import "./elevations.css";
 @import "./typography.css";
 @import "./responsiveBreakpoints.css";

--- a/packages/design/src/opacity.css
+++ b/packages/design/src/opacity.css
@@ -1,0 +1,4 @@
+:root {
+  --opacity-overlay: 0.8;
+  --opacity-pressed: 0.6;
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
To help setup a single source of truth for Design Tokens between jobber-mobile and web, opacity tokens now live in Atlantis

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

 <!-- new features -->
Added `opacity.css` to be included in the design build

## Testing

<!-- How to test your changes. -->
Run `npm run build -w @jobber/design` in Atlantis to see the opacity tokens land in `packages/design/foundation.js`

pre-release: `npm i @jobber/components@4.7.1-tay.2+92c06a7b @jobber/design@0.32.1-tay.5+92c06a7b`

You can go to `jobber-mobile` and delete the opacity tokens from `mobile-foundation.ts`.  Test on the `Button` in Storybook to see opacity remains and is being pulled from `@jobber/design` & test in simulator


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
