### PR TITLE
chore: Remove upload_to_cloudfare step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,22 +135,6 @@ jobs:
       - *generate_base_path
       - run:
           command: npm run build
-      - *persist_to_workspace
-
-  upload_to_cloudflare:
-    <<: *container_config
-    environment:
-      ATLANTIS_BRANCH: << pipeline.git.branch >>
-    steps:
-      - *attach_workspace
-      - *generate_base_path
-      - run:
-          command: |
-            if [ "$ATLANTIS_BRANCH" = "master" ]; then
-              npx wrangler pages publish storybook-static --project-name=atlantis
-            else
-              npx wrangler pages publish storybook-static --project-name=atlantis --branch=$ATLANTIS_BRANCH
-            fi
 
   release:
     <<: *container_config
@@ -193,9 +177,6 @@ workflows:
       - build_docs:
           requires:
             - check_for_manual_release
-      - upload_to_cloudflare:
-          requires:
-            - build_docs
       - release:
           filters:
             branches:


### PR DESCRIPTION
## Motivations

Removing `upload_to_clodfare` step in CircleCI as we don't need it anymore. It was previously added because we did a workaround to build the docs first and then upload it cloudfare, but now that Cloudfare supports Node 18 without errors, we can go back to build and host it there directly.

## Changes

- Removed `upload_to_cloudfare` step

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
