### PR TITLE
fix(components): Autocomplete Menu Test Bug

### DIFF
--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -107,7 +107,7 @@ export function Menu({
 
   function setupKeyListeners() {
     useEffect(() => {
-      menuRef?.children[highlightedIndex].scrollIntoView?.({
+      menuRef?.children[highlightedIndex]?.scrollIntoView?.({
         behavior: "smooth",
         block: "nearest",
         inline: "start",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Tests fails in our main repo because the children of the menu are not defined. Adding this guard `?` prevents the failure.

### Fixed

- Check if there are children before calling `scrollIntoView` on them.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
