### PR TITLE
feat(design): Move mobile fontSizes into design

### DIFF
--- a/packages/design/jobberStyle.js
+++ b/packages/design/jobberStyle.js
@@ -6,6 +6,8 @@ const customPropertiesObject = require("./src/foundation.js");
 const { getShadowStyles } = require("./src/getMobileShadows.js");
 // eslint-disable-next-line import/no-internal-modules
 const { getMobileLineHeights } = require("./src/getMobileLineHeights");
+// eslint-disable-next-line import/no-internal-modules
+const { getMobileFontSizes } = require("./src/getMobileFontSizes");
 
 const regexExpressions = {
   cssVars: /var\((.*)\)/,
@@ -254,15 +256,18 @@ function removeNewLines(text) {
 function writeMobileFoundationFiles() {
   const { androidShadows, iOSShadows } = getShadowStyles(resolvedCssVars);
   const mobileLineHeightValues = getMobileLineHeights();
+  const mobileFontSizeValues = getMobileFontSizes();
   const androidFoundationJobberStyle = {
     ...resolvedCssVars,
     ...androidShadows,
     ...mobileLineHeightValues,
+    ...mobileFontSizeValues,
   };
   const iOSFoundationJobberStyle = {
     ...resolvedCssVars,
     ...iOSShadows,
     ...mobileLineHeightValues,
+    ...mobileFontSizeValues,
   };
   const androidFoundationsExportString = `export const JobberStyle = ${JSON.stringify(
     androidFoundationJobberStyle,

--- a/packages/design/src/getMobileFontSizes.js
+++ b/packages/design/src/getMobileFontSizes.js
@@ -1,0 +1,17 @@
+function getMobileFontSizes() {
+  return {
+    "typography--fontSize-extravagant": 42,
+    "typography--fontSize-jumbo": 32,
+    "typography--fontSize-largest": 24,
+    "typography--fontSize-larger": 20,
+    "typography--fontSize-large": 18,
+    "typography--fontSize-base": 16,
+    "typography--fontSize-small": 14,
+    "typography--fontSize-smaller": 12,
+    "typography--fontSize-smallest": 10,
+  };
+}
+
+module.exports = {
+  getMobileFontSizes,
+};


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Add ability to use Mobile specific design tokens (`typography-fontSize`) and have them bundle with @jobber/design

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

<!-- new features -->
`typography--fontSize` tokens from mobile now build within mobile related foundation files

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
