### PR TITLE
fix(components): calculate Z index for autocomplete 

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.css
+++ b/packages/components/src/Autocomplete/Autocomplete.css
@@ -6,7 +6,7 @@
 .options {
   display: none;
   position: absolute;
-  z-index: var(--elevation-menu);
+  z-index: calc(var(--elevation-menu) + var(--elevation-modal));
   width: 100%;
   /* Unfortunately this is how we define our line item picker height in jobber online.
   This is a concession to maintain visual parity. */


### PR DESCRIPTION
## Motivations

There was an issue where the autocomplete options would appear behind the modal. Screenshot: 
![image](https://user-images.githubusercontent.com/23041211/234700739-835bfdce-09dd-4ab9-b8fe-413febcae641.png)


## Changes

Now it will appear in front of the modal so it can be selected. This is a quick fix so the component can be used. 


### Security

- <!-- in case of vulnerabilities -->

## Testing

- Go to anchor as test@example.com
- Go to an account 
- Go to update account
- Scroll down to the distribution channel component 
![image](https://user-images.githubusercontent.com/23041211/234701044-4d8e6473-db56-4214-9a1c-2cc862a8c6b7.png)
- Attempt to type in there, and you'll see it appear in front now. 


![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
