### PR TITLE
refactor(design): Change archive icon to standard greyBlue

### DIFF
--- a/packages/design/src/icons/Icon.css
+++ b/packages/design/src/icons/Icon.css
@@ -79,10 +79,6 @@
   fill: var(--color-orange);
 }
 
-.archive {
-  fill: var(--color-blue);
-}
-
 .video {
   fill: var(--color-lightBlue);
 }

--- a/packages/design/src/icons/Icon.css.d.ts
+++ b/packages/design/src/icons/Icon.css.d.ts
@@ -27,7 +27,6 @@ declare const styles: {
   readonly "badInvoice": string;
   readonly "payment": string;
   readonly "expense": string;
-  readonly "archive": string;
   readonly "video": string;
   readonly "excel": string;
   readonly "pdf": string;

--- a/packages/design/src/icons/getIcon.ts
+++ b/packages/design/src/icons/getIcon.ts
@@ -107,7 +107,6 @@ function getPathClassNames(name: string, color?: IconColorNames) {
     [styles.paidInvoice]: name === "paidInvoice",
     [styles.payment]: name === "payment",
     [styles.expense]: name === "expense",
-    [styles.archive]: name === "archive",
     [styles.excel]: name === "excel",
     [styles.pdf]: name === "pdf",
     [styles.word]: name === "word",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
The `archive` icon was made `--color-blue` to match with SG-1 icons ([see PR here](https://github.com/GetJobber/atlantis/pull/142)) however we've decided that `archive` in particular should be the base icon color instead.


### Removed

<!-- now removed features -->
`archive` no longer has specific styling

### Before
<img width="725" alt="Screenshot 2023-04-27 at 3 21 48 PM" src="https://user-images.githubusercontent.com/104797704/234969707-c51caa03-a032-46e4-9ef3-46537868d0c9.png">

### After
<img width="649" alt="Screenshot 2023-04-27 at 3 20 55 PM" src="https://user-images.githubusercontent.com/104797704/234969507-7d5a9c5d-fad1-46ec-8f2f-3e70ed084407.png">





## Testing
In Storybook, check that the `archive` icon has a fill of `--color-greyBlue` to match the majority of other icons

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
