### PR TITLE
fix: Ensure form fields positioned children are contained

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -137,6 +137,8 @@
   display: flex;
   flex: 1;
   position: relative;
+  /* Ensure input stays with the rest of the element stack */
+  z-index: var(--elevation-default);
 }
 
 .childrenWrapper {

--- a/packages/design/src/elevations.css
+++ b/packages/design/src/elevations.css
@@ -7,7 +7,6 @@
    * Modal has this much z-index to overcome docz z-index. This can be lowered
    * once we create our own docz theme
    */
-  --elevation-topbar: 1000;
   --elevation-modal: 1001;
   --elevation-tooltip: 1002;
   --elevation-toast: 1003;

--- a/packages/design/src/elevations.css
+++ b/packages/design/src/elevations.css
@@ -1,4 +1,5 @@
 :root {
+  --elevation-default: 0;
   --elevation-base: 1;
   --elevation-menu: 6;
   --elevation-datepicker: 6;
@@ -6,6 +7,7 @@
    * Modal has this much z-index to overcome docz z-index. This can be lowered
    * once we create our own docz theme
    */
+  --elevation-topbar: 1000;
   --elevation-modal: 1001;
   --elevation-tooltip: 1002;
   --elevation-toast: 1003;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We're dealing with some z-index within the form field component. Sadly, the way z-index works, we have to contain it within the component itself since it is leaking outside of it and creating issues

### Before


https://user-images.githubusercontent.com/15986172/235973729-982444ac-a291-4be9-8440-9a6f0092d735.mp4

### After

https://user-images.githubusercontent.com/15986172/235973995-519c5994-4192-4496-bfc7-e40d98d76107.mp4

### Test it here
- Go here https://codesandbox.io/s/placeholder-issue-zrdq7u?file=/src/App.js
- Scroll down
- To fix the issue, open package.json
- Update @jobber/component version to `4.11.1-fix-form-f.2`

## Wait, how did that fix it?

Lemme start with z-index doesn't work the way you think it works.

- On the surface level, 2 is higher than 1 (makes sense)
- DOM structure-wise, the lower it is on the DOM, the higher it is on the Z-axis if you think about it as layers (still makes sense)
- If you have 2 children and the 1st child has a z index of 2 and the 2nd child has 3, the 2nd child is still higher.
  - If you wrap the 2nd child with a div that has a z index of 0, the 1st child is now higher. (wait what?)

### No z-index

```html
<TopBar />
<FormField>
  <Placeholder />
  <Input />
  <Mask />
</FormField>
```

#### Would be rendered as 

<img width="499" alt="image" src="https://user-images.githubusercontent.com/15986172/235986956-2cc00580-593a-44c9-be3b-5c8c9177a9ec.png">

### With z-index
```html
<TopBar style={{ zIndex: 1 }} />
<FormField>
  <Placeholder  style={{ zIndex: 2 }} />
  <Input style={{ zIndex: 1 }} />
  <Mask />
</FormField>
```

#### Would be rendered as 

<img width="456" alt="image" src="https://user-images.githubusercontent.com/15986172/235987580-09968dfd-615b-4098-9bea-645fb9556de6.png">

### With contained z-index
```html
<TopBar style={{ zIndex: 1 }} />
<FormField style={{ zIndex: 0 }} >
  <Placeholder  style={{ zIndex: 2 }} />
  <Input style={{ zIndex: 1 }} />
  <Mask />
</FormField>
```

#### Would be rendered as 

<img width="459" alt="image" src="https://user-images.githubusercontent.com/15986172/235988131-20197e17-deab-43cb-a2f2-ffbe8849a955.png">




## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- 

### Changed

- Ensured that the z-indexes within the form field are contained within it

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
