### PR TITLE
fix(components): fix the styling of DescriptionList component

### DIFF
--- a/packages/components/src/DescriptionList/DescriptionList.css
+++ b/packages/components/src/DescriptionList/DescriptionList.css
@@ -23,9 +23,9 @@
   box-sizing: border-box;
   padding-right: var(--space-small);
   margin-inline-start: 0;
-  flex: 1 1 40%;
+  flex: 1 1 60%;
 }
 
 .termGroup dt {
-  flex: 1 1 60%;
+  flex: 1 1 40%;
 }


### PR DESCRIPTION
## Motivations
Currently DescriptionList component width for `key` is `60%` and width for `value` is `40%`. I believe it should be the opposite since usually the keyse are shorter than values

## Changes
Updated `dd` element width from `40%` to `60%`
Updated `dt` element width from `60%` to `40%`

Before:
![Screenshot 2023-05-04 at 11 41 37 AM](https://user-images.githubusercontent.com/59518540/236277149-4ae7cbba-4e7c-4b1f-8fd5-26d2d871aefe.png)


After:
![Screenshot 2023-05-04 at 11 41 50 AM](https://user-images.githubusercontent.com/59518540/236277151-25770400-6699-4ea2-9855-e06a34ea7538.png)
