### PR TITLE
feat(components): Added replace function to InputText

### DIFF
--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -148,3 +148,16 @@ test("it should handle inserting text", () => {
   textRef.current.insert("sure");
   expect(changeHandler).toHaveBeenCalledWith(secondResult);
 });
+
+test("it should replace the text", () => {
+  const initial = "Got milk?";
+  const result = "YUP";
+
+  const textRef = React.createRef<InputTextRef>();
+  const changeHandler = jest.fn();
+
+  render(<InputText value={initial} onChange={changeHandler} ref={textRef} />);
+
+  textRef.current?.replace("YUP");
+  expect(changeHandler).toHaveBeenCalledWith(result);
+});

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -35,6 +35,7 @@ interface BaseProps
 
 export interface InputTextRef {
   insert(text: string): void;
+  replace(text: string): void;
   blur(): void;
   focus(): void;
 }
@@ -68,6 +69,9 @@ function InputTextInternal(
   useImperativeHandle(ref, () => ({
     insert: (text: string) => {
       insertText(text);
+    },
+    replace: (text: string) => {
+      replaceText(text);
     },
     blur: () => {
       const input = inputRef.current;
@@ -147,6 +151,18 @@ function InputTextInternal(
     const input = inputRef.current;
     if (input) {
       insertAtCursor(input, text);
+
+      const newValue = input.value;
+      actionsRef.current?.setValue(newValue);
+      props.onChange && props.onChange(newValue);
+    }
+  }
+
+  function replaceText(text: string) {
+    const input = inputRef.current;
+    if (input) {
+      input.value = text;
+      input.focus();
 
       const newValue = input.value;
       actionsRef.current?.setValue(newValue);


### PR DESCRIPTION
## Motivations
We wanted to have the ability for SC's to have their addresses autofilled via google complete when they're trying to book our SP's via online booking (here's an [example of how that flow looks like](https://clienthub.getjobber.com/booking/b4f3d728-20fd-4235-9c91-ec5a9c63ef22/)). Since there is only insert method in the select component, if the SC selects the wrong address they will have to manually clear out the autofilled fields before selecting another address. Adding this feature will remove that manual step. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added


- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
