### PR TITLE
feat(components): Add validation support to Autocomplete component

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.stories.mdx
+++ b/packages/components/src/Autocomplete/Autocomplete.stories.mdx
@@ -43,6 +43,14 @@ import { Autocomplete } from "@jobber/components/Autocomplete";
           value={value}
           onChange={setValue}
           getOptions={getOptions}
+          name={"autocompleteInput"}
+          validations={{
+            maxLength: 255,
+            required: {
+              value: true,
+              message: "This is a required field",
+            },
+          }}
         />
       );
       function getOptions(text) {

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -10,7 +10,10 @@ import { FormFieldProps } from "../FormField";
 type OptionCollection = XOR<Option[], GroupOption[]>;
 
 interface AutocompleteProps
-  extends Pick<FormFieldProps, "size" | "onBlur" | "onFocus" | "invalid"> {
+  extends Pick<
+    FormFieldProps,
+    "size" | "onBlur" | "onFocus" | "invalid" | "name" | "validations"
+  > {
   /**
    * Initial options to show when user first focuses the Autocomplete
    */
@@ -73,6 +76,8 @@ export function Autocomplete({
   placeholder,
   onBlur,
   onFocus,
+  name,
+  validations,
 }: AutocompleteProps) {
   const [options, setOptions] = useState(initialOptions);
   const [menuVisible, setMenuVisible] = useState(false);
@@ -101,6 +106,8 @@ export function Autocomplete({
         placeholder={placeholder}
         onFocus={handleInputFocus}
         onBlur={handleInputBlur}
+        name={name}
+        validations={validations}
       />
       {menuVisible && (
         <Menu


### PR DESCRIPTION
## Motivations
SC First Touch team is using the [Autocomplete](https://atlantis.getjobber.com/?path=/docs/components-autocomplete--autocomplete) component on the SC facing Online Booking Form in one of the input fields on the Contact details page of the form.

This field is being modified to use Google Autocomplete service to show address predictions based on SC's input in the field in [this PR](https://github.com/GetJobber/Jobber/pull/35510) where it was noticed that the Autocomplete component does not support validations.

This PR adds that support to autocomplete component by utilizing the validation functionality of the [InputText](https://atlantis.getjobber.com/?path=/docs/components-inputtext--input-text) component which gets utilized within the autocomplete component.

## Changes
### Added
- Added `name` and `validations` props to Autocomplete component which were then passed to the `InputText` component
- Modified the existing (first) example in the storybooks documentation of this component to showcase the validation case.

## Testing
- Test by running storybooks locally
- Test using the SC facing OLB form on [this PR](https://github.com/GetJobber/Jobber/pull/35510) and removing the content of "street1" input field.

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)

## References:
- PR where the need for this addition was realized: https://github.com/GetJobber/Jobber/pull/35510
- Jira Ticket: https://jobber.atlassian.net/browse/JOB-67045