### PR TITLE
chore: Add components-native to the allow PR titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@
 
   SCOPE should be one of:
     - components
+    - components-native
     - design
     - eslint
     - generators

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -19,6 +19,7 @@ jobs:
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |
             components
+            components-native
             deps
             design
             docx


### PR DESCRIPTION
## Motivations

Adds `components-native` as a valid scope for the PR titles

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
