### PR TITLE
fix(components): Fix Select component hit area

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -177,6 +177,10 @@
   resize: vertical;
 }
 
+.select .input {
+  z-index: var(--field--label-elevation);
+}
+
 .input:-webkit-autofill,
 .input:-webkit-autofill:hover,
 .input:-webkit-autofill:focus,
@@ -291,8 +295,4 @@
 
 .description {
   margin-top: var(--space-smaller);
-}
-
-select.input {
-  z-index: var(--field--label-elevation);
 }

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -294,5 +294,5 @@
 }
 
 select.input {
-  z-index: calc(var(--field--base-elevation) + 1);
+  z-index: var(--field--label-elevation);
 }

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -292,3 +292,7 @@
 .description {
   margin-top: var(--space-smaller);
 }
+
+select.input {
+  z-index: calc(var(--field--base-elevation) + 1);
+}

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -13,6 +13,7 @@ declare const styles: {
   readonly "inputWrapper": string;
   readonly "childrenWrapper": string;
   readonly "input": string;
+  readonly "select": string;
   readonly "label": string;
   readonly "postfix": string;
   readonly "affixIcon": string;

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -42,6 +42,7 @@ export function FormFieldWrapper({
   inline,
   identifier,
 }: PropsWithChildren<FormFieldWrapperProps>) {
+  console.log({ type });
   const wrapperClasses = classnames(
     styles.wrapper,
     size && styles[size],
@@ -54,6 +55,7 @@ export function FormFieldWrapper({
         // Naively assume that if the the type is tel, it is the InputPhoneNumber
         (placeholder && type === "tel"),
       [styles.textarea]: type === "textarea",
+      [styles.select]: type === "select",
       [styles.invalid]: invalid ?? error,
       [styles.disabled]: disabled,
       [styles.inline]: inline,

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -42,7 +42,6 @@ export function FormFieldWrapper({
   inline,
   identifier,
 }: PropsWithChildren<FormFieldWrapperProps>) {
-  console.log({ type });
   const wrapperClasses = classnames(
     styles.wrapper,
     size && styles[size],

--- a/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders a Select with many options 1`] = `
 <div>
   <div
-    class="wrapper"
+    class="wrapper select"
   >
     <div
       class="inputWrapper"
@@ -56,7 +56,7 @@ exports[`renders a Select with many options 1`] = `
 exports[`renders a Select with no options 1`] = `
 <div>
   <div
-    class="wrapper"
+    class="wrapper select"
   >
     <div
       class="inputWrapper"
@@ -96,7 +96,7 @@ exports[`renders a Select with no options 1`] = `
 exports[`renders a Select with one option 1`] = `
 <div>
   <div
-    class="wrapper"
+    class="wrapper select"
   >
     <div
       class="inputWrapper"
@@ -140,7 +140,7 @@ exports[`renders a Select with one option 1`] = `
 exports[`renders correctly as large 1`] = `
 <div>
   <div
-    class="wrapper large"
+    class="wrapper large select"
   >
     <div
       class="inputWrapper"
@@ -184,7 +184,7 @@ exports[`renders correctly as large 1`] = `
 exports[`renders correctly as small 1`] = `
 <div>
   <div
-    class="wrapper small"
+    class="wrapper small select"
   >
     <div
       class="inputWrapper"
@@ -228,7 +228,7 @@ exports[`renders correctly as small 1`] = `
 exports[`renders correctly when disabled 1`] = `
 <div>
   <div
-    class="wrapper disabled"
+    class="wrapper select disabled"
   >
     <div
       class="inputWrapper"
@@ -273,7 +273,7 @@ exports[`renders correctly when disabled 1`] = `
 exports[`renders correctly when invalid 1`] = `
 <div>
   <div
-    class="wrapper invalid"
+    class="wrapper select invalid"
   >
     <div
       class="inputWrapper"


### PR DESCRIPTION
## Motivations

The `Select` component what not opening the options if the user clicked on the label. With this fix, I created a class for the select, similar to what we do with textarea and changed the z-index of the input that was behind the label, making it impossible to trigger the select by clicking on the label.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Add a class specific for the select and changed its z-index

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
