### PR TITLE
refactor(components-native): Add tests to components-native's Typography

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37771,22 +37771,6 @@
         "nullthrows": "^1.1.1"
       }
     },
-    "node_modules/react-native-gesture-handler": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.10.0.tgz",
-      "integrity": "sha512-vuNupfa8+6MAUMgbZMk5jSxrmqWyNnR/gR77/iuhdx6cPg1z2MJeeJNmqEtKQcF0InvHp45dOoyRK62peqTJ3Q==",
-      "dependencies": {
-        "@egjs/hammerjs": "^2.0.17",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-gradle-plugin": {
       "version": "0.71.17",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.17.tgz",
@@ -44885,8 +44869,8 @@
       "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "@jobber/design": "^0.38.2",
-        "react-native-gesture-handler": "^2.10.0",
+        "@jobber/design": "^0.39.0",
+        "react-native-gesture-handler": "^2.5.0",
         "react-native-svg": "^13.9.0",
         "ts-xor": "^1.1.0"
       },
@@ -44902,6 +44886,22 @@
         "@babel/core": "^7.4.5",
         "react": "^18",
         "react-native": ">=0.69.2"
+      }
+    },
+    "packages/components-native/node_modules/react-native-gesture-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.5.0.tgz",
+      "integrity": "sha512-djZdcprFf08PZC332D+AeG5wcGeAPhzfCJtB3otUgOgTlvjVXmg/SLFdPJSpzLBqkRAmrC77tM79QgKbuLxkfw==",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "packages/components-native/node_modules/react-native-svg": {

--- a/packages/components-native/jest.config.js
+++ b/packages/components-native/jest.config.js
@@ -2,7 +2,10 @@
 module.exports = {
   displayName: "Atlantis Mobile",
   preset: "react-native",
-  setupFilesAfterEnv: ["./jestMobileSetupConfig.js"],
+  setupFilesAfterEnv: [
+    "./jestMobileSetupConfig.js",
+    "./node_modules/react-native-gesture-handler/jestSetup.js",
+  ],
   testPathIgnorePatterns: ["/node_modules/"],
   transformIgnorePatterns: [
     "node_modules/(?!(jest-)?@?react-native|@react-native-community|@react-native)",

--- a/packages/components-native/package.json
+++ b/packages/components-native/package.json
@@ -21,9 +21,9 @@
     "build:clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "react-native-gesture-handler": "^2.10.0",
-    "react-native-svg": "^13.9.0",
     "@jobber/design": "^0.39.0",
+    "react-native-gesture-handler": "^2.5.0",
+    "react-native-svg": "^13.9.0",
     "ts-xor": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/components-native/src/Typography/Typography.test.tsx
+++ b/packages/components-native/src/Typography/Typography.test.tsx
@@ -1,0 +1,219 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { I18nManager } from "react-native";
+import { Typography } from "./Typography";
+
+it("renders text with no additional props", () => {
+  const typography = render(<Typography>Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with regular style", () => {
+  const typography = render(
+    <Typography fontStyle="regular">Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with bold style", () => {
+  const typography = render(
+    <Typography fontWeight="bold">Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with italic style", () => {
+  const typography = render(
+    <Typography fontStyle="italic">Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with bold weight and italic style", () => {
+  const typography = render(
+    <Typography fontStyle="italic" fontWeight="bold">
+      Test Text
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with bold style and display as fontFamily", () => {
+  const typography = render(
+    <Typography fontFamily="display" fontWeight="bold">
+      Test Text
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with extraBold weight and display as fontFamily", () => {
+  const typography = render(
+    <Typography fontFamily="display" fontWeight="extraBold">
+      Test Text
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with black style and display as fontFamily", () => {
+  const typography = render(
+    <Typography fontFamily="display" fontWeight="black">
+      Test Text
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with uppercase transform", () => {
+  const typography = render(
+    <Typography transform="uppercase">Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with lowercase transform", () => {
+  const typography = render(
+    <Typography transform="lowercase">Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with white color", () => {
+  const typography = render(<Typography color="white">Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with green color", () => {
+  const typography = render(<Typography color="green">Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with default color", () => {
+  const typography = render(<Typography color="default">Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with center align", () => {
+  const typography = render(<Typography align="center">Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text respecting the text direction", () => {
+  I18nManager.isRTL = true;
+
+  const typography = render(<Typography>Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+  I18nManager.isRTL = false;
+});
+
+it("renders text with small size", () => {
+  const typography = render(<Typography size="small">Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with large size", () => {
+  const typography = render(<Typography size="large">Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with default size", () => {
+  const typography = render(<Typography size="default">Test Text</Typography>);
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with multiple properties", () => {
+  const typography = render(
+    <Typography fontWeight="bold" size="large" color="white">
+      Test Text
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with line height override", () => {
+  const typography = render(
+    <Typography lineHeight="jumbo">Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with letter spacing", () => {
+  const typography = render(
+    <Typography letterSpacing="loose">Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with reverseTheme true with reversible color", () => {
+  const typography = render(
+    <Typography reverseTheme={true} color="success">
+      Test Text
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with reverseTheme false with reversible color", () => {
+  const typography = render(
+    <Typography reverseTheme={false} color="success">
+      Test Text
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with adjustsFontSizeToFit set to true", () => {
+  const typography = render(
+    <Typography adjustsFontSizeToFit={true} maxLines="single">
+      Test Text that happens to be longer than the rest of the text. This just
+      keeps going on and on. maxLines being set will make this work its magic
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text accessibilityRole", () => {
+  const typography = render(
+    <Typography accessibilityRole="text">Test Text</Typography>,
+  );
+  expect(typography.getByRole("text")).toBeDefined();
+});
+
+it("renders header accessibilityRole", () => {
+  const typography = render(
+    <Typography accessibilityRole="header">Test Text</Typography>,
+  );
+  expect(typography.getByRole("header")).toBeDefined();
+});
+
+it("renders text using the maxLines is also passed", () => {
+  const typography = render(
+    <Typography maxLines="small">
+      Test Text that happens to be longer than the rest of the text. This just
+      keeps going on and on. maxLines being set will make this work its magic
+    </Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text with strikethough styling", () => {
+  const typography = render(
+    <Typography strikeThrough={true}>Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
+it("renders text that is inaccessible", () => {
+  const typography = render(
+    <Typography hideFromScreenReader={true}>Test Text</Typography>,
+  );
+
+  expect(typography.root.props).toEqual(
+    expect.objectContaining({
+      accessible: false,
+      accessibilityRole: "none",
+      importantForAccessibility: "no-hide-descendants",
+    }),
+  );
+});

--- a/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
@@ -1,0 +1,864 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders text respecting the text direction 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "right",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text using the maxLines is also passed 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  numberOfLines={2}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text that happens to be longer than the rest of the text. This just keeps going on and on. maxLines being set will make this work its magic
+</Text>
+`;
+
+exports[`renders text with adjustsFontSizeToFit set to true 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={true}
+  allowFontScaling={true}
+  collapsable={false}
+  numberOfLines={1}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text that happens to be longer than the rest of the text. This just keeps going on and on. maxLines being set will make this work its magic
+</Text>
+`;
+
+exports[`renders text with black style and display as fontFamily 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "jobberpro-blk",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with bold style 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-bold",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with bold style and display as fontFamily 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "jobberpro-bd",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with bold weight and italic style 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with center align 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "center",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with default color 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with default size 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with extraBold weight and display as fontFamily 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "jobberpro-xbd",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with green color 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgb(125, 176, 14)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with italic style 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with large size 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 18,
+        "lineHeight": 22,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with letter spacing 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0.4,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with line height override 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 36,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with lowercase transform 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  test text
+</Text>
+`;
+
+exports[`renders text with multiple properties 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-bold",
+      },
+      {
+        "color": "rgba(255, 255, 255, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 18,
+        "lineHeight": 22,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with no additional props 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with regular style 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with reverseTheme false with reversible color 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgb(81, 114, 9)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with reverseTheme true with reversible color 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgb(125, 176, 14)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with small size 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 14,
+        "lineHeight": 18,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with strikethough styling 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+      {
+        "textDecorationLine": "line-through",
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`renders text with uppercase transform 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(101, 120, 132, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  TEST TEXT
+</Text>
+`;
+
+exports[`renders text with white color 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="rgb(160, 215, 42)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "rgba(255, 255, 255, 1)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Adding tests to `Typography` on components-native.

I had to install the same version of `react-native-gesture-handler` that we're using on jobber-mobile because they introduced a rule that doesn't make sense for us. 

https://github.com/software-mansion/react-native-gesture-handler/commit/ad626405d966b14966c14d45a0a0c141ed6251e6#diff-10cc5c6712f3dadbd9f8ff4fd42423bf6aa26d6678a909ea908971826e7b115bR403-R409

Now, `GestureDetector` needs to be wrapped on a `GestureHandlerRootView`, but it's already being declared in the root of the app, we don't need it on a simple `Typography` component. Anyways, just venting.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
