### PR TITLE
feat(components-native): Import StatusLabel to components-native

### DIFF
--- a/packages/components-native/src/StatusLabel/StatusLabel.style.ts
+++ b/packages/components-native/src/StatusLabel/StatusLabel.style.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from "react-native";
+import { tokens } from "../utils/design";
+
+const statusLabelIconDiameter = tokens["space-base"] - tokens["space-smaller"]; //12px
+
+const indicatorOffset = tokens["space-smallest"] + tokens["space-minuscule"];
+
+export const styles = StyleSheet.create({
+  statusLabelRow: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    flexWrap: "nowrap",
+  },
+  statusLabelText: {
+    flexShrink: 1,
+  },
+  statusLabelIcon: {
+    borderRadius: tokens["radius-base"],
+    backgroundColor: tokens["color-success"],
+    width: statusLabelIconDiameter,
+    height: statusLabelIconDiameter,
+    marginTop: indicatorOffset,
+  },
+  labelTextStartAligned: {
+    flexDirection: "row-reverse",
+  },
+  innerPad: {
+    width: tokens["space-small"],
+  },
+});

--- a/packages/components-native/src/StatusLabel/StatusLabel.test.tsx
+++ b/packages/components-native/src/StatusLabel/StatusLabel.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { StatusLabel } from "./StatusLabel";
+
+describe("StatusLabel", () => {
+  describe("alignment", () => {
+    describe('when alignment prop set to default ("start")', () => {
+      it("should match snapshot", () => {
+        const view = render(<StatusLabel text="Start Aligned" />).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when alignment prop set to "end"', () => {
+      it("should match snapshot", () => {
+        const view = render(
+          <StatusLabel text="End Aligned" alignment="end" />,
+        ).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe("status", () => {
+    describe('when status prop set to default ("success")', () => {
+      it("should match snapshot", () => {
+        const view = render(<StatusLabel text="Success" />).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when status prop set to "warning"', () => {
+      it("should match snapshot", () => {
+        const view = render(
+          <StatusLabel text="Warning" status="warning" />,
+        ).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when status prop set to "critical"', () => {
+      it("should match snapshot", () => {
+        const view = render(
+          <StatusLabel text="Critical" status="critical" />,
+        ).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when status prop set to "inactive"', () => {
+      it("should match snapshot", () => {
+        const view = render(
+          <StatusLabel text="Inactive" status="inactive" />,
+        ).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when status prop set to "informative"', () => {
+      it("should match snapshot", () => {
+        const view = render(
+          <StatusLabel text="Informative" status="informative" />,
+        ).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/packages/components-native/src/StatusLabel/StatusLabel.tsx
+++ b/packages/components-native/src/StatusLabel/StatusLabel.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { View } from "react-native";
+import { styles } from "./StatusLabel.style";
+import { tokens } from "../utils/design";
+import { Text } from "../Text";
+
+export type StatusType =
+  | "success"
+  | "warning"
+  | "critical"
+  | "inactive"
+  | "informative";
+
+export interface StatusLabelType {
+  readonly statusLabel: string;
+  readonly statusType?: StatusType;
+}
+
+interface StatusLabelProps {
+  /**
+   * Text to display.
+   */
+  readonly text: string;
+
+  /**
+   * Alignment of text
+   */
+  readonly alignment?: "start" | "end";
+
+  /**
+   * Status color of the square beside text
+   */
+  readonly status?: StatusType;
+}
+
+export function StatusLabel({
+  text,
+  alignment = "end",
+  status = "success",
+}: StatusLabelProps): JSX.Element {
+  return (
+    <View
+      style={[
+        styles.statusLabelRow,
+        alignment === "start" && styles.labelTextStartAligned,
+      ]}
+    >
+      <View style={styles.statusLabelText}>
+        <Text align={alignment} level="textSupporting" variation="subdued">
+          {text}
+        </Text>
+      </View>
+      <View style={styles.innerPad} />
+      <StatusLabelIcon status={status} />
+    </View>
+  );
+}
+
+interface StatusLabelIconProps {
+  status: StatusType;
+}
+
+function StatusLabelIcon({ status }: StatusLabelIconProps) {
+  return (
+    <View
+      testID={`${status}LabelIcon`}
+      style={[
+        styles.statusLabelIcon,
+        { backgroundColor: tokens[`color-${status}`] },
+      ]}
+    />
+  );
+}

--- a/packages/components-native/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/components-native/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -1,0 +1,554 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StatusLabel alignment when alignment prop set to "end" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "flex-end",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexShrink": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      adjustsFontSizeToFit={false}
+      allowFontScaling={true}
+      collapsable={false}
+      maxFontSizeMultiplier={1.1428571428571428}
+      selectable={true}
+      selectionColor="rgb(160, 215, 42)"
+      style={
+        [
+          {
+            "fontFamily": "inter-medium",
+          },
+          {
+            "color": "rgba(101, 120, 132, 1)",
+          },
+          {
+            "textAlign": "right",
+          },
+          {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          {
+            "letterSpacing": 0,
+          },
+        ]
+      }
+    >
+      End Aligned
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "width": 8,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+          "borderRadius": 2,
+          "height": 12,
+          "marginTop": 3,
+          "width": 12,
+        },
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+        },
+      ]
+    }
+    testID="successLabelIcon"
+  />
+</View>
+`;
+
+exports[`StatusLabel alignment when alignment prop set to default ("start") should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "flex-end",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexShrink": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      adjustsFontSizeToFit={false}
+      allowFontScaling={true}
+      collapsable={false}
+      maxFontSizeMultiplier={1.1428571428571428}
+      selectable={true}
+      selectionColor="rgb(160, 215, 42)"
+      style={
+        [
+          {
+            "fontFamily": "inter-medium",
+          },
+          {
+            "color": "rgba(101, 120, 132, 1)",
+          },
+          {
+            "textAlign": "right",
+          },
+          {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          {
+            "letterSpacing": 0,
+          },
+        ]
+      }
+    >
+      Start Aligned
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "width": 8,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+          "borderRadius": 2,
+          "height": 12,
+          "marginTop": 3,
+          "width": 12,
+        },
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+        },
+      ]
+    }
+    testID="successLabelIcon"
+  />
+</View>
+`;
+
+exports[`StatusLabel status when status prop set to "critical" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "flex-end",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexShrink": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      adjustsFontSizeToFit={false}
+      allowFontScaling={true}
+      collapsable={false}
+      maxFontSizeMultiplier={1.1428571428571428}
+      selectable={true}
+      selectionColor="rgb(160, 215, 42)"
+      style={
+        [
+          {
+            "fontFamily": "inter-medium",
+          },
+          {
+            "color": "rgba(101, 120, 132, 1)",
+          },
+          {
+            "textAlign": "right",
+          },
+          {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          {
+            "letterSpacing": 0,
+          },
+        ]
+      }
+    >
+      Critical
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "width": 8,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+          "borderRadius": 2,
+          "height": 12,
+          "marginTop": 3,
+          "width": 12,
+        },
+        {
+          "backgroundColor": "rgb(201, 66, 33)",
+        },
+      ]
+    }
+    testID="criticalLabelIcon"
+  />
+</View>
+`;
+
+exports[`StatusLabel status when status prop set to "inactive" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "flex-end",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexShrink": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      adjustsFontSizeToFit={false}
+      allowFontScaling={true}
+      collapsable={false}
+      maxFontSizeMultiplier={1.1428571428571428}
+      selectable={true}
+      selectionColor="rgb(160, 215, 42)"
+      style={
+        [
+          {
+            "fontFamily": "inter-medium",
+          },
+          {
+            "color": "rgba(101, 120, 132, 1)",
+          },
+          {
+            "textAlign": "right",
+          },
+          {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          {
+            "letterSpacing": 0,
+          },
+        ]
+      }
+    >
+      Inactive
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "width": 8,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+          "borderRadius": 2,
+          "height": 12,
+          "marginTop": 3,
+          "width": 12,
+        },
+        {
+          "backgroundColor": "rgb(77, 105, 116)",
+        },
+      ]
+    }
+    testID="inactiveLabelIcon"
+  />
+</View>
+`;
+
+exports[`StatusLabel status when status prop set to "informative" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "flex-end",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexShrink": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      adjustsFontSizeToFit={false}
+      allowFontScaling={true}
+      collapsable={false}
+      maxFontSizeMultiplier={1.1428571428571428}
+      selectable={true}
+      selectionColor="rgb(160, 215, 42)"
+      style={
+        [
+          {
+            "fontFamily": "inter-medium",
+          },
+          {
+            "color": "rgba(101, 120, 132, 1)",
+          },
+          {
+            "textAlign": "right",
+          },
+          {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          {
+            "letterSpacing": 0,
+          },
+        ]
+      }
+    >
+      Informative
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "width": 8,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+          "borderRadius": 2,
+          "height": 12,
+          "marginTop": 3,
+          "width": 12,
+        },
+        {
+          "backgroundColor": "rgb(60, 162, 224)",
+        },
+      ]
+    }
+    testID="informativeLabelIcon"
+  />
+</View>
+`;
+
+exports[`StatusLabel status when status prop set to "warning" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "flex-end",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexShrink": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      adjustsFontSizeToFit={false}
+      allowFontScaling={true}
+      collapsable={false}
+      maxFontSizeMultiplier={1.1428571428571428}
+      selectable={true}
+      selectionColor="rgb(160, 215, 42)"
+      style={
+        [
+          {
+            "fontFamily": "inter-medium",
+          },
+          {
+            "color": "rgba(101, 120, 132, 1)",
+          },
+          {
+            "textAlign": "right",
+          },
+          {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          {
+            "letterSpacing": 0,
+          },
+        ]
+      }
+    >
+      Warning
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "width": 8,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+          "borderRadius": 2,
+          "height": 12,
+          "marginTop": 3,
+          "width": 12,
+        },
+        {
+          "backgroundColor": "rgb(221, 195, 15)",
+        },
+      ]
+    }
+    testID="warningLabelIcon"
+  />
+</View>
+`;
+
+exports[`StatusLabel status when status prop set to default ("success") should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+        "flexWrap": "nowrap",
+        "justifyContent": "flex-end",
+      },
+      false,
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexShrink": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      adjustsFontSizeToFit={false}
+      allowFontScaling={true}
+      collapsable={false}
+      maxFontSizeMultiplier={1.1428571428571428}
+      selectable={true}
+      selectionColor="rgb(160, 215, 42)"
+      style={
+        [
+          {
+            "fontFamily": "inter-medium",
+          },
+          {
+            "color": "rgba(101, 120, 132, 1)",
+          },
+          {
+            "textAlign": "right",
+          },
+          {
+            "fontSize": 14,
+            "lineHeight": 18,
+          },
+          {
+            "letterSpacing": 0,
+          },
+        ]
+      }
+    >
+      Success
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "width": 8,
+      }
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+          "borderRadius": 2,
+          "height": 12,
+          "marginTop": 3,
+          "width": 12,
+        },
+        {
+          "backgroundColor": "rgb(125, 176, 14)",
+        },
+      ]
+    }
+    testID="successLabelIcon"
+  />
+</View>
+`;

--- a/packages/components-native/src/StatusLabel/index.ts
+++ b/packages/components-native/src/StatusLabel/index.ts
@@ -1,0 +1,2 @@
+export { StatusLabel } from "./StatusLabel";
+export type { StatusType, StatusLabelType } from "./StatusLabel";

--- a/packages/components-native/src/index.ts
+++ b/packages/components-native/src/index.ts
@@ -6,3 +6,4 @@ export * from "./ErrorMessageWrapper";
 export * from "./ActionLabel";
 export * from "./Content";
 export * from "./ActivityIndicator";
+export * from "./StatusLabel";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `StatusLabel` component in components-native

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
