### PR TITLE
fix(components): BREAKING CHANGE: Prevent menu from appearing onChange in freeform Autocomplete fields

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -146,8 +146,9 @@ export function Autocomplete({
     updateInput(newText);
     if (allowFreeForm) {
       onChange({ label: newText });
+    } else {
+      setMenuVisible(true);
     }
-    setMenuVisible(true);
   }
 
   function handleInputBlur() {


### PR DESCRIPTION
## Motivations
When a freeform Autocomplete field is modified without focusing it, due to e.g. browser address autofill, the dropdown menu still appears even though the user never focused the field. This change makes that behaviour unique to just Autocomplete fields that do not allow freeform changes.

### Before

https://github.com/GetJobber/atlantis/assets/872151/ec7ce8ed-0b28-4056-aefd-1fee220737b7

### After

https://github.com/GetJobber/atlantis/assets/872151/035d3986-a429-405b-b74f-04e6084e558f

## Changes

### Added

### Changed

### Deprecated

### Removed

Autocomplete no longer shows menu options based solely on an onChange event when allowFreeform is true

### Fixed

### Security

## Testing

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
