### PR TITLE
build: Split pre release install string based on Web or Mobile

### DIFF
--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -1,5 +1,6 @@
 :root {
   /* Jobber Semantic Layer */
+  /* Final trigger test */
 
   /* Interactive and States */
   --color-interactive: var(--color-green);

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -1,8 +1,5 @@
 :root {
   /* Jobber Semantic Layer */
-  /* Trigger both mobile and web changes /*
-  /* Re-Trigger both mobile and web changes /*
-
 
   /* Interactive and States */
   --color-interactive: var(--color-green);

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -1,6 +1,8 @@
 :root {
   /* Jobber Semantic Layer */
   /* Trigger both mobile and web changes /*
+  /* Re-Trigger both mobile and web changes /*
+
 
   /* Interactive and States */
   --color-interactive: var(--color-green);

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -1,6 +1,5 @@
 :root {
   /* Jobber Semantic Layer */
-  /* Final trigger test */
 
   /* Interactive and States */
   --color-interactive: var(--color-green);

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -1,5 +1,6 @@
 :root {
   /* Jobber Semantic Layer */
+  /* Trigger both mobile and web changes /*
 
   /* Interactive and States */
   --color-interactive: var(--color-green);

--- a/scripts/commentOnPrAfterPreRelease.js
+++ b/scripts/commentOnPrAfterPreRelease.js
@@ -24,18 +24,14 @@ async function generatePRComment({
   existingComment,
 }) {
   if (!process.env.SUMMARY_JSON_STRING) {
-    const workflowRun = await github.rest.actions.getWorkflowRun({
-      owner,
+    const failedBuildString = await handleBuildFailure({
+      context,
       repo,
-      run_id: context.runId,
+      existingComment,
+      github,
+      owner,
     });
-    const workflowRunUrl = workflowRun.data.html_url;
-    const quotedPreviousComment = quotePreviousComment(existingComment?.body);
-
-    const previousBuildStatus = quotedPreviousComment
-      ? `\nPrevious build information:\n${quotedPreviousComment}`
-      : "";
-    return `Could not publish Pre-release for ${process.env.COMMIT_SHA}. [View Logs](${workflowRunUrl})\nThe problem is likely in the \`NPM Publish\` or \`NPM CI\` step in the \`Trigger Pre-release Build\` Job.\n${previousBuildStatus}.\n `;
+    return failedBuildString;
   }
   const summaryFileJson = JSON.parse(process.env.SUMMARY_JSON_STRING);
 
@@ -45,20 +41,26 @@ async function generatePRComment({
       return `  - ${packageName}@${version}\n`;
     })
     .join("");
-  const webInstallString = getInstallPackageString(
+  const webPackagesString = getInstallPackageString(
     summaryFileJson.filter(releaseSummary => {
       const { packageName } = releaseSummary;
       return packageName !== "@jobber/components-native";
     }),
   );
-  const mobileInstallString = getInstallPackageString(
+  const mobilePackagesString = getInstallPackageString(
     summaryFileJson.filter(releaseSummary => {
       const { packageName } = releaseSummary;
       return packageName !== "@jobber/components";
     }),
   );
+  const mobileInstallString = mobilePackagesString
+    ? `\n\nTo install the new version(s) for Mobile run:\n\`\`\`\nnpm install ${mobilePackagesString}\n\`\`\``
+    : "";
+  const webInstallString = webPackagesString
+    ? `\n\nTo install the new version(s) for Web run:\n\`\`\`\nnpm install ${webPackagesString}\n\`\`\``
+    : "";
 
-  return `Published Pre-release for ${process.env.COMMIT_SHA} with versions:\n\`\`\`\n${releaseString}\`\`\`\n\nTo install the new version(s) for Web run:\n\`\`\`\nnpm install ${webInstallString}\n\`\`\`\n\nTo install the new version(s) for Mobile run:\n\`\`\`\nnpm install ${mobileInstallString}\n\`\`\``;
+  return `Published Pre-release for ${process.env.COMMIT_SHA} with versions:\n\`\`\`\n${releaseString}\`\`\`${webInstallString}${mobileInstallString}`;
 }
 
 async function getPRs({ github, repo, owner, ref }) {
@@ -131,4 +133,25 @@ function getInstallPackageString(packages) {
       return `${packageName}@${version}`;
     })
     .join(" ");
+}
+
+async function handleBuildFailure({
+  owner,
+  repo,
+  context,
+  existingComment,
+  github,
+}) {
+  const workflowRun = await github.rest.actions.getWorkflowRun({
+    owner,
+    repo,
+    run_id: context.runId,
+  });
+  const workflowRunUrl = workflowRun.data.html_url;
+  const quotedPreviousComment = quotePreviousComment(existingComment?.body);
+
+  const previousBuildStatus = quotedPreviousComment
+    ? `\nPrevious build information:\n${quotedPreviousComment}`
+    : "";
+  return `Could not publish Pre-release for ${process.env.COMMIT_SHA}. [View Logs](${workflowRunUrl})\nThe problem is likely in the \`NPM Publish\` or \`NPM CI\` step in the \`Trigger Pre-release Build\` Job.\n${previousBuildStatus}.\n `;
 }

--- a/scripts/commentOnPrAfterPreRelease.js
+++ b/scripts/commentOnPrAfterPreRelease.js
@@ -45,13 +45,20 @@ async function generatePRComment({
       return `  - ${packageName}@${version}\n`;
     })
     .join("");
-  const toInstallString = summaryFileJson
-    .map(releaseSummary => {
-      const { packageName, version } = releaseSummary;
-      return `${packageName}@${version}`;
-    })
-    .join(" ");
-  return `Published Pre-release for ${process.env.COMMIT_SHA} with versions:\n\`\`\`\n${releaseString}\`\`\`\n\nTo install the new version(s) run:\n\`\`\`\nnpm install ${toInstallString}\n\`\`\``;
+  const webInstallString = getInstallPackageString(
+    summaryFileJson.filter(releaseSummary => {
+      const { packageName } = releaseSummary;
+      return packageName !== "components-native";
+    }),
+  );
+  const mobileInstallString = getInstallPackageString(
+    summaryFileJson.filter(releaseSummary => {
+      const { packageName } = releaseSummary;
+      return packageName !== "components";
+    }),
+  );
+
+  return `Published Pre-release for ${process.env.COMMIT_SHA} with versions:\n\`\`\`\n${releaseString}\`\`\`\n\nTo install the new version(s) for Web run:\n\`\`\`\nnpm install ${webInstallString}\n\`\`\`\n\nTo install the new version(s) for Web run:\n\`\`\`\nnpm install ${mobileInstallString}\n\`\`\``;
 }
 
 async function getPRs({ github, repo, owner, ref }) {
@@ -115,4 +122,13 @@ function quotePreviousComment(previousCommentBody) {
       return `> ${commentBodyLine}`;
     })
     .join("\n");
+}
+
+function getInstallPackageString(packages) {
+  return packages
+    .map(releaseSummary => {
+      const { packageName, version } = releaseSummary;
+      return `${packageName}@${version}`;
+    })
+    .join(" ");
 }

--- a/scripts/commentOnPrAfterPreRelease.js
+++ b/scripts/commentOnPrAfterPreRelease.js
@@ -48,13 +48,13 @@ async function generatePRComment({
   const webInstallString = getInstallPackageString(
     summaryFileJson.filter(releaseSummary => {
       const { packageName } = releaseSummary;
-      return packageName !== "components-native";
+      return packageName !== "@jobber/components-native";
     }),
   );
   const mobileInstallString = getInstallPackageString(
     summaryFileJson.filter(releaseSummary => {
       const { packageName } = releaseSummary;
-      return packageName !== "components";
+      return packageName !== "@jobber/components";
     }),
   );
 

--- a/scripts/commentOnPrAfterPreRelease.js
+++ b/scripts/commentOnPrAfterPreRelease.js
@@ -58,7 +58,7 @@ async function generatePRComment({
     }),
   );
 
-  return `Published Pre-release for ${process.env.COMMIT_SHA} with versions:\n\`\`\`\n${releaseString}\`\`\`\n\nTo install the new version(s) for Web run:\n\`\`\`\nnpm install ${webInstallString}\n\`\`\`\n\nTo install the new version(s) for Web run:\n\`\`\`\nnpm install ${mobileInstallString}\n\`\`\``;
+  return `Published Pre-release for ${process.env.COMMIT_SHA} with versions:\n\`\`\`\n${releaseString}\`\`\`\n\nTo install the new version(s) for Web run:\n\`\`\`\nnpm install ${webInstallString}\n\`\`\`\n\nTo install the new version(s) for Mobile run:\n\`\`\`\nnpm install ${mobileInstallString}\n\`\`\``;
 }
 
 async function getPRs({ github, repo, owner, ref }) {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes
- Changed it so the github action splits the install command into Web and Mobile for the different component packages

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
