### PR TITLE
fix(components): TECH-22 Fixing Grid prop type

### DIFF
--- a/packages/components/src/Grid/Grid.tsx
+++ b/packages/components/src/Grid/Grid.tsx
@@ -21,7 +21,9 @@ interface GridProps {
   /**
    * Array of `Grid.Cell` children
    */
-  readonly children: Array<ReactElement<GridCellProps>>;
+  readonly children:
+    | Array<ReactElement<GridCellProps>>
+    | ReactElement<GridCellProps>;
 }
 
 export const GRID_TEST_ID = "ATL-Grid";


### PR DESCRIPTION
Typescript complains if you try to give Grid only a single Grid.Cell child, but this is valid and should be supported.

## Motivations

Ran into a problem using Grid where I only needed one child element, but Typescript complained about it.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

Updated the type of `children` for the `Grid` component

## Testing

```
<Grid>
  <Grid.Cell size={{xs: 12}} >Content!</Grid.Cell>
</Grid>
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
