### PR TITLE
feat(components-native): Import TextList (currently ListBulleted in JB) to components-native

### DIFF
--- a/packages/components-native/src/TextList/TextList.style.ts
+++ b/packages/components-native/src/TextList/TextList.style.ts
@@ -1,0 +1,17 @@
+import { StyleSheet } from "react-native";
+import { tokens } from "../utils/design";
+
+export const styles = StyleSheet.create({
+  details: {
+    flexDirection: "column",
+    marginTop: tokens["space-small"],
+  },
+  detail: {
+    flexDirection: "row",
+    paddingLeft: tokens["space-small"],
+  },
+  detailText: {
+    paddingLeft: tokens["space-small"],
+    flex: 1,
+  },
+});

--- a/packages/components-native/src/TextList/TextList.test.tsx
+++ b/packages/components-native/src/TextList/TextList.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { TextList } from "./TextList";
+
+describe("TextList", () => {
+  describe("when the bulletItems is provided", () => {
+    it("displays the text list", () => {
+      const items = ["this is list item uno", "this is list item dos"];
+      const tree = render(<TextList items={items} />);
+
+      expect(tree.toJSON()).toMatchSnapshot();
+    });
+
+    it("displays will not display a bulleted list", () => {
+      const tree = render(<TextList />);
+
+      expect(tree.toJSON()).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/components-native/src/TextList/TextList.tsx
+++ b/packages/components-native/src/TextList/TextList.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { View } from "react-native";
+import { styles } from "./TextList.style";
+import { Content, Spacing } from "../Content";
+import { Text, TextLevel } from "../Text";
+
+const BULLET_SYMBOL = `\u2022`;
+
+interface TextListProps {
+  /**
+   * Text to display.
+   */
+  readonly items?: string[];
+
+  /**
+   * Change the appearance of the text
+   */
+  readonly emphasis?: "strong";
+
+  /**
+   * Visual hierarchy of the text.
+   * @default "text"
+   */
+  readonly level?: TextLevel;
+
+  /**
+   * The amount of spacing that content will give.
+   * @default "none"
+   */
+  readonly spacing?: Spacing;
+
+  /**
+   * The amount of spacing that will be applied between the list items.
+   * @default "none"
+   */
+  readonly childSpacing?: Spacing;
+}
+
+export function TextList({
+  items,
+  childSpacing = "none",
+  emphasis,
+  level = "text",
+  spacing = "none",
+}: TextListProps): JSX.Element {
+  return (
+    <>
+      {items && (
+        <View style={styles.details}>
+          <Content spacing={spacing} childSpacing={childSpacing}>
+            {items.map((item, index) => (
+              <View style={styles.detail} key={index}>
+                <Text level={level} emphasis={emphasis}>
+                  {BULLET_SYMBOL}
+                </Text>
+                <View style={styles.detailText}>
+                  <Text level={level} emphasis={emphasis}>
+                    {item}
+                  </Text>
+                </View>
+              </View>
+            ))}
+          </Content>
+        </View>
+      )}
+    </>
+  );
+}

--- a/packages/components-native/src/TextList/__snapshots__/TextList.test.tsx.snap
+++ b/packages/components-native/src/TextList/__snapshots__/TextList.test.tsx.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextList when the bulletItems is provided displays the text list 1`] = `
+<View
+  style={
+    {
+      "flexDirection": "column",
+      "marginTop": 8,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {},
+        {
+          "padding": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {},
+        ]
+      }
+    >
+      <View
+        style={
+          {
+            "flexDirection": "row",
+            "paddingLeft": 8,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          adjustsFontSizeToFit={false}
+          allowFontScaling={true}
+          collapsable={false}
+          maxFontSizeMultiplier={3.125}
+          selectable={true}
+          selectionColor="rgb(132, 234, 0)"
+          style={
+            [
+              {
+                "fontFamily": "inter-regular",
+              },
+              {
+                "color": "rgb(66, 78, 86)",
+              },
+              {
+                "textAlign": "left",
+              },
+              {
+                "fontSize": 16,
+                "lineHeight": 20,
+              },
+              {
+                "letterSpacing": 0,
+              },
+            ]
+          }
+        >
+          •
+        </Text>
+        <View
+          style={
+            {
+              "flex": 1,
+              "paddingLeft": 8,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            adjustsFontSizeToFit={false}
+            allowFontScaling={true}
+            collapsable={false}
+            maxFontSizeMultiplier={3.125}
+            selectable={true}
+            selectionColor="rgb(132, 234, 0)"
+            style={
+              [
+                {
+                  "fontFamily": "inter-regular",
+                },
+                {
+                  "color": "rgb(66, 78, 86)",
+                },
+                {
+                  "textAlign": "left",
+                },
+                {
+                  "fontSize": 16,
+                  "lineHeight": 20,
+                },
+                {
+                  "letterSpacing": 0,
+                },
+              ]
+            }
+          >
+            this is list item uno
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        [
+          {},
+          {
+            "padding": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          {
+            "flexDirection": "row",
+            "paddingLeft": 8,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          adjustsFontSizeToFit={false}
+          allowFontScaling={true}
+          collapsable={false}
+          maxFontSizeMultiplier={3.125}
+          selectable={true}
+          selectionColor="rgb(132, 234, 0)"
+          style={
+            [
+              {
+                "fontFamily": "inter-regular",
+              },
+              {
+                "color": "rgb(66, 78, 86)",
+              },
+              {
+                "textAlign": "left",
+              },
+              {
+                "fontSize": 16,
+                "lineHeight": 20,
+              },
+              {
+                "letterSpacing": 0,
+              },
+            ]
+          }
+        >
+          •
+        </Text>
+        <View
+          style={
+            {
+              "flex": 1,
+              "paddingLeft": 8,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            adjustsFontSizeToFit={false}
+            allowFontScaling={true}
+            collapsable={false}
+            maxFontSizeMultiplier={3.125}
+            selectable={true}
+            selectionColor="rgb(132, 234, 0)"
+            style={
+              [
+                {
+                  "fontFamily": "inter-regular",
+                },
+                {
+                  "color": "rgb(66, 78, 86)",
+                },
+                {
+                  "textAlign": "left",
+                },
+                {
+                  "fontSize": 16,
+                  "lineHeight": 20,
+                },
+                {
+                  "letterSpacing": 0,
+                },
+              ]
+            }
+          >
+            this is list item dos
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`TextList when the bulletItems is provided displays will not display a bulleted list 1`] = `null`;

--- a/packages/components-native/src/TextList/index.ts
+++ b/packages/components-native/src/TextList/index.ts
@@ -1,0 +1,1 @@
+export { TextList } from "./TextList";

--- a/packages/components-native/src/index.ts
+++ b/packages/components-native/src/index.ts
@@ -16,6 +16,7 @@ export * from "./IconButton";
 export * from "./InputFieldWrapper";
 export * from "./InputPressable";
 export * from "./InputText";
+export * from "./TextList";
 export * from "./ProgressBar";
 export * from "./StatusLabel";
 export * from "./Switch";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Migrate `TextList`. It was called `ListBulleted` in jobber-mobile.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `TextList` component in components-native

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

I created a branch to test this change on jobber-mobile: https://github.com/GetJobber/jobber-mobile/compare/test-branch-textlist?expand=1

As it's just being used by `Banner`, I changed the usage there to `TextList` and also created a example of each (`Banner` and `TextList`) in `ActivityFeed` so it's easier to test.

<img width="376" alt="image" src="https://github.com/GetJobber/atlantis/assets/12849476/bd8ab8f6-50c7-457e-9fa5-8b8bf64df23d">



---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
