### PR TITLE
feat(components): Update formatDate component with optional date

### DIFF
--- a/packages/components/src/FormatDate/FormatDate.test.tsx
+++ b/packages/components/src/FormatDate/FormatDate.test.tsx
@@ -31,17 +31,33 @@ describe("strFormatDate", () => {
   const mockLocaleDateFormat: Intl.DateTimeFormatOptions = {
     day: "numeric",
     month: "short",
+  };
+  const mockLocaleDateFormatWithYear: Intl.DateTimeFormatOptions = {
+    day: "numeric",
+    month: "short",
     year: "numeric",
   };
 
   it("should return the right locale date format", () => {
     const mockDateSpy = jest.spyOn(Date.prototype, "toLocaleDateString");
     strFormatDate(expectedDate);
-    expect(mockDateSpy).toHaveBeenCalledWith(mockLocale, mockLocaleDateFormat);
+    expect(mockDateSpy).toHaveBeenCalledWith(
+      mockLocale,
+      mockLocaleDateFormatWithYear,
+    );
   });
 
   it("should return the proper date format", () => {
     expect(strFormatDate(expectedDate)).toBe(
+      new Date(expectedDateString).toLocaleDateString(
+        mockLocale,
+        mockLocaleDateFormatWithYear,
+      ),
+    );
+  });
+
+  it("should return the proper date format with year is hidden", () => {
+    expect(strFormatDate(expectedDate, false)).toBe(
       new Date(expectedDateString).toLocaleDateString(
         mockLocale,
         mockLocaleDateFormat,

--- a/packages/components/src/FormatDate/FormatDate.tsx
+++ b/packages/components/src/FormatDate/FormatDate.tsx
@@ -8,9 +8,23 @@ interface FormatDateProps {
    * A `string` should be an ISO 8601 format date string.
    */
   readonly date: CivilDate | Date | string;
+
+  /**
+   * Boolean to show year or not.
+   */
+  readonly showYear?: boolean;
 }
 
-export function FormatDate({ date: inputDate }: FormatDateProps) {
+interface formatOptions {
+  readonly month: "short";
+  readonly day: "numeric";
+  readonly year?: "numeric";
+}
+
+export function FormatDate({
+  date: inputDate,
+  showYear = true,
+}: FormatDateProps) {
   let dateObject: Date;
 
   if (inputDate instanceof Date) {
@@ -21,13 +35,19 @@ export function FormatDate({ date: inputDate }: FormatDateProps) {
     dateObject = new Date(inputDate.year, inputDate.month - 1, inputDate.day);
   }
 
-  return <>{strFormatDate(dateObject)}</>;
+  return <>{strFormatDate(dateObject, showYear)}</>;
 }
 
-export function strFormatDate(date: Date) {
-  return date.toLocaleDateString(undefined, {
-    year: "numeric",
+export function strFormatDate(date: Date, showYear = true) {
+  let formatOptions: formatOptions = {
     month: "short",
     day: "numeric",
-  });
+  };
+  if (showYear) {
+    formatOptions = {
+      ...formatOptions,
+      year: "numeric",
+    };
+  }
+  return date.toLocaleDateString(undefined, formatOptions);
 }

--- a/packages/components/src/FormatDate/FormatDate.tsx
+++ b/packages/components/src/FormatDate/FormatDate.tsx
@@ -15,12 +15,6 @@ interface FormatDateProps {
   readonly showYear?: boolean;
 }
 
-interface formatOptions {
-  readonly month: "short";
-  readonly day: "numeric";
-  readonly year?: "numeric";
-}
-
 export function FormatDate({
   date: inputDate,
   showYear = true,
@@ -39,7 +33,7 @@ export function FormatDate({
 }
 
 export function strFormatDate(date: Date, showYear = true) {
-  let formatOptions: formatOptions = {
+  let formatOptions: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "numeric",
   };


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
This change is required for the Jobber Payments team to display the date using the `FormatDate` component without a year

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `FormatDate` component now has a new optional `showYear` argument.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
