### PR TITLE
feat(components-native): Import Select to components-native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7585,6 +7585,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.10.tgz",
+      "integrity": "sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-native": ">=0.57"
+      }
+    },
     "node_modules/@react-native/assets": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/assets/-/assets-1.0.0.tgz",
@@ -45194,6 +45203,7 @@
       "license": "MIT",
       "dependencies": {
         "@jobber/design": "^0.41.3",
+        "@react-native-picker/picker": "^2.4.10",
         "lodash.chunk": "^4.2.0",
         "lodash.identity": "^3.0.0",
         "react-hook-form": "^7.30.0",

--- a/packages/components-native/package.json
+++ b/packages/components-native/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@jobber/design": "^0.41.3",
+    "@react-native-picker/picker": "^2.4.10",
     "lodash.chunk": "^4.2.0",
     "lodash.identity": "^3.0.0",
     "react-hook-form": "^7.30.0",

--- a/packages/components-native/src/Select/Select.style.ts
+++ b/packages/components-native/src/Select/Select.style.ts
@@ -1,0 +1,51 @@
+import { StyleSheet } from "react-native";
+import { commonInputStyles } from "../InputFieldWrapper";
+import { tokens } from "../utils/design";
+
+export const styles = StyleSheet.create({
+  container: StyleSheet.flatten([
+    commonInputStyles.container,
+    {
+      flexDirection: "column",
+      justifyContent: "flex-end",
+      minHeight: tokens["space-largest"] + tokens["border-base"],
+    },
+  ]),
+
+  input: StyleSheet.flatten([
+    commonInputStyles.input,
+    {
+      flexDirection: "row",
+      flexGrow: 0,
+      paddingBottom: tokens["space-smaller"],
+      minHeight: 0,
+      minWidth: "100%",
+    },
+  ]),
+
+  value: {
+    flexGrow: 1,
+    flexShrink: 1,
+  },
+
+  icon: {
+    flexGrow: 0,
+    flexShrink: 0,
+  },
+
+  invalid: {
+    color: tokens["color-critical"],
+    borderColor: tokens["color-critical"],
+  },
+
+  errorMessageWrapperIcon: {
+    flex: 0,
+    flexBasis: "auto",
+    paddingTop: tokens["space-minuscule"],
+    paddingRight: tokens["space-smaller"],
+  },
+  messageWrapper: {
+    paddingTop: tokens["space-smaller"],
+    flexDirection: "row",
+  },
+});

--- a/packages/components-native/src/Select/Select.test.tsx
+++ b/packages/components-native/src/Select/Select.test.tsx
@@ -1,0 +1,323 @@
+import React from "react";
+import {
+  RenderAPI,
+  cleanup,
+  fireEvent,
+  render,
+} from "@testing-library/react-native";
+import { tokens } from "@jobber/design/foundation";
+import { AccessibilityInfo } from "react-native";
+import { Option, Select } from ".";
+import { messages } from "./messages";
+import { SelectInternalPicker } from "./components/SelectInternalPicker";
+
+const A11yInfoSpy = jest.spyOn(AccessibilityInfo, "isScreenReaderEnabled");
+
+const onChange = jest.fn();
+
+beforeEach(() => {
+  A11yInfoSpy.mockImplementation(() => Promise.resolve(false));
+});
+
+afterEach(() => {
+  cleanup();
+  jest.resetAllMocks();
+});
+
+describe("Select", () => {
+  it("renders a Select", () => {
+    const component = render(
+      <Select onChange={onChange}>
+        <Option value={"one"}>one</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+    expect(component.getByTestId("arrowDown")).toBeDefined();
+    expect(
+      component.getByText(messages.emptyValue.defaultMessage, {
+        includeHiddenElements: true,
+      }),
+    ).toBeDefined();
+  });
+
+  it("renders a Select with a label", () => {
+    const label = "Press me";
+    const { getByText } = render(
+      <Select onChange={onChange} label={label}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+
+    expect(getByText(label, { includeHiddenElements: true })).toBeDefined();
+  });
+
+  it("renders a Select with a placeholder", () => {
+    const placeholder = "I am a placeholder";
+    const { getByText } = render(
+      <Select onChange={onChange} placeholder={placeholder}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+
+    expect(
+      getByText(placeholder, { includeHiddenElements: true }),
+    ).toBeDefined();
+  });
+
+  it("renders a Select with assistive text", () => {
+    const assistiveText = "You need to pick something";
+    const { getByText } = render(
+      <Select onChange={onChange} assistiveText={assistiveText}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+    expect(
+      getByText(assistiveText, { includeHiddenElements: true }),
+    ).toBeDefined();
+  });
+
+  describe("when invalid", () => {
+    const labelText = "labelText";
+
+    it("renders an invalid Select", () => {
+      const { getByText } = render(
+        <Select onChange={onChange} invalid={true} label={labelText}>
+          <Option value={"1"}>1</Option>
+          <Option value={"2"}>2</Option>
+        </Select>,
+      );
+      expect(
+        getByText(labelText, { includeHiddenElements: true }).props.style,
+      ).toContainEqual({
+        color: tokens["color-critical"],
+      });
+    });
+
+    it("renders an invalid Select with placeholder", () => {
+      const placeholder = "Place me in the holder";
+      const { getByText } = render(
+        <Select
+          label={labelText}
+          onChange={onChange}
+          invalid={true}
+          placeholder={placeholder}
+        >
+          <Option value={"1"}>1</Option>
+          <Option value={"2"}>2</Option>
+        </Select>,
+      );
+
+      expect(
+        getByText(placeholder, { includeHiddenElements: true }),
+      ).toBeDefined();
+      expect(
+        getByText(labelText, { includeHiddenElements: true }).props.style,
+      ).toContainEqual({
+        color: tokens["color-critical"],
+      });
+    });
+  });
+
+  it("renders a disabled Select", () => {
+    const labelText = "labelText";
+    const { getByText } = render(
+      <Select label={labelText} onChange={onChange} disabled={true}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+    expect(
+      getByText(labelText, { includeHiddenElements: true }).props.style,
+    ).toContainEqual({
+      color: tokens["color-disabled"],
+    });
+  });
+
+  it("renders a Select with a value provided", () => {
+    const expectedValue = "That should be me";
+    const { getByText } = render(
+      <Select onChange={onChange} value={"2"}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>{expectedValue}</Option>
+      </Select>,
+    );
+
+    expect(
+      getByText(expectedValue, { includeHiddenElements: true }),
+    ).toBeDefined();
+  });
+
+  it("renders a Select with a defaultValue provided", () => {
+    const expectedValue = "It's the 3rd value";
+    const { getByText } = render(
+      <Select onChange={onChange} defaultValue={"3"}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+        <Option value={"3"}>{expectedValue}</Option>
+      </Select>,
+    );
+
+    expect(
+      getByText(expectedValue, { includeHiddenElements: true }),
+    ).toBeDefined();
+  });
+
+  describe("fires the onChange callback", () => {
+    it("fires", () => {
+      const { getByTestId } = render(
+        <Select onChange={onChange} value={"2"}>
+          <Option value={"1"}>1</Option>
+          <Option value={"2"}>2</Option>
+        </Select>,
+      );
+
+      const select = getByTestId("ATL-Select").findByType(SelectInternalPicker);
+      expect(select).toBeTruthy();
+      fireEvent(select, "onChange", "1");
+      expect(onChange).toHaveBeenCalledWith("1");
+    });
+  });
+
+  describe("Invalid value", () => {
+    it("renders with the empty value option", () => {
+      const { getByText } = render(
+        <Select onChange={onChange} value={"invalid"}>
+          <Option value={"first"}>first</Option>
+          <Option value={"2"}>2</Option>
+        </Select>,
+      );
+
+      expect(
+        getByText(messages.emptyValue.defaultMessage, {
+          includeHiddenElements: true,
+        }),
+      ).toBeDefined();
+    });
+
+    it("renders with the placeholder", () => {
+      const { getByText } = render(
+        <Select
+          onChange={onChange}
+          value={"invalid"}
+          placeholder={"Make a selection"}
+        >
+          <Option value={"1"}>1</Option>
+          <Option value={"2"}>2</Option>
+        </Select>,
+      );
+
+      expect(
+        getByText("Make a selection", { includeHiddenElements: true }),
+      ).toBeDefined();
+    });
+  });
+
+  describe("accessibilityLabel", () => {
+    it("uses accessibilityLabel if specified", () => {
+      const { getByLabelText } = render(
+        <Select
+          onChange={onChange}
+          label="label"
+          accessibilityLabel="accessibilityLabel"
+        >
+          <Option value={"1"}>1</Option>
+          <Option value={"2"}>2</Option>
+        </Select>,
+      );
+
+      expect(getByLabelText("accessibilityLabel")).toBeTruthy();
+    });
+  });
+
+  describe("when validations are passed to the component", () => {
+    describe("validations fail", () => {
+      let tree: RenderAPI;
+      const labelText = "labelText";
+      const errorMsg = "Too short";
+      beforeEach(() => {
+        tree = render(
+          <Select
+            label={labelText}
+            onChange={onChange}
+            value={"Watermelon"}
+            validations={{
+              minLength: { value: 60, message: errorMsg },
+            }}
+          >
+            <Option value={"Apple"}>Apple</Option>
+            <Option value={"Watermelon"}>Watermelon</Option>
+          </Select>,
+        );
+      });
+
+      it("renders the error message when there is an error", async () => {
+        const select = tree
+          .getByTestId("ATL-Select")
+          .findByType(SelectInternalPicker);
+        fireEvent(select, "onChange", "Apple");
+        expect(
+          await tree.findByText(errorMsg, { includeHiddenElements: true }),
+        ).toBeTruthy();
+      });
+
+      it("shows the invalid colours", async () => {
+        const select = tree
+          .getByTestId("ATL-Select")
+          .findByType(SelectInternalPicker);
+        fireEvent(select, "onChange", "Apple");
+        expect(
+          (await tree.findByText(labelText, { includeHiddenElements: true }))
+            .props.style,
+        ).toContainEqual({
+          color: tokens["color-critical"],
+        });
+      });
+    });
+
+    describe("validations passes", () => {
+      let tree: RenderAPI;
+      const labelText = "labelText";
+      const errorMsg = "Not too short";
+      beforeEach(() => {
+        tree = render(
+          <Select
+            label={labelText}
+            onChange={onChange}
+            value={"Watermelon"}
+            validations={{
+              minLength: { value: 4, message: errorMsg },
+            }}
+          >
+            <Option value={"Apple"}>Apple</Option>
+            <Option value={"Watermelon"}>Watermelon</Option>
+          </Select>,
+        );
+      });
+
+      it("does not render any error messages", () => {
+        const select = tree
+          .getByTestId("ATL-Select")
+          .findByType(SelectInternalPicker);
+        expect(select).toBeTruthy();
+        fireEvent(select, "onChange", "Apple");
+        expect(tree.queryByText(errorMsg)).toBeNull();
+      });
+
+      it("has non-critical colours", () => {
+        const select = tree
+          .getByTestId("ATL-Select")
+          .findByType(SelectInternalPicker);
+        fireEvent(select, "onChange", "Apple");
+        expect(
+          tree.getByText(labelText, { includeHiddenElements: true }).props
+            .style,
+        ).toContainEqual({
+          color: tokens["color-text--secondary"],
+        });
+      });
+    });
+  });
+});

--- a/packages/components-native/src/Select/Select.tsx
+++ b/packages/components-native/src/Select/Select.tsx
@@ -1,0 +1,240 @@
+import React, { ReactElement } from "react";
+import { View } from "react-native";
+import { useIntl } from "react-intl";
+import { RegisterOptions } from "react-hook-form";
+import { styles } from "./Select.style";
+import { SelectInternalPicker } from "./components/SelectInternalPicker";
+import { messages } from "./messages";
+import { InputFieldWrapper } from "../InputFieldWrapper";
+import { Icon } from "../Icon";
+import { TextVariation } from "../Typography";
+import { Text } from "../Text";
+import { useFormController } from "../hooks";
+
+interface SelectOption {
+  /**
+   * Text that shows up as the option
+   */
+  readonly children: string;
+
+  /**
+   * The value that gets returned when an option is selected
+   */
+  readonly value: string;
+}
+
+interface SelectProps {
+  /**
+   * Current value of the component
+   */
+  readonly value?: string;
+
+  /**
+   * Default value for when the component is uncontrolled
+   */
+  readonly defaultValue?: string;
+
+  /**
+   * Adds a first option to let users select a "no value".
+   * Placeholder item selected by default until a selection is made.
+   */
+  readonly placeholder?: string;
+
+  /**
+   * Label text shown above the selection.
+   */
+  readonly label?: string;
+
+  /**
+   * Help text shown below the control.
+   */
+  readonly assistiveText?: string;
+
+  /**
+   * Callback that provides the new value when the selection changes
+   */
+  readonly onChange?: (newValue?: string) => void;
+
+  /**
+   * Disables input selection
+   */
+  readonly disabled?: boolean;
+
+  /**
+   * Indicates the current selection is invalid
+   */
+  readonly invalid?: boolean;
+
+  /**
+   * VoiceOver will read this string when a user selects the element
+   */
+  readonly accessibilityLabel?: string;
+
+  /**
+   * Helps users understand what will happen when they perform an action
+   */
+  readonly accessibilityHint?: string;
+
+  /**
+   * Name of the input.
+   */
+  readonly name?: string;
+
+  /**
+   * The options to select from
+   */
+  readonly children: ReactElement<SelectOption>[];
+
+  /**
+   * The validations that will mark this component as invalid
+   */
+  readonly validations?: RegisterOptions;
+}
+
+export function Select({
+  value,
+  defaultValue,
+  onChange,
+  children,
+  placeholder,
+  label,
+  assistiveText,
+  disabled,
+  invalid,
+  validations,
+  accessibilityLabel,
+  name,
+}: SelectProps): JSX.Element {
+  const { field, error } = useFormController({
+    name,
+    validations,
+    value: value ?? defaultValue,
+  });
+
+  const { formatMessage } = useIntl();
+  const internalValue = value ?? field.value;
+  const textVariation = getTextVariation({
+    disabled,
+    invalid: invalid || !!error,
+  });
+  const valueTextVariation = disabled ? "disabled" : undefined;
+  const hasValue = internalValue && internalValue?.length > 0;
+
+  return (
+    <InputFieldWrapper
+      error={error}
+      invalid={invalid || !!error}
+      hasValue={hasValue}
+      styleOverride={{
+        container: { borderBottomWidth: undefined },
+      }}
+    >
+      <View
+        testID="ATL-Select"
+        accessible={true}
+        accessibilityLabel={getA11yLabel()}
+        accessibilityValue={{ text: getValue() }}
+        accessibilityHint={formatMessage(messages.a11yHint)}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: disabled }}
+      >
+        <SelectInternalPicker
+          disabled={disabled}
+          options={getOptions()}
+          onChange={handleChange}
+        >
+          <View
+            style={[styles.container, (invalid || !!error) && styles.invalid]}
+          >
+            {label && (
+              <Text
+                level="textSupporting"
+                variation={textVariation}
+                hideFromScreenReader={true}
+              >
+                {label}
+              </Text>
+            )}
+
+            <View style={styles.input}>
+              <View style={styles.value}>
+                <Text
+                  variation={disabled ? "disabled" : "base"}
+                  hideFromScreenReader={true}
+                >
+                  {getValue()}
+                </Text>
+              </View>
+              <View style={styles.icon}>
+                <Icon name="arrowDown" color={valueTextVariation} />
+              </View>
+            </View>
+          </View>
+        </SelectInternalPicker>
+
+        {assistiveText && (
+          <Text
+            level="textSupporting"
+            variation={textVariation}
+            hideFromScreenReader={true}
+          >
+            {assistiveText}
+          </Text>
+        )}
+      </View>
+    </InputFieldWrapper>
+  );
+
+  function getA11yLabel(): string | undefined {
+    let text = [accessibilityLabel || label, assistiveText];
+    text = text.filter(Boolean);
+    return text.join(", ");
+  }
+
+  function handleChange(val: string) {
+    onChange?.(val);
+    // need this onBlur for validations to occur
+    field.onBlur();
+    field.onChange(val);
+  }
+
+  function getOptions() {
+    const options = children.map(({ props }) => ({
+      label: props.children,
+      value: props.value,
+      isActive: props.value === internalValue,
+    }));
+
+    if (!internalValue || placeholder) {
+      options.unshift({
+        label: placeholder || formatMessage(messages.emptyValue),
+        value: "",
+        isActive: !internalValue,
+      });
+    }
+
+    return options;
+  }
+
+  function getValue() {
+    const options = getOptions();
+
+    const activeValue = options.find(option => option.isActive);
+    return (
+      activeValue?.label || placeholder || formatMessage(messages.emptyValue)
+    );
+  }
+}
+
+function getTextVariation({
+  invalid,
+  disabled,
+}: Pick<SelectProps, "invalid" | "disabled">): TextVariation {
+  if (invalid) return "error";
+  if (disabled) return "disabled";
+  return "subdued";
+}
+
+export function Option({ children }: SelectOption): JSX.Element {
+  return <>{children}</>;
+}

--- a/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.ios.tsx
+++ b/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.ios.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from "react";
+import {
+  // Need to use iOS style button
+  // eslint-disable-next-line no-restricted-imports
+  Button,
+  Modal,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { Picker } from "@react-native-picker/picker";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useIntl } from "react-intl";
+import { styles } from "./SelectDefaultPicker.style";
+import { messages } from "./messages";
+import { SelectInternalPickerProps } from "../../types";
+import { SelectPressable } from "../SelectPressable/SelectPressable";
+
+type SelectDefaultPickerProps = SelectInternalPickerProps;
+
+export function SelectDefaultPicker({
+  children,
+  options,
+  onChange,
+}: SelectDefaultPickerProps): JSX.Element {
+  const [show, setShow] = useState(false);
+  const { formatMessage } = useIntl();
+  const selectedLanguage = options.find(option => option.isActive);
+
+  return (
+    <>
+      <SelectPressable onPress={showPicker}>{children}</SelectPressable>
+      <Modal
+        visible={show}
+        transparent
+        animationType="slide"
+        onRequestClose={hidePicker}
+      >
+        <TouchableOpacity style={styles.overlay} onPress={hidePicker} />
+        <View style={styles.actionBar}>
+          <Button title={formatMessage(messages.done)} onPress={hidePicker} />
+        </View>
+        <View style={styles.pickerContainer} testID="select-wheel-picker">
+          <SafeAreaView edges={["bottom"]}>
+            <Picker
+              selectedValue={selectedLanguage?.value}
+              onValueChange={onChange}
+            >
+              {options.map(({ label, value }, i) => (
+                <Picker.Item key={i} label={label} value={value} />
+              ))}
+            </Picker>
+          </SafeAreaView>
+        </View>
+      </Modal>
+    </>
+  );
+
+  function showPicker() {
+    setShow(true);
+  }
+
+  function hidePicker() {
+    setShow(false);
+  }
+}

--- a/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.ios.tsx
+++ b/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.ios.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import {
   // Need to use iOS style button
-  // eslint-disable-next-line no-restricted-imports
   Button,
   Modal,
   TouchableOpacity,

--- a/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.style.ts
+++ b/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.style.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  overlay: { flex: 1 },
+  actionBar: {
+    flexDirection: "row",
+    height: 45,
+    justifyContent: "flex-end",
+    alignItems: "center",
+    paddingHorizontal: 10,
+    backgroundColor: "#f8f8f8",
+    borderTopWidth: 1,
+    borderTopColor: "#dedede",
+    zIndex: 2,
+  },
+  pickerContainer: {
+    justifyContent: "center",
+    backgroundColor: "#d0d4da",
+  },
+  androidPickerContainer: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    color: "transparent",
+    backgroundColor: "transparent",
+    opacity: 0,
+  },
+});

--- a/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.test.tsx
+++ b/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react-native";
+import { AccessibilityInfo, View } from "react-native";
+import { SelectDefaultPicker } from "./SelectDefaultPicker";
+import { messages } from "./messages";
+import { Text } from "../../../Text";
+
+const A11yInfoSpy = jest.spyOn(AccessibilityInfo, "isScreenReaderEnabled");
+const handleChange = jest.fn();
+
+function MockPicker() {
+  return React.createElement("MockPicker");
+}
+const MockPickerItem = () => <></>;
+jest.mock("@react-native-picker/picker", () => ({ Picker: MockPicker }));
+MockPicker.Item = MockPickerItem;
+
+beforeEach(() => {
+  A11yInfoSpy.mockImplementation(() => Promise.resolve(false));
+});
+
+afterEach(() => {
+  cleanup();
+  jest.resetAllMocks();
+});
+
+const childText = "Click me";
+function setup() {
+  return render(
+    <View testID="SelectDefaultPicker">
+      <SelectDefaultPicker
+        onChange={handleChange}
+        options={[
+          { value: "1", label: "First option" },
+          { value: "2", label: "Second option" },
+        ]}
+      >
+        <Text>{childText}</Text>
+      </SelectDefaultPicker>
+    </View>,
+  );
+}
+
+describe("SelectDefaultPicker", () => {
+  it("opens the picker", () => {
+    const screen = setup();
+
+    fireEvent.press(screen.getByText(childText));
+    expect(
+      screen.getByTestId("SelectDefaultPicker").findByType(MockPicker),
+    ).toBeDefined();
+  });
+
+  it("closes the picker", () => {
+    const screen = setup();
+
+    fireEvent.press(screen.getByText(childText));
+    fireEvent.press(screen.getByText(messages.done.defaultMessage));
+    expect(
+      screen.getByTestId("SelectDefaultPicker").findAllByType(MockPicker),
+    ).toEqual([]);
+  });
+
+  it("fires the onChange", () => {
+    const screen = setup();
+
+    fireEvent.press(screen.getByText(childText));
+    const menu = screen
+      .getByTestId("SelectDefaultPicker")
+      .findByType(MockPicker);
+
+    expect(menu).toBeDefined();
+    fireEvent(menu, "onValueChange", "2");
+    expect(handleChange).toHaveBeenCalledWith("2");
+  });
+});

--- a/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.tsx
+++ b/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.tsx
@@ -1,0 +1,45 @@
+import React, { useRef } from "react";
+import { Picker } from "@react-native-picker/picker";
+import { styles } from "./SelectDefaultPicker.style";
+import { SelectInternalPickerProps } from "../../types";
+import { SelectPressable } from "../SelectPressable";
+import { tokens } from "../../../utils/design";
+
+type SelectDefaultPickerProps = SelectInternalPickerProps;
+
+export function SelectDefaultPicker({
+  children,
+  options,
+  disabled,
+  onChange,
+}: SelectDefaultPickerProps): JSX.Element {
+  const selectedItem = options.find(option => option.isActive);
+  const pickerRef = useRef<Picker<string>>(null);
+
+  return (
+    <SelectPressable onPress={pickerRef.current?.focus}>
+      {children}
+      <Picker
+        ref={pickerRef}
+        selectedValue={selectedItem?.value}
+        onValueChange={onChange}
+        mode="dropdown"
+        enabled={!disabled}
+        style={styles.androidPickerContainer}
+      >
+        {options.map(({ label, value, isActive }, i) => (
+          <Picker.Item
+            key={i}
+            label={label}
+            value={value}
+            color={isSelected(isActive)}
+          />
+        ))}
+      </Picker>
+    </SelectPressable>
+  );
+
+  function isSelected(isActive: boolean | undefined): string {
+    return isActive ? tokens["color-interactive"] : tokens["color-text"];
+  }
+}

--- a/packages/components-native/src/Select/components/SelectDefaultPicker/index.ts
+++ b/packages/components-native/src/Select/components/SelectDefaultPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectDefaultPicker";

--- a/packages/components-native/src/Select/components/SelectDefaultPicker/messages.ts
+++ b/packages/components-native/src/Select/components/SelectDefaultPicker/messages.ts
@@ -1,0 +1,9 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  done: {
+    id: "done",
+    defaultMessage: "Done",
+    description: "Done action",
+  },
+});

--- a/packages/components-native/src/Select/components/SelectIOSPicker/SelectIOSPicker.tsx
+++ b/packages/components-native/src/Select/components/SelectIOSPicker/SelectIOSPicker.tsx
@@ -1,0 +1,16 @@
+import { HostComponent, requireNativeComponent } from "react-native";
+import {
+  SelectInternalPickerProps,
+  SelectOnOptionPressEvent,
+} from "../../types";
+
+interface NativeSelectIOSPickerProps
+  extends Pick<SelectInternalPickerProps, "options" | "children"> {
+  /**
+   * Callback when one of the option is pressed
+   */
+  readonly onOptionPress: (event: SelectOnOptionPressEvent) => void;
+}
+
+export const SelectIOSPicker: HostComponent<NativeSelectIOSPickerProps> =
+  requireNativeComponent?.<NativeSelectIOSPickerProps>("RCTPicker");

--- a/packages/components-native/src/Select/components/SelectIOSPicker/index.ts
+++ b/packages/components-native/src/Select/components/SelectIOSPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectIOSPicker";

--- a/packages/components-native/src/Select/components/SelectInternalPicker/SelectInternalPicker.test.tsx
+++ b/packages/components-native/src/Select/components/SelectInternalPicker/SelectInternalPicker.test.tsx
@@ -1,0 +1,100 @@
+import React, { ElementType } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react-native";
+import { View } from "react-native";
+import { SelectInternalPicker } from ".";
+import { SelectInternalPickerProps } from "../../types";
+import { Text } from "../../../Text";
+
+let Platform: { OS: "ios" | "android"; Version: string | number };
+beforeEach(() => {
+  Platform = require("react-native").Platform;
+  Object.defineProperty(Platform, "Version", { get: () => undefined });
+});
+
+function MockPicker() {
+  return React.createElement("MockPicker");
+}
+const MockPickerItem = () => <></>;
+jest.mock("@react-native-picker/picker", () => ({ Picker: MockPicker }));
+MockPicker.Item = MockPickerItem;
+
+afterEach(() => {
+  cleanup();
+  jest.resetAllMocks();
+});
+
+const RCTPicker = "RCTPicker" as ElementType;
+const childText = "Click me";
+const handleChange = jest.fn();
+
+function setup(props?: Partial<SelectInternalPickerProps>) {
+  return render(
+    <View testID="SelectInternalPicker">
+      <SelectInternalPicker
+        onChange={handleChange}
+        disabled={props?.disabled}
+        options={[
+          { value: "1", label: "First option" },
+          { value: "2", label: "Second option" },
+        ]}
+      >
+        <Text>{childText}</Text>
+      </SelectInternalPicker>
+    </View>,
+  );
+}
+
+describe("SelectInternalPicker", () => {
+  it("fires the onChange", () => {
+    const screen = setup();
+    fireEvent.press(screen.getByText(childText));
+    const menu = screen
+      .getByTestId("SelectInternalPicker")
+      .findByType(MockPicker);
+
+    expect(menu).toBeDefined();
+    fireEvent(menu, "onChange", "1");
+    expect(handleChange).toHaveBeenCalledWith("1");
+  });
+
+  describe("iOS 13 and below fallback", () => {
+    it("renders the iOS 14 native menu picker", () => {
+      Platform.OS = "ios";
+      Object.defineProperty(Platform, "Version", { get: () => "14.1" });
+
+      const screen = setup();
+
+      const menu = screen
+        .getByTestId("SelectInternalPicker")
+        .findByType(RCTPicker);
+
+      expect(menu).toBeDefined();
+    });
+
+    it.each<[typeof Platform.OS, typeof Platform.Version]>([
+      ["ios", "13.1"],
+      ["android", 100],
+    ])("renders the menu picker on %s", (os, version) => {
+      Platform.OS = os;
+      Object.defineProperty(Platform, "Version", { get: () => version });
+      const screen = setup();
+
+      fireEvent.press(screen.getByText(childText));
+      expect(
+        screen.getByTestId("SelectInternalPicker").findByType(MockPicker),
+      ).toBeDefined();
+    });
+  });
+
+  describe("Disabled", () => {
+    it("should not render the picker", () => {
+      const screen = setup({ disabled: true });
+
+      const menu = screen
+        .getByTestId("SelectInternalPicker")
+        .findAllByType(RCTPicker);
+
+      expect(menu).toEqual([]);
+    });
+  });
+});

--- a/packages/components-native/src/Select/components/SelectInternalPicker/SelectInternalPicker.tsx
+++ b/packages/components-native/src/Select/components/SelectInternalPicker/SelectInternalPicker.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { handlePress, isIOS14AndUp } from "./utils";
+import { SelectInternalPickerProps } from "../../types";
+import { SelectIOSPicker } from "../SelectIOSPicker";
+import { SelectPressable } from "../SelectPressable";
+import { SelectDefaultPicker } from "../SelectDefaultPicker";
+
+export function SelectInternalPicker({
+  children,
+  options,
+  disabled,
+  onChange,
+}: SelectInternalPickerProps): JSX.Element {
+  if (disabled) return <>{children}</>;
+  if (isIOS14AndUp()) {
+    return (
+      <SelectPressable>
+        <SelectIOSPicker
+          options={options}
+          onOptionPress={handlePress(onChange)}
+        >
+          {children}
+        </SelectIOSPicker>
+      </SelectPressable>
+    );
+  }
+
+  return (
+    <SelectDefaultPicker options={options} onChange={onChange}>
+      {children}
+    </SelectDefaultPicker>
+  );
+}

--- a/packages/components-native/src/Select/components/SelectInternalPicker/index.ts
+++ b/packages/components-native/src/Select/components/SelectInternalPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectInternalPicker";

--- a/packages/components-native/src/Select/components/SelectInternalPicker/utils.ts
+++ b/packages/components-native/src/Select/components/SelectInternalPicker/utils.ts
@@ -1,0 +1,20 @@
+import { Platform } from "react-native";
+import {
+  SelectInternalPickerProps,
+  SelectOnOptionPressEvent,
+} from "../../types";
+
+export function handlePress(onChange: SelectInternalPickerProps["onChange"]) {
+  return ({ nativeEvent: { event } }: SelectOnOptionPressEvent): void => {
+    return onChange(event);
+  };
+}
+
+export function isIOS14AndUp(): boolean {
+  if (Platform.OS === "ios") {
+    const majorVersionIOS = parseInt(Platform.Version, 10);
+    return majorVersionIOS >= 14;
+  }
+
+  return false;
+}

--- a/packages/components-native/src/Select/components/SelectPressable/SelectPressable.style.ts
+++ b/packages/components-native/src/Select/components/SelectPressable/SelectPressable.style.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from "react-native";
+import { tokens } from "../../../utils/design";
+
+export const styles = StyleSheet.create({
+  pressed: {
+    opacity: tokens["opacity-pressed"],
+  },
+});

--- a/packages/components-native/src/Select/components/SelectPressable/SelectPressable.tsx
+++ b/packages/components-native/src/Select/components/SelectPressable/SelectPressable.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Keyboard, Pressable, PressableProps } from "react-native";
+import { styles } from "./SelectPressable.style";
+import { SelectInternalPickerProps } from "../../types";
+import { useIsScreenReaderEnabled } from "../../../hooks";
+
+type SelectPressableProps = Pick<SelectInternalPickerProps, "children"> &
+  Pick<PressableProps, "onPress">;
+
+/**
+ * Switches between Pressable with pressed styling and a fragment when a
+ * screen-reader is being used to avoid screen-readers from ignoring the press
+ * on the MenuView
+ */
+export function SelectPressable({
+  children,
+  onPress,
+}: SelectPressableProps): JSX.Element {
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
+
+  if (isScreenReaderEnabled) return <>{children}</>;
+
+  return (
+    <Pressable
+      style={({ pressed }) => [pressed && styles.pressed]}
+      onPressIn={Keyboard.dismiss}
+      onPress={onPress}
+    >
+      {children}
+    </Pressable>
+  );
+}

--- a/packages/components-native/src/Select/components/SelectPressable/index.ts
+++ b/packages/components-native/src/Select/components/SelectPressable/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectPressable";

--- a/packages/components-native/src/Select/index.ts
+++ b/packages/components-native/src/Select/index.ts
@@ -1,0 +1,1 @@
+export { Select, Option } from "./Select";

--- a/packages/components-native/src/Select/messages.ts
+++ b/packages/components-native/src/Select/messages.ts
@@ -1,0 +1,14 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  a11yHint: {
+    id: "a11yHint",
+    defaultMessage: "Select to open the picker",
+    description: "Accessibility hint on how to interact with the select",
+  },
+  emptyValue: {
+    id: "emptyValue",
+    defaultMessage: "Select an option",
+    description: "Accessibility hint on how to interact with the select",
+  },
+});

--- a/packages/components-native/src/Select/types.ts
+++ b/packages/components-native/src/Select/types.ts
@@ -1,0 +1,46 @@
+import { ReactNode } from "react";
+
+export interface SelectInternalPickerProps {
+  /**
+   * Tapping the children opens the picker
+   */
+  readonly children: ReactNode;
+
+  /**
+   * The list of options that user can choose from
+   */
+  readonly options: SelectInternalPickerOption[];
+
+  /**
+   * Prevents the menu from opening
+   */
+  readonly disabled?: boolean;
+
+  /**
+   * Callback to fire when an option is pressed
+   */
+  readonly onChange: (value: string) => void;
+}
+
+export interface SelectInternalPickerOption {
+  /**
+   * The value that gets returned whenever the option is selected
+   */
+  readonly value: string;
+
+  /**
+   * What the user chooses on the UI
+   */
+  readonly label: string;
+
+  /**
+   * Determines if the option is selected or not
+   */
+  readonly isActive?: boolean;
+}
+
+export interface SelectOnOptionPressEvent {
+  readonly nativeEvent: {
+    readonly event: string;
+  };
+}

--- a/packages/components-native/src/index.ts
+++ b/packages/components-native/src/index.ts
@@ -19,6 +19,7 @@ export * from "./InputPressable";
 export * from "./InputText";
 export * from "./TextList";
 export * from "./ProgressBar";
+export * from "./Select";
 export * from "./StatusLabel";
 export * from "./Switch";
 export * from "./Text";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

### Added
- `Select` now imported into `components-native`
<!-- new features -->


## Testing

On Atlantis root:
```sh
npm pack -w @jobber/components-native
```

On jobber-mobile root (assuming you have them in the same folder): 
```sh
npm install ../atlantis/jobber-components-native-0.21.1.tgz
```

Then you can replace the usages in jobber-mobile


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
