### PR TITLE
feat(components-native): Import ButtonGroup

### DIFF
--- a/packages/components-native/src/ButtonGroup/ButtonGroup.style.ts
+++ b/packages/components-native/src/ButtonGroup/ButtonGroup.style.ts
@@ -1,0 +1,19 @@
+import { StyleSheet } from "react-native";
+import { tokens } from "../utils/design";
+
+export const styles = StyleSheet.create({
+  buttonGroup: {
+    width: "100%",
+    flexDirection: "row",
+    justifyContent: "flex-end",
+  },
+  button: {
+    flexBasis: tokens["space-largest"],
+    flexGrow: 1,
+    paddingRight: tokens["space-smaller"],
+  },
+  moreButton: {
+    flexBasis: tokens["space-largest"],
+    flexGrow: 0,
+  },
+});

--- a/packages/components-native/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/components-native/src/ButtonGroup/ButtonGroup.test.tsx
@@ -1,0 +1,325 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { Host } from "react-native-portalize";
+import { Alert } from "react-native";
+import { messages } from "./messages";
+import { ButtonGroup, ButtonGroupProps } from "./ButtonGroup";
+import { Button } from "../Button";
+import * as atlantisContext from "../AtlantisContext/AtlantisContext";
+import { defaultValues as contextDefaultValue } from "../AtlantisContext";
+
+const mockOnOpen = jest.fn();
+
+function ButtonGroupForTest(props: ButtonGroupProps) {
+  return (
+    <Host>
+      <ButtonGroup
+        bottomSheetHeading={props.bottomSheetHeading}
+        showCancelInBottomSheet={props.showCancelInBottomSheet}
+        onOpenBottomSheet={mockOnOpen}
+      >
+        {props.children}
+      </ButtonGroup>
+    </Host>
+  );
+}
+
+it("renders a single primary action", () => {
+  const createAction = jest.fn();
+  const { getByText, queryByLabelText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+      />
+    </ButtonGroupForTest>,
+  );
+
+  expect(getByText("Create")).not.toBeNull();
+  expect(queryByLabelText(messages.more.defaultMessage)).toBeNull();
+});
+
+it("renders 2 primary actions", () => {
+  const createAction = jest.fn();
+  const editAction = jest.fn();
+  const { getByText, queryByLabelText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+      />
+      <ButtonGroup.PrimaryAction
+        label="Edit"
+        icon="edit"
+        onPress={editAction}
+      />
+    </ButtonGroupForTest>,
+  );
+
+  expect(getByText("Create")).not.toBeNull();
+  expect(getByText("Edit")).not.toBeNull();
+  expect(queryByLabelText(messages.more.defaultMessage)).toBeNull();
+});
+
+it("does not render more than 2 primary actions but adds a More button", () => {
+  const createAction = jest.fn();
+  const editAction = jest.fn();
+  const mysteryAction = jest.fn();
+  const { getByText, queryByText, getByLabelText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+      />
+      <ButtonGroup.PrimaryAction
+        label="Edit"
+        icon="edit"
+        onPress={editAction}
+      />
+      <ButtonGroup.PrimaryAction
+        label="Mystery"
+        icon="edit"
+        onPress={mysteryAction}
+      />
+    </ButtonGroupForTest>,
+  );
+
+  expect(getByText("Create")).not.toBeNull();
+  expect(getByText("Edit")).not.toBeNull();
+  expect(queryByText("Mystery")).toBeNull();
+  expect(getByLabelText(messages.more.defaultMessage)).toBeDefined();
+});
+
+it("does not render secondary actions", () => {
+  const createAction = jest.fn();
+  const editAction = jest.fn();
+  const deleteAction = jest.fn();
+  const { getByText, queryByText, getByLabelText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+      />
+      <ButtonGroup.SecondaryAction
+        label="Edit"
+        icon="edit"
+        onPress={editAction}
+      />
+      <ButtonGroup.SecondaryAction
+        label="Delete"
+        icon="trash"
+        onPress={deleteAction}
+      />
+    </ButtonGroupForTest>,
+  );
+  expect(getByText("Create")).not.toBeNull();
+  expect(queryByText("Edit")).toBeNull();
+  expect(queryByText("Delete")).toBeNull();
+  expect(getByLabelText(messages.more.defaultMessage)).toBeDefined();
+});
+
+it("renders first secondary action as a primary action button if no primary action specified", () => {
+  const editAction = jest.fn();
+  const deleteAction = jest.fn();
+  const { queryByText, getByText, getByLabelText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.SecondaryAction
+        label="Edit"
+        icon="edit"
+        onPress={editAction}
+      />
+      <ButtonGroup.SecondaryAction
+        label="Delete"
+        icon="trash"
+        onPress={deleteAction}
+      />
+    </ButtonGroupForTest>,
+  );
+  expect(getByText("Edit")).not.toBeNull();
+  expect(queryByText("Delete")).toBeNull();
+  expect(getByLabelText(messages.more.defaultMessage)).toBeDefined();
+});
+
+it("fires the press handlers when the primary action buttons are pressed", () => {
+  const createAction = jest.fn();
+  const editAction = jest.fn();
+  const { getByText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+      />
+      <ButtonGroup.PrimaryAction
+        label="Edit"
+        icon="edit"
+        onPress={editAction}
+      />
+    </ButtonGroupForTest>,
+  );
+
+  fireEvent.press(getByText("Create"));
+  expect(createAction).toHaveBeenCalled();
+  fireEvent.press(getByText("Edit"));
+  expect(editAction).toHaveBeenCalled();
+});
+
+it("opens the secondary action menu when the More button is pressed", () => {
+  const createAction = jest.fn();
+  const editAction = jest.fn();
+  const deleteAction = jest.fn();
+  const { getByText, queryByText, getByLabelText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+      />
+      <ButtonGroup.SecondaryAction
+        label="Edit"
+        icon="edit"
+        onPress={editAction}
+      />
+      <ButtonGroup.SecondaryAction
+        label="Delete"
+        icon="trash"
+        onPress={deleteAction}
+      />
+    </ButtonGroupForTest>,
+  );
+
+  expect(queryByText("Edit")).toBeNull();
+
+  fireEvent.press(getByLabelText(messages.more.defaultMessage));
+
+  expect(getByText("Edit")).not.toBeNull();
+  expect(getByText("Delete")).not.toBeNull();
+});
+
+it("renders heading and cancel options if passed in", () => {
+  const createAction = jest.fn();
+  const editAction = jest.fn();
+  const { getByText, getByLabelText } = render(
+    <ButtonGroupForTest
+      bottomSheetHeading={"Heading"}
+      showCancelInBottomSheet={true}
+    >
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+      />
+      <ButtonGroup.SecondaryAction
+        label="Edit"
+        icon="edit"
+        onPress={editAction}
+      />
+    </ButtonGroupForTest>,
+  );
+
+  fireEvent.press(getByLabelText(messages.more.defaultMessage));
+
+  expect(getByText("Heading")).not.toBeNull();
+  expect(getByText("Cancel")).not.toBeNull();
+});
+
+it("renders custom button for primary action if passed in", () => {
+  const createAction = jest.fn();
+
+  const customCreateButton = (
+    <Button label="CustomCreate" onPress={createAction} />
+  );
+
+  const { queryByText, getByText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+        customButton={customCreateButton}
+      />
+    </ButtonGroupForTest>,
+  );
+
+  expect(getByText("CustomCreate")).not.toBeNull();
+  expect(queryByText("Create")).toBeNull();
+});
+
+it("calls onOpenBottomSheet when the secondary actions are opened", () => {
+  const createAction = jest.fn();
+  const editAction = jest.fn();
+  const deleteAction = jest.fn();
+  const { getByLabelText } = render(
+    <ButtonGroupForTest>
+      <ButtonGroup.PrimaryAction
+        label="Create"
+        icon="plus"
+        onPress={createAction}
+      />
+      <ButtonGroup.SecondaryAction
+        label="Edit"
+        icon="edit"
+        onPress={editAction}
+      />
+      <ButtonGroup.SecondaryAction
+        label="Delete"
+        icon="trash"
+        onPress={deleteAction}
+      />
+    </ButtonGroupForTest>,
+  );
+
+  fireEvent.press(getByLabelText(messages.more.defaultMessage));
+
+  expect(mockOnOpen).toHaveBeenCalled();
+});
+
+describe("ButtonGroup Offline/Online", () => {
+  const atlantisContextSpy = jest.spyOn(atlantisContext, "useAtlantisContext");
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const handlePress = jest.fn();
+  const label = "Click me";
+  const setup = () =>
+    render(
+      <ButtonGroupForTest>
+        <ButtonGroup.PrimaryAction
+          label={label}
+          icon="plus"
+          onPress={handlePress}
+        />
+      </ButtonGroupForTest>,
+    );
+
+  it("should show an alert and not fire the onPress", () => {
+    const alertSpy = jest.spyOn(Alert, "alert");
+    atlantisContextSpy.mockReturnValue({
+      ...contextDefaultValue,
+      isOnline: false,
+    });
+
+    const { getByText } = setup();
+
+    fireEvent.press(getByText(label));
+
+    expect(alertSpy).toHaveBeenCalled();
+    expect(handlePress).not.toHaveBeenCalled();
+  });
+
+  it("should fire the onPress and not show an alert", () => {
+    const alertSpy = jest.spyOn(Alert, "alert");
+    const { getByText } = setup();
+
+    fireEvent.press(getByText(label));
+
+    expect(handlePress).toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components-native/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components-native/src/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,113 @@
+import React, { useRef } from "react";
+import { useIntl } from "react-intl";
+import { View } from "react-native";
+import { PrimaryAction, SecondaryAction } from "./ButtonGroupAction";
+import { messages } from "./messages";
+import { styles } from "./ButtonGroup.style";
+import { SecondaryActionSheet } from "./components/SecondaryActionSheet";
+import { getActions, usePreventTapWhenOffline } from "./utils";
+import { ButtonGroupActionElement } from "./types";
+import { Button } from "../Button";
+import { BottomSheetRef } from "../BottomSheet/BottomSheet";
+
+export interface ButtonGroupProps {
+  readonly children: ButtonGroupActionElement | ButtonGroupActionElement[];
+
+  /**
+   * Display a cancel button in the secondary bottom sheet footer.
+   */
+  readonly showCancelInBottomSheet?: boolean;
+
+  /**
+   * An optional heading to display in the secondary bottom sheet header.
+   */
+  readonly bottomSheetHeading?: string;
+
+  /**
+   * Callback that is called when the secondary actions bottom sheet is opened.
+   */
+  readonly onOpenBottomSheet?: () => void;
+
+  /**
+   * Callback that is called when the secondary actions bottom sheet is closed.
+   */
+  readonly onCloseBottomSheet?: () => void;
+
+  /**
+   * Allows you to Tap the button while offline
+   */
+  readonly allowTapWhenOffline?: boolean;
+}
+
+export function ButtonGroup({
+  children,
+  showCancelInBottomSheet,
+  bottomSheetHeading,
+  onOpenBottomSheet,
+  onCloseBottomSheet,
+  allowTapWhenOffline = false,
+}: ButtonGroupProps): JSX.Element {
+  const { formatMessage } = useIntl();
+  const { handlePress } = usePreventTapWhenOffline();
+  const secondaryActionsRef = useRef<BottomSheetRef>();
+  const { primaryActions, secondaryActions } = getActions(children);
+  return (
+    <View style={styles.buttonGroup}>
+      {primaryActions.map((action, index) => {
+        const {
+          label,
+          onPress,
+          buttonType,
+          buttonVariation,
+          icon,
+          customButton,
+          loading,
+        } = action.props;
+
+        return (
+          <View style={styles.button} key={index}>
+            {customButton || (
+              <Button
+                label={label}
+                accessibilityLabel={label}
+                onPress={allowTapWhenOffline ? onPress : handlePress(onPress)}
+                type={buttonType}
+                variation={buttonVariation}
+                fullHeight={true}
+                icon={icon}
+                loading={loading}
+              />
+            )}
+          </View>
+        );
+      })}
+
+      {secondaryActions.length > 0 && (
+        <View style={styles.moreButton}>
+          <Button
+            icon={"more"}
+            accessibilityLabel={formatMessage(messages.more)}
+            onPress={handlePress(openBottomSheet)}
+            fullHeight={true}
+          />
+        </View>
+      )}
+
+      <SecondaryActionSheet
+        heading={bottomSheetHeading}
+        showCancel={showCancelInBottomSheet}
+        secondaryActionsRef={secondaryActionsRef}
+        actions={secondaryActions.map(secondaryAction => secondaryAction.props)}
+        onOpenBottomSheet={onOpenBottomSheet}
+        onCloseBottomSheet={onCloseBottomSheet}
+      />
+    </View>
+  );
+
+  function openBottomSheet() {
+    secondaryActionsRef.current?.open();
+  }
+}
+
+ButtonGroup.PrimaryAction = PrimaryAction;
+ButtonGroup.SecondaryAction = SecondaryAction;

--- a/packages/components-native/src/ButtonGroup/ButtonGroupAction.tsx
+++ b/packages/components-native/src/ButtonGroup/ButtonGroupAction.tsx
@@ -1,0 +1,66 @@
+import { IconColorNames, IconNames } from "@jobber/design";
+import React from "react";
+import { ButtonType, ButtonVariation } from "../Button";
+
+export interface ButtonGroupActionProps {
+  /**
+   * Text to be displayed on the action button
+   */
+  label: string;
+
+  /**
+   * Icon to be displayed on the action button
+   */
+  icon?: IconNames;
+
+  /**
+   * Determines the color of the icon. If not specified, some icons have a default system colour which will be used
+   * Others that don't have a system colour fall back to greyBlue.
+   * Only applies the iconColor to ButtonGroup.PrimaryAction when it is rendered under the "more" menu.
+   */
+  iconColor?: IconColorNames;
+
+  /**
+   * Press handler for the action button
+   */
+  onPress: () => void;
+  loading?: boolean;
+}
+
+export interface ButtonGroupSecondaryActionProps
+  extends ButtonGroupActionProps {
+  /**
+   * Indicates whether the secondary action is destructive in nature.
+   */
+  destructive?: boolean;
+}
+
+export interface ButtonGroupPrimaryActionProps extends ButtonGroupActionProps {
+  /**
+   * Sets the action button style (default: "primary")
+   */
+  buttonType?: ButtonType;
+
+  /**
+   * Themes the action button to the type of action it performs (default: "work")
+   */
+  buttonVariation?: ButtonVariation;
+
+  /**
+   * Optional custom button that can be rendered in place of the primary action button
+   */
+  customButton?: JSX.Element;
+  loading?: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function PrimaryAction(_: ButtonGroupPrimaryActionProps): JSX.Element {
+  return <></>;
+}
+
+export function SecondaryAction(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _: ButtonGroupSecondaryActionProps,
+): JSX.Element {
+  return <></>;
+}

--- a/packages/components-native/src/ButtonGroup/components/SecondaryActionSheet/SecondaryActionSheet.tsx
+++ b/packages/components-native/src/ButtonGroup/components/SecondaryActionSheet/SecondaryActionSheet.tsx
@@ -1,0 +1,55 @@
+import React, { RefObject } from "react";
+import { View } from "react-native";
+import { Portal } from "react-native-portalize";
+import { ButtonGroupSecondaryActionProps } from "../../types";
+import { BottomSheetOption } from "../../../BottomSheet/components/BottomSheetOption";
+import { BottomSheet, BottomSheetRef } from "../../../BottomSheet/BottomSheet";
+
+interface SecondaryActionSheetProps {
+  actions: ButtonGroupSecondaryActionProps[];
+  secondaryActionsRef: RefObject<BottomSheetRef>;
+  showCancel?: boolean;
+  heading?: string;
+  onOpenBottomSheet?: () => void;
+  onCloseBottomSheet?: () => void;
+}
+
+export function SecondaryActionSheet({
+  actions,
+  secondaryActionsRef,
+  heading,
+  showCancel,
+  onOpenBottomSheet,
+  onCloseBottomSheet,
+}: SecondaryActionSheetProps): JSX.Element {
+  return (
+    <Portal>
+      <BottomSheet
+        heading={heading}
+        showCancel={showCancel}
+        ref={secondaryActionsRef}
+        onOpen={onOpenBottomSheet}
+        onClose={onCloseBottomSheet}
+      >
+        <View>
+          {actions.map((action, index) => {
+            const { label, onPress, icon, iconColor, destructive } = action;
+            return (
+              <BottomSheetOption
+                destructive={destructive}
+                key={index}
+                text={label}
+                onPress={() => {
+                  secondaryActionsRef?.current?.close();
+                  onPress();
+                }}
+                icon={icon}
+                iconColor={iconColor}
+              />
+            );
+          })}
+        </View>
+      </BottomSheet>
+    </Portal>
+  );
+}

--- a/packages/components-native/src/ButtonGroup/components/SecondaryActionSheet/index.ts
+++ b/packages/components-native/src/ButtonGroup/components/SecondaryActionSheet/index.ts
@@ -1,0 +1,1 @@
+export { SecondaryActionSheet } from "./SecondaryActionSheet";

--- a/packages/components-native/src/ButtonGroup/index.ts
+++ b/packages/components-native/src/ButtonGroup/index.ts
@@ -1,2 +1,8 @@
 export { ButtonGroup } from "./ButtonGroup";
-export type { ButtonGroupActionProps } from "./ButtonGroupAction";
+export type {
+  ButtonGroupActionProps,
+  ButtonGroupPrimaryActionProps,
+  ButtonGroupSecondaryActionProps,
+  ButtonGroupActionElement,
+} from "./types";
+export { usePreventTapWhenOffline } from "./utils";

--- a/packages/components-native/src/ButtonGroup/index.ts
+++ b/packages/components-native/src/ButtonGroup/index.ts
@@ -1,0 +1,2 @@
+export { ButtonGroup } from "./ButtonGroup";
+export type { ButtonGroupActionProps } from "./ButtonGroupAction";

--- a/packages/components-native/src/ButtonGroup/messages.ts
+++ b/packages/components-native/src/ButtonGroup/messages.ts
@@ -1,0 +1,19 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  more: {
+    id: "more",
+    defaultMessage: "More",
+    description: "Accessibility label for the More button",
+  },
+  unavailableNetworkTitle: {
+    id: "unavailableNetworkTitle",
+    defaultMessage: "Network unavailable",
+    description: "The title for alert about network unavailable",
+  },
+  unavailableNetworkMessage: {
+    id: "unavailableNetworkMessage",
+    defaultMessage: "Check your internet connection and try again later.",
+    description: "The message for alert about network unavailable",
+  },
+});

--- a/packages/components-native/src/ButtonGroup/types.ts
+++ b/packages/components-native/src/ButtonGroup/types.ts
@@ -1,0 +1,30 @@
+import { ReactElement } from "react";
+import {
+  ButtonGroupActionProps,
+  ButtonGroupPrimaryActionProps,
+  ButtonGroupSecondaryActionProps,
+  PrimaryAction,
+  SecondaryAction,
+} from "./ButtonGroupAction";
+
+export type ButtonGroupPrimaryActionElement = ReactElement<
+  ButtonGroupPrimaryActionProps,
+  typeof PrimaryAction
+>;
+
+export type ButtonGroupSecondaryActionElement = ReactElement<
+  ButtonGroupActionProps,
+  typeof SecondaryAction
+>;
+
+export type ButtonGroupActionElement =
+  | ButtonGroupPrimaryActionElement
+  | ButtonGroupSecondaryActionElement;
+
+export type BottomSheetTextTransform = "capitalize" | "none";
+
+export type {
+  ButtonGroupActionProps,
+  ButtonGroupPrimaryActionProps,
+  ButtonGroupSecondaryActionProps,
+};

--- a/packages/components-native/src/ButtonGroup/utils.ts
+++ b/packages/components-native/src/ButtonGroup/utils.ts
@@ -1,0 +1,86 @@
+import React, { useCallback } from "react";
+import { useIntl } from "react-intl";
+import { Alert } from "react-native";
+import { messages } from "./messages";
+import {
+  ButtonGroupActionElement,
+  ButtonGroupPrimaryActionElement,
+} from "./types";
+import {
+  ButtonGroupActionProps,
+  PrimaryAction,
+  SecondaryAction,
+} from "./ButtonGroupAction";
+import { useAtlantisContext } from "../AtlantisContext/AtlantisContext";
+
+interface UsePreventTapWhenOfflineShape {
+  readonly handlePress: (
+    callback: ButtonGroupActionProps["onPress"],
+  ) => () => void;
+}
+
+/**
+ * Determine if the onPress should be fired or an alert when the device is
+ * online or offline
+ */
+export function usePreventTapWhenOffline(): UsePreventTapWhenOfflineShape {
+  const { formatMessage } = useIntl();
+  const { isOnline } = useAtlantisContext();
+
+  const handlePress = useCallback(
+    (callback: ButtonGroupActionProps["onPress"]) => {
+      if (isOnline) return callback;
+
+      return () =>
+        Alert.alert(
+          formatMessage(messages.unavailableNetworkTitle),
+          formatMessage(messages.unavailableNetworkMessage),
+        );
+    },
+    [formatMessage, isOnline],
+  );
+
+  return { handlePress };
+}
+
+interface GetActionShape {
+  readonly primaryActions: ButtonGroupPrimaryActionElement[];
+  readonly secondaryActions: ButtonGroupActionElement[];
+}
+
+/**
+ * Separate the Primary and Secondary actions into 2 const
+ */
+export function getActions(
+  children: ButtonGroupActionElement | ButtonGroupActionElement[],
+): GetActionShape {
+  const childArray = React.Children.toArray(
+    children,
+  ) as ButtonGroupActionElement[];
+
+  let primaryActions = childArray.filter(
+    action =>
+      /* Checking the component type does not work in dev environments due to
+       * wrapper components used for hot-reload
+       * However, checking the type name does not work in prod due to code minification
+       * Hence 2 different checks here */
+      action.type === PrimaryAction || action.type.name === "PrimaryAction",
+  ) as ButtonGroupPrimaryActionElement[];
+
+  let secondaryActions = childArray.filter(
+    action =>
+      action.type === SecondaryAction || action.type.name === "SecondaryAction",
+  );
+
+  if (primaryActions.length > 2) {
+    secondaryActions = primaryActions.slice(2).concat(secondaryActions);
+    primaryActions = primaryActions.slice(0, 2);
+  }
+
+  if (primaryActions.length === 0) {
+    primaryActions = secondaryActions.slice(0, 1);
+    secondaryActions = secondaryActions.slice(1);
+  }
+
+  return { primaryActions, secondaryActions };
+}

--- a/packages/components-native/src/index.ts
+++ b/packages/components-native/src/index.ts
@@ -4,6 +4,7 @@ export * from "./ActivityIndicator";
 export * from "./AtlantisContext";
 export * from "./BottomSheet";
 export * from "./Button";
+export * from "./ButtonGroup";
 export * from "./Card";
 export * from "./Chip";
 export * from "./Content";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- feat(components-native): Added ButtonGroup component

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

`npm run pack @jobber/components-native`
Replace `ButtonGroup` with the button group in `@jobber/components-native` verify it works as expected

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
