### PR TITLE
fix(components): Fix initial resize of InputText when rows are passed in

### DIFF
--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -1,4 +1,10 @@
-import React, { Ref, createRef, forwardRef, useImperativeHandle } from "react";
+import React, {
+  Ref,
+  createRef,
+  forwardRef,
+  useImperativeHandle,
+  useLayoutEffect,
+} from "react";
 import { XOR } from "ts-xor";
 import {
   CommonFormFieldProps,
@@ -82,6 +88,12 @@ function InputTextInternal(
       }
     },
   }));
+
+  useLayoutEffect(() => {
+    if (inputRef && inputRef.current instanceof HTMLTextAreaElement) {
+      resize(inputRef.current);
+    }
+  }, [inputRef.current]);
 
   return (
     <FormField


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

`InputText` was not initially resizing if the user passed the `rows` prop with a `min` and `max` values because `rowRange.min` is passed to `FormField` and we just resized when the `onChange` was called.

Now, it will use `useLayoutEffect` to resize it on the first render too and it will handle the resizing if the input value is longer than the minimum row value.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `InputText` now resizes in the initial render if the consumer passes the `rows` prop

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
