### PR TITLE
fix(components): InputNumber doesn't run custom validations

### DIFF
--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -199,6 +199,70 @@ test("allows custom validation", async () => {
   });
 });
 
+test("it should call the custom validate function if provided", async () => {
+  const validationHandler = jest.fn();
+  const expectedValidationValue = Math.floor(
+    Math.random() * Number.MAX_SAFE_INTEGER,
+  );
+  const { getByLabelText } = render(
+    <InputNumber
+      value={expectedValidationValue}
+      placeholder="Custom validation function"
+      validations={{
+        validate: validationHandler,
+      }}
+    />,
+  );
+
+  const input = getByLabelText("Custom validation function");
+
+  input.focus();
+  input.blur();
+
+  await waitFor(() => {
+    expect(validationHandler).toHaveBeenCalled();
+    // expect(validationHandler).toHaveBeenCalledWith(expectedValidationValue);
+    // Expected: 12
+    // Received: 12, {"generatedName--123e4567-e89b-12d3-a456-426655440063": 12}
+  });
+});
+
+test("it should use the custom validate object if provided", async () => {
+  const validationHandler = jest.fn();
+  const validationHandler2 = jest.fn();
+  const expectedValidationValue = Math.floor(
+    Math.random() * Number.MAX_SAFE_INTEGER,
+  );
+
+  const { getByLabelText } = render(
+    <InputNumber
+      value={expectedValidationValue}
+      placeholder="Custom validation function"
+      validations={{
+        validate: {
+          validationHandler,
+          validationHandler2,
+        },
+      }}
+    />,
+  );
+
+  const input = getByLabelText("Custom validation function");
+
+  input.focus();
+  input.blur();
+
+  await waitFor(() => {
+    expect(validationHandler).toHaveBeenCalled();
+    expect(validationHandler2).toHaveBeenCalled();
+    // expect(validationHandler).toHaveBeenCalledWith(expectedValidationValue);
+    // expect(validationHandler2).toHaveBeenCalledWith(expectedValidationValue);
+  });
+});
+
+// it should do overlimit if no validation provided
+// it merge validations if given object
+
 test("it should handle focus", () => {
   const inputRef = React.createRef<InputNumberRef>();
   const placeholder = "Number";

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -220,9 +220,10 @@ test("it should call the custom validate function if provided", async () => {
   input.blur();
 
   await waitFor(() => {
-    expect(validationHandler).toHaveBeenCalled();
-    // expect(validationHandler).toHaveBeenCalledWith(expectedValidationValue);
-    // Expected: 12
+    expect(validationHandler).toHaveBeenCalledWith(
+      expectedValidationValue,
+      expect.anything(),
+    );
     // Received: 12, {"generatedName--123e4567-e89b-12d3-a456-426655440063": 12}
   });
 });
@@ -253,10 +254,14 @@ test("it should use the custom validate object if provided", async () => {
   input.blur();
 
   await waitFor(() => {
-    expect(validationHandler).toHaveBeenCalled();
-    expect(validationHandler2).toHaveBeenCalled();
-    // expect(validationHandler).toHaveBeenCalledWith(expectedValidationValue);
-    // expect(validationHandler2).toHaveBeenCalledWith(expectedValidationValue);
+    expect(validationHandler).toHaveBeenCalledWith(
+      expectedValidationValue,
+      expect.anything(),
+    );
+    expect(validationHandler2).toHaveBeenCalledWith(
+      expectedValidationValue,
+      expect.anything(),
+    );
   });
 });
 

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -222,7 +222,7 @@ test("it should call the custom validate function if provided", async () => {
   await waitFor(() => {
     expect(validationHandler).toHaveBeenCalledWith(
       expectedValidationValue,
-      expect.anything(),
+      expect.any(Object),
     );
     // Received: 12, {"generatedName--123e4567-e89b-12d3-a456-426655440063": 12}
   });
@@ -265,8 +265,55 @@ test("it should use the custom validate object if provided", async () => {
   });
 });
 
-// it should do overlimit if no validation provided
-// it merge validations if given object
+test("it should call the min validation if the custom validation passes", async () => {
+  const { getByLabelText, getByText } = render(
+    <InputNumber
+      value={98}
+      min={99}
+      validations={{
+        validate: {
+          alwaysPasses: () => true,
+        },
+      }}
+      placeholder="Count to 100"
+    />,
+  );
+
+  const input = getByLabelText("Count to 100");
+  input.focus();
+  input.blur();
+
+  await waitFor(() => {
+    expect(
+      getByText("Enter a number that is greater than or equal to 99"),
+    ).toBeInTheDocument();
+  });
+});
+
+test("it should call the max validation if the custom validation passes", async () => {
+  const { getByLabelText, getByText } = render(
+    <InputNumber
+      value={101}
+      max={100}
+      validations={{
+        validate: {
+          alwaysPasses: () => true,
+        },
+      }}
+      placeholder="Count to 100"
+    />,
+  );
+
+  const input = getByLabelText("Count to 100");
+  input.focus();
+  input.blur();
+
+  await waitFor(() => {
+    expect(
+      getByText("Enter a number that is less than or equal to 100"),
+    ).toBeInTheDocument();
+  });
+});
 
 test("it should handle focus", () => {
   const inputRef = React.createRef<InputNumberRef>();

--- a/packages/components/src/InputNumber/InputNumber.tsx
+++ b/packages/components/src/InputNumber/InputNumber.tsx
@@ -1,4 +1,5 @@
 import React, { Ref, createRef, forwardRef, useImperativeHandle } from "react";
+import { RegisterOptions } from "react-hook-form";
 import { CommonFormFieldProps, FormField, FormFieldProps } from "../FormField";
 
 interface InputNumberProps
@@ -57,10 +58,28 @@ function InputNumberInternal(
       onChange={handleChange}
       validations={{
         ...props.validations,
-        validate: getOverLimitMessage,
+        validate: customValidators(props.validations?.validate),
       }}
     />
   );
+
+  function customValidators(
+    validators?: RegisterOptions["validate"],
+  ): RegisterOptions["validate"] {
+    if (validators == null) {
+      return getOverLimitMessage;
+    } else if (typeof validators === "function") {
+      return {
+        customValidation: validators,
+        getOverLimitMessage,
+      };
+    }
+
+    return {
+      ...validators,
+      getOverLimitMessage,
+    };
+  }
 
   function handleChange(newValue: number) {
     props.onChange && props.onChange(newValue);


### PR DESCRIPTION
## Motivations

If you define a custom validation function on InputNumber like this,
```
    <InputNumber
      placeholder="Custom validation function"
      validations={{
        validate: validationHandler,
      }}
    />
```

The validation function won't run. This was because there's a validation function already defined internally for the component and it doesn't merge the user-defined function with the internal function.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

Added a function to merge the validation functions together.
I had to add the function because if I just spread the `validate` property like this,
```
      validations={{
        ...props.validations,
        validate: {
          ...props.validations?.validate,
          getOverLimitMessage,
        },
```
it fails in the cases where there's no `validate` value defined.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
