### PR TITLE
docs: Fix contribution guide and pr title tool links on Github 

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -150,7 +150,7 @@ follow the following format.
 `<TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>`
 
 Want help with your pull request title? We have a
-[tool to help](../?path=/docs/guides-pull-request-title-generator--page).
+[tool to help](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page).
 
 ##### Requesting review
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -156,7 +156,7 @@ For more information on how the packages are bootstrapped, check out
 ## Contributing
 
 Everyone is a friend of Atlantis and we welcome pull requests. See the
-[contribution guidelines](../?path=/docs/contributing--page) to learn how.
+[contribution guidelines](https://atlantis.getjobber.com/?path=/docs/contributing--page) to learn how.
 
 ## Publishing
 


### PR DESCRIPTION
Updated the link from relative to absolute so it would take you to Storybook, as Storybook page links and Github markdown links are not compatible with each other.

## Motivations

The docs on Github were breaking (blank screen) when following the storybook formatted relative link to the contribution guide.

## Changes

Made the link absolute to point to the appropriate storybook documentation.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
