### PR TITLE
build(components-native): Add force publish to components-native on Github actions

### DIFF
--- a/.github/workflows/trigger-qa-build.yml
+++ b/.github/workflows/trigger-qa-build.yml
@@ -51,6 +51,8 @@ jobs:
           else
             if [ "$PUBLISH_SETTING" == "Force Publish Components" ]; then
             FORCE_PUBLISH_SETTINGS="--force-publish @jobber/components"
+            if [ "$PUBLISH_SETTING" == "Force Publish Components-native" ]; then
+            FORCE_PUBLISH_SETTINGS="--force-publish @jobber/components-native"
             elif [ "$PUBLISH_SETTING" == "Force Publish Design" ]; then
             FORCE_PUBLISH_SETTINGS="--force-publish @jobber/design"
             elif [ "$PUBLISH_SETTING" == "Force Publish Components & Design" ]; then


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Add force publish pre-release to `@jobber/components-native` on Github Actions

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
