### PR TITLE
fix(components): nesting menu on a clickable parent shouldn't trigger the parent click [JOB-72895]

### DIFF
--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -153,7 +153,8 @@ describe("Menu", () => {
   });
 });
 
-it("should focus first action item from the menu when activated", () => {
+it("should focus first action item from the menu when activated", async () => {
+  jest.useFakeTimers();
   const { getByRole } = render(
     <Menu
       activator={<Button label="Menu" />}
@@ -177,5 +178,8 @@ it("should focus first action item from the menu when activated", () => {
 
   fireEvent.click(getByRole("button"));
   const firstMenuItem = screen.getAllByRole("menuitem")[0];
+  expect(firstMenuItem).not.toHaveFocus();
+  jest.runAllTimers();
   expect(firstMenuItem).toHaveFocus();
+  jest.useRealTimers();
 });

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -117,7 +117,11 @@ export function Menu({ activator, items }: MenuProps) {
   });
 
   return (
-    <div className={wrapperClasses} ref={wrapperRef}>
+    <div
+      className={wrapperClasses}
+      ref={wrapperRef}
+      onClick={handleParentClick}
+    >
       {React.cloneElement(activator, {
         onClick: toggle(activator.props.onClick),
         id: buttonID,
@@ -195,6 +199,14 @@ export function Menu({ activator, items }: MenuProps) {
     event.preventDefault();
     event.stopPropagation();
     key === "Escape" && hide();
+  }
+
+  function handleParentClick(event: MouseEvent<HTMLDivElement>) {
+    // Since the menu is being rendered within the same parent as the activator,
+    // we need to stop the click event from bubbling up. If the Menu component
+    // gets added within a parent that has a click handler, any click on the
+    // menu will trigger the parent's click handler.
+    event.stopPropagation();
   }
 }
 

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -12,6 +12,7 @@ import { v1 as uuidv1 } from "uuid";
 import classnames from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
 import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
+import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
 import { IconNames } from "@jobber/design";
 import styles from "./Menu.css";
 import { Button } from "../Button";
@@ -92,6 +93,7 @@ export function Menu({ activator, items }: MenuProps) {
       setPosition(newPosition);
     }
   }, [visible, fullWidth]);
+  useRefocusOnActivator(visible);
 
   if (!activator) {
     activator = (
@@ -267,8 +269,9 @@ function Action({
   const actionButtonRef = useRef() as RefObject<HTMLButtonElement>;
 
   useEffect(() => {
-    if (actionButtonRef.current && shouldFocus) {
-      actionButtonRef.current.focus();
+    if (shouldFocus) {
+      // Focus on the next tick to allow useRefocusOnActivator to initialize
+      setTimeout(() => actionButtonRef.current?.focus(), 0);
     }
   }, [shouldFocus]);
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When you have a clickable row like this

![image](https://github.com/GetJobber/atlantis/assets/15986172/9dc6c026-89ec-40b2-9191-9abb197e988a)

and you try to click the menu (ellipsis), it'll fire both the click on the row and the click for the ellipsis. Clicking outside or a menu item fires the row click again because the menu is nested within the row.

This PR prevents that from happening and treats the menu as a standalone thing that gets no side effect

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Stop event bubbling on menu click
- Implement refocus on activator

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

```diff
diff --git a/packages/components/src/Menu/Menu.stories.mdx b/packages/components/src/Menu/Menu.stories.mdx
index f50ad907..3b98401a 100644
--- a/packages/components/src/Menu/Menu.stories.mdx
+++ b/packages/components/src/Menu/Menu.stories.mdx
@@ -57,7 +57,11 @@ import { Menu } from "@jobber/components/Menu";
       ],
     }}
   >
-    {args => <Menu {...args} />}
+    {args => (
+      <div onClick={() => alert("I should not be showing up!")}>
+        <Menu {...args} />
+      </div>
+    )}
   </Story>
 </Canvas>
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
