### PR TITLE
fix: responsive tab padding when inside a modal

### DIFF
--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -1,11 +1,12 @@
 :root {
   --modal--width: calc(var(--base-unit) * 37.5);
-  --modal--padding: var(--space-base);
-}
+  --modal--padding-horizontal: var(--space-base);
+  --modal--padding-vertical: var(--space-base);
+  --modal--padding: var(--modal--padding-vertical)
+    var(--modal--padding-horizontal);
 
-@media (--medium-screens-and-up) {
-  :root {
-    --modal--padding: var(--space-base) var(--space-large);
+  @media (--medium-screens-and-up) {
+    --modal--padding-horizontal: var(--space-large);
   }
 }
 

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -45,10 +45,11 @@
   background-color: var(--color-surface);
 }
 
-/* Adjust `Content` components public padding to match the modal */
+/* Adjust `Content` and `Tab` components public padding to match the modal */
 
 .modal > * {
   --public-content--padding: var(--modal--padding);
+  --public-tab--inset: var(--modal--padding-horizontal);
 }
 
 /* Remove the nested `Content` components public padding */

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -32,8 +32,6 @@
 }
 
 .modal {
-  --public-tab--inset: var(--space-large);
-
   position: relative;
   flex: 0 0 auto;
   width: 100%;

--- a/packages/components/src/Modal/Sizes.css
+++ b/packages/components/src/Modal/Sizes.css
@@ -1,5 +1,6 @@
 .small {
   --modal--padding: var(--space-base);
+  --public-tab--inset: var(--space-base);
   max-width: calc(var(--base-unit) * 25);
 }
 

--- a/packages/components/src/Tabs/Tabs.css
+++ b/packages/components/src/Tabs/Tabs.css
@@ -25,12 +25,12 @@
 
 .overflowRight:after {
   right: 0;
-  box-shadow: inset -16px 0 16px -16px var(--color-blue);
+  box-shadow: inset -16px 0 16px -16px rgba(var(--color-black--rgb), 0.25);
 }
 
 .overflowLeft:before {
   left: 0;
-  box-shadow: inset 16px 0 16px -16px var(--color-blue);
+  box-shadow: inset 16px 0 16px -16px rgba(var(--color-black--rgb), 0.25);
 }
 
 .tabRow {

--- a/packages/components/src/Tabs/Tabs.css
+++ b/packages/components/src/Tabs/Tabs.css
@@ -35,6 +35,7 @@
 
 .tabRow {
   display: flex;
+  margin: 0;
   margin-bottom: calc(-1 * var(--border-base));
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Noticed the tab adjusts itself to the padding of the big modal. But doesn't do it responsively or when the modal is small. This aims to fix that

![Components___Modal_-_Modal_⋅_Storybook](https://github.com/GetJobber/atlantis/assets/15986172/cab049cb-6173-43c8-be87-ca7fdff5a6ae)

![Components___Modal_-_Modal_⋅_Storybook](https://github.com/GetJobber/atlantis/assets/15986172/2cc1f3dd-2874-4d6d-a322-45bd5664c8c0)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Responsive tab horizontal padding 

### Changed

- Make shadow match our shadows

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

```diff
diff --git a/packages/components/src/Modal/Modal.stories.mdx b/packages/components/src/Modal/Modal.stories.mdx
index 3916e6f2..8483392d 100644
--- a/packages/components/src/Modal/Modal.stories.mdx
+++ b/packages/components/src/Modal/Modal.stories.mdx
@@ -5,6 +5,7 @@ import { Button } from "@jobber/components/Button";
 import { Content } from "@jobber/components/Content";
 import { InputText } from "@jobber/components/InputText";
 import { Text } from "@jobber/components/Text";
+import { Tab, Tabs } from "@jobber/components/Tabs";

 <Meta title="Components/Modal" component={Modal} />

@@ -34,9 +35,23 @@ import { Modal } from "@jobber/components/Modal";
             open={modalOpen}
             onRequestClose={() => setModalOpen(false)}
           >
-            <Content>
-              <Text>It's harder, better, faster, and stronger! 🤖</Text>
-            </Content>
+            <Tabs>
+              <Tab label="Eggs">
+                🍳 Some eggs are laid by female animals of many different
+                species, including birds, reptiles, amphibians, mammals, and
+                fish, and have been eaten by humans for thousands of years.
+              </Tab>
+              <Tab label="Cheese">
+                🧀 Cheese is a dairy product derived from milk that is produced
+                in a wide range of flavors, textures, and forms by coagulation
+                of the milk protein casein.
+              </Tab>
+              <Tab label="Berries">
+                🍓 A berry is a small, pulpy, and often edible fruit. Typically,
+                berries are juicy, rounded, brightly colored, sweet, sour or
+                tart, and do not have a stone or pit.
+              </Tab>
+            </Tabs>
           </Modal>
           <Button label="Open Modal" onClick={() => setModalOpen(true)} />
         </>
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
