### PR TITLE
fix(components-native): Workaround to make dictation work without duplicating the text

### DIFF
--- a/packages/components-native/src/InputText/InputText.tsx
+++ b/packages/components-native/src/InputText/InputText.tsx
@@ -267,6 +267,7 @@ function InputTextInternal(
   ref: Ref<InputTextRef>,
 ) {
   const isAndroid = Platform.OS === "android";
+  const isIOS = Platform.OS === "ios";
 
   const {
     input: inputTransform = identity,
@@ -419,7 +420,13 @@ function InputTextInternal(
   );
 
   function handleChangeText(value: string) {
-    const newValue = outputTransform(value);
+    /**
+     * Replacing the U+FFFC character because it's duplicating text
+     * when dictating on iOS 16.
+     * https://github.com/facebook/react-native/issues/36521#issuecomment-1555421134
+     */
+    const removedIOSCharValue = isIOS ? value.replace(/\uFFFC/g, "") : value;
+    const newValue = outputTransform(removedIOSCharValue);
     setHasMiniLabel(Boolean(newValue));
     onChangeText?.(newValue);
     field.onChange(newValue);


### PR DESCRIPTION
## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- This PR fixes the duplication of text when dictating on an InputText.
This issue is related to this one from react native: https://github.com/facebook/react-native/issues/36521
- Removed the character U+FFFC on iOS on InputText's handleChangeText

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
