### PR TITLE
docs: Move Link component to correct folder

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,8 +1,7 @@
 import { addons } from "@storybook/addons";
 import theme from "./theme";
 import favicon from "./assets/favicon.svg";
-import React from "react";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 
 const link = document.createElement("link");
 link.setAttribute("rel", "shortcut icon");

--- a/packages/components/src/Link/Link.stories.mdx
+++ b/packages/components/src/Link/Link.stories.mdx
@@ -3,7 +3,7 @@ import { Link } from ".";
 
 # Link
 
-<Meta title="Components/Link" component={Link} />
+<Meta title="Components/Text and Typography/Link" component={Link} />
 
 ```ts
 import { Link } from "@jobber/components/Link";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`Link` component was not in a component folder & React imports were not combined


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
