### PR TITLE
refactor(components-native): Make useScreenInformation use headerHeight from Atlantis Context

### DIFF
--- a/packages/components-native/src/Form/context/AtlantisFormContext.tsx
+++ b/packages/components-native/src/Form/context/AtlantisFormContext.tsx
@@ -10,7 +10,6 @@ export const defaultValues = {
     setLocalCache: () => undefined,
     removeLocalCache: () => undefined,
   }),
-  headerHeight: 0,
 };
 
 export const AtlantisFormContext =

--- a/packages/components-native/src/Form/context/types.ts
+++ b/packages/components-native/src/Form/context/types.ts
@@ -30,5 +30,4 @@ export interface AtlantisFormContextProps {
     setLocalCache: (data: TData) => void;
     removeLocalCache: () => void;
   };
-  headerHeight: number;
 }

--- a/packages/components-native/src/Form/hooks/useScreenInformation.ts
+++ b/packages/components-native/src/Form/hooks/useScreenInformation.ts
@@ -1,7 +1,7 @@
 import { useWindowDimensions } from "react-native";
 import { EdgeInsets, useSafeAreaInsets } from "react-native-safe-area-context";
 import { KEYBOARD_TOP_PADDING_AUTO_SCROLL } from "../constants";
-import { useAtlantisFormContext } from "../context";
+import { useAtlantisContext } from "../../AtlantisContext";
 
 interface UseScreenInformation {
   readonly windowHeight: number;
@@ -10,7 +10,7 @@ interface UseScreenInformation {
 }
 
 export function useScreenInformation(): UseScreenInformation {
-  const { headerHeight } = useAtlantisFormContext();
+  const { headerHeight } = useAtlantisContext();
   const windowHeight = useWindowDimensions().height;
   const headerHeightWithPadding =
     headerHeight + KEYBOARD_TOP_PADDING_AUTO_SCROLL;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When migrating `Form`, I created the form context and ended up adding the `headerHeight` to it, but the same property was also added to `AtlantisContext` during the `Menu` migration, so now this value is being used only from `useAtlantisContext`

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `useScreenInformation` now uses `headerHeight` value from `useAtlantisContext`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
