### PR TITLE
refactor(components-native): Remove react-native-localize dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45277,7 +45277,6 @@
         "react-intl": "^6.4.2",
         "react-native-gesture-handler": "^2.10.2",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",
-        "react-native-localize": "^2.2.6",
         "react-native-modalize": "^2.0.13",
         "react-native-portalize": "^1.0.7",
         "react-native-reanimated": "^2.17.0",
@@ -45317,25 +45316,6 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "packages/components-native/node_modules/react-native-localize": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/react-native-localize/-/react-native-localize-2.2.6.tgz",
-      "integrity": "sha512-EZETlC1ZlW/4g6xfsNCwAkAw5BDL2A6zk/08JjFR/GRGxYuKRD7iP1hHn1+h6DEu+xROjPpoNeXfMER2vkTVIQ==",
-      "peerDependencies": {
-        "react": ">=16.8.6",
-        "react-native": ">=0.60.0",
-        "react-native-macos": ">=0.64.0",
-        "react-native-windows": ">=0.62.0"
-      },
-      "peerDependenciesMeta": {
-        "react-native-macos": {
-          "optional": true
-        },
-        "react-native-windows": {
-          "optional": true
-        }
       }
     },
     "packages/components-native/node_modules/react-native-safe-area-context": {

--- a/packages/components-native/package.json
+++ b/packages/components-native/package.json
@@ -46,7 +46,6 @@
     "react-intl": "^6.4.2",
     "react-native-gesture-handler": "^2.10.2",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-localize": "^2.2.6",
     "react-native-modalize": "^2.0.13",
     "react-native-portalize": "^1.0.7",
     "react-native-reanimated": "^2.17.0",

--- a/packages/components-native/src/AtlantisContext/AtlantisContext.tsx
+++ b/packages/components-native/src/AtlantisContext/AtlantisContext.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { createContext, useContext } from "react";
-import RNLocalize from "react-native-localize";
 import { DEFAULT_CURRENCY_SYMBOL } from "../InputCurrency/constants";
 
 export interface AtlantisContextProps {
@@ -53,7 +52,7 @@ export const defaultValues: AtlantisContextProps = {
   dateFormat: "PP",
   // The system time is "p"
   timeFormat: "p",
-  timeZone: RNLocalize.getTimeZone(),
+  timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   isOnline: true,
   onLogError: _ => {
     return;

--- a/packages/components-native/src/InputCurrency/InputCurrency.test.tsx
+++ b/packages/components-native/src/InputCurrency/InputCurrency.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
-import RNLocalize from "react-native-localize";
 import { InputCurrency } from "./InputCurrency";
 import { AtlantisContext, AtlantisContextProps } from "../AtlantisContext";
 
@@ -8,7 +7,7 @@ const mockCurrencySymbol = "£";
 const atlantisContext: AtlantisContextProps = {
   currencySymbol: mockCurrencySymbol,
   timeFormat: "p",
-  timeZone: RNLocalize.getTimeZone(),
+  timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   isOnline: true,
   onLogError: err => {
     return err;

--- a/packages/components-native/src/__mocks__/__mocks.ts
+++ b/packages/components-native/src/__mocks__/__mocks.ts
@@ -1,13 +1,7 @@
 import { MissingTranslationError } from "react-intl";
-import mockRNLocalize from "react-native-localize/mock";
 import * as ReactNative from "react-native";
 import React from "react";
 import { MockModal } from "./MockModal";
-
-jest.mock("react-native-localize", () => ({
-  ...mockRNLocalize,
-  getTimeZone: () => "UTC",
-}));
 
 jest.mock("react-native/Libraries/Modal/Modal", () => MockModal);
 


### PR DESCRIPTION
## Motivations

We were just using one function from `react-native-localize`, and we actually can replace that function call with a native one from `Intl`.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- The default `timezone` value from `AtlantisContext` is now using the timezone from the native `Intl`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
