### PR TITLE
docs: add extra warning on code sandbox when it errors out

### DIFF
--- a/.storybook/components/Playground/Playground.css
+++ b/.storybook/components/Playground/Playground.css
@@ -8,3 +8,16 @@
 .sp-stack {
   min-width: 0;
 }
+
+.sandbox {
+  display: flex;
+}
+
+.localDevNotice {
+  padding: var(--base-unit);
+  background-color: var(--color-warning);
+}
+
+.localDevNotice pre {
+  background-color: var(--color-yellow--light);
+}

--- a/.storybook/components/Playground/Playground.test.tsx
+++ b/.storybook/components/Playground/Playground.test.tsx
@@ -154,6 +154,26 @@ describe("Playground", () => {
       'import { Content } from "@jobber/components/Content";',
     );
   });
+
+  it("should use the parameter code imports when it's available", () => {
+    mockStoryData({
+      // @ts-expect-error - Storybook API types does allow this
+      parameters: {
+        code: {
+          imports: `import { Tabs, Tab } from "@jobber/components/Tab";`,
+        },
+      },
+      sourceCode: `args => <Content>Sup!</Content>`,
+    });
+    const { container } = render(<Playground />);
+
+    expect(container).not.toHaveTextContent(
+      'import { Content } from "@jobber/components/Content";',
+    );
+    expect(container).toHaveTextContent(
+      'import { Tabs, Tab } from "@jobber/components/Tab";',
+    );
+  });
 });
 
 interface MockStoryDataType extends Partial<sbAPI.Story> {
@@ -162,12 +182,13 @@ interface MockStoryDataType extends Partial<sbAPI.Story> {
 
 function mockStoryData({
   sourceCode = "args => <div {...args} />",
+  parameters,
   ...rest
 }: MockStoryDataType) {
   sbAPISpy.mockImplementation(() => ({
     getCurrentStoryData: () => ({
-      parameters: { storySource: { source: sourceCode } },
       ...rest,
+      parameters: { ...parameters, storySource: { source: sourceCode } },
     }),
   }));
 }

--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -1,3 +1,4 @@
+import process from "process";
 import React from "react";
 import { Story, useStorybookApi } from "@storybook/api";
 import {
@@ -40,7 +41,7 @@ export function Playground() {
       {canPreview && (
         <div className="sandbox">
           <SandpackPreview />
-          <PlaygroundWarning />
+          {process.env.NODE_ENV !== "production" && <PlaygroundWarning />}
         </div>
       )}
       <SandpackCodeEditor

--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -7,6 +7,7 @@ import {
 } from "@codesandbox/sandpack-react";
 import dedent from "ts-dedent";
 import "./Playground.css";
+import { PlaygroundWarning } from "./PlaygroundWarning";
 
 export function Playground() {
   const { getCurrentStoryData } = useStorybookApi();
@@ -36,7 +37,12 @@ export function Playground() {
         "/Example.tsx": getExampleJsCode(),
       }}
     >
-      {canPreview && <SandpackPreview />}
+      {canPreview && (
+        <div className="sandbox">
+          <SandpackPreview />
+          <PlaygroundWarning />
+        </div>
+      )}
       <SandpackCodeEditor
         showLineNumbers={true}
         showInlineErrors={true}

--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -99,6 +99,10 @@ function getSourceCode(
 }
 
 function getImportStrings(parameters: Story["parameters"]): string {
+  if (parameters && "code" in parameters && parameters.code?.imports) {
+    return parameters.code.imports;
+  }
+
   if (parameters && "storySource" in parameters) {
     const { componentNames, hookNames } = parseSourceStringForImports(
       parameters.storySource.source,

--- a/.storybook/components/Playground/PlaygroundWarning.tsx
+++ b/.storybook/components/Playground/PlaygroundWarning.tsx
@@ -1,14 +1,10 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useSandpack } from "@codesandbox/sandpack-react";
 import dedent from "ts-dedent";
 
 export function PlaygroundWarning() {
   const { sandpack } = useSandpack();
   const { error } = sandpack;
-
-  useEffect(() => {
-    console.log(error);
-  }, [error]);
 
   if (error?.title === "ModuleNotFoundError") {
     return (

--- a/.storybook/components/Playground/PlaygroundWarning.tsx
+++ b/.storybook/components/Playground/PlaygroundWarning.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect } from "react";
+import { useSandpack } from "@codesandbox/sandpack-react";
+import dedent from "ts-dedent";
+
+export function PlaygroundWarning() {
+  const { sandpack } = useSandpack();
+  const { error } = sandpack;
+
+  useEffect(() => {
+    console.log(error);
+  }, [error]);
+
+  if (error?.title === "ModuleNotFoundError") {
+    return (
+      <div className="localDevNotice">
+        <h2>Well, that didn&apos;t work</h2>
+        <p>
+          <b>If the error within the preview isn&apos;t helpful</b>, there are
+          also other reasons why this would fail.
+        </p>
+
+        <p>1. You&apos;re creating a new component</p>
+        <p>
+          Unfortunately, code sandbox doesn&apos;t support new components as it
+          relies on the production build of the components package. You can help
+          us support this and open a PR for Atlantis.
+        </p>
+
+        <p>2. Auto imports are wrong</p>
+        <p>
+          You can override the auto-import by adding your own
+          <code>code.imports</code> parameter on the storybook meta tag.
+        </p>
+
+        <pre>
+          {dedent`export default {
+            title: ...,
+            component: ...,
+            parameters: {
+              ...,
+              code: {
+                imports: 'import { Component } from "@jobber/components/MyComponent";'
+              },
+            },
+          } as ComponentMeta<>;`}
+        </pre>
+      </div>
+    );
+  }
+
+  return <></>;
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There are a few limitations that would arise the more we enable the sandbox.

- New components won't work since the sandbox uses the production version of atlantis components
- The automatic imports isn't perfect and it will make mistakes eventually so we need to implement an escape hatch

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Override auto imports through parameters.code.imports
- Show extra warning when dealing with missing imports error
  - This only shows up on dev/local

![image](https://github.com/GetJobber/atlantis/assets/15986172/a78ea3bc-9453-4121-bb24-0249507d9234)


### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)

JOB-73908
