### PR TITLE
docs: add IconButton docs

### DIFF
--- a/docs/components/IconButton/IconButton.stories.mdx
+++ b/docs/components/IconButton/IconButton.stories.mdx
@@ -1,0 +1,27 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Figma } from "storybook-addon-designs/blocks";
+import { IconButton } from "@jobber/components-native";
+
+<Meta
+  title="Components/Actions/IconButton/Docs"
+  component={IconButton}
+  parameters={{
+    viewMode: "docs",
+  }}
+/>
+
+# Icon Button
+
+IconButtons are used to create pressable components (buttons) that render an
+Icon. IconButtons are used for navigation between different screens or
+performing core actions.
+
+Please read the [Icon](?path=/docs/components-images-and-icons-icon-docs--page)
+documentation for more information regarding which icons to use.
+
+## Mockup
+
+<Figma
+  collapsable
+  url="https://www.figma.com/file/avvgu5SkbBvS8lGVePBsqO/%F0%9F%92%99-Product%2FMobile?node-id=15033%3A12444"
+/>

--- a/docs/components/IconButton/Mobile.stories.tsx
+++ b/docs/components/IconButton/Mobile.stories.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { IconButton } from "@jobber/components-native";
+
+export default {
+  title: "Components/Actions/IconButton/Mobile",
+  component: IconButton,
+  parameters: {
+    viewMode: "story",
+  },
+} as ComponentMeta<typeof IconButton>;
+
+const BasicTemplate: ComponentStory<typeof IconButton> = args => (
+  <IconButton {...args} />
+);
+
+export const Basic = BasicTemplate.bind({});
+Basic.args = {
+  accessibilityLabel: "New Job",
+  name: "remove",
+  onPress: () => alert("👍"),
+};


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

What's that? Oh yeah, docs migration.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- IconButton docs baby!

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
