### PR TITLE
docs: Allow to PlayGround component to use third party dependencies

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,8 +6,5 @@ packages/design/src/icons/iconStyles.*
 packages/design/icons
 packages/generators/templates
 storybook-static
-!.storybook
-.storybook/*
-!.storybook/components
 
 **/*/*.css.d.ts

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,8 @@ packages/design/src/icons/iconStyles.*
 packages/design/icons
 packages/generators/templates
 storybook-static
+!.storybook
+.storybook/*
+!.storybook/components
 
 **/*/*.css.d.ts

--- a/.storybook/components/Playground/Playground.css
+++ b/.storybook/components/Playground/Playground.css
@@ -15,6 +15,7 @@
 
 .localDevNotice {
   padding: var(--base-unit);
+  overflow-y: scroll;
   background-color: var(--color-warning);
 }
 

--- a/.storybook/components/Playground/Playground.test.tsx
+++ b/.storybook/components/Playground/Playground.test.tsx
@@ -155,25 +155,50 @@ describe("Playground", () => {
     );
   });
 
-  it("should use the parameter code imports when it's available", () => {
+  it("should include the parameter extra imports when it's available", () => {
     mockStoryData({
       // @ts-expect-error - Storybook API types does allow this
       parameters: {
-        code: {
-          imports: `import { Tabs, Tab } from "@jobber/components/Tab";`,
+        previewTabs: {
+          code: {
+            extraImports: { "@jobber/components/Tab": ["Tabs", "Tab"], },
+          },
         },
       },
       sourceCode: `args => <Content>Sup!</Content>`,
     });
     const { container } = render(<Playground />);
 
-    expect(container).not.toHaveTextContent(
+    expect(container).toHaveTextContent(
       'import { Content } from "@jobber/components/Content";',
     );
     expect(container).toHaveTextContent(
       'import { Tabs, Tab } from "@jobber/components/Tab";',
     );
   });
+
+  it("should allow aliases for extra imports parameter", () => {
+    mockStoryData({
+      // @ts-expect-error - Storybook API types does allow this
+      parameters: {
+        previewTabs: {
+          code: {
+            extraImports: {"react-router-dom": [
+          "Route",
+          { name: "BrowserRouter", alias: "Router" },
+          "Switch",
+        ], },
+          },
+        },
+      },
+      sourceCode: `args => <Content>Sup!</Content>`,
+     });
+    const { container } = render(<Playground />);
+
+    expect(container).toHaveTextContent(
+      'import { Route, BrowserRouter as Router, Switch } from "react-router-dom";',
+    );
+  })
 });
 
 interface MockStoryDataType extends Partial<sbAPI.Story> {

--- a/.storybook/components/Playground/Playground.test.tsx
+++ b/.storybook/components/Playground/Playground.test.tsx
@@ -201,7 +201,44 @@ describe("Playground", () => {
     );
 
     expect(container).not.toHaveTextContent(
-      `import { Router } from "@jobber/compponents/Router`,
+      `import { Router } from "@jobber/components/Router`,
+    );
+  });
+
+  it("should allow imports of subcomponents of @jobber/components", () => {
+    mockStoryData({
+      // @ts-expect-error - Storybook API types does allow this
+      parameters: {
+        previewTabs: {
+          code: {
+            extraImports: {
+              "react-router-dom": ["Router"],
+              "@jobber/components/Drawer": ["DrawerGrid"],
+            },
+          },
+        },
+      },
+      sourceCode: `args => (
+        <Router basename="/components/button">
+        <DrawerGrid>
+          <Content>Sup!</Content>
+          <Drawer>
+            <Content>Hello</Content>
+          </Drawer>
+        </DrawerGrid>
+        </Router>
+        )`,
+    });
+    const { container } = render(<Playground />);
+
+    expect(container).toHaveTextContent(
+      'import { DrawerGrid } from "@jobber/components/Drawer";',
+    );
+    expect(container).toHaveTextContent(
+      'import { Drawer } from "@jobber/components/Drawer";',
+    );
+    expect(container).not.toHaveTextContent(
+      'import { DrawerGrid } from "@jobber/components/DrawerGrid";',
     );
   });
 });

--- a/.storybook/components/Playground/Playground.test.tsx
+++ b/.storybook/components/Playground/Playground.test.tsx
@@ -161,7 +161,7 @@ describe("Playground", () => {
       parameters: {
         previewTabs: {
           code: {
-            extraImports: { "@jobber/components/Tab": ["Tabs", "Tab"], },
+            extraImports: { "@jobber/components/Tab": ["Tabs", "Tab"] },
           },
         },
       },
@@ -183,22 +183,27 @@ describe("Playground", () => {
       parameters: {
         previewTabs: {
           code: {
-            extraImports: {"react-router-dom": [
-          "Route",
-          { name: "BrowserRouter", alias: "Router" },
-          "Switch",
-        ], },
+            extraImports: {
+              "react-router-dom": ["Router"],
+            },
           },
         },
       },
-      sourceCode: `args => <Content>Sup!</Content>`,
-     });
+      sourceCode: `args => (
+        <Router basename="/components/button">
+          <Content>Sup!</Content>
+        </Router>)`,
+    });
     const { container } = render(<Playground />);
 
     expect(container).toHaveTextContent(
-      'import { Route, BrowserRouter as Router, Switch } from "react-router-dom";',
+      'import { Router } from "react-router-dom";',
     );
-  })
+
+    expect(container).not.toHaveTextContent(
+      `import { Router } from "@jobber/compponents/Router`,
+    );
+  });
 });
 
 interface MockStoryDataType extends Partial<sbAPI.Story> {

--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -221,7 +221,7 @@ function getExtraDependencyImports(parameters: Story["parameters"]): {
 } {
   const extraImportsParameter: PlaygroundImports =
     parameters?.previewTabs?.code?.extraImports || {};
-  const extraDepedencyImports = Object.entries(
+  const extraDependencyImports = Object.entries(
     extraImportsParameter,
   ).reduce<ExtraImports>(
     (previousValue, entry) => {
@@ -262,8 +262,8 @@ function getExtraDependencyImports(parameters: Story["parameters"]): {
     { importStrings: [], componentNames: [] },
   );
   return {
-    importString: extraDepedencyImports.importStrings.join("\n"),
-    componentNames: extraDepedencyImports.componentNames,
+    importString: extraDependencyImports.importStrings.join("\n"),
+    componentNames: extraDependencyImports.componentNames,
   };
 }
 

--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -12,8 +12,6 @@ import { PlaygroundWarning } from "./PlaygroundWarning";
 import { PlaygroundImports } from "./types";
 import { THIRD_PARTY_PACKAGE_VERSIONS } from "./constants";
 
-
-
 export function Playground() {
   const { getCurrentStoryData } = useStorybookApi();
   const activeStory = getCurrentStoryData() as Story;
@@ -24,7 +22,6 @@ export function Playground() {
   const importsString = getImportStrings(parameters);
   const extraDependencies = getExtraDependencies(parameters);
 
-  // console.warn(extraDeps)
   const canPreview = Boolean(importsString);
   return (
     <SandpackProvider

--- a/.storybook/components/Playground/PlaygroundWarning.tsx
+++ b/.storybook/components/Playground/PlaygroundWarning.tsx
@@ -37,14 +37,16 @@ export function PlaygroundWarning() {
             component: ...,
             parameters: {
               ...,
-              code: {
-                extraImports: {
-                  "react-router-dom": [
-                    "Route",
-                    { name: "BrowserRouter", alias: "Router" },
-                    "Switch",
-                  ],
-                }
+              previewTabs: {
+                code: {
+                  extraImports: {
+                    "react-router-dom": [
+                      "Route",
+                      { name: "BrowserRouter", alias: "Router" },
+                      "Switch",
+                    ],
+                  },
+                },
               },
             },
           } as ComponentMeta<>;`}

--- a/.storybook/components/Playground/PlaygroundWarning.tsx
+++ b/.storybook/components/Playground/PlaygroundWarning.tsx
@@ -25,7 +25,7 @@ export function PlaygroundWarning() {
         <p>2. Extra imports are wrong</p>
         <p>
           You can add extra imports by adding your own
-          <code>code.extraImports</code> parameter on the storybook meta tag.
+          <code>previewTabs.code.extraImports</code> parameter on the storybook meta tag.
           You may need to modify `.storybook/components/Playground/constants.ts`
           to add the dependency to the list of Third-party dependencies usable
           in the `Playground`

--- a/.storybook/components/Playground/PlaygroundWarning.tsx
+++ b/.storybook/components/Playground/PlaygroundWarning.tsx
@@ -22,10 +22,13 @@ export function PlaygroundWarning() {
           us support this and open a PR for Atlantis.
         </p>
 
-        <p>2. Auto imports are wrong</p>
+        <p>2. Extra imports are wrong</p>
         <p>
-          You can override the auto-import by adding your own
-          <code>code.imports</code> parameter on the storybook meta tag.
+          You can add extra imports by adding your own
+          <code>code.extraImports</code> parameter on the storybook meta tag.
+          You may need to modify `.storybook/components/Playground/constants.ts`
+          to add the dependency to the list of Third-party dependencies usable
+          in the `Playground`
         </p>
 
         <pre>
@@ -35,7 +38,13 @@ export function PlaygroundWarning() {
             parameters: {
               ...,
               code: {
-                imports: 'import { Component } from "@jobber/components/MyComponent";'
+                extraImports: {
+                  "react-router-dom": [
+                    "Route",
+                    { name: "BrowserRouter", alias: "Router" },
+                    "Switch",
+                  ],
+                }
               },
             },
           } as ComponentMeta<>;`}

--- a/.storybook/components/Playground/constants.ts
+++ b/.storybook/components/Playground/constants.ts
@@ -1,0 +1,7 @@
+/**
+ *  Dependencies that may be added to a Playground for a story
+ */
+export const THIRD_PARTY_PACKAGE_VERSIONS: Record<string, string> = {
+    "react-router-dom": "^5.3.4",
+
+}

--- a/.storybook/components/Playground/constants.ts
+++ b/.storybook/components/Playground/constants.ts
@@ -2,6 +2,5 @@
  *  Dependencies that may be added to a Playground for a story
  */
 export const THIRD_PARTY_PACKAGE_VERSIONS: Record<string, string> = {
-    "react-router-dom": "^5.3.4",
-
-}
+  "react-router-dom": "^5.3.4",
+};

--- a/.storybook/components/Playground/index.ts
+++ b/.storybook/components/Playground/index.ts
@@ -1,1 +1,2 @@
 export * from "./Playground";
+export * from "./types";

--- a/.storybook/components/Playground/types.ts
+++ b/.storybook/components/Playground/types.ts
@@ -1,0 +1,7 @@
+export type ImportMap = {
+  name: string
+  alias: string
+}
+export interface PlaygroundImports {
+    [dependency: string]: Array<string|ImportMap>;
+}

--- a/.storybook/components/Playground/types.ts
+++ b/.storybook/components/Playground/types.ts
@@ -1,7 +1,7 @@
-export type ImportMap = {
-  name: string
-  alias: string
+export interface ImportMap {
+  name: string;
+  alias: string;
 }
 export interface PlaygroundImports {
-    [dependency: string]: Array<string|ImportMap>;
+  [dependency: string]: Array<string | ImportMap>;
 }

--- a/docs/components/Button/Web.stories.tsx
+++ b/docs/components/Button/Web.stories.tsx
@@ -53,7 +53,18 @@ export const ClientSideRouting = RoutingTemplate.bind({});
 ClientSideRouting.parameters = {
   // Hide this for now. Need some set up to turn the sandbox for this to ON
   // Need to override import dependencies and install react-router-dom on sandbox
-  previewTabs: { code: { hidden: true } },
+  previewTabs: {
+    code: {
+      hidden: false,
+      extraImports: {
+        "react-router-dom": [
+          "Route",
+          { name: "BrowserRouter", alias: "Router" },
+          "Switch",
+        ],
+      },
+    },
+  },
 };
 
 const FormTemplate: ComponentStory<typeof Button> = () => (

--- a/docs/components/Button/Web.stories.tsx
+++ b/docs/components/Button/Web.stories.tsx
@@ -51,8 +51,6 @@ const RoutingTemplate: ComponentStory<typeof Button> = () => (
 
 export const ClientSideRouting = RoutingTemplate.bind({});
 ClientSideRouting.parameters = {
-  // Hide this for now. Need some set up to turn the sandbox for this to ON
-  // Need to override import dependencies and install react-router-dom on sandbox
   previewTabs: {
     code: {
       hidden: false,


### PR DESCRIPTION
Updated tests
Enable third party depedencies in Button's Web storybook

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added the ability to use Third Party dependencies in the Storybook Playground

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

 - Verify `Button`'s web story correctly imports `react-router-dom`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
