### PR TITLE
docs: add Google Analytics tracking

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { addons, types } from "@storybook/addons";
+import { STORY_CHANGED, STORY_ERRORED, STORY_MISSING } from '@storybook/core-events';
 import { SidebarLabel } from "./components/SidebarLabel";
 import theme from "./theme";
 import favicon from "./assets/favicon.svg";
 import { Playground } from "./components/Playground";
+import ReactGA from "react-ga4";
 
 import "./assets/css/manager.css";
 import "@jobber/design/foundation.css";
@@ -37,5 +39,29 @@ addons.register("code/tab", () => {
       `/code/${[refId, storyId].filter(Boolean).join("_")}`,
     match: ({ viewMode }) => viewMode === "code",
     render: ({ key, active }) => <>{active && <Playground key={key} />}</>,
+  });
+});
+
+addons.register('google-analytics', (api) => {
+  ReactGA.initialize("G-V1N3TQVQB5");
+
+  api.on(STORY_CHANGED, () => {
+    const { title, name } = api.getCurrentStoryData();
+    const { path } = api.getUrlState();
+    ReactGA.send({ hitType: "pageview", page: path, title: `${title} - ${name}` });
+  });
+
+  api.on(STORY_ERRORED, ({ description }) => {
+    ReactGA.event({
+      category: "story error",
+      action: description,
+    });
+  });
+
+  api.on(STORY_MISSING, (id) => {
+    ReactGA.event({
+      action: `attempted to render ${id}, but it is missing`,
+      category: "story missing",
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-ga4": "^2.1.0",
         "react-intl": "^6.4.2",
         "react-native": "^0.71.7",
         "react-native-modal-datetime-picker": "^15.0.1",
@@ -38269,6 +38270,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==",
+      "dev": true
     },
     "node_modules/react-hook-form": {
       "version": "7.30.0",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-ga4": "^2.1.0",
     "react-intl": "^6.4.2",
     "react-native": "^0.71.7",
     "react-native-modal-datetime-picker": "^15.0.1",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Because we want to know how much traffic we getting and where

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- installed `react-ga4` package instead of @storybook/google-analytics since it doesn't support GA4.
- Tracked page visits through manager js
- Also included errors since that's what the @storybook/google-analytics does 

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Install this [chrome extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en)
- Ensure your browser extensions that blocks trackers are disabled
- Once done, click the google analytics extension to turn it on. It should have an ON badge
- It should start console logging the infos when viewing pages

Or just trust that it works

<img width="467" alt="image" src="https://github.com/GetJobber/atlantis/assets/15986172/0ee711a2-db0d-4471-9314-ce52b32fc0e1">
<img width="1090" alt="image" src="https://github.com/GetJobber/atlantis/assets/15986172/27f78bdf-0db7-46b9-9919-11e9a5a0cc27">


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
