### PR TITLE
docs(components): Add InputCurrency Docs

### DIFF
--- a/docs/components/InputCurrency/InputCurrency.stories.mdx
+++ b/docs/components/InputCurrency/InputCurrency.stories.mdx
@@ -1,0 +1,9 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="Components/Forms and Inputs/InputCurrency/Docs" />
+
+# Input Currency
+
+InputCurrency is a component that displays a currency input field.
+
+## Design & usage guidelines

--- a/docs/components/InputCurrency/InputCurrency.stories.mdx
+++ b/docs/components/InputCurrency/InputCurrency.stories.mdx
@@ -4,6 +4,15 @@ import { Meta } from "@storybook/addon-docs";
 
 # Input Currency
 
-InputCurrency is a component that displays a currency input field.
+InputCurrency is a component that displays a currency input field with a
+currency symbol.
 
 ## Design & usage guidelines
+
+InputCurrency defaults to displaying a minimum of two decimal places and a
+maximum of five places. If a user continues to try and enter numbers beyond the
+`maxDecimalPlaces` default or set number, the component will automatically round
+the value to the nearest two decimal places.
+
+The users local currency can displayed to them by setting `showCurrencySymbol`
+to true.

--- a/docs/components/InputCurrency/InputCurrency.stories.mdx
+++ b/docs/components/InputCurrency/InputCurrency.stories.mdx
@@ -10,9 +10,9 @@ currency symbol.
 ## Design & usage guidelines
 
 InputCurrency defaults to displaying a minimum of two decimal places and a
-maximum of five places. If a user continues to try and enter numbers beyond the
-`maxDecimalPlaces` default or set number, the component will automatically round
-the value to the nearest two decimal places.
+maximum of five decimal places. If a user continues to try and enter numbers
+beyond the `maxDecimalPlaces` default or set number, the component will
+automatically round the value to the nearest two decimal places.
 
-The users local currency can displayed to them by setting `showCurrencySymbol`
-to true.
+By setting `showCurrencySymbol` to true, the users currency prefix will be
+displayed to them.

--- a/docs/components/InputCurrency/Mobile.stories.tsx
+++ b/docs/components/InputCurrency/Mobile.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { InputCurrency } from "@jobber/components-native";
+
+export default {
+  title: "Components/Forms and Inputs/InputCurrency/Mobile",
+  component: InputCurrency,
+  parameters: {
+    viewMode: "story",
+  },
+} as ComponentMeta<typeof InputCurrency>;
+
+const BasicTemplate: ComponentStory<typeof InputCurrency> = args => (
+  <InputCurrency {...args} />
+);
+
+export const Basic = BasicTemplate.bind({});
+Basic.args = {
+  placeholder: "Unit Price",
+};


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Need to add InputCurrency to the docs!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
