### PR TITLE
docs: allow code tab with no preview for mobile and other improvements

### DIFF
--- a/.storybook/components/Playground/Playground.css
+++ b/.storybook/components/Playground/Playground.css
@@ -9,6 +9,30 @@
   min-width: 0;
 }
 
+.sp-loading {
+  background-color: var(--color-grey--lighter);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0px,
+    rgba(var(--color-white--rgb), 80%) 50%,
+    transparent 100%
+  );
+  background-repeat: no-repeat;
+  background-size: 50% 100%;
+  animation: glimmer 2s infinite linear;
+}
+
+@keyframes glimmer {
+  0%,
+  20% {
+    background-position-x: -100%;
+  }
+
+  100% {
+    background-position-x: 200%;
+  }
+}
+
 .sandbox {
   display: flex;
 }
@@ -21,4 +45,8 @@
 
 .localDevNotice pre {
   background-color: var(--color-yellow--light);
+}
+
+.codeUnavailable ~ #storybook-preview-wrapper {
+  display: block;
 }

--- a/.storybook/components/Playground/Playground.css
+++ b/.storybook/components/Playground/Playground.css
@@ -2,7 +2,7 @@
   display: grid;
   height: 100%;
   grid-template-columns: auto;
-  grid-template-rows: 50% 50%;
+  grid-auto-rows: minmax(50%, auto);
 }
 
 .sp-stack {

--- a/.storybook/components/Playground/Playground.test.tsx
+++ b/.storybook/components/Playground/Playground.test.tsx
@@ -13,12 +13,24 @@ afterEach(() => {
 });
 
 describe("Playground", () => {
+  it("should render a playground", () => {
+    mockStoryData({ sourceCode: "args => <Button />" });
+    const { container, getByTitle } = render(<Playground />);
+
+    expect(container).toHaveTextContent(
+      "export function Example() { return <Button />; }",
+    );
+
+    expect(getByTitle("Sandpack Preview")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("Read-only");
+  });
+
   it("should render a basic read only source code", () => {
     mockStoryData({ sourceCode: "() => <p></p>" });
     const { container } = render(<Playground />);
 
     expect(container).toHaveTextContent(
-      "export function Example() { return <p></p> }",
+      "export function Example() { return <p></p>; }",
     );
     expect(container).toHaveTextContent("Read-only");
   });
@@ -33,6 +45,13 @@ describe("Playground", () => {
     expect(container).toMatchInlineSnapshot(`<div />`);
   });
 
+  it("should render the code unavailable div when it's not a story", () => {
+    mockStoryData({ type: "docs", parent: "design-web" });
+    const { getByTestId } = render(<Playground />);
+
+    expect(getByTestId("code-unavailable")).toBeInTheDocument();
+  });
+
   describe("Props and arg values", () => {
     it("should render the spread arg values", () => {
       mockStoryData({
@@ -42,7 +61,7 @@ describe("Playground", () => {
       const { container } = render(<Playground />);
 
       expect(container).toHaveTextContent(
-        `export function Example() { return <Button size={"large"} /> }`,
+        `export function Example() { return <Button size={"large"} />; }`,
       );
     });
 
@@ -84,9 +103,7 @@ describe("Playground", () => {
       mockStoryData({ args: { data: ["fee", "fi", "fo", "fum"] } });
       const { container } = render(<Playground />);
 
-      expect(container).toHaveTextContent(
-        `data={["fee", "fi", "fo", "fum", ]}`,
-      );
+      expect(container).toHaveTextContent(`data={["fee", "fi", "fo", "fum"]}`);
     });
 
     it("should render an object arg value", () => {
@@ -96,7 +113,7 @@ describe("Playground", () => {
       const { container } = render(<Playground />);
 
       expect(container).toHaveTextContent(
-        `action={{label: "click me", onClick: () => undefined, }}`,
+        `action={{ label: "click me", onClick: () => undefined }}`,
       );
     });
   });
@@ -124,7 +141,7 @@ describe("Playground", () => {
       'import { Button } from "@jobber/components/Button";',
     );
     expect(container).toHaveTextContent(
-      "export function Example() { return <Button /> }",
+      "export function Example() { return <Button />; }",
     );
     expect(container).not.toHaveTextContent("Read-only");
   });
@@ -155,70 +172,71 @@ describe("Playground", () => {
     );
   });
 
-  it("should include the parameter extra imports when it's available", () => {
-    mockStoryData({
-      // @ts-expect-error - Storybook API types does allow this
-      parameters: {
-        previewTabs: {
-          code: {
-            extraImports: { "@jobber/components/Tab": ["Tabs", "Tab"] },
-          },
-        },
-      },
-      sourceCode: `args => <Content>Sup!</Content>`,
-    });
-    const { container } = render(<Playground />);
-
-    expect(container).toHaveTextContent(
-      'import { Content } from "@jobber/components/Content";',
-    );
-    expect(container).toHaveTextContent(
-      'import { Tabs, Tab } from "@jobber/components/Tab";',
-    );
-  });
-
-  it("should allow aliases for extra imports parameter", () => {
-    mockStoryData({
-      // @ts-expect-error - Storybook API types does allow this
-      parameters: {
-        previewTabs: {
-          code: {
-            extraImports: {
-              "react-router-dom": ["Router"],
+  describe("Extra imports", () => {
+    it("should include the parameter extra imports when it's available", () => {
+      mockStoryData({
+        // @ts-expect-error - Storybook API types does allow this
+        parameters: {
+          previewTabs: {
+            code: {
+              extraImports: { "@jobber/components/Tab": ["Tabs", "Tab"] },
             },
           },
         },
-      },
-      sourceCode: `args => (
+        sourceCode: `args => <Content>Sup!</Content>`,
+      });
+      const { container } = render(<Playground />);
+
+      expect(container).toHaveTextContent(
+        'import { Content } from "@jobber/components/Content";',
+      );
+      expect(container).toHaveTextContent(
+        'import { Tabs, Tab } from "@jobber/components/Tab";',
+      );
+    });
+
+    it("should allow aliases for extra imports parameter", () => {
+      mockStoryData({
+        // @ts-expect-error - Storybook API types does allow this
+        parameters: {
+          previewTabs: {
+            code: {
+              extraImports: {
+                "react-router-dom": ["Router"],
+              },
+            },
+          },
+        },
+        sourceCode: `args => (
         <Router basename="/components/button">
           <Content>Sup!</Content>
         </Router>)`,
+      });
+      const { container } = render(<Playground />);
+
+      expect(container).toHaveTextContent(
+        'import { Router } from "react-router-dom";',
+      );
+
+      expect(container).not.toHaveTextContent(
+        `import { Router } from "@jobber/components/Router`,
+      );
     });
-    const { container } = render(<Playground />);
 
-    expect(container).toHaveTextContent(
-      'import { Router } from "react-router-dom";',
-    );
-
-    expect(container).not.toHaveTextContent(
-      `import { Router } from "@jobber/components/Router`,
-    );
-  });
-
-  it("should allow imports of subcomponents of @jobber/components", () => {
-    mockStoryData({
-      // @ts-expect-error - Storybook API types does allow this
-      parameters: {
-        previewTabs: {
-          code: {
-            extraImports: {
-              "react-router-dom": ["Router"],
-              "@jobber/components/Drawer": ["DrawerGrid"],
+    it("should allow imports of subcomponents of @jobber/components", () => {
+      mockStoryData({
+        // @ts-expect-error - Storybook API types does allow this
+        parameters: {
+          previewTabs: {
+            code: {
+              extraImports: {
+                "react-router-dom": ["Router"],
+                "@jobber/components/Drawer": ["DrawerGrid"],
+              },
             },
           },
         },
-      },
-      sourceCode: `args => (
+        sourceCode: `args => (
         <Router basename="/components/button">
         <DrawerGrid>
           <Content>Sup!</Content>
@@ -228,18 +246,35 @@ describe("Playground", () => {
         </DrawerGrid>
         </Router>
         )`,
-    });
-    const { container } = render(<Playground />);
+      });
+      const { container } = render(<Playground />);
 
-    expect(container).toHaveTextContent(
-      'import { DrawerGrid } from "@jobber/components/Drawer";',
-    );
-    expect(container).toHaveTextContent(
-      'import { Drawer } from "@jobber/components/Drawer";',
-    );
-    expect(container).not.toHaveTextContent(
-      'import { DrawerGrid } from "@jobber/components/DrawerGrid";',
-    );
+      expect(container).toHaveTextContent(
+        'import { DrawerGrid } from "@jobber/components/Drawer";',
+      );
+      expect(container).toHaveTextContent(
+        'import { Drawer } from "@jobber/components/Drawer";',
+      );
+      expect(container).not.toHaveTextContent(
+        'import { DrawerGrid } from "@jobber/components/DrawerGrid";',
+      );
+    });
+  });
+
+  describe("Mobile stories", () => {
+    beforeEach(() => {
+      mockStoryData({
+        parent: "components-mobile",
+        sourceCode: "args => <Button />",
+      });
+    });
+
+    it("should only render the code", () => {
+      const { container, queryByTitle } = render(<Playground />);
+
+      expect(container).toHaveTextContent("Read-only");
+      expect(queryByTitle("Sandpack Preview")).not.toBeInTheDocument();
+    });
   });
 });
 
@@ -254,6 +289,8 @@ function mockStoryData({
 }: MockStoryDataType) {
   sbAPISpy.mockImplementation(() => ({
     getCurrentStoryData: () => ({
+      type: "story",
+      parent: "components-web",
       ...rest,
       parameters: { ...parameters, storySource: { source: sourceCode } },
     }),

--- a/.storybook/components/Playground/Playground.test.tsx
+++ b/.storybook/components/Playground/Playground.test.tsx
@@ -46,7 +46,7 @@ describe("Playground", () => {
   });
 
   it("should render the code unavailable div when it's not a story", () => {
-    mockStoryData({ type: "docs", parent: "design-web" });
+    mockStoryData({ type: "docs", title: "Design/Foundation" });
     const { getByTestId } = render(<Playground />);
 
     expect(getByTestId("code-unavailable")).toBeInTheDocument();
@@ -264,7 +264,7 @@ describe("Playground", () => {
   describe("Mobile stories", () => {
     beforeEach(() => {
       mockStoryData({
-        parent: "components-mobile",
+        title: "Components/Mobile",
         sourceCode: "args => <Button />",
       });
     });
@@ -279,6 +279,7 @@ describe("Playground", () => {
 });
 
 interface MockStoryDataType extends Partial<sbAPI.Story> {
+  title?: string;
   sourceCode?: string;
 }
 
@@ -290,7 +291,7 @@ function mockStoryData({
   sbAPISpy.mockImplementation(() => ({
     getCurrentStoryData: () => ({
       type: "story",
-      parent: "components-web",
+      title: "Components/Web",
       ...rest,
       parameters: { ...parameters, storySource: { source: sourceCode } },
     }),

--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -11,6 +11,7 @@ import "./Playground.css";
 import { PlaygroundWarning } from "./PlaygroundWarning";
 import { PlaygroundImports } from "./types";
 import { THIRD_PARTY_PACKAGE_VERSIONS } from "./constants";
+import { formatCode } from "./utils";
 
 export function Playground() {
   const { getCurrentStoryData } = useStorybookApi();
@@ -68,7 +69,9 @@ export function Playground() {
       }
     `;
 
-    return [importsString, exampleComponent].filter(Boolean).join("\n\n");
+    return formatCode(
+      [importsString, exampleComponent].filter(Boolean).join("\n\n"),
+    );
   }
 }
 
@@ -107,8 +110,10 @@ function getSourceCode(
   }
 }
 
-function getImportStrings(parameters: Story["parameters"],
-  isComponentsNative: boolean,): string {
+function getImportStrings(
+  parameters: Story["parameters"],
+  isComponentsNative: boolean,
+): string {
   const extraDepencyImports = getExtraDependencyImports(parameters);
 
   if (parameters && "storySource" in parameters) {
@@ -122,7 +127,11 @@ function getImportStrings(parameters: Story["parameters"],
       ? [getSingleModuleImport("@jobber/components-native", componentNames)]
       : getComponentsImports(componentNames);
 
-    return [getSingleModuleImport("react", hookNames), ...componentImports, extraDepencyImports.importString]
+    return [
+      getSingleModuleImport("react", hookNames),
+      ...componentImports,
+      extraDepencyImports.importString,
+    ]
       .filter(Boolean)
       .join("\n");
   }

--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -76,14 +76,14 @@ export function Playground() {
   }
 }
 
-function getPlaygroundInfo({ parameters, type, parent }: Story) {
-  const isComponentsNative = parent.endsWith("mobile");
+function getPlaygroundInfo({ parameters, type, title }: Story) {
+  const isComponentsNative = title.includes("/Mobile");
   const importsString = getImportStrings(parameters, isComponentsNative);
 
   return {
     isComponentsNative,
     importsString,
-    isComponentStory: type === "story" && parent.startsWith("components"),
+    isComponentStory: type === "story" && title.startsWith("Components/"),
     extraDependencies: getExtraDependencies(parameters),
     canPreview: Boolean(importsString) && !isComponentsNative,
   };

--- a/.storybook/components/Playground/utils.ts
+++ b/.storybook/components/Playground/utils.ts
@@ -1,0 +1,11 @@
+import { format as prettierFormat } from "prettier";
+// Need the parser to be imported like this
+// eslint-disable-next-line import/no-internal-modules
+import parserBabel from "prettier/parser-babel";
+
+export function formatCode(code: string): string {
+  return prettierFormat(code, {
+    parser: "babel",
+    plugins: [parserBabel],
+  });
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -20,7 +20,7 @@ try {
 
 export const parameters = {
   viewMode: "docs",
-  previewTabs: { code: { hidden: true } },
+  previewTabs: { code: { hidden: false } },
   controls: {
     expanded: true,
     sort: "alpha",

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -20,7 +20,7 @@ try {
 
 export const parameters = {
   viewMode: "docs",
-  previewTabs: { code: { hidden: false } },
+  previewTabs: { code: { hidden: true } },
   controls: {
     expanded: true,
     sort: "alpha",

--- a/docs/components/ActionLabel/Mobile.stories.tsx
+++ b/docs/components/ActionLabel/Mobile.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: "Components/Actions/ActionLabel/Mobile",
   parameters: {
     viewMode: "story",
+    previewTabs: { code: { hidden: false } },
   },
   component: ActionLabel,
 } as ComponentMeta<typeof ActionLabel>;

--- a/docs/components/Button/Mobile.stories.tsx
+++ b/docs/components/Button/Mobile.stories.tsx
@@ -7,6 +7,7 @@ export default {
   component: Button,
   parameters: {
     viewMode: "story",
+    previewTabs: { code: { hidden: false } },
   },
 } as ComponentMeta<typeof Button>;
 

--- a/docs/components/ButtonGroup/Mobile.PrimaryAction.stories.tsx
+++ b/docs/components/ButtonGroup/Mobile.PrimaryAction.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: "Components/Actions/ButtonGroup/Mobile/ButtonGroup.PrimaryAction",
   parameters: {
     viewMode: "story",
+    previewTabs: { code: { hidden: false } },
     viewport: { defaultViewport: "mobile1" },
     showNativeOnWebDisclaimer: true,
   },

--- a/docs/components/ButtonGroup/Mobile.SecondaryAction.stories.tsx
+++ b/docs/components/ButtonGroup/Mobile.SecondaryAction.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: "Components/Actions/ButtonGroup/Mobile/ButtonGroup.SecondaryAction",
   parameters: {
     viewMode: "story",
+    previewTabs: { code: { hidden: false } },
     viewport: { defaultViewport: "mobile1" },
     showNativeOnWebDisclaimer: true,
   },

--- a/docs/components/ButtonGroup/Mobile.stories.tsx
+++ b/docs/components/ButtonGroup/Mobile.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: "Components/Actions/ButtonGroup/Mobile",
   parameters: {
     viewMode: "story",
+    previewTabs: { code: { hidden: false } },
     viewport: { defaultViewport: "mobile1" },
     showNativeOnWebDisclaimer: true,
   },

--- a/docs/components/IconButton/Mobile.stories.tsx
+++ b/docs/components/IconButton/Mobile.stories.tsx
@@ -7,6 +7,7 @@ export default {
   component: IconButton,
   parameters: {
     viewMode: "story",
+    previewTabs: { code: { hidden: false } },
   },
 } as ComponentMeta<typeof IconButton>;
 

--- a/docs/components/Text/Mobile.stories.mdx
+++ b/docs/components/Text/Mobile.stories.mdx
@@ -17,7 +17,7 @@ import { Text } from "@jobber/components-native";
         '"640K is more memory than anyone will ever need on a computer" - Not Bill Gates',
     }}
   >
-    {args => <Text {...args} />}
+    {args => <Text {...args}>{args.children}</Text>}
   </Story>
 </Canvas>
 

--- a/docs/components/Text/Web.stories.mdx
+++ b/docs/components/Text/Web.stories.mdx
@@ -17,7 +17,7 @@ import { Text } from "@jobber/components/Text";
         '"640K is more memory than anyone will ever need on a computer" - Not Bill Gates',
     }}
   >
-    {args => <Text {...args} />}
+    {args => <Text {...args}>{args.children}</Text>}
   </Story>
 </Canvas>
 

--- a/packages/components/src/Typography/Typography.stories.mdx
+++ b/packages/components/src/Typography/Typography.stories.mdx
@@ -21,7 +21,7 @@ import { Typography } from "@jobber/components/Typography";
       children: "Just some type here.",
     }}
   >
-    {args => <Typography {...args} />}
+    {args => <Typography {...args}>{args.children}</Typography>}}
   </Story>
 </Canvas>
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- Enable us to show the source code for mobile examples without rendering the preview. This allows consumers to grab the code for the component easily

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Support for playground to render the code snippet without playground ![image](https://github.com/GetJobber/atlantis/assets/15986172/a9e2f58c-495f-4634-a8cc-b74d475b4057)
- Glimmer loading for preview that's still loading ![image](https://github.com/GetJobber/atlantis/assets/15986172/197ea6e8-9503-42d8-9aa1-da0567fa704e)
- Render docs when a code tab shows up for docs ![image](https://github.com/GetJobber/atlantis/assets/15986172/7c655902-e116-44fe-b636-a746bf6bab10)
  - Only happens when we do pull the trigger to turn Code tab ON for everything by default
  -  Note, this closely follows storybook UX with canvas tab being clickable on docs

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
