### PR TITLE
docs: track code tab in GA

### DIFF
--- a/.storybook/components/Playground/Playground.test.tsx
+++ b/.storybook/components/Playground/Playground.test.tsx
@@ -37,6 +37,7 @@ describe("Playground", () => {
 
   it("should render nothing when there's no story data", () => {
     sbAPISpy.mockImplementation(() => ({
+      emit: jest.fn(),
       getCurrentStoryData: () => undefined,
     }));
     const { container } = render(<Playground />);
@@ -289,6 +290,7 @@ function mockStoryData({
   ...rest
 }: MockStoryDataType) {
   sbAPISpy.mockImplementation(() => ({
+    emit: jest.fn(),
     getCurrentStoryData: () => ({
       type: "story",
       title: "Components/Web",

--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -12,10 +12,15 @@ import { PlaygroundWarning } from "./PlaygroundWarning";
 import { PlaygroundImports } from "./types";
 import { THIRD_PARTY_PACKAGE_VERSIONS } from "./constants";
 import { formatCode } from "./utils";
+import { STORY_CHANGED } from '@storybook/core-events';
 
 export function Playground() {
-  const { getCurrentStoryData } = useStorybookApi();
+  const { getCurrentStoryData, emit } = useStorybookApi();
   const activeStory = getCurrentStoryData() as Story | undefined;
+
+  // Emit story changed so GA can track it as a page change. This mimics the
+  // default behaviour of Canvas and Docs tab.
+  emit(STORY_CHANGED);
 
   if (!activeStory) {
     return <></>;

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -47,8 +47,8 @@ addons.register('google-analytics', (api) => {
 
   api.on(STORY_CHANGED, () => {
     const { title, name } = api.getCurrentStoryData();
-    const { path } = api.getUrlState();
-    ReactGA.send({ hitType: "pageview", page: path, title: `${title} - ${name}` });
+    const { path, viewMode } = api.getUrlState();
+    ReactGA.send({ hitType: "pageview", page: path, title: `${title} - ${name} - ${viewMode}` });
   });
 
   api.on(STORY_ERRORED, ({ description }) => {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

It's apparently not tracking page visits to the Code tab. This should fix that.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Emit `STORY_CHANGED` on code tab navigation so GA can track them

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Turn off all browser extensions that blocks tracking
- Install [this](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) and turn it on
  - It should start logging on the console when GA is being triggered
- Going to code tab should trigger it

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
