### PR TITLE
docs(components): Fix Disclosure mobile example

### DIFF
--- a/docs/components/Disclosure/Mobile.stories.tsx
+++ b/docs/components/Disclosure/Mobile.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Disclosure, Text } from "@jobber/components-native";
+import { Disclosure } from "@jobber/components-native";
 
 export default {
   title: "Components/Layouts and Structure/Disclosure/Mobile",
@@ -20,7 +20,7 @@ const BasicTemplate: ComponentStory<typeof Disclosure> = args => {
 
 export const Basic = BasicTemplate.bind({});
 Basic.args = {
-  header: <Text>Advanced Instructions</Text>,
+  header: "Advanced Instructions",
   content: "For every 2 team members you add, your profits will triple.",
   isEmpty: false,
 };


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Having the `<Text>` component within the `args` was breaking to code output in the code tab.  I changed it back to a string.  It can be a Text within `header` in the template however I decided to just keep it simple with a string in `args`.

## Before

![Screenshot 2023-07-21 at 4 51 49 PM](https://github.com/GetJobber/atlantis/assets/104797704/7d3feab5-a0d3-4a40-ba48-6ed494fed2dd)

## After

![Screenshot 2023-07-21 at 4 59 01 PM](https://github.com/GetJobber/atlantis/assets/104797704/2d1acd10-5965-4b05-9001-cfc3230291a0)




---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
