### PR TITLE
fix: include index.tsx on component packing

### DIFF
--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -5,7 +5,7 @@ import postcss from "rollup-plugin-postcss";
 import commonjs from "@rollup/plugin-commonjs";
 
 export default {
-  input: `src/*/index.ts`,
+  input: `src/*/index.{ts,tsx}`,
   plugins: [
     multiInput(),
     typescript({

--- a/scripts/entryPoints.ts
+++ b/scripts/entryPoints.ts
@@ -34,7 +34,7 @@ async function clean() {
 }
 
 async function getEntryPoints() {
-  const indices = await pGlob("./src/*/index.ts");
+  const indices = await pGlob("./src/*/index.{ts,tsx}");
 
   return indices.reduce((entryPoints: EntryPoint[], entryPoint) => {
     const pathParts = entryPoint.split(sep);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Noticed that RecurringSelect isn't being released with the package.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- components rollup to include index.tsx files

#### Production
https://www.npmjs.com/package/@jobber/components?activeTab=code

https://codesandbox.io/s/recurringselect-atlantis-prod-h7fwd3?file=/Example.tsx

![image](https://github.com/GetJobber/atlantis/assets/15986172/9972e2ed-4d71-4a82-8b93-b8b7183c4f67)

![_jobber_components_-_npm](https://github.com/GetJobber/atlantis/assets/15986172/b793ac2c-3d36-44d2-85e2-7f9ad2eff32f)



#### This PR

https://www.npmjs.com/package/@jobber/components/v/4.23.39-include-in.1?activeTab=code

https://codesandbox.io/s/recurrinselect-atlantis-this-pr-735zkz?file=/Example.tsx

![image](https://github.com/GetJobber/atlantis/assets/15986172/3cf5175e-cd23-49ab-92a1-9b7711a86b72)

![_jobber_components_-_npm](https://github.com/GetJobber/atlantis/assets/15986172/4621417f-b014-440d-a5a4-36d17e8babb6)



### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
