### PR TITLE
docs(components): fix InputFile code examples

### DIFF
--- a/docs/components/InputFile/Web.stories.tsx
+++ b/docs/components/InputFile/Web.stories.tsx
@@ -14,18 +14,20 @@ export default {
   component: InputFile,
   parameters: {
     viewMode: "story",
-    options: { showPanel: true },
     previewTabs: {
       code: {
         hidden: false,
+        extraImports: {
+          "@jobber/components/InputFile": [
+            "FileUpload",
+            "InputFile",
+            "updateFiles",
+          ],
+        },
       },
     },
   },
 } as ComponentMeta<typeof InputFile>;
-
-function fetchUploadParams() {
-  return Promise.resolve({ url: "https://httpbin.org/post" });
-}
 
 const StatefulTemplate: ComponentStory<typeof InputFile> = args => {
   const [files, setFiles] = useState<FileUpload[]>([]);
@@ -47,27 +49,44 @@ const StatefulTemplate: ComponentStory<typeof InputFile> = args => {
   }
 };
 
-const VariationsAndSizesTemplate: ComponentStory<typeof InputFile> = () => {
+const VariationsAndSizesTemplate: ComponentStory<typeof InputFile> = args => {
   return (
     <Content>
+      <Heading level={2}>Default</Heading>
+      <InputFile {...args} />
+
       <Heading level={2}>Dropzone</Heading>
-      <InputFile getUploadParams={fetchUploadParams} />
-      <InputFile size="small" getUploadParams={fetchUploadParams} />
+      <InputFile
+        buttonLabel="Base Dropzone Uploader"
+        getUploadParams={fetchUploadParams}
+      />
+      <InputFile
+        size="small"
+        getUploadParams={fetchUploadParams}
+        buttonLabel="Small Dropzone Uploader"
+      />
 
       <Heading level={2}>Button</Heading>
-      <InputFile variation="button" getUploadParams={fetchUploadParams} />
+      <InputFile
+        variation="button"
+        size="base"
+        buttonLabel="Base Button Uploader"
+        getUploadParams={fetchUploadParams}
+      />
       <InputFile
         variation="button"
         size="small"
+        buttonLabel="Small Button Uploader"
         getUploadParams={fetchUploadParams}
       />
     </Content>
   );
+
+  function fetchUploadParams() {
+    return Promise.resolve({ url: "https://httpbin.org/post" });
+  }
 };
 export const VariationsAndSizes = VariationsAndSizesTemplate.bind({});
-VariationsAndSizes.parameters = {
-  options: { showPanel: false },
-};
 
 export const UsingUpdateFiles = StatefulTemplate.bind({});
 UsingUpdateFiles.args = {


### PR DESCRIPTION
## Motivations

Some code tab examples were broken for `InputFile` and the "Variations and Sizes" example didn't behave very nicely, it just hid the controls. 

## Changes

### Changed
- Improved the "Variations and Sizes" example allowing a default to handle the args.  Also stopped hiding the controls since the user can just turn them back on. 

### Fixed
- Code tab is working for all InputFile examples now. 

## Testing
- [x] Confirm the Code sandbox works properly for all examples. 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
