### PR TITLE
feat(components): InputText Props for Autocomplete

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -12,7 +12,15 @@ type OptionCollection = XOR<Option[], GroupOption[]>;
 interface AutocompleteProps
   extends Pick<
     FormFieldProps,
-    "size" | "onBlur" | "onFocus" | "invalid" | "name" | "validations"
+    | "invalid"
+    | "inputRef"
+    | "name"
+    | "onBlur"
+    | "onFocus"
+    | "prefix"
+    | "size"
+    | "suffix"
+    | "validations"
   > {
   /**
    * Initial options to show when user first focuses the Autocomplete
@@ -59,11 +67,8 @@ interface AutocompleteProps
   readonly placeholder: string;
 }
 
-/**
- * Max statements disabled here to make room for the
- * debounce functions.
- */
-// eslint-disable-next-line max-statements
+// Max statements increased to make room for the debounce functions
+/* eslint max-statements: ["error", 14] */
 export function Autocomplete({
   initialOptions = [],
   value,
@@ -76,8 +81,8 @@ export function Autocomplete({
   placeholder,
   onBlur,
   onFocus,
-  name,
   validations,
+  ...inputProps
 }: AutocompleteProps) {
   const [options, setOptions] = useState(initialOptions);
   const [menuVisible, setMenuVisible] = useState(false);
@@ -106,8 +111,8 @@ export function Autocomplete({
         placeholder={placeholder}
         onFocus={handleInputFocus}
         onBlur={handleInputBlur}
-        name={name}
         validations={validations}
+        {...inputProps}
       />
       {menuVisible && (
         <Menu

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -12,8 +12,8 @@ type OptionCollection = XOR<Option[], GroupOption[]>;
 interface AutocompleteProps
   extends Pick<
     FormFieldProps,
-    | "invalid"
     | "inputRef"
+    | "invalid"
     | "name"
     | "onBlur"
     | "onFocus"
@@ -74,7 +74,6 @@ export function Autocomplete({
   value,
   allowFreeForm = true,
   size = undefined,
-  invalid,
   debounce: debounceRate = 300,
   onChange,
   getOptions,
@@ -105,7 +104,6 @@ export function Autocomplete({
       <InputText
         autocomplete={false}
         size={size}
-        invalid={invalid}
         value={inputText}
         onChange={handleInputChange}
         placeholder={placeholder}


### PR DESCRIPTION
## Motivations

The `Autocomplete` component utilizes `InputText` behind the scenes to provide the primary input element that is rendered.

We've encountered a scenario where the following props need to be passed down to the underlying InputText element:

* `suffix` - To style the input with an icon suffix.
* `prefix` - To enable a clear action for the input.
* `inputRef` - A reference to the input element in the DOM so that focus can be activated programatically.


## Changes

This PR exposes the props listed above on `Autocomplete` and forwards them to the `InputText` child. As the current `name` prop is also forwarded to the input, I opted to remove the explicit reference in favour of forwarding the prop via the spread operator.

### Changed

- Add the `suffix`, `prefix` and `inputRef` props to the `Autocomplete` component.

## Testing

The additional props are editable in the [StoryBook documentation](https://feat-autocomplete-props.atlantis.pages.dev/?path=/docs/components-forms-and-inputs-autocomplete-web--basic). Happy to add additional stories to the docs if necessary!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
