### PR TITLE
fix(components): Fix Tabbing on InputDate

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.test.tsx
+++ b/packages/components/src/DatePicker/DatePicker.test.tsx
@@ -158,7 +158,7 @@ describe("Tabbing behavior", () => {
     jest.useRealTimers();
   });
 
-  it("tabbing should not hide the calendar when inline", async () => {
+  it("should not hide the calendar when inline and tabbing", async () => {
     const monthChangeHandler = jest.fn();
     const { queryByText } = render(
       <DatePicker

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -82,6 +82,7 @@ interface DatePickerInlineProps extends BaseDatePickerProps {
 
 type DatePickerProps = XOR<DatePickerModalProps, DatePickerInlineProps>;
 
+// eslint-disable-next-line max-statements
 export function DatePicker({
   onChange,
   onMonthChange,
@@ -119,6 +120,7 @@ export function DatePicker({
   }
 
   const datePickerRef = useRef<ReactDatePicker>(null);
+  useDatePickerTabListener(ref, datePickerRef, open, inline, activator);
 
   return (
     <div className={wrapperClassName} ref={ref}>
@@ -161,20 +163,35 @@ export function DatePicker({
   }
 
   function handleCalendarOpen() {
-    ref.current?.addEventListener("keydown", (event: KeyboardEvent) => {
-      setTimeout(() => {
-        if (
-          event.key === "Tab" &&
-          !ref.current.contains(document.activeElement)
-        ) {
-          datePickerRef.current?.setOpen(false);
-        }
-      }, 0);
-    });
     setOpen(true);
   }
 
   function handleCalendarClose() {
     setOpen(false);
   }
+}
+function useDatePickerTabListener(
+  ref: React.RefObject<HTMLDivElement>,
+  datePickerRef: React.RefObject<ReactDatePicker>,
+  open: boolean,
+  inline: boolean | undefined,
+  activator: DatePickerModalProps["activator"],
+) {
+  useEffect(() => {
+    const handleTabbing = (event: KeyboardEvent) => {
+      setTimeout(() => {
+        const activeElementInDatePicker =
+          ref.current && !ref.current.contains(document.activeElement);
+        if (event.key === "Tab" && activeElementInDatePicker) {
+          datePickerRef.current?.setOpen(false);
+        }
+      }, 0);
+    };
+    if (!inline && open && activator) {
+      ref.current?.addEventListener("keydown", handleTabbing);
+    }
+    return () => {
+      ref.current?.removeEventListener("keydown", handleTabbing);
+    };
+  }, [open, datePickerRef, ref, activator]);
 }

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
 import { XOR } from "ts-xor";
@@ -118,6 +118,8 @@ export function DatePicker({
     useEffect(focusOnSelectedDate, [open]);
   }
 
+  const datePickerRef = useRef<ReactDatePicker>(null);
+
   return (
     <div className={wrapperClassName} ref={ref}>
       <ReactDatePicker
@@ -127,9 +129,11 @@ export function DatePicker({
         inline={inline}
         disabled={disabled}
         readOnly={readonly}
+        enableTabLoop={false}
         onChange={handleChange}
         maxDate={maxDate}
         minDate={minDate}
+        ref={datePickerRef}
         useWeekdaysShort={true}
         customInput={
           <DatePickerActivator activator={activator} fullWidth={fullWidth} />
@@ -157,6 +161,16 @@ export function DatePicker({
   }
 
   function handleCalendarOpen() {
+    ref.current?.addEventListener("keydown", (event: KeyboardEvent) => {
+      setTimeout(() => {
+        if (
+          event.key === "Tab" &&
+          !ref.current.contains(document.activeElement)
+        ) {
+          datePickerRef.current?.setOpen(false);
+        }
+      }, 0);
+    });
     setOpen(true);
   }
 

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -126,7 +126,7 @@ it("doesn't fire onChange when the new value is invalid", async () => {
   expect(changeHandler).toHaveBeenCalledTimes(0);
 });
 
-describe("tabbing accessibility", () => {
+describe("Tabbing behavior", () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -136,23 +136,20 @@ describe("tabbing accessibility", () => {
   it("should hide the calendar when focus is lost via tabbing", async () => {
     const date = "11/22/1963";
     const changeHandler = jest.fn();
+    const expectedTabCount = 5;
     const { getByDisplayValue, findByText, queryByText } = render(
       <InputDate value={new Date(date)} onChange={changeHandler} />,
     );
 
     const form = getByDisplayValue(date);
     fireEvent.focus(form);
-
+    // https://github.com/testing-library/react-testing-library/issues/276#issuecomment-492469539
+    form.focus();
     await findByText("22");
-
     act(() => {
-      userEvent.tab();
-      userEvent.tab();
-      userEvent.tab();
-      userEvent.tab();
-      userEvent.tab();
-      userEvent.tab();
-      userEvent.tab();
+      for (let i = 0; i < expectedTabCount; i++) {
+        userEvent.tab();
+      }
       jest.runOnlyPendingTimers();
     });
 

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { InputDate } from ".";
 
 afterEach(cleanup);
@@ -123,4 +124,38 @@ it("doesn't fire onChange when the new value is invalid", async () => {
     target: { value: badInput },
   });
   expect(changeHandler).toHaveBeenCalledTimes(0);
+});
+
+describe("tabbing accessibility", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+  it("should hide the calendar when focus is lost via tabbing", async () => {
+    const date = "11/22/1963";
+    const changeHandler = jest.fn();
+    const { getByDisplayValue, findByText, queryByText } = render(
+      <InputDate value={new Date(date)} onChange={changeHandler} />,
+    );
+
+    const form = getByDisplayValue(date);
+    fireEvent.focus(form);
+
+    await findByText("22");
+
+    act(() => {
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(queryByText("22")).toBeNull();
+  });
 });


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There are issue with keyboard behavior
- Tabbing will never leave the date picker while open
- With the enableTabLoop disabled, the date picker does not close when losing focus

## Changes

Added a listener to close the datepicker on tab press if none of the elements in the date picker, including the input or custom activator, are the currently focused element.
<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
Close on Tab press.


### Changed
Consecutive Tab presses no longer loop, locked in the open date picker.


### Deprecated

N/A

### Removed

Technically removed the debatable behavior of keeping focus trapped in the open dialog. There are arguments for that pattern even if I personally don't love it.
https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/


### Fixed

Inability to Tab out of date picker to close.

### Security
N/A

## Testing
**DatePicker**
As a standalone component, invoke it with your activator. Give focus to your activator with the keyboard which should immediately open the date picker.

Tab through however many elements separate your current focus position and the date picker. Be aware this can be anywhere between 0 and N elements depending entirely on your custom input/activator. 

For example the DatePicker "Basic" example will immediately put focus on a day in the calendar, meaning the next tab will close it.

Tabbing out of the input/activator should keep the DatePicker open. Shift tabbing focus entirely out of both the picker and activator should close the picker. Tabbing past the Next/Previous month buttons and the days which are treated as a single tabbable group should also close the date picker.

**Input Date**
Pretty much the same thing as above except with InputDate we know what structure to expect and starting from the input it should take 5 tabs to lose focus in the foward direction.

Focus the input with keyboard, once again launching the picker. Tab again to focus the icon within the initial input. Tab again to focus the picker and beyond to close it. Same idea for Shift Tab, blurring away from the initial input should also close the picker.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
