### PR TITLE
fix(components): Only render the label element if a placeholder value has been provided

### DIFF
--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -83,15 +83,20 @@ export function FormFieldWrapper({
       <div className={wrapperClasses} style={wrapperInlineStyle}>
         {prefix?.icon && <AffixIcon {...prefix} size={size} />}
         <div className={styles.inputWrapper}>
-          <label
-            className={styles.label}
-            htmlFor={identifier}
-            style={
-              prefixRef?.current || suffixRef?.current ? labelStyle : undefined
-            }
-          >
-            {placeholder}
-          </label>
+          {placeholder && (
+            <label
+              className={styles.label}
+              htmlFor={identifier}
+              style={
+                prefixRef?.current || suffixRef?.current
+                  ? labelStyle
+                  : undefined
+              }
+            >
+              {placeholder}
+            </label>
+          )}
+
           {prefix?.label && <AffixLabel {...prefix} labelRef={prefixRef} />}
           <div className={styles.childrenWrapper}>{children}</div>
           {suffix?.label && (

--- a/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
+++ b/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
@@ -8,10 +8,6 @@ exports[`FormField when small renders 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440005"
-      />
       <div
         class="childrenWrapper"
       >
@@ -35,10 +31,6 @@ exports[`FormField with no props renders 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440001"
-      />
       <div
         class="childrenWrapper"
       >

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -14,10 +14,6 @@ it("renders an input type number", () => {
         <div
           class="inputWrapper"
         >
-          <label
-            class="label"
-            for="123e4567-e89b-12d3-a456-426655440001"
-          />
           <div
             class="childrenWrapper"
           >

--- a/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
+++ b/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
@@ -8,10 +8,6 @@ exports[`<InputPassword /> renders an input type password 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440001"
-      />
       <div
         class="childrenWrapper"
       >

--- a/packages/components/src/InputTime/InputTime.test.tsx
+++ b/packages/components/src/InputTime/InputTime.test.tsx
@@ -15,10 +15,6 @@ it("renders a InputTime", () => {
         <div
           class="inputWrapper"
         >
-          <label
-            class="label"
-            for="123e4567-e89b-12d3-a456-426655440001"
-          />
           <div
             class="childrenWrapper"
           >
@@ -47,10 +43,6 @@ it("renders an initial time when given 'defaultValue'", () => {
         <div
           class="inputWrapper"
         >
-          <label
-            class="label"
-            for="123e4567-e89b-12d3-a456-426655440007"
-          />
           <div
             class="childrenWrapper"
           >
@@ -79,10 +71,6 @@ it("renders correctly in a readonly state", () => {
         <div
           class="inputWrapper"
         >
-          <label
-            class="label"
-            for="123e4567-e89b-12d3-a456-426655440009"
-          />
           <div
             class="childrenWrapper"
           >
@@ -112,10 +100,6 @@ it("adds a error border when invalid", () => {
         <div
           class="inputWrapper"
         >
-          <label
-            class="label"
-            for="123e4567-e89b-12d3-a456-426655440015"
-          />
           <div
             class="childrenWrapper"
           >
@@ -143,10 +127,6 @@ it("should set the value when given 'value' and 'onChange'", () => {
         <div
           class="inputWrapper"
         >
-          <label
-            class="label"
-            for="123e4567-e89b-12d3-a456-426655440021"
-          />
           <div
             class="childrenWrapper"
           >

--- a/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
@@ -8,10 +8,6 @@ exports[`renders a Select with many options 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440005"
-      />
       <div
         class="childrenWrapper"
       >
@@ -61,10 +57,6 @@ exports[`renders a Select with no options 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440001"
-      />
       <div
         class="childrenWrapper"
       >
@@ -101,10 +93,6 @@ exports[`renders a Select with one option 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440003"
-      />
       <div
         class="childrenWrapper"
       >
@@ -145,10 +133,6 @@ exports[`renders correctly as large 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440009"
-      />
       <div
         class="childrenWrapper"
       >
@@ -189,10 +173,6 @@ exports[`renders correctly as small 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440007"
-      />
       <div
         class="childrenWrapper"
       >
@@ -233,10 +213,6 @@ exports[`renders correctly when disabled 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440011"
-      />
       <div
         class="childrenWrapper"
       >
@@ -278,10 +254,6 @@ exports[`renders correctly when invalid 1`] = `
     <div
       class="inputWrapper"
     >
-      <label
-        class="label"
-        for="123e4567-e89b-12d3-a456-426655440013"
-      />
       <div
         class="childrenWrapper"
       >


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
The value that is provided to the `placeholder` prop is the value that we use for our label element. This value is not required and there are use cases where we aren't providing a placeholder value when using inputs such as when we want an [inline label](https://atlantis.getjobber.com/?path=/code/components-forms-and-inputs-inputvalidation-web--basic). 

Because we weren't conditionally rendering the label element in form filed wrapper only if a placeholder value was provided this element is still being created as an empty label when there is no placeholder value. See markup below with empty label:
<img width="925" alt="image" src="https://github.com/GetJobber/atlantis/assets/9436525/48b8445a-9533-47f3-bdba-6fef4d0d453d">

This will cause accessibility concerns and is semantically messy.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
I have added a small change to only add this label element when there is a placeholder value present.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
