### PR TITLE
fix(components): Prevent Open on DatePicker Focus

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -129,6 +129,7 @@ export function DatePicker({
         readOnly={readonly}
         onChange={handleChange}
         maxDate={maxDate}
+        preventOpenOnFocus={true}
         minDate={minDate}
         useWeekdaysShort={true}
         customInput={

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useRef, useState } from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
 import { XOR } from "ts-xor";
@@ -112,7 +112,6 @@ export function DatePicker({
   const datePickerClassNames = classnames(styles.datePicker, {
     [styles.inline]: inline,
   });
-  const { pickerRef } = useEscapeKeyToCloseDatePicker(open, ref);
 
   if (smartAutofocus) {
     useRefocusOnActivator(open);
@@ -122,7 +121,6 @@ export function DatePicker({
   return (
     <div className={wrapperClassName} ref={ref}>
       <ReactDatePicker
-        ref={pickerRef}
         calendarClassName={datePickerClassNames}
         showPopperArrow={false}
         selected={selected}
@@ -166,29 +164,4 @@ export function DatePicker({
   function handleCalendarClose() {
     setOpen(false);
   }
-}
-
-function useEscapeKeyToCloseDatePicker(
-  open: boolean,
-  ref: React.RefObject<HTMLDivElement>,
-): { pickerRef: React.RefObject<ReactDatePicker> } {
-  const pickerRef = useRef<ReactDatePicker>(null);
-
-  const escFunction = (event: KeyboardEvent) => {
-    if (event.key === "Escape" && open) {
-      pickerRef.current?.setOpen(false);
-      event.stopPropagation();
-    }
-  };
-  useEffect(() => {
-    ref.current?.addEventListener("keydown", escFunction);
-
-    return () => {
-      ref.current?.removeEventListener("keydown", escFunction);
-    };
-  }, [open, ref, pickerRef]);
-
-  return {
-    pickerRef,
-  };
 }

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
 import { XOR } from "ts-xor";
@@ -112,6 +112,7 @@ export function DatePicker({
   const datePickerClassNames = classnames(styles.datePicker, {
     [styles.inline]: inline,
   });
+  const { pickerRef } = useEscapeKeyToCloseDatePicker(open, ref);
 
   if (smartAutofocus) {
     useRefocusOnActivator(open);
@@ -121,6 +122,7 @@ export function DatePicker({
   return (
     <div className={wrapperClassName} ref={ref}>
       <ReactDatePicker
+        ref={pickerRef}
         calendarClassName={datePickerClassNames}
         showPopperArrow={false}
         selected={selected}
@@ -164,4 +166,29 @@ export function DatePicker({
   function handleCalendarClose() {
     setOpen(false);
   }
+}
+
+function useEscapeKeyToCloseDatePicker(
+  open: boolean,
+  ref: React.RefObject<HTMLDivElement>,
+): { pickerRef: React.RefObject<ReactDatePicker> } {
+  const pickerRef = useRef<ReactDatePicker>(null);
+
+  const escFunction = (event: KeyboardEvent) => {
+    if (event.key === "Escape" && open) {
+      pickerRef.current?.setOpen(false);
+      event.stopPropagation();
+    }
+  };
+  useEffect(() => {
+    ref.current?.addEventListener("keydown", escFunction);
+
+    return () => {
+      ref.current?.removeEventListener("keydown", escFunction);
+    };
+  }, [open, ref, pickerRef]);
+
+  return {
+    pickerRef,
+  };
 }

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -134,13 +134,13 @@ it("doesn't display the calendar when input is focused with keyboard", () => {
   const { queryByText, getByDisplayValue } = render(
     <InputDate value={new Date(date)} onChange={changeHandler} />,
   );
-  const form = getByDisplayValue(date);
+  const input = getByDisplayValue(date);
 
   act(() => {
-    fireEvent.focus(form);
+    fireEvent.focus(input);
   });
 
-  expect(queryByText("15")).toBeNull();
+  expect(queryByText("15")).not.toBeInTheDocument();
 });
 it("doesn't display the calendar when calendar button is focused with keyboard", () => {
   const date = "11/11/2011";
@@ -148,13 +148,13 @@ it("doesn't display the calendar when calendar button is focused with keyboard",
   const { queryByText, getByRole } = render(
     <InputDate value={new Date(date)} onChange={changeHandler} />,
   );
-  const form = getByRole("button");
+  const calendarButton = getByRole("button");
 
   act(() => {
-    fireEvent.focus(form);
+    fireEvent.focus(calendarButton);
   });
 
-  expect(queryByText("15")).toBeNull();
+  expect(queryByText("15")).not.toBeInTheDocument();
 });
 
 it("displays the calendar when button is pressed", () => {
@@ -169,7 +169,7 @@ it("displays the calendar when button is pressed", () => {
     fireEvent.click(calendarButton);
   });
 
-  expect(getByText("15")).toBeDefined();
+  expect(getByText("15")).toBeInTheDocument();
 });
 
 it("displays the calendar when input is focused with a click", () => {
@@ -178,11 +178,11 @@ it("displays the calendar when input is focused with a click", () => {
   const { getByText, getByDisplayValue } = render(
     <InputDate value={new Date(date)} onChange={changeHandler} />,
   );
-  const form = getByDisplayValue(date);
+  const input = getByDisplayValue(date);
 
   act(() => {
-    fireEvent.click(form);
+    fireEvent.click(input);
   });
 
-  expect(getByText("15")).toBeDefined();
+  expect(getByText("15")).toBeInTheDocument();
 });

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { InputDate } from ".";
 
 afterEach(cleanup);
@@ -16,12 +16,14 @@ it("fires onChange with the new value when you click a date", () => {
   const date = "11/11/2011";
   const newDate = "11/15/2011";
   const changeHandler = jest.fn();
-  const { getByDisplayValue, getByText } = render(
+  const { getByText, getByRole } = render(
     <InputDate value={new Date(date)} onChange={changeHandler} />,
   );
+  const calendarButton = getByRole("button");
 
-  const form = getByDisplayValue(date);
-  fireEvent.focus(form);
+  act(() => {
+    fireEvent.click(calendarButton);
+  });
 
   const selectDate = getByText("15");
   fireEvent.click(selectDate);
@@ -32,7 +34,7 @@ it("shouldn't call onChange with the new value when you click a disabled date", 
   const minDate = "11/9/2011";
   const maxDate = "11/15/2011";
   const changeHandler = jest.fn();
-  const { getByDisplayValue, getByText } = render(
+  const { getByRole, getByText } = render(
     <InputDate
       minDate={new Date(minDate)}
       maxDate={new Date(maxDate)}
@@ -40,9 +42,10 @@ it("shouldn't call onChange with the new value when you click a disabled date", 
       onChange={changeHandler}
     />,
   );
-
-  const form = getByDisplayValue(date);
-  fireEvent.focus(form);
+  const calendarButton = getByRole("button");
+  act(() => {
+    fireEvent.click(calendarButton);
+  });
 
   const selectDate1 = getByText("7");
   fireEvent.click(selectDate1);
@@ -123,4 +126,32 @@ it("doesn't fire onChange when the new value is invalid", async () => {
     target: { value: badInput },
   });
   expect(changeHandler).toHaveBeenCalledTimes(0);
+});
+
+it("doesn't display the calendar when input is focused", () => {
+  const date = "11/11/2011";
+  const changeHandler = jest.fn();
+  const { queryByText, getByDisplayValue } = render(
+    <InputDate value={new Date(date)} onChange={changeHandler} />,
+  );
+  const form = getByDisplayValue(date);
+  act(() => {
+    fireEvent.focus(form);
+  });
+
+  expect(queryByText("15")).toBeNull();
+});
+
+it("displays the calendar when button is pressed", () => {
+  const date = "11/11/2011";
+  const changeHandler = jest.fn();
+  const { getByText, getByRole } = render(
+    <InputDate value={new Date(date)} onChange={changeHandler} />,
+  );
+  const calendarButton = getByRole("button");
+  act(() => {
+    fireEvent.click(calendarButton);
+  });
+
+  expect(getByText("15")).toBeDefined();
 });

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -128,13 +128,28 @@ it("doesn't fire onChange when the new value is invalid", async () => {
   expect(changeHandler).toHaveBeenCalledTimes(0);
 });
 
-it("doesn't display the calendar when input is focused", () => {
+it("doesn't display the calendar when input is focused with keyboard", () => {
   const date = "11/11/2011";
   const changeHandler = jest.fn();
   const { queryByText, getByDisplayValue } = render(
     <InputDate value={new Date(date)} onChange={changeHandler} />,
   );
   const form = getByDisplayValue(date);
+
+  act(() => {
+    fireEvent.focus(form);
+  });
+
+  expect(queryByText("15")).toBeNull();
+});
+it("doesn't display the calendar when calendar button is focused with keyboard", () => {
+  const date = "11/11/2011";
+  const changeHandler = jest.fn();
+  const { queryByText, getByRole } = render(
+    <InputDate value={new Date(date)} onChange={changeHandler} />,
+  );
+  const form = getByRole("button");
+
   act(() => {
     fireEvent.focus(form);
   });
@@ -149,8 +164,24 @@ it("displays the calendar when button is pressed", () => {
     <InputDate value={new Date(date)} onChange={changeHandler} />,
   );
   const calendarButton = getByRole("button");
+
   act(() => {
     fireEvent.click(calendarButton);
+  });
+
+  expect(getByText("15")).toBeDefined();
+});
+
+it("displays the calendar when input is focused with a click", () => {
+  const date = "11/11/2011";
+  const changeHandler = jest.fn();
+  const { getByText, getByDisplayValue } = render(
+    <InputDate value={new Date(date)} onChange={changeHandler} />,
+  );
+  const form = getByDisplayValue(date);
+
+  act(() => {
+    fireEvent.click(form);
   });
 
   expect(getByText("15")).toBeDefined();

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -69,22 +69,24 @@ export function InputDate(inputProps: InputDateProps) {
         value && formFieldActionsRef.current?.setValue(value);
 
         return (
-          <FormField
-            {...newActivatorProps}
-            {...inputProps}
-            value={value}
-            onChange={(_, event) => onChange && onChange(event)}
-            onBlur={() => {
-              inputProps.onBlur && inputProps.onBlur();
-              activatorProps.onBlur && activatorProps.onBlur();
-            }}
-            onFocus={() => {
-              inputProps.onFocus && inputProps.onFocus();
-              activatorProps.onFocus && activatorProps.onFocus();
-            }}
-            actionsRef={formFieldActionsRef}
-            suffix={suffix}
-          />
+          <div onClick={onClick}>
+            <FormField
+              {...newActivatorProps}
+              {...inputProps}
+              value={value}
+              onChange={(_, event) => onChange && onChange(event)}
+              onBlur={() => {
+                inputProps.onBlur && inputProps.onBlur();
+                activatorProps.onBlur && activatorProps.onBlur();
+              }}
+              onFocus={() => {
+                inputProps.onFocus && inputProps.onFocus();
+                activatorProps.onFocus && activatorProps.onFocus();
+              }}
+              actionsRef={formFieldActionsRef}
+              suffix={suffix}
+            />
+          </div>
         );
       }}
     />

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -69,6 +69,7 @@ export function InputDate(inputProps: InputDateProps) {
         value && formFieldActionsRef.current?.setValue(value);
 
         return (
+          // We prevent the picker from opening on focus for keyboard navigation, so to maintain a good UX for mouse users we want to open the picker on click
           <div onClick={onClick}>
             <FormField
               {...newActivatorProps}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There's an undesirable flow with the InputDate where tabbing over the input opens the picker, then the tabs are trapped within it, and the only way to close it is to make a selection. This can be annoying if you didn't want to change the date and only wanted to tab past the InputDate.



## Changes



### Added

N/A

### Changed
Set the preventOpenOnFocus prop to true, making it so that you may interact with the input - perhaps editing the date text without opening the picker or even just tab past it. If you wish to open the picker you must tab onto the button and press enter, alternatively with the `InputDate` component specifically, **clicking** on the input will also launch the picker. This reduces friction for mouse users, allowing them to quick open and close the picker.

This `preventOpenOnFocus` behavior also applies to custom activators for DatePicker where you must either click on say the button, or give it focus with the keyboard and then press enter or spacebar.

Worth mentioning that this change did cause tests to break and required updating since they expected focusing the input to have opened the dialog.


### Deprecated

N/A

### Removed

Removed the open on focus behavior.

### Fixed

Pretty much the same thing as "Changed" depending on how you feel about this functionality it could be classified as either one.

### Security

N/A

## Testing

**InputDate**
Give focus to the input with the keyboard, see that the picker does not open. Tab again to give focus to the calendar button contained inside the input, activate it with enter/space. See that the calendar picker opens and can only be closed by either picking a date or using the escape key. Tabs will remain trapped in the dialog.

If using a mouse, click on the input. It **should** open the picker. Click on the button, it should also open the picker. Same conditions to close, but clicking outside of it will also close it.

**DatePicker**

Same thing as InputDate except now you must click on or otherwise activate your custom activator. The docs have examples of a button.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
