### PR TITLE
fix(components): Prevent Closing Parent on DatePicker ESC

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.test.tsx
+++ b/packages/components/src/DatePicker/DatePicker.test.tsx
@@ -105,6 +105,37 @@ it("should call onMonthChange when the user switches month", async () => {
   expect(monthChangeHandler).toHaveBeenCalledWith(expect.any(Date));
 });
 
+describe("ESC key behavior", () => {
+  const handleEscape = jest.fn();
+  const handleKeyDown = (e: any) => e.key === "Escape" && handleEscape();
+  beforeEach(() => {
+    window.addEventListener("keydown", handleKeyDown);
+  });
+  afterEach(() => {
+    window.removeEventListener("keydown", handleKeyDown);
+  });
+  it("should not trigger parent ESC listener when closed with ESC key", async () => {
+    const { getByRole, queryByRole } = render(
+      <div onKeyDown={handleKeyDown}>
+        <DatePicker selected={new Date()} onChange={jest.fn()} />
+      </div>,
+    );
+    // Open the picker
+    const button = getByRole("button", { name: /open datepicker/i });
+    fireEvent.click(button);
+
+    const nextMonthButton = getByRole("button", { name: /next month/i });
+    nextMonthButton.focus();
+    // Close the picker with ESC
+    fireEvent.keyDown(nextMonthButton, { key: "Escape", code: "Escape" });
+
+    expect(
+      queryByRole("button", { name: /next month/i }),
+    ).not.toBeInTheDocument();
+    expect(handleEscape).not.toHaveBeenCalled();
+  });
+});
+
 describe("Ensure ReactDatePicker CSS class names exists", () => {
   it("should have the click outside class", async () => {
     const { getByRole } = render(<ReactDatePicker onChange={jest.fn} />);

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -176,6 +176,8 @@ function useEscapeKeyToCloseDatePicker(
 
   const escFunction = (event: KeyboardEvent) => {
     if (event.key === "Escape" && open) {
+      // Close the picker ourselves and prevent propagation so that ESC presses with the picker open
+      // do not close parent elements that may also be listening for ESC presses such as Modals
       pickerRef.current?.setOpen(false);
       event.stopPropagation();
     }

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
 import { XOR } from "ts-xor";
@@ -112,6 +112,7 @@ export function DatePicker({
   const datePickerClassNames = classnames(styles.datePicker, {
     [styles.inline]: inline,
   });
+  const { pickerRef } = useEscapeKeyToCloseDatePicker(open, ref);
 
   if (smartAutofocus) {
     useRefocusOnActivator(open);
@@ -121,6 +122,7 @@ export function DatePicker({
   return (
     <div className={wrapperClassName} ref={ref}>
       <ReactDatePicker
+        ref={pickerRef}
         calendarClassName={datePickerClassNames}
         showPopperArrow={false}
         selected={selected}
@@ -163,4 +165,29 @@ export function DatePicker({
   function handleCalendarClose() {
     setOpen(false);
   }
+}
+
+function useEscapeKeyToCloseDatePicker(
+  open: boolean,
+  ref: React.RefObject<HTMLDivElement>,
+): { pickerRef: React.RefObject<ReactDatePicker> } {
+  const pickerRef = useRef<ReactDatePicker>(null);
+
+  const escFunction = (event: KeyboardEvent) => {
+    if (event.key === "Escape" && open) {
+      pickerRef.current?.setOpen(false);
+      event.stopPropagation();
+    }
+  };
+  useEffect(() => {
+    ref.current?.addEventListener("keydown", escFunction);
+
+    return () => {
+      ref.current?.removeEventListener("keydown", escFunction);
+    };
+  }, [open, ref, pickerRef]);
+
+  return {
+    pickerRef,
+  };
 }

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { InputDate } from ".";
 import { Modal } from "../Modal";
 import { Button } from "../Button";
@@ -24,9 +24,7 @@ it("fires onChange with the new value when you click a date", () => {
   );
   const calendarButton = getByRole("button");
 
-  act(() => {
-    fireEvent.click(calendarButton);
-  });
+  fireEvent.click(calendarButton);
 
   const selectDate = getByText("15");
   fireEvent.click(selectDate);
@@ -46,9 +44,7 @@ it("shouldn't call onChange with the new value when you click a disabled date", 
     />,
   );
   const calendarButton = getByRole("button");
-  act(() => {
-    fireEvent.click(calendarButton);
-  });
+  fireEvent.click(calendarButton);
 
   const selectDate1 = getByText("7");
   fireEvent.click(selectDate1);
@@ -139,9 +135,7 @@ it("doesn't display the calendar when input is focused with keyboard", () => {
   );
   const input = getByDisplayValue(date);
 
-  act(() => {
-    fireEvent.focus(input);
-  });
+  fireEvent.focus(input);
 
   expect(queryByText("15")).not.toBeInTheDocument();
 });
@@ -153,9 +147,7 @@ it("doesn't display the calendar when calendar button is focused with keyboard",
   );
   const calendarButton = getByRole("button");
 
-  act(() => {
-    fireEvent.focus(calendarButton);
-  });
+  fireEvent.focus(calendarButton);
 
   expect(queryByText("15")).not.toBeInTheDocument();
 });
@@ -168,9 +160,7 @@ it("displays the calendar when button is pressed", () => {
   );
   const calendarButton = getByRole("button");
 
-  act(() => {
-    fireEvent.click(calendarButton);
-  });
+  fireEvent.click(calendarButton);
 
   expect(getByText("15")).toBeInTheDocument();
 });
@@ -183,9 +173,7 @@ it("displays the calendar when input is focused with a click", () => {
   );
   const input = getByDisplayValue(date);
 
-  act(() => {
-    fireEvent.click(input);
-  });
+  fireEvent.click(input);
 
   expect(getByText("15")).toBeInTheDocument();
 });

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { InputDate } from ".";
+import { Modal } from "../Modal";
+import { Button } from "../Button";
+import { Text } from "../Text";
 
 afterEach(cleanup);
 
@@ -186,3 +189,40 @@ it("displays the calendar when input is focused with a click", () => {
 
   expect(getByText("15")).toBeInTheDocument();
 });
+
+describe("when InputDate is used within a Modal", () => {
+  it("should close only the open picker when the escape key is pressed", async () => {
+    const date = "11/11/2011";
+    const { getByRole, getByText, getByDisplayValue, queryByText } = render(
+      <NestedTestComponent date={date} />,
+    );
+    const button = getByRole("button");
+    fireEvent.click(button);
+
+    const input = getByDisplayValue(date);
+    fireEvent.click(input);
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(getByText("Test Modal Content")).toBeInTheDocument();
+    expect(queryByText("15")).not.toBeInTheDocument();
+  });
+});
+
+function NestedTestComponent(props: { date: string }): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const changeHandler = jest.fn();
+
+  return (
+    <div>
+      <Modal open={isOpen}>
+        <Text>Test Modal Content</Text>
+        <InputDate value={new Date(props.date)} onChange={changeHandler} />
+      </Modal>
+      <Button
+        onClick={() => setIsOpen(!isOpen)}
+        label={isOpen ? "Close" : "Open"}
+      />
+    </div>
+  );
+}

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -190,6 +190,7 @@ describe("when InputDate is used within a Modal", () => {
     const input = getByDisplayValue(date);
     fireEvent.click(input);
 
+    expect(getByText("15")).toBeInTheDocument();
     fireEvent.keyDown(input, { key: "Escape" });
 
     expect(getByText("Test Modal Content")).toBeInTheDocument();


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When the InputDate, or DatePicker is used within another component that closes on ESC key press, when the DatePicker is open pressing ESC will close both the picker and the parent component. This is not what we want it to do in that scenario. It should only close the picker, and require another ESC if you want to close say the Modal.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

N/A

### Changed

N/A

### Deprecated

N/A

### Removed

N/A

### Fixed

While the date picker is open, pressing ESC will only close the picker. If there is some parent component that can also be closed on ESC, it will remain open.

### Security

N/A

## Testing

Setup a component that listens to ESC presses for closing, such as a `Modal`, inside there add an `InputDate` or `DatePicker`. Activate the date picker so that the picker is open. Now press ESC and only the picker should close.



---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
