### PR TITLE
docs: fix custom radio option code tab

### DIFF
--- a/docs/components/RadioGroup/Web.stories.tsx
+++ b/docs/components/RadioGroup/Web.stories.tsx
@@ -18,6 +18,7 @@ export default {
         hidden: false,
         extraImports: {
           "@jobber/components/RadioGroup": ["RadioGroup", "RadioOption"],
+          "@jobber/components/Chips": ["Chips", "Chip"],
         },
       },
     },
@@ -96,59 +97,55 @@ const DescriptionTemplate: ComponentStory<typeof RadioGroup> = args => {
 
 const CustomRadioOptionContentTemplate: ComponentStory<
   typeof RadioGroup
-> = () => {
+> = args => {
   const [reminderSetting, setReminderSetting] = useState("fixed");
   const [fixedTimeSetting, setFixedTimeSetting] = useState("MINUTES_30");
 
   return (
-    <>
-      <Content>
-        <RadioGroup
-          onChange={(value: string) => setReminderSetting(value)}
-          value={reminderSetting}
-          ariaLabel="Reminder Settings"
+    <RadioGroup
+      {...args}
+      onChange={(value: string) => setReminderSetting(value)}
+      value={reminderSetting}
+    >
+      <RadioOption
+        value={"fixed"}
+        label="Fixed Time"
+        description="Select from the 15 mins interval"
+      >
+        <Chips
+          onChange={setting => setFixedTimeSetting(setting ?? "MINUTES_30")}
+          selected={fixedTimeSetting}
         >
-          <RadioOption
-            value={"fixed"}
-            label="Fixed Time"
-            description="Select from the 15 mins interval"
-          >
-            <Chips
-              onChange={setting => setFixedTimeSetting(setting ?? "MINUTES_30")}
-              selected={fixedTimeSetting}
-            >
-              <Chip label="15 min" value="MINUTES_15" />
-              <Chip label="30 min" value="MINUTES_30" />
-              <Chip label="45 min" value="MINUTES_45" />
-              <Chip label="60 min" value="MINUTES_60" />
-            </Chips>
-          </RadioOption>
-          <RadioOption
-            value={"specific"}
-            label="Specific Time"
-            description="Set your reminder down to the seconds"
-          >
-            Remind me at{" "}
-            <InputNumber
-              size="small"
-              suffix={{ label: "mins" }}
-              defaultValue={"42"}
-              maxLength={5}
-              inline
-            />{" "}
-            and{" "}
-            <InputNumber
-              size="small"
-              suffix={{ label: "sec" }}
-              defaultValue={"3"}
-              maxLength={5}
-              inline
-            />{" "}
-            interval
-          </RadioOption>
-        </RadioGroup>
-      </Content>
-    </>
+          <Chip label="15 min" value="MINUTES_15" />
+          <Chip label="30 min" value="MINUTES_30" />
+          <Chip label="45 min" value="MINUTES_45" />
+          <Chip label="60 min" value="MINUTES_60" />
+        </Chips>
+      </RadioOption>
+      <RadioOption
+        value={"specific"}
+        label="Specific Time"
+        description="Set your reminder down to the seconds"
+      >
+        Remind me at{" "}
+        <InputNumber
+          size="small"
+          suffix={{ label: "mins" }}
+          defaultValue={"42"}
+          maxLength={5}
+          inline
+        />{" "}
+        and{" "}
+        <InputNumber
+          size="small"
+          suffix={{ label: "sec" }}
+          defaultValue={"3"}
+          maxLength={5}
+          inline
+        />{" "}
+        interval
+      </RadioOption>
+    </RadioGroup>
   );
 };
 
@@ -161,3 +158,7 @@ export const Disabled = DisabledTemplate.bind({});
 export const CustomRadioOptionContent = CustomRadioOptionContentTemplate.bind(
   {},
 );
+
+CustomRadioOptionContent.args = {
+  ariaLabel: "Reminder Settings",
+};


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Code tab was failing for RadioGroup's [Custom Radio](https://atlantis.getjobber.com/?path=/code/components-forms-and-inputs-radiogroup-web--custom-radio-option-content) example

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- proper import for chips in the Custom Radio Option example
- enabled args on Custom Radio Option example
- remove unnecessary code on the same example

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Code tab in custom radio option under radio group should render

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
