### PR TITLE
chore(components): Restrict React DatePicker Package to Patch Versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45693,7 +45693,7 @@
         "framer-motion": "6.3.16",
         "lodash": "^4.17.21",
         "react-countdown": "^2.3.2",
-        "react-datepicker": "^4.10.0",
+        "react-datepicker": "~4.10.0",
         "react-dropzone": "^11.0.2",
         "react-hook-form": "^7.43.7",
         "react-markdown": "^8.0.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,7 +39,7 @@
     "framer-motion": "6.3.16",
     "lodash": "^4.17.21",
     "react-countdown": "^2.3.2",
-    "react-datepicker": "^4.10.0",
+    "react-datepicker": "~4.10.0",
     "react-dropzone": "^11.0.2",
     "react-hook-form": "^7.43.7",
     "react-markdown": "^8.0.3",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

While doing some InputDate/DatePicker work recently I noticed that newer versions of react-datepicker` have some minor layout differences that mildly break.

The wrapper class in versions under 4.14.0 have this `width: 100%` that plays nice with our `fullWidth` behavior
https://github.com/Hacker0x01/react-datepicker/blob/v4.10.1/src/stylesheets/datepicker.scss#L8

However after that, it's gone
https://github.com/Hacker0x01/react-datepicker/blob/v4.14.0/src/stylesheets/datepicker.scss

Then the `InputDate` is only ever about as wide as the button + the string representation of the date, and not full width like we want it to be with this code.

```
export function InputDate(inputProps: InputDateProps) {
  const formFieldActionsRef = useRef<FieldActionsRef>(null);
  return (
    <DatePicker
      selected={inputProps.value}
      onChange={inputProps.onChange}
      disabled={inputProps.disabled}
      readonly={inputProps.readonly}
      fullWidth={!inputProps.inline}
       ...
```

The fix won't be the worst, we'll just need to shim in some of our own styles to make it be full width again. It's just an easy thing to miss since the changelog doesn't make it super obvious imo.
https://github.com/Hacker0x01/react-datepicker/releases/tag/v4.14.0

So, with that in mind I'm going to make it a bit harder to inadvertently break this by changing it from a caret which accepts patch and minor to the tilde that only accepts patch versions.

## Changes



### Added

n/a

### Changed

`^` -> `~`

### Deprecated

n/a

### Removed

n/a

### Fixed

n/a

### Security

n/a

## Testing

Everything should be exactly the same. If it's not, that's deeply concerning.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
