### PR TITLE
fix(components): Fix broken links for popover docs

### DIFF
--- a/docs/components/Popover/Popover.stories.mdx
+++ b/docs/components/Popover/Popover.stories.mdx
@@ -33,8 +33,8 @@ Reveal a list of available actions to the user. For example, if the user clicks
 on an element and there are four potential actions they might take, Popover is a
 great way to present those actions. If you're looking to provide a menu of
 actions that comes complete with a trigger button,
-[Menu](../?path=/docs/components-navigation-menu--menu) has that bundle ready to
-go.
+[Menu](../?path=/docs/components-navigation-menu-docs--page) has that bundle
+ready to go.
 
 <Banner type="warning" dismissible={false}>
   A "functional" Popover hasn't been implemented in a componentized fashion yet.
@@ -43,11 +43,11 @@ go.
 ### Related components
 
 To add a menu button that presents multiple actions to the user, use
-[Menu](../?path=/docs/components-navigation-menu--menu).
+[Menu](../?path=/docs/components-navigation-menu-docs--page).
 
 To add a hint about a UI element's function in a permanent fashion (ie revealing
 a Button's label on hover), use
-[Tooltip](../?path=/docs/components-overlays-tooltip--tooltip).
+[Tooltip](../?path=/docs/components-overlays-tooltip-docs--page).
 
 To add an inline informational element that the user can dismiss, consider if
 [Banner](../?path=/docs/components-status-and-feedback-banner-docs--page) is the


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
As I was going though the Popover documentation I noticed a few broken links that hadn't been updated after the restructuring of the docs. This is just a small PR to fix those. 


### Fixed

- Broken links for the popover documentation.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
