### PR TITLE
chore(components): add data list tags pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15959,6 +15959,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
+      "dev": true
+    },
     "node_modules/big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -19487,6 +19493,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "dev": true
     },
     "node_modules/css-modules-loader-core": {
       "version": "1.1.0",
@@ -29498,6 +29510,19 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom-testing-mocks": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/jsdom-testing-mocks/-/jsdom-testing-mocks-1.9.0.tgz",
+      "integrity": "sha512-NsuAqHFi0j4FcxIzSp8NOBNB+ln2T5PvJ0ShFgEXwMnTP2K68dRv5mJE/yJadbMAhzYqUL85Aj+cjhG9lHGapQ==",
+      "dev": true,
+      "dependencies": {
+        "bezier-easing": "^2.1.0",
+        "css-mediaquery": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/jsdom/node_modules/entities": {
@@ -45718,6 +45743,7 @@
         "autoprefixer": "^9.5.1",
         "copyfiles": "^2.4.1",
         "glob": "^7.1.4",
+        "jsdom-testing-mocks": "^1.9.0",
         "postcss": "^8.4.21",
         "postcss-import": "^12.0.1",
         "postcss-preset-env": "^8.3.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -64,6 +64,7 @@
     "autoprefixer": "^9.5.1",
     "copyfiles": "^2.4.1",
     "glob": "^7.1.4",
+    "jsdom-testing-mocks": "^1.9.0",
     "postcss": "^8.4.21",
     "postcss-import": "^12.0.1",
     "postcss-preset-env": "^8.3.0",

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -5,6 +5,7 @@
 .header {
   position: sticky;
   top: 0;
+  z-index: var(--elevation-base);
   padding: var(--space-small);
   border-bottom: var(--border-thick) solid var(--color-border);
   background-color: var(--color-surface);

--- a/packages/components/src/DataList/DataList.stories.tsx
+++ b/packages/components/src/DataList/DataList.stories.tsx
@@ -72,10 +72,7 @@ const Template: ComponentStory<typeof DataList> = args => {
   //   loadingNextPage,
   // );
 
-  const dummyString =
-    "Lorem ipsum, dolor sit amet consectetur adipisicing elit. Laudantium obcaecati nemo totam harum, repudiandae nisi necessitatibus velit consequuntur corporis similique".split(
-      " ",
-    );
+  const randomTags = ["SW", "commercial", "pets", "fence"];
   const items = data?.allPeople.edges || [];
   const mappedData = items.map(({ node }) => ({
     label: node.name,
@@ -84,9 +81,9 @@ const Template: ComponentStory<typeof DataList> = args => {
       node.gender,
       node.hairColor?.split(", "),
       node.skinColor?.split(", "),
-      ...dummyString.slice(
-        Math.round(Math.random() * 10),
-        Math.round(11 + Math.random() * 20),
+      ...randomTags.slice(
+        Math.round(Math.random() * 2),
+        Math.round(3 + Math.random() * 4),
       ),
     ],
     homePopulation: node.homeworld.population?.toLocaleString(),

--- a/packages/components/src/DataList/DataList.stories.tsx
+++ b/packages/components/src/DataList/DataList.stories.tsx
@@ -72,8 +72,9 @@ const Template: ComponentStory<typeof DataList> = args => {
   //   loadingNextPage,
   // );
 
-  const randomTags = ["SW", "commercial", "pets", "fence"];
   const items = data?.allPeople.edges || [];
+
+  const randomTags = ["SW", "commercial", "pets", "fence"];
   const mappedData = items.map(({ node }) => ({
     label: node.name,
     home: node.homeworld.name,
@@ -85,7 +86,7 @@ const Template: ComponentStory<typeof DataList> = args => {
         Math.round(Math.random() * 2),
         Math.round(3 + Math.random() * 4),
       ),
-    ],
+    ].filter(t => t !== "n/a"),
     homePopulation: node.homeworld.population?.toLocaleString(),
     created: new Date(node.created),
   }));

--- a/packages/components/src/DataList/DataList.stories.tsx
+++ b/packages/components/src/DataList/DataList.stories.tsx
@@ -21,7 +21,7 @@ export default {
     viewMode: "story",
   },
   // Comment this out to make it show up in storybook
-  excludeStories: ["Basic", "EmptyState"],
+  // excludeStories: ["Basic", "EmptyState"],
   decorators: [
     // Detach from Storybook's layout
     (Story, { viewMode }) => {
@@ -72,6 +72,10 @@ const Template: ComponentStory<typeof DataList> = args => {
   //   loadingNextPage,
   // );
 
+  const dummyString =
+    "Lorem ipsum, dolor sit amet consectetur adipisicing elit. Laudantium obcaecati nemo totam harum, repudiandae nisi necessitatibus velit consequuntur corporis similique".split(
+      " ",
+    );
   const items = data?.allPeople.edges || [];
   const mappedData = items.map(({ node }) => ({
     label: node.name,
@@ -80,6 +84,10 @@ const Template: ComponentStory<typeof DataList> = args => {
       node.gender,
       node.hairColor?.split(", "),
       node.skinColor?.split(", "),
+      ...dummyString.slice(
+        Math.round(Math.random() * 10),
+        Math.round(11 + Math.random() * 20),
+      ),
     ],
     homePopulation: node.homeworld.population?.toLocaleString(),
     created: new Date(node.created),

--- a/packages/components/src/DataList/DataList.stories.tsx
+++ b/packages/components/src/DataList/DataList.stories.tsx
@@ -21,7 +21,7 @@ export default {
     viewMode: "story",
   },
   // Comment this out to make it show up in storybook
-  // excludeStories: ["Basic", "EmptyState"],
+  excludeStories: ["Basic", "EmptyState"],
   decorators: [
     // Detach from Storybook's layout
     (Story, { viewMode }) => {

--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -12,7 +12,7 @@ import {
   EMPTY_FILTER_RESULTS_ACTION_LABEL,
   EMPTY_FILTER_RESULTS_MESSAGE,
 } from "./DataList.const";
-import { DataListTags } from "./components/DataListTags/DataListTags";
+import { DataListTags } from "./components/DataListTags";
 import { FormatDate } from "../FormatDate";
 import { Text } from "../Text";
 

--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -12,8 +12,8 @@ import {
   EMPTY_FILTER_RESULTS_ACTION_LABEL,
   EMPTY_FILTER_RESULTS_MESSAGE,
 } from "./DataList.const";
+import { DataListTags } from "./components/DataListTags/DataListTags";
 import { FormatDate } from "../FormatDate";
-import { InlineLabel } from "../InlineLabel";
 import { Text } from "../Text";
 
 /**
@@ -47,14 +47,7 @@ export function generateListItemElements<T extends DataListObject>(data: T[]) {
       }
 
       if (key === "tags" && Array.isArray(currentItem)) {
-        acc[key] = (
-          // TODO: Create a component specific for this with the experience we want JOB-76771
-          <div style={{ display: "flex", gap: 8, overflow: "hidden" }}>
-            {currentItem.filter(Boolean).map((tag, index) => (
-              <InlineLabel key={index}>{tag}</InlineLabel>
-            ))}
-          </div>
-        );
+        acc[key] = <DataListTags items={currentItem} />;
       } else if (key === "label" && typeof currentItem === "string") {
         acc[key] = <Text>{currentItem}</Text>;
       } else if (isValidElement(currentItem)) {

--- a/packages/components/src/DataList/__tests__/DataList.utils.test.tsx
+++ b/packages/components/src/DataList/__tests__/DataList.utils.test.tsx
@@ -79,22 +79,14 @@ describe("Datalist utils", () => {
 
       // Snapshot needs updating? See comment #1 above the `describe`.
       expect(elementList[0].tags).toMatchInlineSnapshot(`
-        <div
-          style={
-            {
-              "display": "flex",
-              "gap": 8,
-              "overflow": "hidden",
-            }
+        <DataListTags
+          items={
+            [
+              "uno",
+              "dos",
+            ]
           }
-        >
-          <InlineLabel>
-            uno
-          </InlineLabel>
-          <InlineLabel>
-            dos
-          </InlineLabel>
-        </div>
+        />
       `);
     });
 

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css
@@ -1,0 +1,23 @@
+.tags {
+  display: flex;
+  position: relative;
+  overflow: hidden;
+  gap: var(--space-small);
+}
+
+.tagCount {
+  --overflow-bg: var(--color-white);
+
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  padding: 0;
+  padding-left: var(--space-base);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0,
+    var(--overflow-bg) var(--space-base),
+    var(--overflow-bg) 100%
+  );
+}

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css
@@ -1,6 +1,7 @@
 .tags {
   display: flex;
   position: relative;
+  z-index: var(--elevation-default);
   overflow: hidden;
   gap: var(--space-small);
 }
@@ -8,11 +9,11 @@
 .tagCount {
   --overflow-bg: var(--color-white);
 
+  display: flex;
   position: absolute;
   top: 0;
   right: 0;
   height: 100%;
-  padding: 0;
   padding-left: var(--space-base);
   background-image: linear-gradient(
     90deg,
@@ -20,4 +21,5 @@
     var(--overflow-bg) var(--space-base),
     var(--overflow-bg) 100%
   );
+  align-items: center;
 }

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css.d.ts
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "tags": string;
+  readonly "tagCount": string;
+};
+export = styles;
+

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.test.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { mockIntersectionObserver } from "jsdom-testing-mocks";
+import { DataListTags } from "./DataListTags";
+
+const observer = mockIntersectionObserver();
+
+describe("DataListTags", () => {
+  const tags = ["uno", "dos"];
+
+  beforeEach(() => {
+    render(<DataListTags items={tags} />);
+  });
+
+  it("should render the passed in items", () => {
+    expect(screen.getByText(tags[0])).toBeInTheDocument();
+    expect(screen.getByText(tags[1])).toBeInTheDocument();
+  });
+
+  it("should NOT render the '+' counter", () => {
+    expect(screen.queryByText("+", { exact: false })).not.toBeInTheDocument();
+  });
+
+  it("should render the '+' counter with the amount of tags hidden", () => {
+    act(observer.leaveAll);
+
+    expect(screen.getByText(`+${tags.length}`)).toBeInTheDocument();
+
+    // Testing the inverse of the one on other test and ensure that's not a
+    // false positive
+    expect(screen.getByText("+", { exact: false })).toBeInTheDocument();
+  });
+
+  it("should count the correct amount of overflown tags", async () => {
+    const element = screen.getByText(tags[1]);
+    const target: HTMLElement | null = element.closest("[data-tag-element]");
+    act(() => {
+      target && observer.leaveNode(target);
+    });
+
+    expect(await screen.findByText("+1")).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.test.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import { mockIntersectionObserver } from "jsdom-testing-mocks";
-import { DataListTags } from "./DataListTags";
+import { DataListTags } from ".";
 
 const observer = mockIntersectionObserver();
 

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -52,12 +52,13 @@ export function DataListTags({ items }: DataListTagsProps) {
   ) {
     entries.forEach(entry => {
       const index = entry.target.getAttribute("data-tag-element");
-      if (!index || isNaN(Number(index))) return;
+      const indexNumber = Number(index);
+      if (!index || isNaN(indexNumber)) return;
 
-      setVisibleIndex(arr => {
-        const newArr = [...arr];
-        newArr[Number(index)] = entry.intersectionRatio !== 1;
-        return newArr;
+      setVisibleIndex(prevState => {
+        const newState = [...prevState];
+        newState[indexNumber] = entry.intersectionRatio !== 1;
+        return newState;
       });
     });
   }

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -15,18 +15,21 @@ export function DataListTags({ items }: DataListTagsProps) {
   useEffect(() => {
     if (!window.IntersectionObserver) return;
 
+    // Reset counter every time the items change
+    setVisibleIndex([]);
+
     const observer = new IntersectionObserver(handleIntersection, {
       root: ref.current,
       threshold: buildIntersectionThreshold(items),
     });
 
-    const tagElements = ref.current?.querySelectorAll("[data-tag-element");
-    tagElements?.forEach(tag => observer.observe(tag));
+    const elements = ref.current?.querySelectorAll("[data-tag-element");
+    elements?.forEach(element => observer.observe(element));
 
     return () => {
-      tagElements?.forEach(tag => observer.unobserve(tag));
+      elements?.forEach(element => observer.unobserve(element));
     };
-  }, []);
+  }, [items]);
 
   return (
     <div className={styles.tags} ref={ref}>
@@ -53,7 +56,7 @@ export function DataListTags({ items }: DataListTagsProps) {
 
       setVisibleIndex(arr => {
         const newArr = [...arr];
-        newArr[Number(index)] = entry.intersectionRatio < 0.5;
+        newArr[Number(index)] = entry.intersectionRatio !== 1;
         return newArr;
       });
     });

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -23,7 +23,7 @@ export function DataListTags({ items }: DataListTagsProps) {
       threshold: buildIntersectionThreshold(items),
     });
 
-    const elements = ref.current?.querySelectorAll("[data-tag-element");
+    const elements = ref.current?.querySelectorAll("[data-tag-element]");
     elements?.forEach(element => observer.observe(element));
 
     return () => {
@@ -34,7 +34,7 @@ export function DataListTags({ items }: DataListTagsProps) {
   return (
     <div className={styles.tags} ref={ref}>
       {items.filter(Boolean).map((tag, index) => (
-        <div key={index} data-tag-element={index}>
+        <div key={tag} data-tag-element={index}>
           <InlineLabel>{tag}</InlineLabel>
         </div>
       ))}

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState } from "react";
+import styles from "./DataListTags.css";
+import { InlineLabel } from "../../../InlineLabel";
+
+interface DataListTagsProps {
+  readonly items: string[];
+}
+
+export function DataListTags({ items }: DataListTagsProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visibleIndex, setVisibleIndex] = useState<boolean[]>([]);
+  const visibleItems = visibleIndex.filter(Boolean).length;
+
+  useEffect(() => {
+    if (!window.IntersectionObserver) return;
+
+    const observer = new IntersectionObserver(handleIntersection, {
+      root: ref.current,
+      threshold: buildIntersectionThreshold(items),
+    });
+
+    const tagElements = ref.current?.querySelectorAll("[data-tag-element");
+    tagElements?.forEach(tag => observer.observe(tag));
+
+    return () => {
+      tagElements?.forEach(tag => observer.unobserve(tag));
+    };
+  }, []);
+
+  return (
+    <div className={styles.tags} ref={ref}>
+      {items.filter(Boolean).map((tag, index) => (
+        <div key={index} data-tag-element={index}>
+          <InlineLabel>{tag}</InlineLabel>
+        </div>
+      ))}
+
+      <span className={styles.tagCount}>+{visibleItems}</span>
+    </div>
+  );
+
+  function handleIntersection(
+    ...[entries]: Parameters<IntersectionObserverCallback>
+  ) {
+    entries.forEach(entry => {
+      const index = entry.target.getAttribute("data-tag-element");
+      if (!index || isNaN(Number(index))) return;
+
+      setVisibleIndex(arr => {
+        const newArr = [...arr];
+        newArr[Number(index)] = entry.intersectionRatio < 0.5;
+        return newArr;
+      });
+    });
+  }
+}
+
+function buildIntersectionThreshold(items: DataListTagsProps["items"]) {
+  const thresholds = [];
+  const totalItems = items.length;
+
+  for (let i = 1.0; i <= totalItems; i++) {
+    const ratio = i / totalItems;
+    thresholds.push(ratio);
+  }
+
+  thresholds.push(0);
+  return thresholds;
+}

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import styles from "./DataListTags.css";
 import { InlineLabel } from "../../../InlineLabel";
+import { Text } from "../../../Text";
 
 interface DataListTagsProps {
   readonly items: string[];
@@ -35,7 +36,11 @@ export function DataListTags({ items }: DataListTagsProps) {
         </div>
       ))}
 
-      <span className={styles.tagCount}>+{visibleItems}</span>
+      {Boolean(visibleItems) && (
+        <div className={styles.tagCount}>
+          <Text>+{visibleItems}</Text>
+        </div>
+      )}
     </div>
   );
 

--- a/packages/components/src/DataList/components/DataListTags/index.ts
+++ b/packages/components/src/DataList/components/DataListTags/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListTags";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There's a pretty specific tags pattern in the list where it overflows and counts the ones that aren't visible/half-visible to convey that there are more tags.

This aims to add that pattern.

This is the logic behind it. Say you have 5 tags
- If only 3 are visible, it'll add a + 2 count
- If all 5 are visible, it won't add the + counter
- If 4 are visible and the last is half visible, it'll count that as not visible and add +1
  - This is a designer-approved logic.

![image](https://github.com/GetJobber/atlantis/assets/15986172/e990b768-73a9-4799-af1e-c25f16b39ea3)


`IntersectionObserver` is also not available in Jest so a plugin needs to be added to mock it within the test.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- DataList Tag component
- Also test

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Resize your screen to the point that the attributes column content doesn't fit
- It should start counting the labels that gets cut-off/not visible

---

[In Atlantis we use Github's built-in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
