### PR TITLE
feat(components): Add DataTable loader skeleton [JOB-76695]

### DIFF
--- a/docs/components/DataTable/Web.stories.tsx
+++ b/docs/components/DataTable/Web.stories.tsx
@@ -511,3 +511,91 @@ EmptyState.args = {
     },
   ],
 };
+
+const LoadingTemplate: ComponentStory<typeof DataTable> = args => (
+  <DataTable {...args} />
+);
+
+export const LoadingState = LoadingTemplate.bind({});
+LoadingState.args = {
+  pagination: { manualPagination: false, itemsPerPage: [5, 10, 15] },
+  sorting: { manualSorting: false },
+  height: 200,
+  loading: true,
+  data: [],
+  columns: [
+    {
+      id: "name",
+      accessorKey: "name",
+      header: "Name",
+      footer: "Totals",
+      cell: info => (
+        <Typography align="end">{<>{info.getValue()}</>}</Typography>
+      ),
+      size: 538,
+      minSize: 438,
+      maxSize: 538,
+    },
+    {
+      id: "points",
+      accessorKey: "points",
+      header: () => (
+        <div style={{ display: "flex", flex: 1 }}>
+          <Typography align="end" fontWeight="bold">
+            Points
+          </Typography>
+        </div>
+      ),
+      footer: () => (
+        <Typography align="end" fontWeight="bold">
+          10,050,400
+        </Typography>
+      ),
+      cell: info => (
+        <Typography align="end">{<>{info.getValue()}</>}</Typography>
+      ),
+      size: 268,
+      minSize: 168,
+      maxSize: 268,
+    },
+    {
+      id: "chance",
+      accessorKey: "chance",
+      header: () => (
+        <div style={{ display: "flex", flex: 1 }}>
+          <Typography align="end" fontWeight="bold">
+            Chance (%)
+          </Typography>
+        </div>
+      ),
+      cell: info => (
+        <Typography align="end">{<>{info.getValue()}</>}</Typography>
+      ),
+      size: 268,
+      minSize: 168,
+      maxSize: 268,
+    },
+    {
+      id: "power",
+      accessorKey: "power",
+      header: () => (
+        <div style={{ display: "flex", flex: 1 }}>
+          <Typography align="end" fontWeight="bold">
+            Power
+          </Typography>
+        </div>
+      ),
+      footer: () => (
+        <Typography align="end" fontWeight="bold">
+          300,000
+        </Typography>
+      ),
+      cell: info => (
+        <Typography align="end">{<>{info.getValue()}</>}</Typography>
+      ),
+      size: 268,
+      minSize: 168,
+      maxSize: 268,
+    },
+  ],
+};

--- a/docs/components/DataTable/Web.stories.tsx
+++ b/docs/components/DataTable/Web.stories.tsx
@@ -518,9 +518,9 @@ const LoadingTemplate: ComponentStory<typeof DataTable> = args => (
 
 export const LoadingState = LoadingTemplate.bind({});
 LoadingState.args = {
-  pagination: { manualPagination: false, itemsPerPage: [5, 10, 15] },
+  pagination: { manualPagination: false, itemsPerPage: [20, 30, 40] },
   sorting: { manualSorting: false },
-  height: 200,
+  height: 600,
   loading: true,
   data: [],
   columns: [

--- a/packages/components/src/DataTable/Body.tsx
+++ b/packages/components/src/DataTable/Body.tsx
@@ -2,18 +2,21 @@ import { Row, Table, flexRender } from "@tanstack/react-table";
 import classNames from "classnames";
 import React, { ReactNode, useCallback } from "react";
 import styles from "./DataTable.css";
+import { Glimmer } from "../Glimmer";
 
 interface BodyProps<T> {
   table: Table<T>;
   onRowClick?: (row: Row<T>) => void;
   height?: number;
   emptyState?: ReactNode | ReactNode[];
+  loading?: boolean;
 }
 
 export function Body<T extends object>({
   table,
   onRowClick,
   emptyState,
+  loading,
 }: BodyProps<T>) {
   const bodyRowClasses = classNames({ [styles.clickableRow]: !!onRowClick });
 
@@ -25,34 +28,59 @@ export function Body<T extends object>({
     [onRowClick],
   );
 
-  return table.getRowModel().rows.length ? (
-    <tbody>
-      {table.getRowModel().rows.map(row => {
-        return (
-          <tr
-            key={row.id}
-            onClick={handleRowClick(row)}
-            className={bodyRowClasses}
-          >
-            {row.getVisibleCells().map(cell => {
+  const loaderRows = table.getState().pagination.pageSize;
+  const loaderColumns = table.getAllColumns().length;
+  return (
+    <>
+      {!loading ? (
+        table.getRowModel().rows.length ? (
+          <tbody>
+            {table.getRowModel().rows.map(row => {
               return (
-                <td
-                  key={cell.id}
-                  style={{
-                    width: cell.column.getSize(),
-                    minWidth: cell.column.columnDef.minSize,
-                    maxWidth: cell.column.columnDef.maxSize,
-                  }}
+                <tr
+                  key={row.id}
+                  onClick={handleRowClick(row)}
+                  className={bodyRowClasses}
                 >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
+                  {row.getVisibleCells().map(cell => {
+                    return (
+                      <td
+                        key={cell.id}
+                        style={{
+                          width: cell.column.getSize(),
+                          minWidth: cell.column.columnDef.minSize,
+                          maxWidth: cell.column.columnDef.maxSize,
+                        }}
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
               );
             })}
-          </tr>
-        );
-      })}
-    </tbody>
-  ) : (
-    <div className={classNames(styles.emptyState)}>{emptyState}</div>
+          </tbody>
+        ) : (
+          <div className={classNames(styles.emptyState)}>
+            {emptyState} <div>is it loading? {loading}</div>
+          </div>
+        )
+      ) : (
+        <tbody>
+          {Array.from(Array(loaderRows).keys()).map(row => (
+            <tr key={row}>
+              {Array.from(Array(loaderColumns).keys()).map(arr => (
+                <td key={arr}>
+                  <Glimmer />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      )}
+    </>
   );
 }

--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -11,6 +11,7 @@ import {
   royaltyReportColumns,
   royaltyReportData,
 } from "./test-utilities";
+import { GLIMMER_TEST_ID } from "../Glimmer";
 
 // Allow us to mock and replace the value of useResizeObserver would return via
 // a spy
@@ -288,5 +289,26 @@ describe("when the table has no data", () => {
 
   it("renders the provided empty state", () => {
     expect(screen.getByText("No data")).toBeDefined();
+  });
+});
+
+describe("when the table has a loading prop set to true", () => {
+  it("Shows the default amount of loaders for each column", async () => {
+    render(
+      <DataTable data={[]} columns={royaltyReportColumns} loading={true} />,
+    );
+    expect(await screen.findAllByTestId(GLIMMER_TEST_ID)).toHaveLength(40);
+  });
+
+  it("Shows the amount of loaders based on smallest items per page value", async () => {
+    render(
+      <DataTable
+        data={[]}
+        pagination={{ manualPagination: false, itemsPerPage: [20, 30, 40] }}
+        columns={royaltyReportColumns}
+        loading={true}
+      />,
+    );
+    expect(await screen.findAllByTestId(GLIMMER_TEST_ID)).toHaveLength(80);
   });
 });

--- a/packages/components/src/DataTable/DataTable.tsx
+++ b/packages/components/src/DataTable/DataTable.tsx
@@ -68,6 +68,11 @@ export interface DataTableProps<T> {
    * The elements to display when the data table is empty
    */
   emptyState?: ReactNode | ReactNode[];
+
+  /**
+   * When true, shows the loading state of the DataTable
+   */
+  loading?: boolean;
 }
 
 export function DataTable<T extends object>({
@@ -80,6 +85,7 @@ export function DataTable<T extends object>({
   pinFirstColumn,
   onRowClick,
   emptyState,
+  loading,
 }: DataTableProps<T>) {
   const [ref, { exactWidth }] = useResizeObserver();
   const tableSettings = createTableSettings(data, columns, {
@@ -111,6 +117,7 @@ export function DataTable<T extends object>({
             onRowClick={onRowClick}
             height={height ? height * 0.7 : undefined}
             emptyState={emptyState}
+            loading={loading}
           />
           {table.getRowModel().rows.length &&
           exactWidth &&


### PR DESCRIPTION
## Motivations

- There have been complicated ways of introducing loading states to the DataTable component externally, with different designs implemented
- As a company it would be nice to have consistent design for the loading state of the DataTable and as a user be able to simply be able to pass in whether the component is in a loading state or not.

## Changes

- The amount of loaders shown is based off the `itemsPerPage` property in the pagination prop object. The number of loader rows will match the currently selected value.
- If there is no pagination prop passed, the value will default to 10 as per [tan stack documentation](https://tanstack.com/table/v8/docs/api/features/pagination#:~:text=Resets%20the%20page%20size%20to%20its%20initial%20state.%20If%20defaultState%20is%20true%2C%20the%20page%20size%20will%20be%20reset%20to%2010%20regardless%20of%20initial%20state.)
<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Loading state to DataTable component

### Changed

- The loading prop is optional and defaults to false, so there are no breaking changes to previous uses.

## Testing

- Check that loading prop displays the design as intended and that displaying data is otherwise unaffected. 
- There are tests for the default loading state and when pagination prop is provided with non-default values

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
