### PR TITLE
docs(components-native): Add ActionItem & ActionItemGroup documentation

### DIFF
--- a/docs/components/ActionItem/ActionItem.stories.mdx
+++ b/docs/components/ActionItem/ActionItem.stories.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Meta } from "@storybook/addon-docs";
 import { Figma } from "storybook-addon-designs/blocks";
 
 <Meta title="Components/Layouts and Structure/ActionItem/Docs" />
@@ -41,7 +41,7 @@ Child content can be whatever you need but typically consists of
 ## Related components
 
 To group multiple ActionItems together with dividers between them, use
-ActionItemGroup.
+[ActionItemGroup](../?path=/docs/components-layouts-and-structure-actionitemgroup-docs--page).
 
 ActionItem is commonly consumed by
 [Card](../?path=/docs/components-layouts-and-structure-card-docs--page). In most

--- a/docs/components/ActionItem/ActionItem.stories.mdx
+++ b/docs/components/ActionItem/ActionItem.stories.mdx
@@ -1,0 +1,240 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Figma } from "storybook-addon-designs/blocks";
+
+<Meta title="Components/Layouts and Structure/ActionItem" />
+
+# Action Item
+
+ActionItem allows for consistent presentation of text content that can be
+actioned on. It can use icons to provide additional visual context about the
+text content.
+
+## Design & usage guidelines
+
+The ActionItem will provide a familiar pattern for enhancing text content with
+icons and providing actions.
+
+### In a card
+
+ActionItem is commonly used in a Card, where it can be grouped with other
+ActionItems or other elements as needed.
+
+<Canvas
+  style={{
+    background: "var(--color-surface--background)",
+  }}
+>
+  <Story
+    name="In a card"
+    args={{
+      onPress: () => alert("👍"),
+    }}
+  >
+    {args => (
+      <Card>
+        <ActionItem icon={"work"} {...args}>
+          <Text>Service Checklist</Text>
+        </ActionItem>
+        <ActionItem icon={"address"} {...args}>
+          <Text>Address</Text>
+        </ActionItem>
+        <ActionItem title={"Quote #64"} icon={"quote"} {...args} />
+      </Card>
+    )}
+  </Story>
+</Canvas>
+
+### Paired with other elements
+
+In forms in particular, you may find the need to pair an ActionItem with other
+types of content, like an input.
+
+<Canvas
+  style={{
+    background: "var(--color-surface--background)",
+  }}
+>
+  <Story
+    name="With other content types"
+    args={{
+      icon: "person",
+      onPress: () => alert("👍"),
+    }}
+  >
+    {args => (
+      <Card>
+        <Content>
+          <InputDate placeholder="Start date" />
+        </Content>
+        <ActionItem {...args}>
+          <TitledDetail title="Assigned to" displayText="Casey Young" />
+        </ActionItem>
+      </Card>
+    )}
+  </Story>
+</Canvas>
+
+### Action alignment
+
+If the action appears directly related to the title, or otherwise is not
+well-suited to be centered in the ActionItem, you can align the action as
+needed.
+
+<Canvas
+  style={{
+    background: "var(--color-surface--background)",
+  }}
+>
+  <Story
+    name="Action alignment"
+    args={{
+      title: "Service details",
+      actionIconAlignment: "flex-start",
+      onPress: () => alert("👍"),
+    }}
+  >
+    {args => (
+      <Card>
+        <ActionItem {...args}>
+          <TitledDetail
+            title="Please provide as much information as you can"
+            displayText="Cut front, back, and area behind garage. Give the customer a heads up."
+          />
+        </ActionItem>
+      </Card>
+    )}
+  </Story>
+</Canvas>
+
+### Title only
+
+You can use the title and not pass in any children. This is useful when you have
+empty states that require the user's attention.
+
+<Canvas
+  style={{
+    background: "var(--color-surface--background)",
+  }}
+>
+  <Story
+    name="Title only"
+    args={{
+      icon: "person",
+      actionIcon: "add",
+      title: "Add client",
+      onPress: () => alert("👍"),
+    }}
+  >
+    {args => (
+      <Card>
+        <ActionItem {...args} />
+      </Card>
+    )}
+  </Story>
+</Canvas>
+
+### With interactive children
+
+**TLDR** You can tap the things inside of a tappable ActionItem.
+
+When an onPress is provided, the entire ActionItem is tappable for easy
+interactivity. If a child of the ActionItem has an onPress, tapping directly on
+that child will trigger the child item's onPress.
+
+<Canvas
+  style={{
+    background: "var(--color-surface--background)",
+  }}
+>
+  <Story
+    name="With interactive children"
+    args={{
+      icon: "presentation",
+      actionIcon: "link",
+      onPress: () => alert("Tapped the entire action item"),
+    }}
+  >
+    {args => (
+      <Card>
+        <ActionItem {...args}>
+          <Content spacing="none">
+            <Text>You can tap this link or the whole ActionItem</Text>
+            <AutoLink>{"www.getjobber.com"}</AutoLink>
+          </Content>
+        </ActionItem>
+      </Card>
+    )}
+  </Story>
+</Canvas>
+
+### When the user can't action the item
+
+If a user might not be able to perform an action, but they still need to see the
+content (for example, a user who can view their schedule but not edit it), you
+can opt to set the `onPress` as undefined, which will hide the action icon.
+
+<Canvas
+  style={{
+    background: "var(--color-surface--background)",
+  }}
+>
+  <Story name="No action">
+    <Card>
+      <ActionItem icon="userSwitch" title="Team">
+        <Text>Nathaniel Lewis</Text>
+        <Text>Christian Carlino</Text>
+        <Text>Lorna Erikssen</Text>
+      </ActionItem>
+    </Card>
+  </Story>
+</Canvas>
+
+## Related components
+
+To group multiple ActionItems together with dividers between them, use
+ActionItemGroup.
+
+ActionItem is commonly consumed by
+[Card](/docs/atlantis-layouts-and-containers-card--card). In most cases, it will
+also render at least one [Icon](/docs/atlantis-images-and-icons-icon--icon).
+
+If you need to generate a longer list of consistently-formatted content,
+consider using [List.](/docs/atlantis-lists-list--list)
+
+## Content guidelines
+
+ActionItem provides a pre-styled "title", which can be used to consistently
+title the element.
+
+Child content can be whatever you need, but typically consists of either Text or
+TitledDetail.
+
+## Accessibility
+
+The Icons in ActionItem should not be announced to assistive technology. Similar
+to a ListItem, the entire contents of the ActionItem should be read as one
+element.
+
+## Responsiveness
+
+ActionItem takes up the full available width of its parent. The title will
+reflow to a new line, while the icons remain aligned on the leading and trailing
+ends.
+
+The child content will use the responsive behviour of its respective components.
+
+## Mockup
+
+<Figma
+  collapsable
+  url="https://www.figma.com/file/avvgu5SkbBvS8lGVePBsqO/%F0%9F%92%99-Product%2FMobile?node-id=41947%3A224683"
+/>
+
+## Notes
+
+<!--
+  What decisions worth remembering have gone into this component? Did we consider any potentially valuable
+  functionality that we’re not implementing right now for scope purposes? Are there any design decisions
+  that might need explaining beyond the usage guidelines? This will help consumers understand this component
+  more fully.
+-->

--- a/docs/components/ActionItem/ActionItem.stories.mdx
+++ b/docs/components/ActionItem/ActionItem.stories.mdx
@@ -1,7 +1,7 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Figma } from "storybook-addon-designs/blocks";
 
-<Meta title="Components/Layouts and Structure/ActionItem" />
+<Meta title="Components/Layouts and Structure/ActionItem/Docs" />
 
 # Action Item
 
@@ -14,180 +14,29 @@ text content.
 The ActionItem will provide a familiar pattern for enhancing text content with
 icons and providing actions.
 
-### In a card
-
-ActionItem is commonly used in a Card, where it can be grouped with other
-ActionItems or other elements as needed.
-
-<Canvas
-  style={{
-    background: "var(--color-surface--background)",
-  }}
->
-  <Story
-    name="In a card"
-    args={{
-      onPress: () => alert("👍"),
-    }}
-  >
-    {args => (
-      <Card>
-        <ActionItem icon={"work"} {...args}>
-          <Text>Service Checklist</Text>
-        </ActionItem>
-        <ActionItem icon={"address"} {...args}>
-          <Text>Address</Text>
-        </ActionItem>
-        <ActionItem title={"Quote #64"} icon={"quote"} {...args} />
-      </Card>
-    )}
-  </Story>
-</Canvas>
-
-### Paired with other elements
-
-In forms in particular, you may find the need to pair an ActionItem with other
-types of content, like an input.
-
-<Canvas
-  style={{
-    background: "var(--color-surface--background)",
-  }}
->
-  <Story
-    name="With other content types"
-    args={{
-      icon: "person",
-      onPress: () => alert("👍"),
-    }}
-  >
-    {args => (
-      <Card>
-        <Content>
-          <InputDate placeholder="Start date" />
-        </Content>
-        <ActionItem {...args}>
-          <TitledDetail title="Assigned to" displayText="Casey Young" />
-        </ActionItem>
-      </Card>
-    )}
-  </Story>
-</Canvas>
-
-### Action alignment
+ActionItem is commonly used
+[in a Card](../?path=/story/components-layouts-and-structure-actionitem-mobile--in-a-card),
+where it can be grouped with other ActionItems or other elements as needed.
 
 If the action appears directly related to the title, or otherwise is not
-well-suited to be centered in the ActionItem, you can align the action as
-needed.
+well-suited to be centered in the ActionItem, you can
+[align the action](../?path=/story/components-layouts-and-structure-actionitem-mobile--action-alignment)
+as needed.
 
-<Canvas
-  style={{
-    background: "var(--color-surface--background)",
-  }}
->
-  <Story
-    name="Action alignment"
-    args={{
-      title: "Service details",
-      actionIconAlignment: "flex-start",
-      onPress: () => alert("👍"),
-    }}
-  >
-    {args => (
-      <Card>
-        <ActionItem {...args}>
-          <TitledDetail
-            title="Please provide as much information as you can"
-            displayText="Cut front, back, and area behind garage. Give the customer a heads up."
-          />
-        </ActionItem>
-      </Card>
-    )}
-  </Story>
-</Canvas>
+## Content guidelines
 
-### Title only
+ActionItem provides a pre-styled `title`, which can be used to consistently
+title the element. You can use the
+[title](../?path=/story/components-layouts-and-structure-actionitem-mobile--title-only)
+and not pass any children. This is useful when you have empty states that
+require the user's attention.
 
-You can use the title and not pass in any children. This is useful when you have
-empty states that require the user's attention.
+When an `onPress` is provided, the entire ActionItem is tappable for easy
+interactivity. If a child of the ActionItem has an `onPress`, tapping directly
+on that child will trigger the child item's `onPress`.
 
-<Canvas
-  style={{
-    background: "var(--color-surface--background)",
-  }}
->
-  <Story
-    name="Title only"
-    args={{
-      icon: "person",
-      actionIcon: "add",
-      title: "Add client",
-      onPress: () => alert("👍"),
-    }}
-  >
-    {args => (
-      <Card>
-        <ActionItem {...args} />
-      </Card>
-    )}
-  </Story>
-</Canvas>
-
-### With interactive children
-
-**TLDR** You can tap the things inside of a tappable ActionItem.
-
-When an onPress is provided, the entire ActionItem is tappable for easy
-interactivity. If a child of the ActionItem has an onPress, tapping directly on
-that child will trigger the child item's onPress.
-
-<Canvas
-  style={{
-    background: "var(--color-surface--background)",
-  }}
->
-  <Story
-    name="With interactive children"
-    args={{
-      icon: "presentation",
-      actionIcon: "link",
-      onPress: () => alert("Tapped the entire action item"),
-    }}
-  >
-    {args => (
-      <Card>
-        <ActionItem {...args}>
-          <Content spacing="none">
-            <Text>You can tap this link or the whole ActionItem</Text>
-            <AutoLink>{"www.getjobber.com"}</AutoLink>
-          </Content>
-        </ActionItem>
-      </Card>
-    )}
-  </Story>
-</Canvas>
-
-### When the user can't action the item
-
-If a user might not be able to perform an action, but they still need to see the
-content (for example, a user who can view their schedule but not edit it), you
-can opt to set the `onPress` as undefined, which will hide the action icon.
-
-<Canvas
-  style={{
-    background: "var(--color-surface--background)",
-  }}
->
-  <Story name="No action">
-    <Card>
-      <ActionItem icon="userSwitch" title="Team">
-        <Text>Nathaniel Lewis</Text>
-        <Text>Christian Carlino</Text>
-        <Text>Lorna Erikssen</Text>
-      </ActionItem>
-    </Card>
-  </Story>
-</Canvas>
+Child content can be whatever you need but typically consists of
+[Text](../?path=/docs/components-text-and-typography-text-docs--page).
 
 ## Related components
 
@@ -195,33 +44,14 @@ To group multiple ActionItems together with dividers between them, use
 ActionItemGroup.
 
 ActionItem is commonly consumed by
-[Card](/docs/atlantis-layouts-and-containers-card--card). In most cases, it will
-also render at least one [Icon](/docs/atlantis-images-and-icons-icon--icon).
-
-If you need to generate a longer list of consistently-formatted content,
-consider using [List.](/docs/atlantis-lists-list--list)
-
-## Content guidelines
-
-ActionItem provides a pre-styled "title", which can be used to consistently
-title the element.
-
-Child content can be whatever you need, but typically consists of either Text or
-TitledDetail.
+[Card](../?path=/docs/components-layouts-and-structure-card-docs--page). In most
+cases, it will also render at least one
+[Icon](../?path=/docs/components-images-and-icons-icon-docs--page).
 
 ## Accessibility
 
-The Icons in ActionItem should not be announced to assistive technology. Similar
-to a ListItem, the entire contents of the ActionItem should be read as one
-element.
-
-## Responsiveness
-
-ActionItem takes up the full available width of its parent. The title will
-reflow to a new line, while the icons remain aligned on the leading and trailing
-ends.
-
-The child content will use the responsive behviour of its respective components.
+The Icons in ActionItem should not be announced to assistive technology. The
+entire contents of the ActionItem should be read as one element.
 
 ## Mockup
 
@@ -229,12 +59,3 @@ The child content will use the responsive behviour of its respective components.
   collapsable
   url="https://www.figma.com/file/avvgu5SkbBvS8lGVePBsqO/%F0%9F%92%99-Product%2FMobile?node-id=41947%3A224683"
 />
-
-## Notes
-
-<!--
-  What decisions worth remembering have gone into this component? Did we consider any potentially valuable
-  functionality that we’re not implementing right now for scope purposes? Are there any design decisions
-  that might need explaining beyond the usage guidelines? This will help consumers understand this component
-  more fully.
--->

--- a/docs/components/ActionItem/Mobile.stories.tsx
+++ b/docs/components/ActionItem/Mobile.stories.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { ActionItem, Text } from "@jobber/components-native";
+import {
+  ActionItem,
+  AutoLink,
+  Card,
+  Content,
+  InputDate,
+  Text,
+} from "@jobber/components-native";
 
 export default {
   title: "Components/Layouts and Structure/ActionItem/Mobile",
@@ -8,6 +15,9 @@ export default {
     viewMode: "story",
     previewTabs: { code: { hidden: false } },
     viewport: { defaultViewport: "mobile1" },
+    backgrounds: {
+      default: "surface background",
+    },
   },
 } as ComponentMeta<typeof ActionItem>;
 
@@ -19,8 +29,120 @@ const BasicTemplate: ComponentStory<typeof ActionItem> = args => {
   );
 };
 
+const InACardTemplate: ComponentStory<typeof ActionItem> = args => {
+  return (
+    <Card>
+      <ActionItem icon="work" {...args}>
+        <Text>Service Checklist</Text>
+      </ActionItem>
+      <ActionItem icon="address" {...args}>
+        <Text>Address</Text>
+      </ActionItem>
+      <ActionItem icon="quote" title="Quote #64" {...args} />
+    </Card>
+  );
+};
+
+const MixedComponentsTemplate: ComponentStory<typeof ActionItem> = args => {
+  return (
+    <Card>
+      <Content>
+        <InputDate placeholder="Start date" />
+      </Content>
+      <ActionItem {...args}>
+        <Text>Casey Young</Text>
+      </ActionItem>
+    </Card>
+  );
+};
+
+const ActionAlignmentTemplate: ComponentStory<typeof ActionItem> = args => {
+  return (
+    <Card>
+      <ActionItem {...args}>
+        <Text>
+          Cut front, back and area behind garage. Give the customer a heads up.
+        </Text>
+      </ActionItem>
+    </Card>
+  );
+};
+
+const TitleOnlyTemplate: ComponentStory<typeof ActionItem> = args => {
+  return (
+    <Card>
+      <ActionItem {...args} />
+    </Card>
+  );
+};
+
+const InteractiveChildrenTemplate: ComponentStory<typeof ActionItem> = args => {
+  return (
+    <Card>
+      <ActionItem {...args}>
+        <Content spacing="none">
+          <Text>You can tap this link or the whole ActionItem</Text>
+          <AutoLink>{"www.getjobber.com"}</AutoLink>
+        </Content>
+      </ActionItem>
+    </Card>
+  );
+};
+
+const NoActionTemplate: ComponentStory<typeof ActionItem> = args => {
+  return (
+    <Card>
+      <ActionItem {...args}>
+        <Text>Nathaniel Lewis</Text>
+        <Text>Christian Carlino</Text>
+        <Text>Lorna Erikssen</Text>
+      </ActionItem>
+    </Card>
+  );
+};
+
 export const Basic = BasicTemplate.bind({});
 Basic.args = {
   icon: "work",
   onPress: () => alert("👍"),
+};
+
+export const InACard = InACardTemplate.bind({});
+InACard.args = {
+  onPress: () => alert("👍"),
+};
+
+export const MixedComponents = MixedComponentsTemplate.bind({});
+MixedComponents.args = {
+  onPress: () => alert("👍"),
+  icon: "person",
+  title: "Assigned to",
+};
+
+export const ActionAlignment = ActionAlignmentTemplate.bind({});
+ActionAlignment.args = {
+  onPress: () => alert("👍"),
+  actionIconAlignment: "flex-start",
+  title: "Service Details",
+};
+
+export const TitleOnly = TitleOnlyTemplate.bind({});
+TitleOnly.args = {
+  title: "Add client",
+  icon: "person",
+  onPress: () => alert("👍"),
+  actionIcon: "add",
+};
+
+export const InteractiveChildren = InteractiveChildrenTemplate.bind({});
+InteractiveChildren.args = {
+  onPress: () => alert("Tapped the entire action item"),
+  icon: "presentation",
+  actionIcon: "link",
+};
+
+export const NoAction = NoActionTemplate.bind({});
+NoAction.args = {
+  icon: "userSwitch",
+  title: "Team",
 };

--- a/docs/components/ActionItem/Mobile.stories.tsx
+++ b/docs/components/ActionItem/Mobile.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { ActionItem, Text } from "@jobber/components-native";
+
+export default {
+  title: "Components/Layouts and Structure/ActionItem/Mobile",
+  parameters: {
+    viewMode: "story",
+    previewTabs: { code: { hidden: false } },
+    viewport: { defaultViewport: "mobile1" },
+  },
+} as ComponentMeta<typeof ActionItem>;
+
+const BasicTemplate: ComponentStory<typeof ActionItem> = args => {
+  return (
+    <ActionItem {...args}>
+      <Text>Service Checklist</Text>
+    </ActionItem>
+  );
+};
+
+export const Basic = BasicTemplate.bind({});
+Basic.args = {
+  icon: "work",
+  onPress: () => alert("👍"),
+};

--- a/docs/components/ActionItemGroup/ActionItemGroup.stories.mdx
+++ b/docs/components/ActionItemGroup/ActionItemGroup.stories.mdx
@@ -1,0 +1,41 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="Components/Layouts and Structure/ActionItemGroup/Docs" />
+
+# Action Item Group
+
+ActionItemGroup is a layout wrapper allowing for quick and easy grouping of
+[ActionItems](../?path=/docs/components-layouts-and-structure-actionitem-docs--page).
+It can also house other content alongside an ActionItem if needed.
+
+## Design & usage guidelines
+
+The ActionItemGroup makes it easy to consistently display several ActionItems
+alongside each other with dividers to segment each item.
+
+## Content guidelines
+
+You'll mostly be passing ActionItems into ActionItemGroup, but as shown it can
+handle other content types if needed.
+
+In forms in particular, you may find the need to add other elements into the
+group. You may need to use
+[Content](../?path=/docs/components-layouts-and-structure-content-docs--page) or
+write some styling to get things aligned. In the Mixed Components
+[example](../?path=/story/components-layouts-and-structure-actionitemgroup-mobile--mixed-components)
+you can see Content being used to layout
+[Text](../?path=/docs/components-text-and-typography-text-docs--page) and
+[Typography](../?path=/docs/components-text-and-typography-typography-docs--page)
+alongside some
+[ActionItems](../?path=/docs/components-layouts-and-structure-actionitem-docs--page).
+
+## Related components
+
+If you only need one
+[ActionItem](../?path=/docs/components-layouts-and-structure-actionitem-docs--page),
+you can use that on its own without this wrapper.
+
+## Accessibility
+
+ActionItemGroup is just a layout wrapper and does not communicate anything to
+screen-readers - that's the job of its children.

--- a/docs/components/ActionItemGroup/Mobile.stories.tsx
+++ b/docs/components/ActionItemGroup/Mobile.stories.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import {
+  ActionItem,
+  ActionItemGroup,
+  Card,
+  Content,
+  Text,
+  Typography,
+} from "@jobber/components-native";
+
+export default {
+  title: "Components/Layouts and Structure/ActionItemGroup/Mobile",
+  parameters: {
+    viewMode: "story",
+    previewTabs: { code: { hidden: false } },
+    viewport: { defaultViewport: "mobile1" },
+    backgrounds: {
+      default: "surface background",
+    },
+  },
+} as ComponentMeta<typeof ActionItemGroup>;
+
+const BasicTemplate: ComponentStory<typeof ActionItemGroup> = () => {
+  return (
+    <ActionItemGroup>
+      <Card>
+        <ActionItem
+          title={"Request #13"}
+          icon={"request"}
+          onPress={() => alert("request")}
+        />
+        <ActionItem
+          title={"Quote #64"}
+          icon={"quote"}
+          onPress={() => alert("quote")}
+        />
+        <ActionItem
+          title={"Job #12"}
+          icon={"job"}
+          onPress={() => alert("job")}
+        />
+        <ActionItem
+          title={"Invoice #72"}
+          icon={"invoice"}
+          onPress={() => alert("invoice")}
+        >
+          <Text>$250.00</Text>
+        </ActionItem>
+      </Card>
+    </ActionItemGroup>
+  );
+};
+
+const MixedComponentsTemplate: ComponentStory<typeof ActionItemGroup> = () => {
+  return (
+    <Card>
+      <ActionItemGroup>
+        <ActionItem
+          title={"Stephen Campbell"}
+          icon={"person"}
+          onPress={() => alert("client")}
+        />
+        <Content>
+          <Typography fontFamily="display">Client name</Typography>
+          <Text>Stephen Campbell</Text>
+          <Typography fontFamily="display">Client type</Typography>
+          <Text>Residential</Text>
+        </Content>
+        <ActionItem
+          title={"Request #13"}
+          icon={"request"}
+          onPress={() => alert("request")}
+        />
+        <ActionItem
+          title={"Quote #64"}
+          icon={"quote"}
+          onPress={() => alert("quote")}
+        />
+        <ActionItem
+          title={"Job #12"}
+          icon={"job"}
+          onPress={() => alert("job")}
+        />
+        <ActionItem
+          title={"Invoice #72"}
+          icon={"invoice"}
+          onPress={() => alert("invoice")}
+        >
+          <Text>$250.00</Text>
+        </ActionItem>
+      </ActionItemGroup>
+    </Card>
+  );
+};
+
+export const Basic = BasicTemplate.bind({});
+
+export const MixedComponents = MixedComponentsTemplate.bind({});


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`ActionItem` & `ActionItemGroup` don't have any Storybook docs


### Added

<!-- new features -->
 - docs pages & mobile examples added for both

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
