### PR TITLE
feat(components): Support semantic HTML elements for Content root element

### DIFF
--- a/docs/components/Content/Content.stories.mdx
+++ b/docs/components/Content/Content.stories.mdx
@@ -29,3 +29,8 @@ interacted with.
 
 Children of the Content component should be presented in a logical order, and
 follow a sensible hierarchy that can be followed by screen readers.
+
+Content supports the use of semantic HTML5 region elements like `<main>`,
+`<section>`, `<article>` etc. to further enhance accessibility when used
+appropriately. Consider using these if the Content represents a meaningful
+region or section of your content. The default tag is a `<div>`.

--- a/docs/components/Content/Web.stories.tsx
+++ b/docs/components/Content/Web.stories.tsx
@@ -21,7 +21,7 @@ export default {
 const BasicTemplate: ComponentStory<typeof Content> = args => (
   <Content {...args}>
     <Card title="About me">
-      <Content tagName="section" {...args}>
+      <Content type="section" {...args}>
         <Heading level={2}>Sign up!</Heading>
         <Text>
           Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis

--- a/docs/components/Content/Web.stories.tsx
+++ b/docs/components/Content/Web.stories.tsx
@@ -21,7 +21,7 @@ export default {
 const BasicTemplate: ComponentStory<typeof Content> = args => (
   <Content {...args}>
     <Card title="About me">
-      <Content {...args}>
+      <Content tagName="section" {...args}>
         <Heading level={2}>Sign up!</Heading>
         <Text>
           Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis

--- a/packages/components/src/Content/Content.test.tsx
+++ b/packages/components/src/Content/Content.test.tsx
@@ -45,8 +45,8 @@ it("renders a Content with a small spacing", () => {
   `);
 });
 
-it("renders with a semantic tag when a valid tagName is set", () => {
-  const { container } = render(<Content tagName="section">A section!</Content>);
+it("renders with a semantic tag when a valid type is set", () => {
+  const { container } = render(<Content type="section">A section!</Content>);
 
   expect(container).toMatchInlineSnapshot(`
     <div>

--- a/packages/components/src/Content/Content.test.tsx
+++ b/packages/components/src/Content/Content.test.tsx
@@ -44,3 +44,17 @@ it("renders a Content with a small spacing", () => {
     </div>
   `);
 });
+
+it("renders with a semantic tag when a valid tagName is set", () => {
+  const { container } = render(<Content tagName="section">A section!</Content>);
+
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <section
+        class="padded base"
+      >
+        A section!
+      </section>
+    </div>
+    `);
+});

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -15,10 +15,10 @@ interface ContentProps {
   /**
    * The html tag name to use as the container element
    * Defaults to 'div'
-   * Must be a valid HTML5 element name
+   * Must be a valid HTML5 element that accepts children
    * @default 'div'
    */
-  readonly tagName?:
+  readonly type?:
     | "section"
     | "aside"
     | "header"
@@ -31,9 +31,9 @@ interface ContentProps {
 export function Content({
   children,
   spacing = "base",
-  tagName = "div",
+  type = "div",
 }: ContentProps) {
   const className = classnames(styles.padded, spacings[spacing]);
 
-  return createElement(tagName, { className }, children);
+  return createElement(type, { className }, children);
 }

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import { ReactNode, createElement } from "react";
 import classnames from "classnames";
 import spacings from "./Spacing.css";
 import styles from "./Content.css";
@@ -11,10 +11,22 @@ interface ContentProps {
    * @default base
    */
   readonly spacing?: keyof typeof spacings;
+
+  /**
+   * The html tag name to use as the container element
+   * Defaults to 'div'
+   * Must be a valid HTML5 element name
+   * @default 'div'
+   */
+  readonly tagName?: "section" | "aside" | "header" | "footer" | "main" | "div";
 }
 
-export function Content({ children, spacing = "base" }: ContentProps) {
+export function Content({
+  children,
+  spacing = "base",
+  tagName = "div",
+}: ContentProps) {
   const className = classnames(styles.padded, spacings[spacing]);
 
-  return <div className={className}>{children}</div>;
+  return createElement(tagName, { className }, children);
 }

--- a/packages/components/src/Content/Content.tsx
+++ b/packages/components/src/Content/Content.tsx
@@ -18,7 +18,14 @@ interface ContentProps {
    * Must be a valid HTML5 element name
    * @default 'div'
    */
-  readonly tagName?: "section" | "aside" | "header" | "footer" | "main" | "div";
+  readonly tagName?:
+    | "section"
+    | "aside"
+    | "header"
+    | "footer"
+    | "article"
+    | "main"
+    | "div";
 }
 
 export function Content({


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/pull-request-name-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
The spacing support provided by `Content` is great, but using the component currently means sacrificing potential semantic HTML regions. This feature would allow you to still get all the benefits of `Content` but with a more semantic element where applicable. 

## Changes
`Content` now accepts a `type` prop to use a semantic HTML5 element as the root element. Still defaults to `<div>`
<!-- https://keepachangelog.com/en/1.0.0/ -->

## Testing

<!-- How to test your changes. -->
Try providing a `type` prop to a `Content`. The type must be a valid HTML5 content container. Try a `<section>`.

Added a unit test to verify the section renders as expected. 
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

❓ 😕 Random Picture of Atlanta
![image](https://github.com/GetJobber/atlantis/assets/10996915/3f78352b-5304-4052-857f-70e8c3247214)

