### PR TITLE
chore(components): Fix DataTable expression that was being rendered as text

### DIFF
--- a/packages/components/src/DataTable/Body.tsx
+++ b/packages/components/src/DataTable/Body.tsx
@@ -33,34 +33,39 @@ export function Body<T extends object>({
 
   return (
     <>
-      table.getRowModel().rows.length ? (
-      <tbody>
-        {table.getRowModel().rows.map(row => {
-          return (
-            <tr
-              key={row.id}
-              onClick={handleRowClick(row)}
-              className={bodyRowClasses}
-            >
-              {row.getVisibleCells().map(cell => {
-                return (
-                  <td
-                    key={cell.id}
-                    style={{
-                      width: cell.column.getSize(),
-                      minWidth: cell.column.columnDef.minSize,
-                      maxWidth: cell.column.columnDef.maxSize,
-                    }}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                );
-              })}
-            </tr>
-          );
-        })}
-      </tbody>
-      ) : (<div className={classNames(styles.emptyState)}>{emptyState}</div>)
+      {table.getRowModel().rows.length ? (
+        <tbody>
+          {table.getRowModel().rows.map(row => {
+            return (
+              <tr
+                key={row.id}
+                onClick={handleRowClick(row)}
+                className={bodyRowClasses}
+              >
+                {row.getVisibleCells().map(cell => {
+                  return (
+                    <td
+                      key={cell.id}
+                      style={{
+                        width: cell.column.getSize(),
+                        minWidth: cell.column.columnDef.minSize,
+                        maxWidth: cell.column.columnDef.maxSize,
+                      }}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      ) : (
+        <div className={classNames(styles.emptyState)}>{emptyState}</div>
+      )}
     </>
   );
 }


### PR DESCRIPTION


<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

Fixes the expression that was being rendered as a text instead of being evaluated in JS.

![image](https://github.com/GetJobber/atlantis/assets/12849476/abb7c976-1205-4478-8a00-856bd11dcc32)


### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fixes the expression that was being rendered as a text instead of being evaluated in JS.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
