### PR TITLE
refactor(components-native): Add setHeaderHeight to AtlantisContext

### DIFF
--- a/packages/components-native/src/AtlantisContext/AtlantisContext.test.tsx
+++ b/packages/components-native/src/AtlantisContext/AtlantisContext.test.tsx
@@ -20,6 +20,10 @@ const providerValues: AtlantisContextProps = {
   },
   floatSeparators: { decimal: ".", group: "," },
   currencySymbol: "€",
+  headerHeight: 50,
+  setHeaderHeight: _ => {
+    return;
+  },
 };
 
 describe("AtlantisContext", () => {

--- a/packages/components-native/src/AtlantisContext/AtlantisContext.tsx
+++ b/packages/components-native/src/AtlantisContext/AtlantisContext.tsx
@@ -46,6 +46,13 @@ export interface AtlantisContextProps {
    * By accurately defining this value, Atlantis can effectively calculate the layout and alignment of its components.
    */
   readonly headerHeight: number;
+
+  /**
+   * The `setHeaderHeight` method allows you to set the height of the app header in Atlantis.
+   * Adjusting this height is essential for ensuring the correct positioning and alignment of various elements within the app.
+   * By setting this value accurately, Atlantis can dynamically adjust the layout of its components based on the specified header height.
+   */
+  readonly setHeaderHeight: (height: number) => void;
 }
 
 export const defaultValues: AtlantisContextProps = {
@@ -60,6 +67,9 @@ export const defaultValues: AtlantisContextProps = {
   floatSeparators: { group: ",", decimal: "." },
   currencySymbol: DEFAULT_CURRENCY_SYMBOL,
   headerHeight: 0,
+  setHeaderHeight: _ => {
+    return;
+  },
 };
 
 export const AtlantisContext = createContext(defaultValues);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

Adds a new property to `AtlantisContext` called `setHeaderHeight` so it can be set dynamically in jobber-mobile.

I added this because currently we can't use `headerHeight` from `@react-navigation/elements` in the `AtlantisProvider` because the navigation/header is still not defined there.

This way, we can use `headerHeight` as a state in `AtlantisProvider` and update its value in `NavigationHeader`

Example: https://github.com/GetJobber/jobber-mobile/pull/7902/files

### Added

- New property in `AtlantisContext` called `setHeaderHeight`

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
