### PR TITLE
feat(components): implement ability to add a data list filters

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -6,6 +6,8 @@ import { DataList, DataListItemType } from "@jobber/components/DataList";
 import { Grid } from "@jobber/components/Grid";
 import { InlineLabel, InlineLabelColors } from "@jobber/components/InlineLabel";
 import { Content } from "@jobber/components/Content";
+import { Button } from "@jobber/components/Button";
+import { DatePicker } from "@jobber/components/DatePicker";
 import { LIST_QUERY, ListQueryType, apolloClient } from "./storyUtils";
 
 export default {
@@ -93,6 +95,33 @@ const Template: ComponentStory<typeof DataList> = args => {
         created: "Created",
       }}
     >
+      <DataList.Filters>
+        <Button
+          label="Filter gender"
+          variation="subtle"
+          icon="add"
+          iconOnRight={true}
+          onClick={() => alert("Run filter by gender query")}
+        />
+        <Button
+          label="Filter attributes"
+          variation="subtle"
+          icon="add"
+          iconOnRight={true}
+          onClick={() => alert("Run filter by attributes query")}
+        />
+        <DatePicker
+          onChange={date => alert(`Filter by created date: ${date}`)}
+          activator={
+            <Button
+              icon="calendar"
+              ariaLabel="Select date"
+              variation="subtle"
+            />
+          }
+        />
+      </DataList.Filters>
+
       <DataList.Layout size="md">
         {(item: DataListItemType<typeof mappedData>) => (
           <Grid alignItems="center">

--- a/package-lock.json
+++ b/package-lock.json
@@ -48124,6 +48124,7 @@
         "@types/react-dom": "^18.0.11",
         "@types/uuid": "^8.3.3",
         "@types/zxcvbn": "^4.4.1",
+        "jsdom-testing-mocks": "^1.9.0",
         "typescript": "^4.9.5",
         "uuid": "^8.3.2"
       },

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -15,6 +15,10 @@
   background-color: var(--color-surface);
 }
 
+.header:empty {
+  display: none;
+}
+
 .headerTitles {
   padding: var(--space-small);
   border-bottom: var(--border-thick) solid var(--color-border);

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -12,9 +12,12 @@
   position: sticky;
   top: 0;
   z-index: var(--elevation-base);
+  background-color: var(--color-surface);
+}
+
+.headerTitles {
   padding: var(--space-small);
   border-bottom: var(--border-thick) solid var(--color-border);
-  background-color: var(--color-surface);
 }
 
 .headerLabel > * {

--- a/packages/components/src/DataList/DataList.css.d.ts
+++ b/packages/components/src/DataList/DataList.css.d.ts
@@ -2,6 +2,7 @@ declare const styles: {
   readonly "wrapper": string;
   readonly "titleContainer": string;
   readonly "header": string;
+  readonly "headerTitles": string;
   readonly "headerLabel": string;
   readonly "listItem": string;
 };

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -18,9 +18,22 @@ import {
   DataListItems,
 } from "./components/DataListLayoutInternal";
 import { useLayoutMediaQueries } from "./hooks/useLayoutMediaQueries";
+import { DataListContext } from "./context/DataListContext";
+import {
+  DataListFilters,
+  InternalDataListFilters,
+} from "./components/DataListFilters";
 import { Heading } from "../Heading";
 
-export function DataList<T extends DataListObject>({
+export function DataList<T extends DataListObject>(props: DataListProps<T>) {
+  return (
+    <DataListContext.Provider value={props}>
+      <InternalDataList {...props} />
+    </DataListContext.Provider>
+  );
+}
+
+function InternalDataList<T extends DataListObject>({
   data,
   headers,
   loading = false,
@@ -48,25 +61,30 @@ export function DataList<T extends DataListObject>({
 
   return (
     <div className={styles.wrapper}>
-      {/* List title and counter */}
       <div className={styles.titleContainer}>
         {title && <Heading level={3}>{title}</Heading>}
         <DataListTotalCount totalCount={totalCount} loading={loading} />
       </div>
+
       {headerData && (
-        <DataListHeader
-          layouts={allLayouts}
-          headerData={headerData}
-          headerVisibility={headerVisibility}
-          mediaMatches={mediaMatches}
-        />
+        <div className={styles.header}>
+          <InternalDataListFilters />
+          <DataListHeader
+            layouts={allLayouts}
+            headerData={headerData}
+            headerVisibility={headerVisibility}
+            mediaMatches={mediaMatches}
+          />
+        </div>
       )}
+
       <DataListLoadingState
         loading={loading}
         headers={headers}
         layouts={allLayouts}
         mediaMatches={mediaMatches}
       />
+
       {!loading && (
         <DataListItems
           data={data}
@@ -74,6 +92,7 @@ export function DataList<T extends DataListObject>({
           mediaMatches={mediaMatches}
         />
       )}
+
       {showEmptyState && EmptyStateComponent}
     </div>
   );
@@ -81,3 +100,4 @@ export function DataList<T extends DataListObject>({
 
 DataList.Layout = DataListLayout;
 DataList.EmptyState = EmptyState;
+DataList.Filters = DataListFilters;

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -66,17 +66,18 @@ function InternalDataList<T extends DataListObject>({
         <DataListTotalCount totalCount={totalCount} loading={loading} />
       </div>
 
-      {headerData && (
-        <div className={styles.header}>
-          <InternalDataListFilters />
+      <div className={styles.header}>
+        <InternalDataListFilters />
+
+        {headerData && (
           <DataListHeader
             layouts={allLayouts}
             headerData={headerData}
             headerVisibility={headerVisibility}
             mediaMatches={mediaMatches}
           />
-        </div>
-      )}
+        )}
+      </div>
 
       <DataListLoadingState
         loading={loading}

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilter.const.ts
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilter.const.ts
@@ -1,0 +1,1 @@
+export const CONTAINER_TEST_ID = "ATL-DataListFilters-Container";

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.css
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.css
@@ -1,6 +1,44 @@
 .filters {
-  display: flex;
-  gap: var(--space-small);
-  align-items: center;
+  position: relative;
+}
+
+.filterActions {
+  display: grid;
   padding: var(--space-small) 0;
+  overflow-x: auto;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  align-items: center;
+}
+
+.filterActions > :nth-child(n + 3):not(:last-child) {
+  margin-left: var(--space-small);
+}
+
+.overflowTrigger {
+  visibility: hidden;
+}
+
+.overflowLeft::before,
+.overflowRight::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  width: var(--space-large);
+  height: 100%;
+  background-image: linear-gradient(
+    var(--data-list-filters-overflow-shadow-angle, to right),
+    var(--color-surface) 0%,
+    rgba(var(--color-white--rgb), 0) 100%
+  );
+  pointer-events: none;
+}
+
+.overflowLeft::before {
+  left: 0;
+}
+
+.overflowRight::after {
+  --data-list-filters-overflow-shadow-angle: to left;
+  right: 0;
 }

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.css
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.css
@@ -1,0 +1,6 @@
+.filters {
+  display: flex;
+  gap: var(--space-small);
+  align-items: center;
+  padding: var(--space-small) 0;
+}

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.css.d.ts
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly "filters": string;
+};
+export = styles;
+

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.css.d.ts
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.css.d.ts
@@ -1,5 +1,9 @@
 declare const styles: {
   readonly "filters": string;
+  readonly "filterActions": string;
+  readonly "overflowTrigger": string;
+  readonly "overflowLeft": string;
+  readonly "overflowRight": string;
 };
 export = styles;
 

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.test.tsx
@@ -7,7 +7,6 @@ import { defaultValues } from "../../context/DataListContext";
 import * as dataListContext from "../../context/DataListContext/DataListContext";
 
 configMocks({ act });
-
 const observer = mockIntersectionObserver();
 
 const spy = jest.spyOn(dataListContext, "useDataListContext");
@@ -72,7 +71,6 @@ describe("InternalDataListFilters", () => {
       const triggers =
         container.querySelectorAll<HTMLElement>(".overflowTrigger");
 
-      observer.leaveAll();
       observer.enterNode(triggers.item(0));
 
       expect(container).toHaveClass("overflowRight");
@@ -86,7 +84,6 @@ describe("InternalDataListFilters", () => {
       const triggers =
         container.querySelectorAll<HTMLElement>(".overflowTrigger");
 
-      observer.leaveAll();
       observer.enterNode(triggers.item(1));
 
       expect(container).not.toHaveClass("overflowRight");

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { configMocks, mockIntersectionObserver } from "jsdom-testing-mocks";
+import { DataListFilters, InternalDataListFilters } from "./DataListFilters";
+import { CONTAINER_TEST_ID } from "./DataListFilter.const";
+import { defaultValues } from "../../context/DataListContext";
+import * as dataListContext from "../../context/DataListContext/DataListContext";
+
+configMocks({ act });
+
+const observer = mockIntersectionObserver();
+
+const spy = jest.spyOn(dataListContext, "useDataListContext");
+const contextValueWithRenderableChildren = {
+  ...defaultValues,
+  children: (
+    <DataListFilters>
+      <button />
+      <button />
+      <button />
+    </DataListFilters>
+  ),
+};
+
+afterEach(() => {
+  cleanup();
+  spy.mockReset();
+});
+
+describe("DataListFilters", () => {
+  it("should not render anything", () => {
+    const text = "Don't render me";
+
+    render(
+      <DataListFilters>
+        <div>{text}</div>
+      </DataListFilters>,
+    );
+
+    expect(screen.queryByText(text)).not.toBeInTheDocument();
+  });
+});
+
+describe("InternalDataListFilters", () => {
+  describe("Overflowing fade", () => {
+    it("should show the overflow fade", () => {
+      spy.mockReturnValue(contextValueWithRenderableChildren);
+      render(<InternalDataListFilters />);
+
+      observer.leaveAll();
+
+      expect(screen.getByTestId(CONTAINER_TEST_ID)).toHaveClass(
+        "overflowLeft overflowRight",
+      );
+    });
+
+    it("should not show the overflow fade", () => {
+      spy.mockReturnValue(contextValueWithRenderableChildren);
+      render(<InternalDataListFilters />);
+
+      observer.enterAll();
+
+      expect(screen.getByTestId(CONTAINER_TEST_ID)).not.toHaveClass(
+        "overflowLeft overflowRight",
+      );
+    });
+
+    it("should only show the right overflow fade", () => {
+      spy.mockReturnValue(contextValueWithRenderableChildren);
+      render(<InternalDataListFilters />);
+      const container = screen.getByTestId(CONTAINER_TEST_ID);
+      const triggers =
+        container.querySelectorAll<HTMLElement>(".overflowTrigger");
+
+      observer.leaveAll();
+      observer.enterNode(triggers.item(0));
+
+      expect(container).toHaveClass("overflowRight");
+      expect(container).not.toHaveClass("overflowLeft");
+    });
+
+    it("should only show the left overflow fade", () => {
+      spy.mockReturnValue(contextValueWithRenderableChildren);
+      render(<InternalDataListFilters />);
+      const container = screen.getByTestId(CONTAINER_TEST_ID);
+      const triggers =
+        container.querySelectorAll<HTMLElement>(".overflowTrigger");
+
+      observer.leaveAll();
+      observer.enterNode(triggers.item(1));
+
+      expect(container).not.toHaveClass("overflowRight");
+      expect(container).toHaveClass("overflowLeft");
+    });
+  });
+
+  it("should render the passed in children when DataListFilters is implemented", () => {
+    spy.mockReturnValue(contextValueWithRenderableChildren);
+    render(<InternalDataListFilters />);
+
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+  });
+
+  it("should render nothing when it's DataListFilters is not implemented", () => {
+    spy.mockReturnValue({ ...defaultValues, children: <button /> });
+    render(<InternalDataListFilters />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
@@ -1,4 +1,6 @@
 import React, { ReactElement } from "react";
+import classNames from "classnames";
+import { useInView } from "@jobber/hooks/useInView";
 import styles from "./DataListFilters.css";
 import { useDataListContext } from "../../context/DataListContext";
 import { getCompoundComponent } from "../../DataList.utils";
@@ -22,9 +24,28 @@ export function InternalDataListFilters() {
     parentChildren,
     DataListFilters,
   );
+
+  const [leftRef, isLeftVisible] = useInView<HTMLSpanElement>();
+  const [rightRef, isRightVisible] = useInView<HTMLSpanElement>();
+
   if (!component) return null;
 
   const { children } = component.props;
 
-  return <div className={styles.filters}>{children}</div>;
+  return (
+    <div
+      className={classNames(styles.filters, {
+        [styles.overflowLeft]: !isLeftVisible,
+        [styles.overflowRight]: !isRightVisible,
+      })}
+    >
+      <div className={styles.filterActions}>
+        <span ref={leftRef} className={styles.overflowTrigger} />
+
+        {children}
+
+        <span ref={rightRef} className={styles.overflowTrigger} />
+      </div>
+    </div>
+  );
 }

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
@@ -1,0 +1,30 @@
+import React, { ReactElement } from "react";
+import styles from "./DataListFilters.css";
+import { useDataListContext } from "../../context/DataListContext";
+import { getCompoundComponent } from "../../DataList.utils";
+
+interface DataListFiltersProps {
+  readonly children: ReactElement | ReactElement[];
+}
+
+// This component is meant to capture the props of the DataList.Filters
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function DataListFilters(_: DataListFiltersProps) {
+  return null;
+}
+
+/**
+ * Renders the DataList.Filters component
+ */
+export function InternalDataListFilters() {
+  const { children: parentChildren } = useDataListContext();
+  const component = getCompoundComponent<DataListFiltersProps>(
+    parentChildren,
+    DataListFilters,
+  );
+  if (!component) return null;
+
+  const { children } = component.props;
+
+  return <div className={styles.filters}>{children}</div>;
+}

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react";
 import classNames from "classnames";
 import { useInView } from "@jobber/hooks/useInView";
 import styles from "./DataListFilters.css";
+import { CONTAINER_TEST_ID } from "./DataListFilter.const";
 import { useDataListContext } from "../../context/DataListContext";
 import { getCompoundComponent } from "../../DataList.utils";
 
@@ -34,6 +35,7 @@ export function InternalDataListFilters() {
 
   return (
     <div
+      data-testid={CONTAINER_TEST_ID}
       className={classNames(styles.filters, {
         [styles.overflowLeft]: !isLeftVisible,
         [styles.overflowRight]: !isRightVisible,

--- a/packages/components/src/DataList/components/DataListFilters/index.ts
+++ b/packages/components/src/DataList/components/DataListFilters/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListFilters";

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListHeader.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListHeader.tsx
@@ -44,7 +44,7 @@ export function DataListHeader<T extends DataListObject>({
       layouts={layouts}
       renderLayout={layout => {
         return (
-          <div className={styles.header}>
+          <div className={styles.headerTitles}>
             {layout.props.children(headerData)}
           </div>
         );

--- a/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
+++ b/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
@@ -1,11 +1,14 @@
 import { createContext, useContext } from "react";
 import { DataListObject, DataListProps } from "../../DataList.types";
 
-export const DataListContext = createContext<DataListProps<DataListObject>>({
+export const defaultValues = {
   data: [],
   headers: {},
   children: [],
-});
+};
+
+export const DataListContext =
+  createContext<DataListProps<DataListObject>>(defaultValues);
 
 export function useDataListContext() {
   return useContext(DataListContext);

--- a/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
+++ b/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from "react";
+import { DataListObject, DataListProps } from "../../DataList.types";
+
+export const DataListContext = createContext<DataListProps<DataListObject>>({
+  data: [],
+  headers: {},
+  children: [],
+});
+
+export function useDataListContext() {
+  return useContext(DataListContext);
+}

--- a/packages/components/src/DataList/context/DataListContext/index.ts
+++ b/packages/components/src/DataList/context/DataListContext/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListContext";

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -29,6 +29,7 @@
     "@types/react-dom": "^18.0.11",
     "@types/uuid": "^8.3.3",
     "@types/zxcvbn": "^4.4.1",
+    "jsdom-testing-mocks": "^1.9.0",
     "typescript": "^4.9.5",
     "uuid": "^8.3.2"
   },

--- a/packages/hooks/src/useInView/index.ts
+++ b/packages/hooks/src/useInView/index.ts
@@ -1,0 +1,1 @@
+export * from "./useInView";

--- a/packages/hooks/src/useInView/useInView.test.tsx
+++ b/packages/hooks/src/useInView/useInView.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { act, render, renderHook, screen } from "@testing-library/react";
+import { configMocks, mockIntersectionObserver } from "jsdom-testing-mocks";
+import { useInView } from "./useInView";
+
+configMocks({ act });
+const observer = mockIntersectionObserver();
+
+describe("useInView", () => {
+  it("should return true when the target element is in view", () => {
+    const { result, rerender } = renderHook(() =>
+      useInView<HTMLButtonElement>(),
+    );
+
+    const [ref, isInView] = result.current;
+    render(<button ref={ref} />);
+    rerender();
+
+    expect(result.current[0].current).toBeInstanceOf(HTMLButtonElement);
+
+    observer.leaveNode(screen.getByRole("button"));
+    expect(isInView).toBe(false);
+  });
+
+  it("should return false when the target element is in view", () => {
+    const { result, rerender } = renderHook(() =>
+      useInView<HTMLButtonElement>(),
+    );
+
+    render(<button ref={result.current[0]} />);
+    rerender();
+
+    observer.enterNode(screen.getByRole("button"));
+    expect(result.current[1]).toBe(true);
+  });
+});

--- a/packages/hooks/src/useInView/useInView.ts
+++ b/packages/hooks/src/useInView/useInView.ts
@@ -1,23 +1,24 @@
-import { RefObject, useEffect, useRef, useState } from "react";
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 
 export function useInView<T extends Element>(): [RefObject<T>, boolean] {
   const ref = useRef<T>(null);
   const [isInView, setIsInView] = useState(false);
 
+  const handleIntersection: IntersectionObserverCallback = useCallback(
+    entries => setIsInView(entries[0].isIntersecting),
+    [setIsInView],
+  );
+
   useEffect(() => {
     if (!window.IntersectionObserver) return;
 
-    const observer = new IntersectionObserver(entries => {
-      setIsInView(entries[0].isIntersecting);
-    });
-
+    const observer = new IntersectionObserver(handleIntersection);
     ref.current && observer.observe(ref.current);
 
     return () => {
-      if (!ref.current) return;
-      observer.unobserve(ref.current);
+      ref.current && observer.unobserve(ref.current);
     };
-  });
+  }, [handleIntersection]);
 
   return [ref, isInView];
 }

--- a/packages/hooks/src/useInView/useInView.ts
+++ b/packages/hooks/src/useInView/useInView.ts
@@ -1,0 +1,23 @@
+import { RefObject, useEffect, useRef, useState } from "react";
+
+export function useInView<T extends Element>(): [RefObject<T>, boolean] {
+  const ref = useRef<T>(null);
+  const [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    if (!window.IntersectionObserver) return;
+
+    const observer = new IntersectionObserver(entries => {
+      setIsInView(entries[0].isIntersecting);
+    });
+
+    ref.current && observer.observe(ref.current);
+
+    return () => {
+      if (!ref.current) return;
+      observer.unobserve(ref.current);
+    };
+  });
+
+  return [ref, isInView];
+}

--- a/packages/hooks/src/useInView/useInView.ts
+++ b/packages/hooks/src/useInView/useInView.ts
@@ -18,7 +18,7 @@ export function useInView<T extends Element>(): [RefObject<T>, boolean] {
     return () => {
       ref.current && observer.unobserve(ref.current);
     };
-  }, [handleIntersection]);
+  }, [handleIntersection, ref.current]);
 
   return [ref, isInView];
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Looking at a large set of data requires some form of filtering ability along with its microinteractions. This adds a place for the filters in DataList.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- An ability to pass in `DataList.Filters` to the DataList
- In the event that the amount of filters is bigger than the space we have, the filters would overflow with a fade indicator
- Added a context for DataList to reduce the amount of prop drilling we do which reduces the type issues we'd have in the future.
- Added a hook called `useInView` to check if an element is visible on the screen
  - In the essence of time, opted to put the documentation for it on another PR.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

To test the overflow, set the story size to small mobile

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
