### PR TITLE
fix(components): add border on DataList header when scrolling without column headers

### DIFF
--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -23,6 +23,7 @@ import {
   DataListFilters,
   InternalDataListFilters,
 } from "./components/DataListFilters";
+import { DataListStickyHeader } from "./components/DataListStickyHeader/DataListStickyHeader";
 import { Heading } from "../Heading";
 
 export function DataList<T extends DataListObject>(props: DataListProps<T>) {
@@ -66,7 +67,7 @@ function InternalDataList<T extends DataListObject>({
         <DataListTotalCount totalCount={totalCount} loading={loading} />
       </div>
 
-      <div className={styles.header}>
+      <DataListStickyHeader>
         <InternalDataListFilters />
 
         {headerData && (
@@ -77,7 +78,7 @@ function InternalDataList<T extends DataListObject>({
             mediaMatches={mediaMatches}
           />
         )}
-      </div>
+      </DataListStickyHeader>
 
       <DataListLoadingState
         loading={loading}

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.css
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.css
@@ -1,5 +1,6 @@
 .header {
   --offset: 1px;
+  --sticky-header-transition-properties: var(--timing-base) ease-in-out;
 
   position: sticky;
   top: calc(var(--offset) * -1);
@@ -9,12 +10,31 @@
 }
 
 /**
- * Use an inner box shadow to create the border that gets covered by the column
- * headers border when it shows up.
+ * Draw a border that gets covered by the column headers border when it shows up.
  *
  * Mostly to prevent us from writing some complex JS to remove the border when
- * the column headers show up
+ * the column headers show up.
  */
-.stuck {
-  box-shadow: inset 0 calc(var(--border-thick) * -1) var(--color-border);
+
+.header::before {
+  content: "";
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  z-index: -1;
+  width: 0;
+  height: 0;
+  background-color: var(--color-border);
+  transform: translateX(-50%);
+  transition: height var(--sticky-header-transition-properties)
+      var(--timing-quick),
+    width var(--sticky-header-transition-properties);
+}
+
+.stuck::before {
+  width: 100%;
+  height: var(--border-thick);
+  transition: height var(--sticky-header-transition-properties),
+    width var(--sticky-header-transition-properties) var(--timing-quick);
 }

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.css
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.css
@@ -8,6 +8,13 @@
   background-color: var(--color-surface);
 }
 
+/**
+ * Use an inner box shadow to create the border that gets covered by the column
+ * headers border when it shows up.
+ *
+ * Mostly to prevent us from writing some complex JS to remove the border when
+ * the column headers show up
+ */
 .stuck {
-  border-bottom: solid var(--border-thick) var(--color-border);
+  box-shadow: inset 0 calc(var(--border-thick) * -1) var(--color-border);
 }

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.css
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.css
@@ -1,0 +1,13 @@
+.header {
+  --offset: 1px;
+
+  position: sticky;
+  top: calc(var(--offset) * -1);
+  z-index: var(--elevation-base);
+  padding-top: var(--offset);
+  background-color: var(--color-surface);
+}
+
+.stuck {
+  border-bottom: solid var(--border-thick) var(--color-border);
+}

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.css.d.ts
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "header": string;
+  readonly "stuck": string;
+};
+export = styles;
+

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.test.tsx
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { configMocks, mockIntersectionObserver } from "jsdom-testing-mocks";
+import { DataListStickyHeader } from "./DataListStickyHeader";
+
+configMocks({ act });
+const observer = mockIntersectionObserver();
+
+describe("DataListStickyHeader", () => {
+  it("should have an isStuck className when it's slightly off screen", () => {
+    render(
+      <DataListStickyHeader>
+        <button>Click me</button>
+      </DataListStickyHeader>,
+    );
+    const el = screen.getByRole("button");
+    const target = el.parentElement as HTMLElement;
+
+    observer.leaveNode(target, { intersectionRatio: 0.9 });
+    expect(target).toHaveClass("stuck");
+  });
+
+  it("should not have an isStuck className it's fully visible on the screen", () => {
+    render(
+      <DataListStickyHeader>
+        <button>Click me</button>
+      </DataListStickyHeader>,
+    );
+    const el = screen.getByRole("button");
+    const target = el.parentElement as HTMLElement;
+
+    // Control test: Make sure it has the class name first before checking if
+    // it's not there
+    observer.leaveNode(target, { intersectionRatio: 0.9 });
+    expect(target).toHaveClass("stuck");
+
+    observer.enterNode(target, { intersectionRatio: 1 });
+    expect(target).not.toHaveClass("stuck");
+  });
+});

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.tsx
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.tsx
@@ -1,0 +1,40 @@
+import classNames from "classnames";
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import styles from "./DataListStickyHeader.css";
+
+export function DataListStickyHeader({ children }: PropsWithChildren<object>) {
+  const [isStuck, setIsStuck] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const handleObserver = useCallback(
+    ([e]: IntersectionObserverEntry[]) => setIsStuck(e.intersectionRatio < 1),
+    [setIsStuck],
+  );
+
+  useEffect(() => {
+    if (!window.IntersectionObserver) return;
+
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold: [1],
+    });
+    ref.current && observer.observe(ref.current);
+
+    return () => {
+      ref.current && observer.unobserve(ref.current);
+    };
+  }, [handleObserver, ref.current]);
+
+  return (
+    <div
+      ref={ref}
+      className={classNames(styles.header, { [styles.stuck]: isStuck })}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.tsx
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.tsx
@@ -19,9 +19,7 @@ export function DataListStickyHeader({ children }: PropsWithChildren<object>) {
   useEffect(() => {
     if (!window.IntersectionObserver) return;
 
-    const observer = new IntersectionObserver(handleObserver, {
-      threshold: [1],
-    });
+    const observer = new IntersectionObserver(handleObserver, { threshold: 1 });
     ref.current && observer.observe(ref.current);
 
     return () => {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The filters stick to the top even without the column header. It doesn't have an indicator where the header stops so this adds a "border" on it when the filters are sticky when there's no column header.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- DataListStickyHeader to control and determine if the header is stuck

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Set the storybook size to small mobile where the header columns disappear
- With the scroll being at the very top, it shouldn't have a border
- When scrolling down and the filter sticks, it should have a border at the bottom of the sticky filters
- When scrolling down and the column headers are visible, it should not add a thicker border at the bottom

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
