### PR TITLE
feat(components): add loading state for filtering and loading more on DataList

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -84,7 +84,7 @@ const Template: ComponentStory<typeof DataList> = args => {
   return (
     <DataList
       {...args}
-      loading={args.loading || loadingInitialContent}
+      loadingState={getLoadingState()}
       totalCount={totalCount}
       data={(args.data as typeof mappedData) || mappedData}
       headers={{
@@ -198,6 +198,11 @@ const Template: ComponentStory<typeof DataList> = args => {
       default:
         return "greyBlue";
     }
+  }
+
+  function getLoadingState() {
+    if (loadingInitialContent) return "initial";
+    return args.loadingState;
   }
 };
 

--- a/packages/components/src/DataList/DataList.const.ts
+++ b/packages/components/src/DataList/DataList.const.ts
@@ -24,3 +24,8 @@ export const BREAKPOINT_SIZES: Record<Breakpoints, number> = {
 };
 
 export const SEARCH_DEBOUNCE_DELAY = tokens["timing-slowest"];
+
+export const DATA_LIST_FILTERING_SPINNER_TEST_ID =
+  "ATL-DataList-filteringSpinner";
+export const DATA_LIST_LOADING_MORE_SPINNER_TEST_ID =
+  "ATL-DataList-loadingMoreSpinner";

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -1,22 +1,14 @@
 .wrapper {
+  position: relative;
   flex: 1;
 }
 
 .titleContainer {
   display: flex;
-  align-items: center;
+  position: relative;
+  z-index: 1;
   margin-bottom: var(--space-small);
-}
-
-.header {
-  position: sticky;
-  top: 0;
-  z-index: var(--elevation-base);
-  background-color: var(--color-surface);
-}
-
-.header:empty {
-  display: none;
+  align-items: center;
 }
 
 .headerFilters {
@@ -38,4 +30,27 @@
 .listItem {
   padding: var(--space-small);
   border-bottom: var(--border-base) solid var(--color-border);
+}
+
+.filtering {
+  display: flex;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: var(--color-overlay--dimmed);
+  align-items: center;
+  justify-content: center;
+}
+
+.filteringSpinner {
+  position: sticky;
+  top: 50vh;
+}
+
+.loadingMore {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-small);
 }

--- a/packages/components/src/DataList/DataList.css.d.ts
+++ b/packages/components/src/DataList/DataList.css.d.ts
@@ -1,11 +1,13 @@
 declare const styles: {
   readonly "wrapper": string;
   readonly "titleContainer": string;
-  readonly "header": string;
   readonly "headerFilters": string;
   readonly "headerTitles": string;
   readonly "headerLabel": string;
   readonly "listItem": string;
+  readonly "filtering": string;
+  readonly "filteringSpinner": string;
+  readonly "loadingMore": string;
 };
 export = styles;
 

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -4,6 +4,8 @@ import { DataList } from "./DataList";
 import {
   BREAKPOINT_SIZES,
   Breakpoints,
+  DATA_LIST_FILTERING_SPINNER_TEST_ID,
+  DATA_LIST_LOADING_MORE_SPINNER_TEST_ID,
   EMPTY_FILTER_RESULTS_ACTION_LABEL,
   EMPTY_FILTER_RESULTS_MESSAGE,
 } from "./DataList.const";
@@ -88,7 +90,7 @@ describe("DataList", () => {
   };
 
   describe("Loading State", () => {
-    it("should render 10 rows of placeholder items when the list is loading", () => {
+    it("should render 10 rows of placeholder items when the list is in initial loading state", () => {
       render(
         <DataList
           loadingState="initial"
@@ -113,9 +115,41 @@ describe("DataList", () => {
 
       const numberOfColumns = Object.keys(mockHeaders).length;
 
-      expect(screen.getAllByTestId(GLIMMER_TEST_ID).length).toBe(
+      expect(screen.getAllByTestId(GLIMMER_TEST_ID)).toHaveLength(
         numberOfColumns * LOADING_STATE_LIMIT_ITEMS,
       );
+    });
+
+    it("should render a spinner when the loading state is filtering", () => {
+      render(
+        <DataList
+          loadingState="filtering"
+          data={mockData}
+          headers={mockHeaders}
+        >
+          <></>
+        </DataList>,
+      );
+
+      expect(
+        screen.getByTestId(DATA_LIST_FILTERING_SPINNER_TEST_ID),
+      ).toBeInTheDocument();
+    });
+
+    it("should render a spinner when the loading state is loadingMore", () => {
+      render(
+        <DataList
+          loadingState="loadingMore"
+          data={mockData}
+          headers={mockHeaders}
+        >
+          <></>
+        </DataList>,
+      );
+
+      expect(
+        screen.getByTestId(DATA_LIST_LOADING_MORE_SPINNER_TEST_ID),
+      ).toBeInTheDocument();
     });
   });
 

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -38,12 +38,7 @@ describe("DataList", () => {
 
     it("should render the total count", () => {
       render(
-        <DataList
-          loading={false}
-          totalCount={10}
-          data={mockData}
-          headers={mockHeader}
-        >
+        <DataList totalCount={10} data={mockData} headers={mockHeader}>
           <></>
         </DataList>,
       );
@@ -53,7 +48,6 @@ describe("DataList", () => {
     it("should not render the total count if the totalCount is null", () => {
       render(
         <DataList
-          loading={false}
           totalCount={null}
           data={mockData}
           headers={mockHeader}
@@ -69,7 +63,7 @@ describe("DataList", () => {
     it("should render the Glimmer on total count when loading", () => {
       render(
         <DataList
-          loading={true}
+          loadingState="initial"
           totalCount={null}
           data={mockData}
           headers={mockHeader}
@@ -97,7 +91,7 @@ describe("DataList", () => {
     it("should render 10 rows of placeholder items when the list is loading", () => {
       render(
         <DataList
-          loading={true}
+          loadingState="initial"
           data={mockData}
           headers={mockHeaders}
           title="All Clients"
@@ -349,12 +343,7 @@ describe("DataList", () => {
 
   it("should render a title when it's provided", () => {
     render(
-      <DataList
-        loading={false}
-        title={mockTitle}
-        headers={{}}
-        data={emptyMockData}
-      >
+      <DataList title={mockTitle} headers={{}} data={emptyMockData}>
         <></>
       </DataList>,
     );
@@ -395,7 +384,7 @@ describe("DataList", () => {
     });
 
     it("should not render when loading", () => {
-      renderEmptyState({ loading: true });
+      renderEmptyState({ loadingState: "initial" });
       expect(screen.queryByText(emptyStateMessage)).not.toBeInTheDocument();
     });
 

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -61,7 +61,6 @@ function InternalDataList() {
   const {
     data,
     headers,
-    loading = false,
     filterApplied = false,
     children,
     title,
@@ -78,7 +77,8 @@ function InternalDataList() {
   const headerData = generateHeaderElements(headers);
   const mediaMatches = useLayoutMediaQueries();
 
-  const showEmptyState = !loading && data.length === 0;
+  const initialLoading = loadingState === "initial";
+  const showEmptyState = !initialLoading && data.length === 0;
   const [isFilterApplied, setIsFilterApplied] = useState(filterApplied);
   const EmptyStateComponent = generateDataListEmptyState({
     children,
@@ -86,13 +86,11 @@ function InternalDataList() {
     setIsFilterApplied,
   });
 
-  const initialLoading = loadingState === "initial";
-
   return (
     <div className={styles.wrapper}>
       <div className={styles.titleContainer}>
         {title && <Heading level={3}>{title}</Heading>}
-        <DataListTotalCount totalCount={totalCount} loading={loading} />
+        <DataListTotalCount totalCount={totalCount} loading={initialLoading} />
       </div>
 
       <DataListStickyHeader>
@@ -111,7 +109,7 @@ function InternalDataList() {
         )}
       </DataListStickyHeader>
 
-      {loading && (
+      {initialLoading && (
         <DataListLoadingState
           headers={headers}
           layouts={allLayouts}

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -66,7 +66,7 @@ function InternalDataList() {
     title,
     totalCount,
     headerVisibility = { xs: true, sm: true, md: true, lg: true, xl: true },
-    loadingState,
+    loadingState = "none",
   } = useDataListContext();
 
   const allLayouts = getCompoundComponents<DataListLayoutProps<DataListObject>>(

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -32,6 +32,10 @@ import {
   InternalDataListSearch,
 } from "./components/DataListSearch";
 import { DataListStickyHeader } from "./components/DataListStickyHeader/DataListStickyHeader";
+import {
+  DATA_LIST_FILTERING_SPINNER_TEST_ID,
+  DATA_LIST_LOADING_MORE_SPINNER_TEST_ID,
+} from "./DataList.const";
 import { Heading } from "../Heading";
 import { Spinner } from "../Spinner";
 
@@ -126,15 +130,21 @@ function InternalDataList() {
       )}
 
       {loadingState === "filtering" && (
-        <div className={styles.filtering}>
+        <div
+          data-testid={DATA_LIST_FILTERING_SPINNER_TEST_ID}
+          className={styles.filtering}
+        >
           <div className={styles.filteringSpinner}>
-            <Spinner />
+            <Spinner size="small" />
           </div>
         </div>
       )}
 
       {loadingState === "loadingMore" && (
-        <div className={styles.loadingMore}>
+        <div
+          data-testid={DATA_LIST_LOADING_MORE_SPINNER_TEST_ID}
+          className={styles.loadingMore}
+        >
           <Spinner size="small" />
         </div>
       )}

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -44,7 +44,15 @@ export type DataListHeader<T extends DataListObject> = {
 };
 
 export interface DataListProps<T extends DataListObject> {
+  /**
+   * The data to render in the DataList.
+   */
   readonly data: T[];
+
+  /**
+   * The header of the DataList. The object keys are determined by the
+   * keys in the data.
+   */
   readonly headers: DataListHeader<T>;
 
   /**
@@ -55,12 +63,20 @@ export interface DataListProps<T extends DataListObject> {
   readonly loading?: boolean;
 
   /**
+   * Set the loading state of the DataList. There are a few guidelines on when to use what.
+   *
+   * - `"initial"` - loading the first set of data
+   * - `"filtering"` - loading after a filter is applied
+   * - `"loadingMore"` - loading more data after the user scrolls to the bottom
+   */
+  readonly loadingState?: "initial" | "filtering" | "loadingMore";
+
+  /**
    * Temporary prop for setting default state for if filters are applied
    *
    * @default false
    */
   readonly filterApplied?: boolean;
-  readonly children: ReactElement | ReactElement[];
 
   /**
    * The title of the DataList.
@@ -82,9 +98,25 @@ export interface DataListProps<T extends DataListObject> {
    * @default { xs: true, sm: true, md: true, lg: true, xl: true }
    */
   readonly headerVisibility?: { [Breakpoint in Breakpoints]?: boolean };
+
+  readonly children: ReactElement | ReactElement[];
+}
+
+export interface DataListLayoutProps<T extends DataListObject> {
+  readonly children: (item: DataListItemType<T[]>) => JSX.Element;
+
+  /**
+   * The breakpoint at which the layout should be displayed. It will be rendered until a layout with a larger breakpoint is found.
+   * @default "xs"
+   */
+  readonly size?: Breakpoints;
 }
 
 export interface DataListSearchProps {
+  /**
+   * The placeholder text for the search input. This either uses the title prop
+   * prepended by "Search" or just falls back to "Search".
+   */
   readonly placeholder?: string;
   readonly onSearch: (search: string) => void;
 }
@@ -97,4 +129,5 @@ export interface DataListContextProps<T extends DataListObject>
   extends DataListProps<T> {
   readonly filterComponent?: ReactElement<DataListFiltersProps>;
   readonly searchComponent?: ReactElement<DataListSearchProps>;
+  readonly layoutComponents?: ReactElement<DataListLayoutProps<T>>[];
 }

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -56,13 +56,6 @@ export interface DataListProps<T extends DataListObject> {
   readonly headers: DataListHeader<T>;
 
   /**
-   * Shows the loading state of the DataList.
-   *
-   * @default false
-   */
-  readonly loading?: boolean;
-
-  /**
    * Set the loading state of the DataList. There are a few guidelines on when to use what.
    *
    * - `"initial"` - loading the first set of data

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -62,7 +62,7 @@ export interface DataListProps<T extends DataListObject> {
    * - `"filtering"` - loading after a filter is applied
    * - `"loadingMore"` - loading more data after the user scrolls to the bottom
    */
-  readonly loadingState?: "initial" | "filtering" | "loadingMore";
+  readonly loadingState?: "initial" | "filtering" | "loadingMore" | "none";
 
   /**
    * Temporary prop for setting default state for if filters are applied

--- a/packages/components/src/DataList/components/DataListLayout/DataListLayout.tsx
+++ b/packages/components/src/DataList/components/DataListLayout/DataListLayout.tsx
@@ -1,19 +1,5 @@
 import React from "react";
-import {
-  Breakpoints,
-  DataListItemType,
-  DataListObject,
-} from "../../DataList.types";
-
-export interface DataListLayoutProps<T extends DataListObject> {
-  readonly children: (item: DataListItemType<T[]>) => JSX.Element;
-
-  /**
-   * The breakpoint at which the layout should be displayed. It will be rendered until a layout with a larger breakpoint is found.
-   * @default "xs"
-   */
-  readonly size?: Breakpoints;
-}
+import { DataListLayoutProps, DataListObject } from "../../DataList.types";
 
 export function DataListLayout<T extends DataListObject>(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/components/src/DataList/components/DataListLoadingState/DataListLoadingState.tsx
+++ b/packages/components/src/DataList/components/DataListLoadingState/DataListLoadingState.tsx
@@ -5,13 +5,12 @@ import {
   Breakpoints,
   DataListHeader,
   DataListItemType,
+  DataListLayoutProps,
   DataListObject,
 } from "../../DataList.types";
-import { DataListLayoutProps } from "../DataListLayout";
 import { DataListLayoutInternal } from "../DataListLayoutInternal";
 
 interface DataListLoadingStateProps<T extends DataListObject> {
-  readonly loading: boolean;
   readonly headers: DataListHeader<T>;
   readonly layouts: React.ReactElement<DataListLayoutProps<T>>[] | undefined;
   readonly mediaMatches?: Record<Breakpoints, boolean>;
@@ -22,13 +21,10 @@ export const DATALIST_LOADINGSTATE_ROW_TEST_ID =
   "ATL-DataList-LoadingState-Row";
 
 export function DataListLoadingState<T extends DataListObject>({
-  loading,
   headers,
   layouts,
   mediaMatches,
 }: DataListLoadingStateProps<T>) {
-  if (!loading) return null;
-
   const loadingData = new Array(LOADING_STATE_LIMIT_ITEMS).fill(headers);
   type DataListElements = DataListItemType<typeof loadingData>;
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We need a way for consumers to trigger a "filtering" loading state on the DataList. This adds it. It was also pretty easy to add a loading more state, so added one as well.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `loadingState` prop where it determines if it's initially loading, filtering, or loading more.
  - All of which have different UX

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- `loading` prop to be replaced by `loadingState`. See above.

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
