### PR TITLE
feat(components): Ability to set selected option for combobox

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -57,10 +57,10 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
           "Sam Gamgee3",
 >>>>>>> 4fec09b3 (Revert "Refactor to use a ref")
         ]}
-        onSelection={selection => {
+        onSelect={selection => {
           console.log(selection);
         }}
-        setSelection="Bilbo Baggins"
+        selected="Bilbo Baggins"
       >
         <Combobox.Action
           label="Add a teammate"
@@ -99,7 +99,7 @@ const ComboboxChip: ComponentStory<typeof Combobox> = args => {
           { id: "4", label: "Merry Brandybuck" },
           { id: "5", label: "Sam Gamgee" },
         ]}
-        onSelection={selection => {
+        onSelect={selection => {
           console.log(selection);
         }}
       >

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -42,6 +42,7 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
         onSelection={selection => {
           console.log(selection);
         }}
+        preSelectedOption="Bilbo Baggins"
       >
         <Combobox.Action
           label="Add a teammate"

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -42,7 +42,7 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
         onSelection={selection => {
           console.log(selection);
         }}
-        preSelectedOption="Bilbo Baggins"
+        setSelection="Bilbo Baggins"
       >
         <Combobox.Action
           label="Add a teammate"

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -23,7 +23,6 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
       />
       <Combobox.Content
         options={[
-<<<<<<< HEAD
           { id: "1", label: "Bilbo Baggins" },
           { id: "2", label: "Frodo Baggins" },
           { id: "3", label: "Pippin Took" },
@@ -39,47 +38,22 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
           { id: "13", label: "Pippin Took3" },
           { id: "14", label: "Merry Brandybuck3" },
           { id: "15", label: "Sam Gamgee3" },
-=======
-          "Bilbo Baggins",
-          "Frodo Baggins",
-          "Pippin Took",
-          "Merry Brandybuck",
-          "Sam Gamgee",
-          "Bilbo Baggins2",
-          "Frodo Baggins2",
-          "Pippin Took2",
-          "Merry Brandybuck2",
-          "Sam Gamgee2",
-          "Bilbo Baggins3",
-          "Frodo Baggins3",
-          "Pippin Took3",
-          "Merry Brandybuck3",
-          "Sam Gamgee3",
->>>>>>> 4fec09b3 (Revert "Refactor to use a ref")
         ]}
         onSelect={selection => {
           console.log(selection);
         }}
-        selected="Bilbo Baggins"
+        selected={1}
       >
         <Combobox.Action
           label="Add a teammate"
           onClick={() => {
-<<<<<<< HEAD
             alert("Added a new teammate ✅");
-=======
-            console.log("Action");
->>>>>>> 4fec09b3 (Revert "Refactor to use a ref")
           }}
         />
         <Combobox.Action
           label="Manage teammates"
           onClick={() => {
-<<<<<<< HEAD
             alert("Managed teammates 👍");
-=======
-            console.log("Action");
->>>>>>> 4fec09b3 (Revert "Refactor to use a ref")
           }}
         />
       </Combobox.Content>

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -23,6 +23,7 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
       />
       <Combobox.Content
         options={[
+<<<<<<< HEAD
           { id: "1", label: "Bilbo Baggins" },
           { id: "2", label: "Frodo Baggins" },
           { id: "3", label: "Pippin Took" },
@@ -38,6 +39,23 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
           { id: "13", label: "Pippin Took3" },
           { id: "14", label: "Merry Brandybuck3" },
           { id: "15", label: "Sam Gamgee3" },
+=======
+          "Bilbo Baggins",
+          "Frodo Baggins",
+          "Pippin Took",
+          "Merry Brandybuck",
+          "Sam Gamgee",
+          "Bilbo Baggins2",
+          "Frodo Baggins2",
+          "Pippin Took2",
+          "Merry Brandybuck2",
+          "Sam Gamgee2",
+          "Bilbo Baggins3",
+          "Frodo Baggins3",
+          "Pippin Took3",
+          "Merry Brandybuck3",
+          "Sam Gamgee3",
+>>>>>>> 4fec09b3 (Revert "Refactor to use a ref")
         ]}
         onSelection={selection => {
           console.log(selection);
@@ -47,13 +65,21 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
         <Combobox.Action
           label="Add a teammate"
           onClick={() => {
+<<<<<<< HEAD
             alert("Added a new teammate ✅");
+=======
+            console.log("Action");
+>>>>>>> 4fec09b3 (Revert "Refactor to use a ref")
           }}
         />
         <Combobox.Action
           label="Manage teammates"
           onClick={() => {
+<<<<<<< HEAD
             alert("Managed teammates 👍");
+=======
+            console.log("Action");
+>>>>>>> 4fec09b3 (Revert "Refactor to use a ref")
           }}
         />
       </Combobox.Content>

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -329,3 +329,25 @@ describe("ComboboxContent Search", () => {
     expect(getByText('No results for "Bilbo"')).toBeInTheDocument();
   });
 });
+
+describe("Combobox selected value", () => {
+  it("has a selected option when selected is passed", () => {
+    const { getByRole } = render(
+      <Combobox>
+        <Combobox.TriggerButton label="Button" />
+        <Combobox.Content
+          options={[
+            { id: "1", label: "Bilbo Baggins" },
+            { id: "2", label: "Frodo Baggins" },
+          ]}
+          onSelect={jest.fn()}
+          selected={1}
+        >
+          <></>
+        </Combobox.Content>
+      </Combobox>,
+    );
+    const option = getByRole("radio", { name: "Bilbo Baggins" });
+    expect(option).toBeChecked();
+  });
+});

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -331,7 +331,7 @@ describe("ComboboxContent Search", () => {
 });
 
 describe("Combobox selected value", () => {
-  it("has a selected option when selected is passed", () => {
+  it("has a selected option when a selected id is passed as a number and option id is a string", () => {
     const { getByRole } = render(
       <Combobox>
         <Combobox.TriggerButton label="Button" />
@@ -339,6 +339,26 @@ describe("Combobox selected value", () => {
           options={[
             { id: "1", label: "Bilbo Baggins" },
             { id: "2", label: "Frodo Baggins" },
+          ]}
+          onSelect={jest.fn()}
+          selected={1}
+        >
+          <></>
+        </Combobox.Content>
+      </Combobox>,
+    );
+    const option = getByRole("radio", { name: "Bilbo Baggins" });
+    expect(option).toBeChecked();
+  });
+
+  it("has a selected option when a selected value is passed as the same type as the option id", () => {
+    const { getByRole } = render(
+      <Combobox>
+        <Combobox.TriggerButton label="Button" />
+        <Combobox.Content
+          options={[
+            { id: 1, label: "Bilbo Baggins" },
+            { id: 2, label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
           selected={1}

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -14,7 +14,7 @@ describe("Combobox validation", () => {
       render(
         <Combobox>
           <Combobox.TriggerButton label="Button" />
-          <Combobox.Content options={[]} onSelection={jest.fn()}>
+          <Combobox.Content options={[]} onSelect={jest.fn()}>
             <></>
           </Combobox.Content>
         </Combobox>,
@@ -28,7 +28,7 @@ describe("Combobox validation", () => {
     try {
       render(
         <Combobox>
-          <Combobox.Content options={[]} onSelection={jest.fn()}>
+          <Combobox.Content options={[]} onSelect={jest.fn()}>
             <></>
           </Combobox.Content>
         </Combobox>,
@@ -48,7 +48,7 @@ describe("Combobox validation", () => {
         <Combobox>
           <Combobox.TriggerButton label="Button" />
           <Combobox.TriggerButton label="Button Again" />
-          <Combobox.Content options={[]} onSelection={jest.fn()}>
+          <Combobox.Content options={[]} onSelect={jest.fn()}>
             <></>
           </Combobox.Content>
         </Combobox>,
@@ -68,7 +68,7 @@ describe("Combobox validation", () => {
         <Combobox>
           <Combobox.TriggerButton label="Button" />
           <Combobox.TriggerChip label="Chippy Chip" />
-          <Combobox.Content options={[]} onSelection={jest.fn()}>
+          <Combobox.Content options={[]} onSelect={jest.fn()}>
             <></>
           </Combobox.Content>
         </Combobox>,
@@ -135,7 +135,7 @@ describe("ComboboxContent", () => {
     const { getByTestId } = render(
       <Combobox>
         <Combobox.TriggerButton label="Button" />
-        <Combobox.Content options={[]} onSelection={jest.fn()}>
+        <Combobox.Content options={[]} onSelect={jest.fn()}>
           <></>
         </Combobox.Content>
       </Combobox>,
@@ -152,7 +152,7 @@ describe("ComboboxContent", () => {
             { id: "1", label: "Bilbo Baggins" },
             { id: "2", label: "Frodo Baggins" },
           ]}
-          onSelection={jest.fn()}
+          onSelect={jest.fn()}
         >
           <></>
         </Combobox.Content>
@@ -179,7 +179,7 @@ describe("ComboboxContent", () => {
             { id: "1", label: "Bilbo Baggins" },
             { id: "2", label: "Frodo Baggins" },
           ]}
-          onSelection={jest.fn()}
+          onSelect={jest.fn()}
         >
           <></>
         </Combobox.Content>
@@ -205,7 +205,7 @@ describe("ComboboxContent", () => {
             { id: "1", label: "Bilbo Baggins" },
             { id: "2", label: "Frodo Baggins" },
           ]}
-          onSelection={jest.fn()}
+          onSelect={jest.fn()}
         >
           <></>
         </Combobox.Content>
@@ -234,7 +234,7 @@ describe("ComboboxContent Search", () => {
             { id: "1", label: "Bilbo Baggins" },
             { id: "2", label: "Frodo Baggins" },
           ]}
-          onSelection={jest.fn()}
+          onSelect={jest.fn()}
         >
           <></>
         </Combobox.Content>
@@ -257,7 +257,7 @@ describe("ComboboxContent Search", () => {
             { id: "1", label: "Bilbo Baggins" },
             { id: "2", label: "Frodo Baggins" },
           ]}
-          onSelection={jest.fn()}
+          onSelect={jest.fn()}
         >
           <></>
         </Combobox.Content>
@@ -283,7 +283,7 @@ describe("ComboboxContent Search", () => {
             { id: "1", label: "Bilbo Baggins" },
             { id: "2", label: "Frodo Baggins" },
           ]}
-          onSelection={jest.fn()}
+          onSelect={jest.fn()}
         >
           <></>
         </Combobox.Content>
@@ -313,7 +313,7 @@ describe("ComboboxContent Search", () => {
             { id: "1", label: "Michael Myers" },
             { id: "2", label: "Jason Vorhees" },
           ]}
-          onSelection={jest.fn()}
+          onSelect={jest.fn()}
         >
           <></>
         </Combobox.Content>

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -40,7 +40,7 @@ interface ComboboxContentProps {
    * @default ""
    * @optional
    * @type string
-   * */
+   */
   readonly selected?: string | number;
 }
 

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -14,7 +14,7 @@ import { Icon } from "../../../Icon";
 import { ComboboxContext } from "../../ComboboxProvider";
 import { ComboboxOption } from "../../Combobox.types";
 
-interface ComboboxContentProps {
+export interface ComboboxContentProps {
   /**
    * List of selectable options to display.
    */

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -14,7 +14,7 @@ import { Icon } from "../../../Icon";
 import { ComboboxContext } from "../../ComboboxProvider";
 import { ComboboxOption } from "../../Combobox.types";
 
-export interface ComboboxContentProps {
+interface ComboboxContentProps {
   /**
    * List of selectable options to display.
    */

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -34,6 +34,14 @@ interface ComboboxContentProps {
    * Placeholder text to display in the search input. Defaults to "Search".
    */
   readonly searchPlaceholder?: string;
+
+  /**
+   * pre selected option
+   * @default ""
+   * @optional
+   * @type string
+   * */
+  readonly preSelectedOption?: string;
 }
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -23,7 +23,7 @@ interface ComboboxContentProps {
   /**
    * Callback function invoked upon the selection of an option. Provides the selected option as an argument.
    */
-  readonly onSelection: (selection: ComboboxOption) => void;
+  readonly onSelect: (selection: ComboboxOption) => void;
 
   /**
    * Optional action button(s) to display at the bottom of the list.
@@ -41,7 +41,7 @@ interface ComboboxContentProps {
    * @optional
    * @type string
    * */
-  readonly setSelection?: string;
+  readonly selected?: string;
 }
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
@@ -116,7 +116,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
 
   function handleSelection(selection: ComboboxOption) {
     setSelectedOption(selection);
-    props.onSelection(selection);
+    props.onSelect(selection);
     setSearchValue("");
     setOpen(false);
   }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -41,7 +41,7 @@ interface ComboboxContentProps {
    * @optional
    * @type string
    * */
-  readonly preSelectedOption?: string;
+  readonly setSelection?: string;
 }
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -41,7 +41,7 @@ interface ComboboxContentProps {
    * @optional
    * @type string
    * */
-  readonly selected?: string;
+  readonly selected?: string | number;
 }
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
@@ -55,11 +55,8 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
     popperRef,
     popperStyles,
     attributes,
-  } = useComboboxContent();
-
-  const filteredOptions = props.options.filter(option =>
-    option.label.toLowerCase().includes(searchValue.toLowerCase()),
-  );
+    filteredOptions,
+  } = useComboboxContent(props.selected, props.options);
 
   const template = (
     <div
@@ -76,16 +73,20 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       />
       <div className={styles.list}>
         {filteredOptions.map(option => (
-          <button
-            className={classnames(
-              styles.option,
-              option.id === selectedOption?.id && styles.selectedOption,
-            )}
-            key={option.id}
-            onClick={() => handleSelection(option)}
-          >
+          <label key={option.id}>
+            <input
+              type="radio"
+              className={classnames(
+                styles.option,
+                option.id === selectedOption?.id && styles.selectedOption,
+              )}
+              checked={option.id.toString() === selectedOption?.id.toString()}
+              value={option.label}
+              name={option.label}
+              onChange={() => handleSelection(option)}
+            />
             {option.label}
-          </button>
+          </label>
         ))}
 
         {filteredOptions.length === 0 && (
@@ -165,7 +166,10 @@ function Search(props: {
   }
 }
 
-function useComboboxContent(): {
+function useComboboxContent(
+  selected: string | number | undefined,
+  options: ComboboxOption[],
+): {
   searchValue: string;
   setSearchValue: React.Dispatch<React.SetStateAction<string>>;
   selectedOption: ComboboxOption | null;
@@ -177,12 +181,20 @@ function useComboboxContent(): {
   popperRef: React.RefObject<HTMLDivElement>;
   popperStyles: { [key: string]: React.CSSProperties };
   attributes: { [key: string]: { [key: string]: string } | undefined };
+  filteredOptions: ComboboxOption[];
 } {
+  const defaultValue = options.find(
+    option => option.id.toString() === selected?.toString(),
+  );
   const [searchValue, setSearchValue] = useState<string>("");
   const [selectedOption, setSelectedOption] = useState<ComboboxOption | null>(
-    null,
+    defaultValue || null,
   );
   const { open, setOpen, wrapperRef } = React.useContext(ComboboxContext);
+
+  const filteredOptions = options.filter(option =>
+    option.label.toLowerCase().includes(searchValue.toLowerCase()),
+  );
 
   useOnKeyDown(() => {
     if (open) {
@@ -217,5 +229,6 @@ function useComboboxContent(): {
     popperRef,
     popperStyles,
     attributes,
+    filteredOptions,
   };
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/index.ts
+++ b/packages/components/src/Combobox/components/ComboboxContent/index.ts
@@ -1,1 +1,1 @@
-export { ComboboxContent, ComboboxContentProps } from "./ComboboxContent";
+export { ComboboxContent } from "./ComboboxContent";

--- a/packages/components/src/Combobox/components/ComboboxContent/index.ts
+++ b/packages/components/src/Combobox/components/ComboboxContent/index.ts
@@ -1,1 +1,1 @@
-export { ComboboxContent } from "./ComboboxContent";
+export { ComboboxContent, ComboboxContentProps } from "./ComboboxContent";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Add ability to set selected option for the combobox component. We may want the ability to pass in an initially selected value for the selected option for a combobox.

Also a small refactor to update the option element to be an input type="radio" instead of a button because this is more semantically correct and it will be easier to implement multiselect moving forward.

Feel free to let me know if the prop name I chose isn't ideal.

### Added

- Added a prop called `preSelectedOption` to set the default selected value from the combobox options.
- Added a test to assure that the selected option is set as the preselected option on render when a value is passed to the new prop.
- Added a test to throw an error if the preselected option provided is not a valid option.


## Testing
- Try passing in a non random value to the `preSelectedOption` prop and confirm that an error gets thrown
- Pass in a value that does exist in the options list and ensure that it is selected on initial render of the component.
<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
