### PR TITLE
feat(components): allow DataList to infinite scroll

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -43,7 +43,7 @@ const Template: ComponentStory<typeof DataList> = args => {
     data,
     /* See useCollectionQuery for example on how to load more */
     // refresh,
-    // nextPage,
+    nextPage,
     // loadingRefresh,
     // loadingNextPage,
     loadingInitialContent,
@@ -94,6 +94,7 @@ const Template: ComponentStory<typeof DataList> = args => {
         gender: "Gender",
         created: "Created",
       }}
+      onLoadMore={nextPage}
     >
       <DataList.Filters>
         <Button

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -45,7 +45,7 @@ const Template: ComponentStory<typeof DataList> = args => {
     // refresh,
     nextPage,
     // loadingRefresh,
-    // loadingNextPage,
+    loadingNextPage,
     loadingInitialContent,
   } = useCollectionQuery<ListQueryType>({
     query: LIST_QUERY,
@@ -203,6 +203,7 @@ const Template: ComponentStory<typeof DataList> = args => {
 
   function getLoadingState() {
     if (loadingInitialContent) return "initial";
+    if (loadingNextPage) return "loadingMore";
     return args.loadingState;
   }
 };

--- a/packages/components/src/DataList/DataList.const.ts
+++ b/packages/components/src/DataList/DataList.const.ts
@@ -29,3 +29,4 @@ export const DATA_LIST_FILTERING_SPINNER_TEST_ID =
   "ATL-DataList-filteringSpinner";
 export const DATA_LIST_LOADING_MORE_SPINNER_TEST_ID =
   "ATL-DataList-loadingMoreSpinner";
+export const DATA_LOAD_MORE_TEST_ID = "ATL-DataList-LoadMore-trigger";

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -139,6 +139,7 @@ function InternalDataList() {
         </div>
       )}
 
+      {shouldRenderLoadMoreTrigger && <DataListLoadMore />}
       {loadingState === "loadingMore" && (
         <div
           data-testid={DATA_LIST_LOADING_MORE_SPINNER_TEST_ID}
@@ -149,7 +150,6 @@ function InternalDataList() {
       )}
 
       {showEmptyState && EmptyStateComponent}
-      {shouldRenderLoadMoreTrigger && <DataListLoadMore />}
     </div>
   );
 }

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -87,6 +87,8 @@ function InternalDataList() {
     setIsFilterApplied,
   });
 
+  const shouldRenderLoadMoreTrigger = !initialLoading && !showEmptyState;
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.titleContainer}>
@@ -147,7 +149,7 @@ function InternalDataList() {
       )}
 
       {showEmptyState && EmptyStateComponent}
-      {!showEmptyState && <DataListLoadMore />}
+      {shouldRenderLoadMoreTrigger && <DataListLoadMore />}
     </div>
   );
 }

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useInView } from "@jobber/hooks/useInView";
 import styles from "./DataList.css";
 import { EmptyState } from "./components/EmptyState";
 import { DataListLayout } from "./components/DataListLayout";
@@ -72,7 +73,16 @@ function InternalDataList() {
     headerVisibility = { xs: true, sm: true, md: true, lg: true, xl: true },
     loadingState = "none",
     layoutComponents,
+    onLoadMore,
   } = useDataListContext();
+  const [inViewRef, isInView] = useInView<HTMLDivElement>();
+
+  useEffect(() => {
+    if (isInView) {
+      console.log("fetch more data");
+      onLoadMore?.();
+    }
+  }, [isInView]);
 
   const headerData = generateHeaderElements(headers);
   const mediaMatches = useLayoutMediaQueries();
@@ -146,6 +156,7 @@ function InternalDataList() {
       )}
 
       {showEmptyState && EmptyStateComponent}
+      {!showEmptyState && <div ref={inViewRef} />}
     </div>
   );
 }

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react";
-import { useInView } from "@jobber/hooks/useInView";
+import React, { useState } from "react";
 import styles from "./DataList.css";
 import { EmptyState } from "./components/EmptyState";
 import { DataListLayout } from "./components/DataListLayout";
@@ -37,6 +36,7 @@ import {
   DATA_LIST_FILTERING_SPINNER_TEST_ID,
   DATA_LIST_LOADING_MORE_SPINNER_TEST_ID,
 } from "./DataList.const";
+import { DataListLoadMore } from "./components/DataListLoadMore";
 import { Heading } from "../Heading";
 import { Spinner } from "../Spinner";
 
@@ -73,16 +73,7 @@ function InternalDataList() {
     headerVisibility = { xs: true, sm: true, md: true, lg: true, xl: true },
     loadingState = "none",
     layoutComponents,
-    onLoadMore,
   } = useDataListContext();
-  const [inViewRef, isInView] = useInView<HTMLDivElement>();
-
-  useEffect(() => {
-    if (isInView) {
-      console.log("fetch more data");
-      onLoadMore?.();
-    }
-  }, [isInView]);
 
   const headerData = generateHeaderElements(headers);
   const mediaMatches = useLayoutMediaQueries();
@@ -156,7 +147,7 @@ function InternalDataList() {
       )}
 
       {showEmptyState && EmptyStateComponent}
-      {!showEmptyState && <div ref={inViewRef} />}
+      {!showEmptyState && <DataListLoadMore />}
     </div>
   );
 }

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -92,9 +92,12 @@ export interface DataListProps<T extends DataListObject> {
    */
   readonly headerVisibility?: { [Breakpoint in Breakpoints]?: boolean };
 
-  readonly onLoadMore?: () => void;
-
   readonly children: ReactElement | ReactElement[];
+
+  /**
+   * The callback function when the user scrolls to the bottom of the list.
+   */
+  readonly onLoadMore?: () => void;
 }
 
 export interface DataListLayoutProps<T extends DataListObject> {

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -92,6 +92,8 @@ export interface DataListProps<T extends DataListObject> {
    */
   readonly headerVisibility?: { [Breakpoint in Breakpoints]?: boolean };
 
+  readonly onLoadMore?: () => void;
+
   readonly children: ReactElement | ReactElement[];
 }
 

--- a/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.css
+++ b/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.css
@@ -1,0 +1,4 @@
+.trigger {
+  position: relative;
+  transform: translateY(calc(var(--space-largest) * -1));
+}

--- a/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.css.d.ts
+++ b/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly "trigger": string;
+};
+export = styles;
+

--- a/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.test.tsx
+++ b/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { configMocks, mockIntersectionObserver } from "jsdom-testing-mocks";
+import { DataListLoadMore } from "./DataListLoadMore";
+import { DataListContext, defaultValues } from "../../context/DataListContext";
+
+configMocks({ act });
+const observer = mockIntersectionObserver();
+
+describe("DataListLoadMore", () => {
+  it("should fire the onLoadMore when the target element is visible", () => {
+    const onLoadMore = jest.fn();
+    render(
+      <DataListContext.Provider value={{ ...defaultValues, onLoadMore }}>
+        <DataListLoadMore />
+      </DataListContext.Provider>,
+    );
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+
+    observer.enterAll();
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.tsx
+++ b/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { useInView } from "@jobber/hooks/useInView";
+import styles from "./DataListLoadMore.css";
 import { useDataListContext } from "../../context/DataListContext";
 
 export function DataListLoadMore() {
@@ -10,5 +11,5 @@ export function DataListLoadMore() {
     isInView && onLoadMore?.();
   }, [isInView]);
 
-  return <div ref={inViewRef} />;
+  return <div ref={inViewRef} className={styles.trigger} />;
 }

--- a/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.tsx
+++ b/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.tsx
@@ -1,0 +1,14 @@
+import React, { useEffect } from "react";
+import { useInView } from "@jobber/hooks/useInView";
+import { useDataListContext } from "../../context/DataListContext";
+
+export function DataListLoadMore() {
+  const { onLoadMore } = useDataListContext();
+  const [inViewRef, isInView] = useInView<HTMLDivElement>();
+
+  useEffect(() => {
+    isInView && onLoadMore?.();
+  }, [isInView]);
+
+  return <div ref={inViewRef} />;
+}

--- a/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.tsx
+++ b/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { useInView } from "@jobber/hooks/useInView";
 import styles from "./DataListLoadMore.css";
 import { useDataListContext } from "../../context/DataListContext";
+import { DATA_LOAD_MORE_TEST_ID } from "../../DataList.const";
 
 export function DataListLoadMore() {
   const { onLoadMore } = useDataListContext();
@@ -11,5 +12,11 @@ export function DataListLoadMore() {
     isInView && onLoadMore?.();
   }, [isInView]);
 
-  return <div ref={inViewRef} className={styles.trigger} />;
+  return (
+    <div
+      ref={inViewRef}
+      className={styles.trigger}
+      data-testid={DATA_LOAD_MORE_TEST_ID}
+    />
+  );
 }

--- a/packages/components/src/DataList/components/DataListLoadMore/index.ts
+++ b/packages/components/src/DataList/components/DataListLoadMore/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListLoadMore";

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -15,9 +15,6 @@ export function DataListTags({ items }: DataListTagsProps) {
   useEffect(() => {
     if (!window.IntersectionObserver) return;
 
-    // Reset counter every time the items change
-    setVisibleIndex([]);
-
     const observer = new IntersectionObserver(handleIntersection, {
       root: ref.current,
       threshold: buildIntersectionThreshold(items),


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The current implementation of DataList forces you to load everything in one go. This allows the user to fire a callback to load more once the user has scrolled closer to the end.

Instead of listening to scroll–which we don't know the element that is scrolling–we watch an invisible element at the end of the list if it's visible using the `useInView` hook. Once visible, this triggers the `onLoadMore` callback for the consumers to start loading more items.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `onLoadMore` callback

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- The ability for the tags to reset everytime the component updates. This removes the flicker that is happening whenever you load more. This isn't really needed as the component is reactive enough to rerender whenever a change happens.

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
