### PR TITLE
feat(components): Combobox Search

### DIFF
--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -326,6 +326,6 @@ describe("ComboboxContent Search", () => {
     const searchInput = getByPlaceholderText("Search");
     fireEvent.change(searchInput, { target: { value: "Bilbo" } });
 
-    expect(getByText("No results for Bilbo")).toBeInTheDocument();
+    expect(getByText('No results for "Bilbo"')).toBeInTheDocument();
   });
 });

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
@@ -1,6 +1,5 @@
 .content {
   z-index: var(--elevation-tooltip);
-  width: max-content;
   max-width: var(--popover--width);
   max-height: 400px;
   box-shadow: var(--shadow-base);
@@ -29,17 +28,6 @@
   top: 0;
 }
 
-.search::after {
-  content: "";
-  display: block;
-  height: var(--space-small);
-  background-image: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0)
-  );
-}
-
 .searchInput {
   width: 100%;
   padding: var(--space-base) var(--space-base);
@@ -51,40 +39,64 @@
   background-color: var(--color-surface);
 }
 
-.triggerIcon {
+.clearSearch {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  width: calc(var(--space-smaller) * 5);
-  height: calc(var(--space-smaller) * 5);
-  border-radius: var(--radius-circle);
-  background-color: var(--color-surface--background);
-}
-
-.search .triggerIcon {
   position: absolute;
+  top: 0;
   top: 50%;
   right: var(--space-small);
   z-index: var(--elevation-tooltip);
-  transform: translateY(-50%);
-}
-
-.optionsList {
-  margin: 0;
+  width: calc(var(--space-smaller) * 5);
+  height: calc(var(--space-smaller) * 5);
   padding: 0;
-  list-style: none;
+  border: none;
+  border-radius: var(--radius-circle);
+  background-color: var(--color-surface--background);
+  transform: translateY(-50%);
+  justify-content: center;
+  align-items: center;
 }
 
-.optionsList li {
-  padding: var(--space-small) var(--space-base);
+.clearSearch:focus {
+  border: 1px solid var(--color-focus);
+}
+
+.list {
+  padding: var(--space-base);
+}
+
+.search::after {
+  content: "";
+  display: block;
+  position: absolute;
+  right: 0;
+  bottom: calc(var(--space-base) * -1);
+  left: 0;
+  height: var(--space-base);
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 1),
+    rgba(255, 255, 255, 0)
+  );
+}
+
+.actions::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: calc(var(--space-base) * -1);
+  right: 0;
+  left: 0;
+  width: 100%;
+  height: var(--space-base);
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 1)
+  );
 }
 
 .selectedOption {
-  background-color: var(--color-surface--background);
-}
-
-.optionsList li:hover,
-.optionsList li:focus {
   background-color: var(--color-surface--background);
 }
 
@@ -92,15 +104,4 @@
   position: sticky;
   bottom: 0;
   width: 100%;
-}
-
-.actions::before {
-  content: "";
-  display: block;
-  height: var(--space-base);
-  background-image: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0),
-    rgba(255, 255, 255, 1)
-  );
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
@@ -58,7 +58,7 @@
 }
 
 .clearSearch:focus {
-  border: 1px solid var(--color-focus);
+  box-shadow: var(--shadow-focus);
 }
 
 .list {

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css.d.ts
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css.d.ts
@@ -4,10 +4,10 @@ declare const styles: {
   readonly "option": string;
   readonly "search": string;
   readonly "searchInput": string;
-  readonly "triggerIcon": string;
-  readonly "optionsList": string;
-  readonly "selectedOption": string;
+  readonly "clearSearch": string;
+  readonly "list": string;
   readonly "actions": string;
+  readonly "selectedOption": string;
 };
 export = styles;
 

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useRef, useState } from "react";
+import React, {
+  Dispatch,
+  ReactElement,
+  SetStateAction,
+  useRef,
+  useState,
+} from "react";
 import classnames from "classnames";
 import ReactDOM from "react-dom";
 import { usePopper } from "react-popper";
@@ -41,7 +47,6 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
     popperRef,
     popperStyles,
     attributes,
-    searchRef,
   } = useComboboxContent();
 
   const filteredOptions = props.options.filter(option =>
@@ -56,29 +61,11 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       style={popperStyles.popper}
       {...attributes.popper}
     >
-      <div className={styles.search}>
-        <input
-          type="search"
-          ref={searchRef}
-          className={styles.searchInput}
-          placeholder={props.searchPlaceholder || "Search"}
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-            handleSearch(event)
-          }
-          value={searchValue}
-        />
-
-        {searchValue && (
-          <button
-            className={styles.clearSearch}
-            onClick={clearSearch}
-            data-testid="ATL-Combobox-Content-Search-Clear"
-            aria-label="Clear search"
-          >
-            <Icon name="remove" size="small" />
-          </button>
-        )}
-      </div>
+      <Search
+        searchPlaceholder={props.searchPlaceholder}
+        searchValue={searchValue}
+        setSearchValue={setSearchValue}
+      />
       <div className={styles.list}>
         {filteredOptions.map(option => (
           <button
@@ -103,20 +90,54 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
 
   return ReactDOM.createPortal(template, document.body);
 
-  function clearSearch() {
-    setSearchValue("");
-    searchRef.current?.focus();
-  }
-
-  function handleSearch(event: React.ChangeEvent<HTMLInputElement>) {
-    setSearchValue(event.target.value);
-  }
-
   function handleSelection(selection: ComboboxOption) {
     setSelectedOption(selection);
     props.onSelection(selection);
     setSearchValue("");
     setOpen(false);
+  }
+}
+
+function Search(props: {
+  searchPlaceholder?: string;
+  searchValue: string;
+  setSearchValue: Dispatch<SetStateAction<string>>;
+}): JSX.Element {
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className={styles.search}>
+      <input
+        type="search"
+        ref={searchRef}
+        className={styles.searchInput}
+        placeholder={props.searchPlaceholder || "Search"}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          handleSearch(event)
+        }
+        value={props.searchValue}
+      />
+
+      {props.searchValue && (
+        <button
+          className={styles.clearSearch}
+          onClick={clearSearch}
+          data-testid="ATL-Combobox-Content-Search-Clear"
+          aria-label="Clear search"
+        >
+          <Icon name="remove" size="small" />
+        </button>
+      )}
+    </div>
+  );
+
+  function clearSearch() {
+    props.setSearchValue("");
+    searchRef.current?.focus();
+  }
+
+  function handleSearch(event: React.ChangeEvent<HTMLInputElement>) {
+    props.setSearchValue(event.target.value);
   }
 }
 
@@ -132,9 +153,7 @@ function useComboboxContent(): {
   popperRef: React.RefObject<HTMLDivElement>;
   popperStyles: { [key: string]: React.CSSProperties };
   attributes: { [key: string]: { [key: string]: string } | undefined };
-  searchRef: React.RefObject<HTMLInputElement>;
 } {
-  const searchRef = useRef<HTMLInputElement>(null);
   const [searchValue, setSearchValue] = useState<string>("");
   const [selectedOption, setSelectedOption] = useState<ComboboxOption | null>(
     null,
@@ -174,6 +193,5 @@ function useComboboxContent(): {
     popperRef,
     popperStyles,
     attributes,
-    searchRef,
   };
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -41,6 +41,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
     popperRef,
     popperStyles,
     attributes,
+    searchRef,
   } = useComboboxContent();
 
   const filteredOptions = props.options.filter(option =>
@@ -58,6 +59,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       <div className={styles.search}>
         <input
           type="search"
+          ref={searchRef}
           className={styles.searchInput}
           placeholder={props.searchPlaceholder || "Search"}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
@@ -67,38 +69,42 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         />
 
         {searchValue && (
-          <div
-            className={styles.triggerIcon}
-            onClick={() => setSearchValue("")}
+          <button
+            className={styles.clearSearch}
+            onClick={clearSearch}
             data-testid="ATL-Combobox-Content-Search-Clear"
             aria-label="Clear search"
-            role="button"
           >
             <Icon name="remove" size="small" />
-          </div>
+          </button>
         )}
       </div>
+      <div className={styles.list}>
+        {filteredOptions.map(option => (
+          <button
+            className={classnames(
+              styles.option,
+              option.id === selectedOption?.id && styles.selectedOption,
+            )}
+            key={option.id}
+            onClick={() => handleSelection(option)}
+          >
+            {option.label}
+          </button>
+        ))}
 
-      {filteredOptions.map(option => (
-        <button
-          className={classnames(
-            styles.option,
-            option.id === selectedOption?.id && styles.selectedOption,
-          )}
-          key={option.id}
-          onClick={() => handleSelection(option)}
-        >
-          {option.label}
-        </button>
-      ))}
-
-      {filteredOptions.length === 0 && <p>No results for {searchValue}</p>}
-
-      {props.children && <div className={styles.actions}>{props.children}</div>}
+        {filteredOptions.length === 0 && <p>No results for {searchValue}</p>}
+      </div>
+      <div className={styles.actions}>{props.children && props.children}</div>
     </div>
   );
 
   return ReactDOM.createPortal(template, document.body);
+
+  function clearSearch() {
+    setSearchValue("");
+    searchRef.current?.focus();
+  }
 
   function handleSearch(event: React.ChangeEvent<HTMLInputElement>) {
     setSearchValue(event.target.value);
@@ -124,7 +130,9 @@ function useComboboxContent(): {
   popperRef: React.RefObject<HTMLDivElement>;
   popperStyles: { [key: string]: React.CSSProperties };
   attributes: { [key: string]: { [key: string]: string } | undefined };
+  searchRef: React.RefObject<HTMLInputElement>;
 } {
+  const searchRef = useRef<HTMLInputElement>(null);
   const [searchValue, setSearchValue] = useState<string>("");
   const [selectedOption, setSelectedOption] = useState<ComboboxOption | null>(
     null,
@@ -164,5 +172,6 @@ function useComboboxContent(): {
     popperRef,
     popperStyles,
     attributes,
+    searchRef,
   };
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -93,7 +93,9 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
           </button>
         ))}
 
-        {filteredOptions.length === 0 && <p>No results for {searchValue}</p>}
+        {filteredOptions.length === 0 && (
+          <p>No results for {`"${searchValue}"`}</p>
+        )}
       </div>
       <div className={styles.actions}>{props.children && props.children}</div>
     </div>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

A few minor adjustments and improvements to the search functionality of the combobox.

## Changes

updated the way we are applying the gradient to the top and bottom of the list area when it has enough items to be scrollable. the previous way resulted in the `.search` div having a larger height than intended due to the pseudo elements, causing the centering of the X clear button to be off-center.

changed the markup around the clear button to be an actual semantic button. added a focused state here to make it easier to see when interacting with it via keyboard.

added a QoL/UX improvement to give the search input focus again after clearing it either with keyboard or clicks because I found it annoying to have to re-focus it after clearing

updated some class names to be a bit clearer

## Testing

not a ton new to test here besides the re-focus after clearing

aside from that it should look OK, though we still have another subtask to finalize the styles on everything

searching should filter results if there are applicable options that match the string
- should be case insensitive
- should have a no-result message
- should reset after a selection
- search should feel fine to use with keyboard only

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
