### PR TITLE
feat(components): Combobox zero index state

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -66,19 +66,16 @@ const ComboboxChip: ComponentStory<typeof Combobox> = args => {
     <Combobox {...args}>
       <Combobox.TriggerChip label="Tags" />
       <Combobox.Content
-        options={
-          [
-            // { id: "1", label: "Bilbo Baggins" },
-            // { id: "2", label: "Frodo Baggins" },
-            // { id: "3", label: "Pippin Took" },
-            // { id: "4", label: "Merry Brandybuck" },
-            // { id: "5", label: "Sam Gamgee" },
-          ]
-        }
+        options={[
+          { id: "1", label: "Bilbo Baggins" },
+          { id: "2", label: "Frodo Baggins" },
+          { id: "3", label: "Pippin Took" },
+          { id: "4", label: "Merry Brandybuck" },
+          { id: "5", label: "Sam Gamgee" },
+        ]}
         onSelect={selection => {
           console.log(selection);
         }}
-        // subjectNoun="teammates"
       >
         <Combobox.Action
           label="Add Teammate"

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -66,16 +66,19 @@ const ComboboxChip: ComponentStory<typeof Combobox> = args => {
     <Combobox {...args}>
       <Combobox.TriggerChip label="Tags" />
       <Combobox.Content
-        options={[
-          { id: "1", label: "Bilbo Baggins" },
-          { id: "2", label: "Frodo Baggins" },
-          { id: "3", label: "Pippin Took" },
-          { id: "4", label: "Merry Brandybuck" },
-          { id: "5", label: "Sam Gamgee" },
-        ]}
+        options={
+          [
+            // { id: "1", label: "Bilbo Baggins" },
+            // { id: "2", label: "Frodo Baggins" },
+            // { id: "3", label: "Pippin Took" },
+            // { id: "4", label: "Merry Brandybuck" },
+            // { id: "5", label: "Sam Gamgee" },
+          ]
+        }
         onSelect={selection => {
           console.log(selection);
         }}
+        // subjectNoun="teammates"
       >
         <Combobox.Action
           label="Add Teammate"

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -45,13 +45,13 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
         selected={1}
       >
         <Combobox.Action
-          label="Add a teammate"
+          label="Add Teammate"
           onClick={() => {
             alert("Added a new teammate ✅");
           }}
         />
         <Combobox.Action
-          label="Manage teammates"
+          label="Manage Teammates"
           onClick={() => {
             alert("Managed teammates 👍");
           }}
@@ -78,13 +78,13 @@ const ComboboxChip: ComponentStory<typeof Combobox> = args => {
         }}
       >
         <Combobox.Action
-          label="Add a teammate"
+          label="Add Teammate"
           onClick={() => {
             alert("Added a new teammate ✅");
           }}
         />
         <Combobox.Action
-          label="Manage teammates"
+          label="Manage Teammates"
           onClick={() => {
             alert("Managed teammates 👍");
           }}

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -411,7 +411,7 @@ describe("Combobox Zero Index State", () => {
           <Combobox.TriggerButton label="Select a tax rate" />
           <Combobox.Content
             options={[{ id: "1", label: "10%" }]}
-            onSelection={jest.fn()}
+            onSelect={jest.fn()}
           />
         </Combobox>,
       );

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -371,3 +371,38 @@ describe("Combobox selected value", () => {
     expect(option).toBeChecked();
   });
 });
+
+describe("Combobox Zero Index State", () => {
+  describe("when no options exist and contentNoun is provided", () => {
+    it("should render the correct zero index state text", () => {
+      const contentNoun = "teammates";
+      const { getByText } = render(
+        <Combobox>
+          <Combobox.TriggerButton label="Select a teammate" />
+          <Combobox.Content
+            options={[]}
+            onSelect={jest.fn()}
+            subjectNoun={contentNoun}
+          />
+        </Combobox>,
+      );
+
+      expect(
+        getByText("You don't have any teammates yet."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when no options exist and contentNoun is not provided", () => {
+    it("should render the default zero index state text", () => {
+      const { getByText } = render(
+        <Combobox>
+          <Combobox.TriggerButton label="Select a tax rate" />
+          <Combobox.Content options={[]} onSelect={jest.fn()} />
+        </Combobox>,
+      );
+
+      expect(getByText("No options yet.")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -387,9 +387,7 @@ describe("Combobox Zero Index State", () => {
         </Combobox>,
       );
 
-      expect(
-        getByText("You don't have any teammates yet."),
-      ).toBeInTheDocument();
+      expect(getByText("You don't have any teammates yet")).toBeInTheDocument();
     });
   });
 
@@ -402,7 +400,7 @@ describe("Combobox Zero Index State", () => {
         </Combobox>,
       );
 
-      expect(getByText("No options yet.")).toBeInTheDocument();
+      expect(getByText("No options yet")).toBeInTheDocument();
     });
   });
 });

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -373,16 +373,16 @@ describe("Combobox selected value", () => {
 });
 
 describe("Combobox Zero Index State", () => {
-  describe("when no options exist and contentNoun is provided", () => {
+  describe("when no options exist and subjectNoun is provided", () => {
     it("should render the correct zero index state text", () => {
-      const contentNoun = "teammates";
+      const subjectNoun = "teammates";
       const { getByText } = render(
         <Combobox>
           <Combobox.TriggerButton label="Select a teammate" />
           <Combobox.Content
             options={[]}
             onSelect={jest.fn()}
-            subjectNoun={contentNoun}
+            subjectNoun={subjectNoun}
           />
         </Combobox>,
       );
@@ -391,7 +391,7 @@ describe("Combobox Zero Index State", () => {
     });
   });
 
-  describe("when no options exist and contentNoun is not provided", () => {
+  describe("when no options exist and subjectNoun is not provided", () => {
     it("should render the default zero index state text", () => {
       const { getByText } = render(
         <Combobox>

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -403,4 +403,20 @@ describe("Combobox Zero Index State", () => {
       expect(getByText("No options yet")).toBeInTheDocument();
     });
   });
+
+  describe("when options do exist", () => {
+    it("should not render default zero index state text", () => {
+      const { queryByText } = render(
+        <Combobox>
+          <Combobox.TriggerButton label="Select a tax rate" />
+          <Combobox.Content
+            options={[{ id: "1", label: "10%" }]}
+            onSelection={jest.fn()}
+          />
+        </Combobox>,
+      );
+
+      expect(queryByText("No options yet")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
@@ -34,6 +34,7 @@
   border: none;
   border-bottom: var(--border-base) solid var(--color-border);
   border-radius: 0;
+  font-family: var(--typography--fontFamily-normal);
   font-size: var(--typography--fontSize-base);
   line-height: normal;
   background-color: var(--color-surface);

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -42,6 +42,11 @@ interface ComboboxContentProps {
    * @type string
    */
   readonly selected?: string | number;
+
+  /**
+   * The encapsulating noun for the content of the combobox. Should be pluralized.
+   */
+  readonly subjectNoun?: string;
 }
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
@@ -58,6 +63,8 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
     filteredOptions,
   } = useComboboxContent(props.selected, props.options);
 
+  const optionsExist = props.options.length > 0;
+
   const template = (
     <div
       ref={popperRef}
@@ -72,26 +79,29 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         setSearchValue={setSearchValue}
       />
       <div className={styles.list}>
-        {filteredOptions.map(option => (
-          <label key={option.id}>
-            <input
-              type="radio"
-              className={classnames(
-                styles.option,
-                option.id === selectedOption?.id && styles.selectedOption,
-              )}
-              checked={option.id.toString() === selectedOption?.id.toString()}
-              value={option.label}
-              name={option.label}
-              onChange={() => handleSelection(option)}
-            />
-            {option.label}
-          </label>
-        ))}
+        {optionsExist &&
+          filteredOptions.map(option => (
+            <label key={option.id}>
+              <input
+                type="radio"
+                className={classnames(
+                  styles.option,
+                  option.id === selectedOption?.id && styles.selectedOption,
+                )}
+                checked={option.id.toString() === selectedOption?.id.toString()}
+                value={option.label}
+                name={option.label}
+                onChange={() => handleSelection(option)}
+              />
+              {option.label}
+            </label>
+          ))}
 
-        {filteredOptions.length === 0 && (
+        {optionsExist && filteredOptions.length === 0 && (
           <p>No results for {`"${searchValue}"`}</p>
         )}
+
+        {!optionsExist && <p>{getZeroIndexStateText(props.subjectNoun)}</p>}
       </div>
 
       {props.children && (
@@ -164,6 +174,14 @@ function Search(props: {
   function handleSearch(event: React.ChangeEvent<HTMLInputElement>) {
     props.setSearchValue(event.target.value);
   }
+}
+
+function getZeroIndexStateText(subjectNoun?: string) {
+  if (subjectNoun) {
+    return `You don't have any ${subjectNoun} yet.`;
+  }
+
+  return "No options yet.";
 }
 
 function useComboboxContent(

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -181,7 +181,7 @@ function getZeroIndexStateText(subjectNoun?: string) {
     return `You don't have any ${subjectNoun} yet.`;
   }
 
-  return "No options yet.";
+  return "No options yet";
 }
 
 function useComboboxContent(

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -74,7 +74,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       {...attributes.popper}
     >
       <Search
-        subjectNoun={props.subjectNoun ?? ""}
+        subjectNoun={props.subjectNoun}
         searchValue={searchValue}
         setSearchValue={setSearchValue}
       />
@@ -134,7 +134,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
 }
 
 function Search(props: {
-  subjectNoun: string;
+  subjectNoun?: string;
   searchValue: string;
   setSearchValue: Dispatch<SetStateAction<string>>;
 }): JSX.Element {
@@ -146,7 +146,9 @@ function Search(props: {
         type="search"
         ref={searchRef}
         className={styles.searchInput}
-        placeholder={`Search ${props.subjectNoun}` || "Search"}
+        placeholder={
+          props.subjectNoun ? `Search ${props.subjectNoun}` : "Search"
+        }
         onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
           handleSearch(event)
         }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -44,7 +44,8 @@ interface ComboboxContentProps {
   readonly selected?: string | number;
 
   /**
-   * The encapsulating noun for the content of the combobox. Should be pluralized.
+   * The encapsulating noun for the content of the combobox. Used
+   * in the empty state, and search placeholder. Should be pluralized.
    */
   readonly subjectNoun?: string;
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -178,7 +178,7 @@ function Search(props: {
 
 function getZeroIndexStateText(subjectNoun?: string) {
   if (subjectNoun) {
-    return `You don't have any ${subjectNoun} yet.`;
+    return `You don't have any ${subjectNoun} yet`;
   }
 
   return "No options yet";

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -74,7 +74,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       {...attributes.popper}
     >
       <Search
-        searchPlaceholder={props.searchPlaceholder}
+        subjectNoun={props.subjectNoun ?? ""}
         searchValue={searchValue}
         setSearchValue={setSearchValue}
       />
@@ -134,7 +134,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
 }
 
 function Search(props: {
-  searchPlaceholder?: string;
+  subjectNoun: string;
   searchValue: string;
   setSearchValue: Dispatch<SetStateAction<string>>;
 }): JSX.Element {
@@ -146,7 +146,7 @@ function Search(props: {
         type="search"
         ref={searchRef}
         className={styles.searchInput}
-        placeholder={props.searchPlaceholder || "Search"}
+        placeholder={`Search ${props.subjectNoun}` || "Search"}
         onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
           handleSearch(event)
         }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -75,7 +75,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       {...attributes.popper}
     >
       <Search
-        subjectNoun={props.subjectNoun}
+        placeholder={props.subjectNoun}
         searchValue={searchValue}
         setSearchValue={setSearchValue}
       />
@@ -135,7 +135,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
 }
 
 function Search(props: {
-  subjectNoun?: string;
+  placeholder?: string;
   searchValue: string;
   setSearchValue: Dispatch<SetStateAction<string>>;
 }): JSX.Element {
@@ -148,7 +148,7 @@ function Search(props: {
         ref={searchRef}
         className={styles.searchInput}
         placeholder={
-          props.subjectNoun ? `Search ${props.subjectNoun}` : "Search"
+          props.placeholder ? `Search ${props.placeholder}` : "Search"
         }
         onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
           handleSearch(event)


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
When there are no `options` loaded into Combobox, there should be a zero index state.  

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- an optional prop called `contentNoun` that is meant to describe what the options are within Combobox (example `teammates`, `tax rates`, etc)
- established a variable for whether options exist or not

Zero index state will either return a default or customized string:
Default:
![Screenshot 2023-09-11 at 3 19 57 PM](https://github.com/GetJobber/atlantis/assets/104797704/febf3ad7-f6cf-4faf-a942-40e9747233ab)

Setting "teammates" to `contentNoun`:
![Screenshot 2023-09-11 at 3 20 36 PM](https://github.com/GetJobber/atlantis/assets/104797704/633bd8b8-3e29-460d-a44d-a2f305569ffa)


## Testing

<!-- How to test your changes. -->
- in the Combobox `Web.stories.tsx` file, comment out the array of options and see the default zero index state message
- now add `contentNoun` to the `Combobox.Content` and pick a noun like "teammates" or "tax rates" and see the customized zero index state message appear
- make sure that search and filter still work as intended

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
