### PR TITLE
feat(components): Add optional role to Button

### DIFF
--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -143,7 +143,7 @@ it("renders button type='submit'", () => {
 });
 
 it("routes when buttons are clicked", () => {
-  const { queryByText } = render(
+  const { getByText, queryByText } = render(
     <Router>
       <Button label="One" to="/" />
       <Button label="Two" to="/two" />
@@ -166,15 +166,33 @@ it("routes when buttons are clicked", () => {
   expect(queryByText("Dos")).not.toBeInstanceOf(HTMLElement);
   expect(queryByText("Tres")).not.toBeInstanceOf(HTMLElement);
 
-  fireEvent.click(queryByText("Two"));
+  fireEvent.click(getByText("Two"));
 
   expect(queryByText("Uno")).not.toBeInstanceOf(HTMLElement);
   expect(queryByText("Dos")).toBeInstanceOf(HTMLElement);
   expect(queryByText("Tres")).not.toBeInstanceOf(HTMLElement);
 
-  fireEvent.click(queryByText("Three"));
+  fireEvent.click(getByText("Three"));
 
   expect(queryByText("Uno")).not.toBeInstanceOf(HTMLElement);
   expect(queryByText("Dos")).not.toBeInstanceOf(HTMLElement);
   expect(queryByText("Tres")).toBeInstanceOf(HTMLElement);
+});
+
+describe("Button role", () => {
+  it("should have a role of button when role not provided", () => {
+    const { getByRole } = render(<Button label="hello" />);
+    expect(getByRole("button")).toBeInstanceOf(HTMLButtonElement);
+  });
+  it("should not have a role of button when role not provided and it's a link", () => {
+    const { queryByRole, getByRole } = render(
+      <Button label="hello" url="myspace.com" />,
+    );
+    expect(queryByRole("button")).not.toBeInTheDocument();
+    expect(getByRole("link")).toBeInTheDocument();
+  });
+  it("should apply provided role when present", () => {
+    const { getByRole } = render(<Button label="hello" role="combobox" />);
+    expect(getByRole("combobox")).toBeInstanceOf(HTMLButtonElement);
+  });
 });

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -82,11 +82,21 @@ interface SubmitButtonProps
   submit: boolean;
 }
 
+interface BasicButtonProps extends ButtonFoundationProps {
+  /**
+   * Used to override the default button role.
+   */
+  readonly role?: string;
+}
+
 export type ButtonProps = XOR<
   BaseActionProps,
   XOR<DestructiveActionProps, SubmitActionProps>
 > &
-  XOR<SubmitButtonProps, XOR<ButtonLinkProps, ButtonAnchorProps>> &
+  XOR<
+    XOR<SubmitButtonProps, BasicButtonProps>,
+    XOR<ButtonLinkProps, ButtonAnchorProps>
+  > &
   XOR<ButtonIconProps, ButtonLabelProps>;
 
 export function Button(props: ButtonProps) {
@@ -105,6 +115,7 @@ export function Button(props: ButtonProps) {
     loading,
     onClick,
     onMouseDown,
+    role,
     size = "base",
     type = "primary",
     url,
@@ -139,6 +150,7 @@ export function Button(props: ButtonProps) {
     "aria-haspopup": ariaHaspopup,
     "aria-expanded": ariaExpanded,
     "aria-label": ariaLabel,
+    role: role,
   };
 
   const buttonInternals = <ButtonInternals {...props} />;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Short version is that accessibility guidelines for Combobox wants the trigger element to have a `role=combobox`

>The combobox role is set on input that controls another element, such as a listbox or grid, that can dynamically pop up to help the user set the value of the input.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role

here are a couple examples, one as a button
![image](https://github.com/GetJobber/atlantis/assets/11843215/86db0fc4-a855-4efd-a22d-043e268723fe)

one as an input
![image](https://github.com/GetJobber/atlantis/assets/11843215/237b7c8a-673f-46bb-8d9d-5e510339dd81)

so in our Combobox implementation this needs to go on our Trigger(s), but it needs to be on the literal `button` itself, not only something wrapping them.

for the `TriggerChip` that's fine since we're using a `button` but for `TriggerButton` that's using an Atlantis `Button` and thus we need to add an optional `role` prop to it which is where things got interesting


**Longer Explanation**
I initially added a default for `role` to be `"button"` but that was not desirable because it would add `role="button"` to elements that ended up being rendered as `a` tags for the  react-router `Link`, `a` tags for normal links, and `submit` type buttons which is fine, but redundant because it already had an implicit `button` role

from there I removed the default and considered if we should even let the `role` be set at all on these other button types. for the `href` or `url` type buttons, I do not think these should support setting some other role. I think the implicit `link` role is preferred

for the react routing links, I'm on the fence. they do kinda behave as buttons, and maybe we should be setting a role on them - however I'm not sure those make sense to accept a prop. if it's being used as a routing button, it's not a combobox and so you would never need to override it with this prop

for submit buttons, same idea. I can't imagine using a submit button to launch a combobox and so I've decided it doesn't make sense to be a prop for those either.

now, due to how the types are set up here with `XOR`s and `&`s I had limited options of how to implement this in such a way that only a small subset of the buttons would have `role` as a supported prop.


### Added

added an optional `role` prop to a subset of button types. this will allow for us to do `role="combobox"` on a `Button` that isn't a submit button, isn't a `url` button nor a `to` button

## Testing

try adding a button somewhere that has the following, which is what we'll need for Combobox's TriggerButton
```
  <Button
    label="booton"
    onClick={() => console.log("clicky click")}
    role="combobox"
    ariaExpanded={false}
    ariaHaspopup={true}
    ariaControls="lmao"
    icon={"arrowDown"}
    iconOnRight={true}
    variation="subtle"
    type="primary"
  />
```
this should be valid according to TypeScript, and result in a `role="combobox"` on the final HTML output
![image](https://github.com/GetJobber/atlantis/assets/11843215/2f264b3e-1bc7-45e6-bde6-ba3cc030881e)

for other buttons, they should _not_ be getting a custom role, or a role at all other than their implicit one provided by say the `a` or `button` tag. this should be true of the final HTML and even before that, TypeScript should complain if you try to have a `url` or `to` or `submit` so try that in your editor please and thank you!

![image](https://github.com/GetJobber/atlantis/assets/11843215/20e3a681-3390-44ec-b2f8-6bcb39ebca73)
![image](https://github.com/GetJobber/atlantis/assets/11843215/25d1e39c-ff65-43c7-a518-b4e23fb2dc40)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
