### PR TITLE
feat(components): Allow actions to be added on a single DataList item

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -128,6 +128,12 @@ const Template: ComponentStory<typeof DataList> = args => {
         placeholder="Search characters..."
       />
 
+      <DataList.ItemActions>
+        <DataList.Action icon="edit" label="Edit" />
+        <DataList.Action icon="email" label="Email" />
+        <DataList.Action icon="note" label="Add note" />
+      </DataList.ItemActions>
+
       <DataList.Layout size="md">
         {(item: DataListItemType<typeof mappedData>) => (
           <Grid alignItems="center">

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -131,7 +131,7 @@ const Template: ComponentStory<typeof DataList> = args => {
       <DataList.ItemActions>
         <DataList.Action icon="edit" label="Edit" />
         <DataList.Action icon="email" label="Email" />
-        <DataList.Action icon="note" label="Add note" />
+        <DataList.Action label="Add note" />
       </DataList.ItemActions>
 
       <DataList.Layout size="md">

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -132,6 +132,9 @@ const Template: ComponentStory<typeof DataList> = args => {
         <DataList.Action icon="edit" label="Edit" />
         <DataList.Action icon="email" label="Email" />
         <DataList.Action label="Add note" />
+        <DataList.Action label="Create new..." />
+        <DataList.Action label="Tag with..." />
+        <DataList.Action label="Delete" destructive={true} />
       </DataList.ItemActions>
 
       <DataList.Layout size="md">

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -129,32 +129,19 @@ const Template: ComponentStory<typeof DataList> = args => {
       />
 
       <DataList.ItemActions>
+        <DataList.Action icon="edit" label="Edit" onClick={handleActionClick} />
         <DataList.Action
-          icon="edit"
-          label="Edit"
-          onClick={item => alert(`You clicked the action for ${item.label}`)}
+          icon="sendMessage"
+          label="Message"
+          onClick={handleActionClick}
         />
+        <DataList.Action label="Create new..." onClick={handleActionClick} />
+        <DataList.Action label="Add attribute..." onClick={handleActionClick} />
         <DataList.Action
-          icon="email"
-          label="Email"
-          onClick={item => alert(`You clicked the action for ${item.label}`)}
-        />
-        <DataList.Action
-          label="Add note"
-          onClick={item => alert(`You clicked the action for ${item.label}`)}
-        />
-        <DataList.Action
-          label="Create new..."
-          onClick={item => alert(`You clicked the action for ${item.label}`)}
-        />
-        <DataList.Action
-          label="Tag with..."
-          onClick={item => alert(`You clicked the action for ${item.label}`)}
-        />
-        <DataList.Action
+          icon="trash"
           label="Delete"
           destructive={true}
-          onClick={item => alert(`You clicked the action for ${item.label}`)}
+          onClick={handleActionClick}
         />
       </DataList.ItemActions>
 
@@ -233,6 +220,10 @@ const Template: ComponentStory<typeof DataList> = args => {
       />
     </DataList>
   );
+
+  function handleActionClick(item: (typeof mappedData)[number]) {
+    alert(`You clicked the action for ${item.label}`);
+  }
 
   function getColor(gender: string): InlineLabelColors | undefined {
     switch (gender) {

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -129,12 +129,33 @@ const Template: ComponentStory<typeof DataList> = args => {
       />
 
       <DataList.ItemActions>
-        <DataList.Action icon="edit" label="Edit" />
-        <DataList.Action icon="email" label="Email" />
-        <DataList.Action label="Add note" />
-        <DataList.Action label="Create new..." />
-        <DataList.Action label="Tag with..." />
-        <DataList.Action label="Delete" destructive={true} />
+        <DataList.Action
+          icon="edit"
+          label="Edit"
+          onClick={item => alert(`You clicked the action for ${item.label}`)}
+        />
+        <DataList.Action
+          icon="email"
+          label="Email"
+          onClick={item => alert(`You clicked the action for ${item.label}`)}
+        />
+        <DataList.Action
+          label="Add note"
+          onClick={item => alert(`You clicked the action for ${item.label}`)}
+        />
+        <DataList.Action
+          label="Create new..."
+          onClick={item => alert(`You clicked the action for ${item.label}`)}
+        />
+        <DataList.Action
+          label="Tag with..."
+          onClick={item => alert(`You clicked the action for ${item.label}`)}
+        />
+        <DataList.Action
+          label="Delete"
+          destructive={true}
+          onClick={item => alert(`You clicked the action for ${item.label}`)}
+        />
       </DataList.ItemActions>
 
       <DataList.Layout size="md">

--- a/packages/components/src/DataList/DataList.const.ts
+++ b/packages/components/src/DataList/DataList.const.ts
@@ -32,3 +32,6 @@ export const DATA_LIST_FILTERING_SPINNER_TEST_ID =
 export const DATA_LIST_LOADING_MORE_SPINNER_TEST_ID =
   "ATL-DataList-loadingMoreSpinner";
 export const DATA_LOAD_MORE_TEST_ID = "ATL-DataList-LoadMore-trigger";
+
+export const TRANSITION_DURATION_IN_SECONDS = tokens["timing-base"] / 1000;
+export const TRANSITION_DELAY_IN_SECONDS = tokens["timing-quick"] / 1000;

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -31,6 +31,7 @@
 }
 
 .listItem {
+  position: relative;
   padding: var(--space-small);
   border-bottom: var(--border-base) solid var(--color-border);
 }

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -25,6 +25,7 @@ import { DataListContext, useDataListContext } from "./context/DataListContext";
 import {
   DataListEmptyStateProps,
   DataListFiltersProps,
+  DataListItemActionsProps,
   DataListLayoutProps,
   DataListObject,
   DataListProps,
@@ -37,6 +38,8 @@ import {
 } from "./DataList.utils";
 import { useLayoutMediaQueries } from "./hooks/useLayoutMediaQueries";
 import { DATA_LIST_FILTERING_SPINNER_TEST_ID } from "./DataList.const";
+import { DataListItemActions } from "./components/DataListItemActions";
+import { DataListAction } from "./components/DataListAction";
 import { Heading } from "../Heading";
 import { Spinner } from "../Spinner";
 
@@ -56,6 +59,9 @@ export function DataList<T extends DataListObject>(props: DataListProps<T>) {
     props.children,
     DataListEmptyState,
   );
+  const itemActionComponent = getCompoundComponent<
+    DataListItemActionsProps<DataListObject>
+  >(props.children, DataListItemActions);
 
   return (
     <DataListContext.Provider
@@ -64,6 +70,7 @@ export function DataList<T extends DataListObject>(props: DataListProps<T>) {
         filterComponent,
         layoutComponents,
         emptyStateComponents,
+        itemActionComponent,
         ...props,
         selected: props.selected ?? [],
       }}
@@ -173,3 +180,5 @@ DataList.Layout = DataListLayout;
 DataList.EmptyState = DataListEmptyState;
 DataList.Filters = DataListFilters;
 DataList.Search = DataListSearch;
+DataList.ItemActions = DataListItemActions;
+DataList.Action = DataListAction;

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -1,4 +1,5 @@
 import { ReactElement, ReactNode } from "react";
+import { IconNames } from "@jobber/design";
 import { Breakpoints } from "./DataList.const";
 import { ButtonProps } from "../Button";
 
@@ -162,4 +163,23 @@ export interface DataListContextProps<T extends DataListObject>
   readonly searchComponent?: ReactElement<DataListSearchProps>;
   readonly emptyStateComponents?: ReactElement<DataListEmptyStateProps>[];
   readonly layoutComponents?: ReactElement<DataListLayoutProps<T>>[];
+  readonly itemActionComponent?: ReactElement<DataListItemActionsProps<T>>;
+}
+
+type Fragment<T> = T | T[];
+
+export interface DataListItemActionsProps<T extends DataListObject> {
+  // readonly onClick?: (data: T) => void;
+  // readonly url?: string | (data: T) => string;
+  // readonly to?: string | (data: T) => string;
+  readonly children?: Fragment<ReactElement<DataListActionProps<T>>>;
+}
+
+export interface DataListActionProps<T extends DataListObject> {
+  readonly label: string;
+  readonly icon?: IconNames;
+  readonly url?: string | ((data: T) => string);
+  readonly to?: string | ((data: T) => string);
+  readonly destructive?: boolean;
+  readonly onClick?: (data: T) => void;
 }

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -169,21 +169,40 @@ export interface DataListContextProps<T extends DataListObject>
 type Fragment<T> = T | T[];
 
 export interface DataListItemActionsProps<T extends DataListObject> {
-  // readonly onClick?: (data: T) => void;
-  // readonly url?: string | (data: T) => string;
-  // readonly to?: string | (data: T) => string;
+  /**
+   * The actions to render for each item in the DataList. This only accepts the
+   * DataList.Action component.
+   */
   readonly children?: Fragment<ReactElement<DataListActionProps<T>>>;
 }
 
 export interface DataListActionProps<T extends DataListObject> {
+  /**
+   * The label of the action
+   */
   readonly label: string;
+
+  /**
+   * The icon beside the label
+   */
   readonly icon?: IconNames;
+
+  /**
+   * Adjust the styling of an action label and icon to be more destructive.
+   */
   readonly destructive?: boolean;
+
+  /**
+   * The callback function when the action is clicked.
+   */
   readonly onClick?: (data: T) => void;
 }
 
 export interface InternalDataListActionProps<T extends DataListObject>
   extends DataListActionProps<T> {
+  /**
+   * Adds a space the size of the icon to the left of the label.
+   */
   readonly withIconOffset: boolean;
   readonly item: T;
 }

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -178,8 +178,12 @@ export interface DataListItemActionsProps<T extends DataListObject> {
 export interface DataListActionProps<T extends DataListObject> {
   readonly label: string;
   readonly icon?: IconNames;
-  readonly url?: string | ((data: T) => string);
-  readonly to?: string | ((data: T) => string);
   readonly destructive?: boolean;
   readonly onClick?: (data: T) => void;
+}
+
+export interface InternalDataListActionProps<T extends DataListObject>
+  extends DataListActionProps<T> {
+  readonly withIconOffset: boolean;
+  readonly item: T;
 }

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -200,9 +200,5 @@ export interface DataListActionProps<T extends DataListObject> {
 
 export interface InternalDataListActionProps<T extends DataListObject>
   extends DataListActionProps<T> {
-  /**
-   * Adds a space the size of the icon to the left of the label.
-   */
-  readonly withIconOffset: boolean;
   readonly item: T;
 }

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css
@@ -16,7 +16,8 @@
   gap: var(--space-small);
 }
 
-.action:hover {
+.action:hover,
+.action:focus {
   background-color: var(--color-surface--hover);
 }
 

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css
@@ -1,0 +1,24 @@
+.action {
+  display: grid;
+  width: 100%;
+  min-height: 44px;
+  padding: var(--space-small);
+  border: none;
+  border-radius: 0;
+  text-align: left;
+  background: none;
+  cursor: pointer;
+  transition: background var(--timing-base) ease;
+  appearance: none;
+  align-items: center;
+  grid-template-columns: minmax(var(--space-large), max-content) auto;
+  gap: var(--space-small);
+}
+
+.action:hover {
+  background-color: var(--color-surface--hover);
+}
+
+.label {
+  font-weight: 500;
+}

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css
@@ -9,14 +9,19 @@
   background: none;
   cursor: pointer;
   transition: background var(--timing-base) ease;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
   appearance: none;
   align-items: center;
-  grid-template-columns: minmax(var(--space-large), max-content) auto;
   gap: var(--space-small);
 }
 
 .action:hover {
   background-color: var(--color-surface--hover);
+}
+
+.withIconOffset {
+  grid-template-columns: minmax(var(--space-large), max-content) auto;
 }
 
 .label {

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css
@@ -1,5 +1,5 @@
 .action {
-  display: grid;
+  display: flex;
   width: 100%;
   min-height: 44px;
   padding: var(--space-small);
@@ -9,8 +9,6 @@
   background: none;
   cursor: pointer;
   transition: background var(--timing-base) ease;
-  grid-auto-flow: column;
-  grid-auto-columns: max-content;
   appearance: none;
   align-items: center;
   gap: var(--space-small);
@@ -19,10 +17,6 @@
 .action:hover,
 .action:focus {
   background-color: var(--color-surface--hover);
-}
-
-.withIconOffset {
-  grid-template-columns: minmax(var(--space-large), max-content) auto;
 }
 
 .label {

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css.d.ts
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "action": string;
+  readonly "label": string;
+};
+export = styles;
+

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css.d.ts
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css.d.ts
@@ -1,6 +1,5 @@
 declare const styles: {
   readonly "action": string;
-  readonly "withIconOffset": string;
   readonly "label": string;
 };
 export = styles;

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css.d.ts
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "action": string;
+  readonly "withIconOffset": string;
   readonly "label": string;
 };
 export = styles;

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
@@ -1,17 +1,40 @@
 import React from "react";
+import classNames from "classnames";
 import styles from "./DataListAction.css";
-import { DataListActionProps, DataListObject } from "../../DataList.types";
+import {
+  DataListActionProps,
+  DataListObject,
+  InternalDataListActionProps,
+} from "../../DataList.types";
 import { Typography } from "../../../Typography";
 import { Icon } from "../../../Icon";
 
-export function DataListAction<T extends DataListObject>({
+export function DataListAction<T extends DataListObject>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _: DataListActionProps<T>,
+) {
+  return null;
+}
+
+export function InternalDataListAction<T extends DataListObject>({
   label,
   icon,
-}: DataListActionProps<T>) {
+  destructive,
+  onClick,
+  item,
+  withIconOffset,
+}: InternalDataListActionProps<T>) {
   return (
-    <button className={styles.action}>
-      <div>{icon && <Icon name={icon} />}</div>
-      <Typography textColor="blue">
+    <button
+      className={classNames(styles.action, {
+        [styles.withIconOffset]: withIconOffset,
+      })}
+      onClick={() => onClick?.(item)}
+    >
+      <div>
+        {icon && <Icon name={icon} color={destructive ? "critical" : "blue"} />}
+      </div>
+      <Typography textColor={destructive ? "critical" : "blue"}>
         <span className={styles.label}>{label}</span>
       </Typography>
     </button>

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
@@ -1,0 +1,8 @@
+import { DataListActionProps, DataListObject } from "../../DataList.types";
+
+export function DataListAction<T extends DataListObject>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _: DataListActionProps<T>,
+) {
+  return null;
+}

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
@@ -22,11 +22,13 @@ export function InternalDataListAction<T extends DataListObject>({
   onClick,
   item,
 }: InternalDataListActionProps<T>) {
+  const color = destructive ? "critical" : "blue";
+
   return (
     <button className={styles.action} onClick={() => onClick?.(item)}>
-      {icon && <Icon name={icon} color={destructive ? "critical" : "blue"} />}
+      {icon && <Icon name={icon} color={color} />}
 
-      <Typography textColor={destructive ? "critical" : "blue"}>
+      <Typography textColor={color}>
         <span className={styles.label}>{label}</span>
       </Typography>
     </button>

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import classNames from "classnames";
 import styles from "./DataListAction.css";
 import {
   DataListActionProps,
@@ -22,18 +21,11 @@ export function InternalDataListAction<T extends DataListObject>({
   destructive,
   onClick,
   item,
-  withIconOffset,
 }: InternalDataListActionProps<T>) {
   return (
-    <button
-      className={classNames(styles.action, {
-        [styles.withIconOffset]: withIconOffset,
-      })}
-      onClick={() => onClick?.(item)}
-    >
-      <div>
-        {icon && <Icon name={icon} color={destructive ? "critical" : "blue"} />}
-      </div>
+    <button className={styles.action} onClick={() => onClick?.(item)}>
+      {icon && <Icon name={icon} color={destructive ? "critical" : "blue"} />}
+
       <Typography textColor={destructive ? "critical" : "blue"}>
         <span className={styles.label}>{label}</span>
       </Typography>

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
@@ -1,8 +1,19 @@
+import React from "react";
+import styles from "./DataListAction.css";
 import { DataListActionProps, DataListObject } from "../../DataList.types";
+import { Typography } from "../../../Typography";
+import { Icon } from "../../../Icon";
 
-export function DataListAction<T extends DataListObject>(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _: DataListActionProps<T>,
-) {
-  return null;
+export function DataListAction<T extends DataListObject>({
+  label,
+  icon,
+}: DataListActionProps<T>) {
+  return (
+    <button className={styles.action}>
+      <div>{icon && <Icon name={icon} />}</div>
+      <Typography textColor="blue">
+        <span className={styles.label}>{label}</span>
+      </Typography>
+    </button>
+  );
 }

--- a/packages/components/src/DataList/components/DataListAction/index.ts
+++ b/packages/components/src/DataList/components/DataListAction/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListAction";

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.css
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.css
@@ -1,0 +1,21 @@
+.menu {
+  position: fixed;
+  top: var(--actions-menu-y, 0);
+  left: var(--actions-menu-x, 0);
+  z-index: var(--elevation-menu);
+  min-width: 150px;
+  box-shadow: var(--shadow-base);
+  padding: var(--space-smaller);
+  border: var(--border-base) solid var(--color-border);
+  border-radius: var(--radius-larger);
+  background-color: var(--color-surface);
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: var(--elevation-menu);
+  width: 100%;
+  height: 100%;
+}

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.css.d.ts
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "menu": string;
+  readonly "overlay": string;
+};
+export = styles;
+

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -1,0 +1,68 @@
+import React, { CSSProperties, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import styles from "./DataListActionsMenu.css";
+import { useDataListContext } from "../../context/DataListContext";
+
+interface DataListActionsMenuProps {
+  readonly visible: boolean;
+  readonly position: {
+    readonly x: number;
+    readonly y: number;
+  };
+  readonly onRequestClose: () => void;
+}
+
+export function DataListActionsMenu({
+  visible = false,
+  position,
+  onRequestClose,
+}: DataListActionsMenuProps) {
+  const [ref, setRef] = useState<HTMLDivElement | null>();
+
+  const { itemActionComponent } = useDataListContext();
+  if (!itemActionComponent) return null;
+  const { children } = itemActionComponent.props;
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <>
+          <div className={styles.overlay} onClick={onRequestClose} />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            ref={setRef}
+            className={styles.menu}
+            style={getPositionCssVars()}
+          >
+            {children}
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+
+  function getPositionCssVars() {
+    const { posX, posY } = getPosition();
+
+    return {
+      "--actions-menu-x": `${posX}px`,
+      "--actions-menu-y": `${posY}px`,
+    } as CSSProperties;
+  }
+
+  function getPosition() {
+    const rect = ref?.getBoundingClientRect();
+    const { width = 0, height = 0 } = rect || {};
+    const { x = 0, y = 0 } = position;
+
+    const xIsOffScreen = x + width > window.innerWidth;
+    const yIsOffScreen = y + height > window.innerHeight;
+
+    const newPosX = Math.floor(xIsOffScreen ? x - width : x);
+    const newPosY = Math.floor(yIsOffScreen ? y - height : y);
+    return { posX: newPosX, posY: newPosY };
+  }
+}

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -1,6 +1,9 @@
 import React, { CSSProperties, PropsWithChildren, useState } from "react";
 import { AnimatePresence, Variants, motion } from "framer-motion";
 import { tokens } from "@jobber/design";
+import { useFocusTrap } from "@jobber/hooks/useFocusTrap";
+import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
+import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
 import styles from "./DataListActionsMenu.css";
 
 interface DataListActionsMenuProps {
@@ -25,6 +28,10 @@ export function DataListActionsMenu({
 }: PropsWithChildren<DataListActionsMenuProps>) {
   const [ref, setRef] = useState<HTMLDivElement | null>();
 
+  useRefocusOnActivator(visible);
+  const focusTrapRef = useFocusTrap<HTMLDivElement>(visible);
+  useOnKeyDown(onRequestClose, "Escape");
+
   return (
     <AnimatePresence>
       {visible && (
@@ -41,7 +48,9 @@ export function DataListActionsMenu({
             className={styles.menu}
             style={getPositionCssVars()}
           >
-            {children}
+            <div tabIndex={0} ref={focusTrapRef}>
+              {children}
+            </div>
           </motion.div>
         </>
       )}

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -1,10 +1,10 @@
 import React, { CSSProperties, PropsWithChildren, useState } from "react";
 import { AnimatePresence, Variants, motion } from "framer-motion";
-import { tokens } from "@jobber/design";
 import { useFocusTrap } from "@jobber/hooks/useFocusTrap";
 import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
 import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
 import styles from "./DataListActionsMenu.css";
+import { TRANSITION_DELAY_IN_SECONDS } from "../../DataList.const";
 
 interface DataListActionsMenuProps {
   readonly visible: boolean;
@@ -44,7 +44,7 @@ export function DataListActionsMenu({
             initial="hidden"
             animate="visible"
             exit="hidden"
-            transition={{ duration: tokens["timing-base"] / 1000 }}
+            transition={{ duration: TRANSITION_DELAY_IN_SECONDS }}
             className={styles.menu}
             style={getPositionCssVars()}
           >

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -1,8 +1,7 @@
-import React, { CSSProperties, useState } from "react";
+import React, { CSSProperties, PropsWithChildren, useState } from "react";
 import { AnimatePresence, Variants, motion } from "framer-motion";
 import { tokens } from "@jobber/design";
 import styles from "./DataListActionsMenu.css";
-import { useDataListContext } from "../../context/DataListContext";
 
 interface DataListActionsMenuProps {
   readonly visible: boolean;
@@ -22,12 +21,9 @@ export function DataListActionsMenu({
   visible = false,
   position,
   onRequestClose,
-}: DataListActionsMenuProps) {
+  children,
+}: PropsWithChildren<DataListActionsMenuProps>) {
   const [ref, setRef] = useState<HTMLDivElement | null>();
-
-  const { itemActionComponent } = useDataListContext();
-  if (!itemActionComponent) return null;
-  const { children } = itemActionComponent.props;
 
   return (
     <AnimatePresence>

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, Variants, motion } from "framer-motion";
+import { tokens } from "@jobber/design";
 import styles from "./DataListActionsMenu.css";
 import { useDataListContext } from "../../context/DataListContext";
 
@@ -11,6 +12,11 @@ interface DataListActionsMenuProps {
   };
   readonly onRequestClose: () => void;
 }
+
+const variants: Variants = {
+  hidden: { opacity: 0, y: -10 },
+  visible: { opacity: 1, y: 0 },
+};
 
 export function DataListActionsMenu({
   visible = false,
@@ -30,10 +36,12 @@ export function DataListActionsMenu({
           <div className={styles.overlay} onClick={onRequestClose} />
 
           <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.9 }}
             ref={setRef}
+            variants={variants}
+            initial="hidden"
+            animate="visible"
+            exit="hidden"
+            transition={{ duration: tokens["timing-base"] / 1000 }}
             className={styles.menu}
             style={getPositionCssVars()}
           >
@@ -60,9 +68,10 @@ export function DataListActionsMenu({
 
     const xIsOffScreen = x + width > window.innerWidth;
     const yIsOffScreen = y + height > window.innerHeight;
+    const yOffSet = y + height - window.innerHeight;
 
     const newPosX = Math.floor(xIsOffScreen ? x - width : x);
-    const newPosY = Math.floor(yIsOffScreen ? y - height : y);
+    const newPosY = Math.floor(yIsOffScreen ? y - yOffSet : y);
     return { posX: newPosX, posY: newPosY };
   }
 }

--- a/packages/components/src/DataList/components/DataListActionsMenu/index.ts
+++ b/packages/components/src/DataList/components/DataListActionsMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListActionsMenu";

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.css
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.css
@@ -1,0 +1,12 @@
+.menu {
+  display: flex;
+  position: absolute;
+  top: -25%;
+  right: 0;
+  z-index: var(--elevation-menu);
+  box-shadow: var(--shadow-base);
+  padding: var(--space-smaller);
+  border-radius: var(--radius-large);
+  background-color: var(--color-surface);
+  gap: var(--space-smaller);
+}

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.css
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.css
@@ -1,12 +1,13 @@
 .menu {
   display: flex;
   position: absolute;
-  top: -25%;
+  top: calc(var(--space-small) * -1);
   right: 0;
   z-index: var(--elevation-menu);
   box-shadow: var(--shadow-base);
   padding: var(--space-smaller);
-  border-radius: var(--radius-large);
+  border: var(--border-base) solid var(--color-border);
+  border-radius: var(--radius-larger);
   background-color: var(--color-surface);
   gap: var(--space-smaller);
 }

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.css.d.ts
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly "menu": string;
+};
+export = styles;
+

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
@@ -59,7 +59,7 @@ export function InternalDataListItemActions<T extends DataListObject>({
       className={styles.menu}
     >
       {exposedActions.map(({ props }) => {
-        if (!props.icon) return <></>;
+        if (!props.icon) return null;
 
         return (
           <Tooltip key={props.label} message={props.label}>

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from "react";
 import { Variants, motion } from "framer-motion";
-import { tokens } from "@jobber/design";
 import styles from "./DataListItemActions.css";
 import { useDataListContext } from "../../context/DataListContext";
 import {
@@ -17,6 +16,10 @@ import {
 import { Button } from "../../../Button";
 import { DataListActionsMenu } from "../DataListActionsMenu";
 import { InternalDataListAction } from "../DataListAction";
+import {
+  TRANSITION_DELAY_IN_SECONDS,
+  TRANSITION_DURATION_IN_SECONDS,
+} from "../../DataList.const";
 
 // This component is meant to capture the props of the DataList.ItemActions
 export function DataListItemActions<T extends DataListObject>(
@@ -61,8 +64,8 @@ export function InternalDataListItemActions<T extends DataListObject>({
       animate="visible"
       exit="hidden"
       transition={{
-        duration: tokens["timing-base"] / 1000,
-        delay: tokens["timing-quick"] / 1000,
+        duration: TRANSITION_DURATION_IN_SECONDS,
+        delay: TRANSITION_DELAY_IN_SECONDS,
       }}
       className={styles.menu}
     >

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
@@ -1,12 +1,7 @@
-import React, {
-  Children,
-  MouseEvent,
-  ReactElement,
-  isValidElement,
-  useState,
-} from "react";
+import React, { Children, ReactElement, isValidElement } from "react";
 import { Variants, motion } from "framer-motion";
 import styles from "./DataListItemActions.css";
+import { DataListItemActionsOverflow } from "./DataListItemActionsOverflow";
 import { useDataListContext } from "../../context/DataListContext";
 import {
   DataListActionProps,
@@ -14,8 +9,6 @@ import {
   DataListObject,
 } from "../../DataList.types";
 import { Button } from "../../../Button";
-import { DataListActionsMenu } from "../DataListActionsMenu";
-import { InternalDataListAction } from "../DataListAction";
 import {
   TRANSITION_DELAY_IN_SECONDS,
   TRANSITION_DURATION_IN_SECONDS,
@@ -42,8 +35,6 @@ export function InternalDataListItemActions<T extends DataListObject>({
   item,
 }: InternalDataListItemActionsProps<T>) {
   const { itemActionComponent } = useDataListContext();
-  const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
-  const [showMenu, setShowMenu] = useState(false);
   if (!itemActionComponent) return null;
 
   const { children } = itemActionComponent.props;
@@ -53,9 +44,6 @@ export function InternalDataListItemActions<T extends DataListObject>({
     );
   const exposedActions = getExposedActions(childrenArray);
   childrenArray.splice(0, exposedActions.length);
-  const hasIconOffset = childrenArray.some(
-    child => child.props.icon !== undefined,
-  );
 
   return (
     <motion.div
@@ -84,39 +72,9 @@ export function InternalDataListItemActions<T extends DataListObject>({
         );
       })}
 
-      <Button
-        icon="more"
-        ariaLabel="More actions"
-        type="secondary"
-        variation="subtle"
-        onClick={handleMoreClick}
-      />
-
-      <DataListActionsMenu
-        visible={showMenu}
-        position={menuPosition}
-        onRequestClose={() => setShowMenu(false)}
-      >
-        {childrenArray.map(action => {
-          return (
-            <InternalDataListAction
-              key={action.props.label}
-              {...action.props}
-              withIconOffset={hasIconOffset}
-              item={item}
-            />
-          );
-        })}
-      </DataListActionsMenu>
+      <DataListItemActionsOverflow actions={childrenArray} item={item} />
     </motion.div>
   );
-
-  function handleMoreClick(event: MouseEvent<HTMLButtonElement>): void {
-    setShowMenu(true);
-
-    const rect = event.currentTarget.getBoundingClientRect();
-    setMenuPosition({ x: rect.x + rect.width, y: rect.y + rect.height });
-  }
 }
 
 function getExposedActions<T extends DataListObject>(

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
@@ -1,0 +1,75 @@
+import React, { Children, ReactElement, isValidElement } from "react";
+import styles from "./DataListItemActions.css";
+import { useDataListContext } from "../../context/DataListContext";
+import {
+  DataListActionProps,
+  DataListItemActionsProps,
+  DataListObject,
+} from "../../DataList.types";
+import { Menu, SectionProps } from "../../../Menu";
+import { Button } from "../../../Button";
+
+// This component is meant to capture the props of the DataList.ItemActions
+export function DataListItemActions<T extends DataListObject>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _: DataListItemActionsProps<T>,
+) {
+  return null;
+}
+
+interface InternalDataListItemActionsProps<T extends DataListObject> {
+  item: T;
+}
+
+export function InternalDataListItemActions<T extends DataListObject>({
+  item,
+}: InternalDataListItemActionsProps<T>) {
+  const { itemActionComponent } = useDataListContext();
+  if (!itemActionComponent) return null;
+
+  const { children } = itemActionComponent.props;
+  const childrenArray =
+    Children.toArray(children).filter<
+      ReactElement<DataListActionProps<DataListObject>>
+    >(isValidElement);
+  const exposedActions = childrenArray.slice(0, 2);
+  const menuItems: SectionProps[] = [
+    {
+      actions: childrenArray.map(({ props }) => ({
+        label: props.label,
+        onClick: () => props.onClick?.(item),
+      })),
+    },
+  ];
+
+  return (
+    <div className={styles.menu}>
+      {exposedActions.map(action => {
+        if (!action.props.icon) return <></>;
+
+        return (
+          <Button
+            key={action.props.label}
+            icon={action.props.icon}
+            ariaLabel={action.props.label}
+            onClick={() => action.props.onClick?.(item)}
+            type="secondary"
+            variation="subtle"
+          />
+        );
+      })}
+
+      <Menu
+        items={menuItems}
+        activator={
+          <Button
+            icon="more"
+            ariaLabel="More actions"
+            type="secondary"
+            variation="subtle"
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
@@ -13,6 +13,7 @@ import {
   TRANSITION_DELAY_IN_SECONDS,
   TRANSITION_DURATION_IN_SECONDS,
 } from "../../DataList.const";
+import { Tooltip } from "../../../Tooltip";
 
 // This component is meant to capture the props of the DataList.ItemActions
 export function DataListItemActions<T extends DataListObject>(
@@ -57,18 +58,19 @@ export function InternalDataListItemActions<T extends DataListObject>({
       }}
       className={styles.menu}
     >
-      {exposedActions.map(action => {
-        if (!action.props.icon) return <></>;
+      {exposedActions.map(({ props }) => {
+        if (!props.icon) return <></>;
 
         return (
-          <Button
-            key={action.props.label}
-            icon={action.props.icon}
-            ariaLabel={action.props.label}
-            onClick={() => action.props.onClick?.(item)}
-            type="secondary"
-            variation="subtle"
-          />
+          <Tooltip key={props.label} message={props.label}>
+            <Button
+              icon={props.icon}
+              ariaLabel={props.label}
+              onClick={() => props.onClick?.(item)}
+              type="secondary"
+              variation="subtle"
+            />
+          </Tooltip>
         );
       })}
 

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
@@ -21,8 +21,6 @@ export function DataListItemActionsOverflow<T extends DataListObject>({
   const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
   const [showMenu, setShowMenu] = useState(false);
 
-  const hasIconOffset = actions.some(child => child.props.icon !== undefined);
-
   return (
     <>
       <Tooltip message="More actions">
@@ -41,11 +39,7 @@ export function DataListItemActionsOverflow<T extends DataListObject>({
         onRequestClose={handleClose}
       >
         {Children.map(actions, action => (
-          <InternalDataListAction
-            {...action.props}
-            withIconOffset={hasIconOffset}
-            item={item}
-          />
+          <InternalDataListAction {...action.props} item={item} />
         ))}
       </DataListActionsMenu>
     </>

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
@@ -1,5 +1,6 @@
 import React, { Children, MouseEvent, ReactElement, useState } from "react";
 import { Button } from "../../../Button";
+import { Tooltip } from "../../../Tooltip";
 import {
   DataListActionProps,
   DataListObject,
@@ -24,13 +25,15 @@ export function DataListItemActionsOverflow<T extends DataListObject>({
 
   return (
     <>
-      <Button
-        icon="more"
-        ariaLabel="More actions"
-        type="secondary"
-        variation="subtle"
-        onClick={handleMoreClick}
-      />
+      <Tooltip message="More actions">
+        <Button
+          icon="more"
+          ariaLabel="More actions"
+          type="secondary"
+          variation="subtle"
+          onClick={handleMoreClick}
+        />
+      </Tooltip>
 
       <DataListActionsMenu
         visible={showMenu}

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export function DataListItemActionsOverflow() {
+  return <></>;
+}

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
@@ -1,5 +1,64 @@
-import React from "react";
+import React, { Children, MouseEvent, ReactElement, useState } from "react";
+import { Button } from "../../../Button";
+import {
+  DataListActionProps,
+  DataListObject,
+  InternalDataListActionProps,
+} from "../../DataList.types";
+import { InternalDataListAction } from "../DataListAction";
+import { DataListActionsMenu } from "../DataListActionsMenu";
 
-export function DataListItemActionsOverflow() {
-  return <></>;
+interface DataListItemActionsOverflowProps<T extends DataListObject>
+  extends Pick<InternalDataListActionProps<T>, "item"> {
+  readonly actions: ReactElement<DataListActionProps<T>>[];
+}
+
+export function DataListItemActionsOverflow<T extends DataListObject>({
+  item,
+  actions,
+}: DataListItemActionsOverflowProps<T>) {
+  const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
+  const [showMenu, setShowMenu] = useState(false);
+
+  const hasIconOffset = actions.some(child => child.props.icon !== undefined);
+
+  return (
+    <>
+      <Button
+        icon="more"
+        ariaLabel="More actions"
+        type="secondary"
+        variation="subtle"
+        onClick={handleMoreClick}
+      />
+
+      <DataListActionsMenu
+        visible={showMenu}
+        position={menuPosition}
+        onRequestClose={handleClose}
+      >
+        {Children.map(actions, action => (
+          <InternalDataListAction
+            {...action.props}
+            withIconOffset={hasIconOffset}
+            item={item}
+          />
+        ))}
+      </DataListActionsMenu>
+    </>
+  );
+
+  function handleMoreClick(event: MouseEvent<HTMLButtonElement>): void {
+    setShowMenu(true);
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    const posX = rect.x + rect.width;
+    const posY = rect.y + rect.height;
+
+    setMenuPosition({ x: posX, y: posY });
+  }
+
+  function handleClose() {
+    setShowMenu(false);
+  }
 }

--- a/packages/components/src/DataList/components/DataListItemActions/index.ts
+++ b/packages/components/src/DataList/components/DataListItemActions/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListItemActions";

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
@@ -37,7 +37,7 @@ export function DataListItems<T extends DataListObject>({
                   onMouseEnter={() => setHover(item.id)}
                   onMouseLeave={() => setHover(undefined)}
                   className={styles.listItem}
-                  key={`${item.id}`}
+                  key={item.id}
                 >
                   <DataListItemInternal item={data[i]}>
                     {layout.props.children(child)}

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { AnimatePresence } from "framer-motion";
 import { DataListLayoutInternal } from "./DataListLayoutInternal";
 import { DataListItemInternal } from "./DataListItemInternal";
 import { Breakpoints } from "../../DataList.const";
@@ -36,15 +37,17 @@ export function DataListItems<T extends DataListObject>({
                   onMouseEnter={() => setHover(item.id)}
                   onMouseLeave={() => setHover(undefined)}
                   className={styles.listItem}
-                  key={`${data[i].id}`}
+                  key={`${item.id}`}
                 >
                   <DataListItemInternal item={data[i]}>
                     {layout.props.children(child)}
                   </DataListItemInternal>
 
-                  {hover === item.id && (
-                    <InternalDataListItemActions item={item} />
-                  )}
+                  <AnimatePresence>
+                    {hover === item.id && (
+                      <InternalDataListItemActions item={item} />
+                    )}
+                  </AnimatePresence>
                 </div>
               );
             })}

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { DataListLayoutInternal } from "./DataListLayoutInternal";
 import { DataListItemInternal } from "./DataListItemInternal";
 import { Breakpoints } from "../../DataList.const";
 import styles from "../../DataList.css";
 import { DataListLayoutProps, DataListObject } from "../../DataList.types";
 import { generateListItemElements } from "../../DataList.utils";
+import { InternalDataListItemActions } from "../DataListItemActions";
 
 interface DataListItemsProps<T extends DataListObject> {
   readonly layouts: React.ReactElement<DataListLayoutProps<T>>[] | undefined;
@@ -18,6 +19,7 @@ export function DataListItems<T extends DataListObject>({
   data,
 }: DataListItemsProps<T>) {
   const elementData = generateListItemElements(data);
+  const [hover, setHover] = useState<T["id"]>();
 
   return (
     <DataListLayoutInternal
@@ -27,11 +29,22 @@ export function DataListItems<T extends DataListObject>({
         return (
           <>
             {elementData.map((child, i) => {
+              const item = data[i];
+
               return (
-                <div className={styles.listItem} key={`${data[i].id}`}>
+                <div
+                  onMouseEnter={() => setHover(item.id)}
+                  onMouseLeave={() => setHover(undefined)}
+                  className={styles.listItem}
+                  key={`${data[i].id}`}
+                >
                   <DataListItemInternal item={data[i]}>
                     {layout.props.children(child)}
                   </DataListItemInternal>
+
+                  {hover === item.id && (
+                    <InternalDataListItemActions item={item} />
+                  )}
                 </div>
               );
             })}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

With a list of items, we need to add a way for the users to trigger actions on them. This allows the user to define what actions can a user do in a single list item.

### What's in it?
- Allow consumers to implement actions
- Menu set up to allow us to show a context menu but not implement it yet

### What's not in it
- Moving the actions with the layout on smaller screens.
  - That's on a different ticket
- Right-click context menu

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Component signature for adding an action on each item

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- It should show the first 2 actions, but only if those 2 actions have an icon
- If none of the actions have icons, it shouldn't expose it
- All remaining actions that aren't exposed should show under the overflow more menu
- It should trap the focus when you open the overflow menu
- It should close the menu when you press escape

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
