### PR TITLE
feat(components): Refactor options as li elements

### DIFF
--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -226,7 +226,7 @@ describe("ComboboxContent", () => {
 
 describe("Combobox selected value", () => {
   it("has a selected option when a selected id is passed as a number and option id is a string", () => {
-    const { getByRole } = render(
+    const { getByText } = render(
       <Combobox>
         <Combobox.TriggerButton label="Button" />
         <Combobox.Content
@@ -241,12 +241,12 @@ describe("Combobox selected value", () => {
         </Combobox.Content>
       </Combobox>,
     );
-    const option = getByRole("radio", { name: "Bilbo Baggins" });
-    expect(option).toBeChecked();
+    const option = getByText("Bilbo Baggins");
+    expect(option).toHaveClass("selectedOption");
   });
 
   it("has a selected option when a selected value is passed as the same type as the option id", () => {
-    const { getByRole } = render(
+    const { getByText } = render(
       <Combobox>
         <Combobox.TriggerButton label="Button" />
         <Combobox.Content
@@ -261,8 +261,8 @@ describe("Combobox selected value", () => {
         </Combobox.Content>
       </Combobox>,
     );
-    const option = getByRole("radio", { name: "Bilbo Baggins" });
-    expect(option).toBeChecked();
+    const option = getByText("Bilbo Baggins");
+    expect(option).toHaveClass("selectedOption");
   });
 });
 

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
@@ -19,8 +19,17 @@
   visibility: hidden;
 }
 
+.optionsList {
+  display: flex;
+  padding: var(--space-base);
+  flex-direction: column;
+}
+
 .option {
-  display: block;
+  border: none;
+  border-radius: var(--radius-large);
+  text-align: left;
+  background: none;
 }
 
 .search {
@@ -60,10 +69,6 @@
 
 .clearSearch:focus {
   box-shadow: var(--shadow-focus);
-}
-
-.list {
-  padding: var(--space-base);
 }
 
 .search::after {

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
@@ -20,16 +20,18 @@
 }
 
 .optionsList {
-  display: flex;
-  padding: var(--space-base);
-  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .option {
-  border: none;
-  border-radius: var(--radius-large);
-  text-align: left;
-  background: none;
+  padding: var(--space-small) var(--space-base);
+  cursor: pointer;
+}
+
+.option:hover {
+  background-color: var(--color-surface--background);
 }
 
 .search {

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css.d.ts
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css.d.ts
@@ -1,11 +1,11 @@
 declare const styles: {
   readonly "content": string;
   readonly "hidden": string;
+  readonly "optionsList": string;
   readonly "option": string;
   readonly "search": string;
   readonly "searchInput": string;
   readonly "clearSearch": string;
-  readonly "list": string;
   readonly "actions": string;
   readonly "selectedOption": string;
   readonly "actionPadding": string;

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -79,10 +79,10 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         searchValue={searchValue}
         setSearchValue={setSearchValue}
       />
-      <div className={styles.optionsList}>
+      <ul className={styles.optionsList}>
         {optionsExist &&
           filteredOptions.map(option => (
-            <button
+            <li
               key={option.id}
               onClick={() => handleSelection(option)}
               className={classnames(
@@ -92,7 +92,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
               )}
             >
               {option.label}
-            </button>
+            </li>
           ))}
 
         {optionsExist && filteredOptions.length === 0 && (
@@ -100,7 +100,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         )}
 
         {!optionsExist && <p>{getZeroIndexStateText(props.subjectNoun)}</p>}
-      </div>
+      </ul>
 
       {props.children && (
         <div className={styles.actions}>

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -79,23 +79,20 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         searchValue={searchValue}
         setSearchValue={setSearchValue}
       />
-      <div className={styles.list}>
+      <div className={styles.optionsList}>
         {optionsExist &&
           filteredOptions.map(option => (
-            <label key={option.id}>
-              <input
-                type="radio"
-                className={classnames(
-                  styles.option,
-                  option.id === selectedOption?.id && styles.selectedOption,
-                )}
-                checked={option.id.toString() === selectedOption?.id.toString()}
-                value={option.label}
-                name={option.label}
-                onChange={() => handleSelection(option)}
-              />
+            <button
+              key={option.id}
+              onClick={() => handleSelection(option)}
+              className={classnames(
+                styles.option,
+                option.id.toString() === selectedOption?.id.toString() &&
+                  styles.selectedOption,
+              )}
+            >
               {option.label}
-            </label>
+            </button>
           ))}
 
         {optionsExist && filteredOptions.length === 0 && (


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Refactor to update the combobox options as li elements instead of radio inputs.
We made this decision due to accessibility concerns with the fact that when using a radio input when using the arrow keys to switch the selected value an option would be made without using spacebar or enter to confirm a selection and the combobox content would close automatically. This created a weird experience for the user.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
