### PR TITLE
feat(components): move sorting to a button when the header disappears

### DIFF
--- a/jest.web.config.js
+++ b/jest.web.config.js
@@ -11,6 +11,7 @@ module.exports = {
     "react-markdown":
       "<rootDir>/node_modules/react-markdown/react-markdown.min.js",
     "^@jobber/hooks/(.*)$": "<rootDir>/packages/hooks/dist/$1",
+    "^@jobber/components/(.*)$": "<rootDir>/packages/components/src/$1",
   },
   // Automatically clear mock calls and instances between every test
   clearMocks: true,

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -409,10 +409,10 @@ describe("DataList", () => {
 
     it("should show the sorting arrows when the header is clicked", () => {
       const mockOnSort = jest.fn();
-      const expectedSorting = {
-        direction: "asc",
+      const expectedSorting: DataListSorting = {
+        order: "asc",
         key: "name",
-      } as DataListSorting;
+      };
 
       const { rerender } = render(
         <MockSortingLayout

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -47,7 +47,7 @@ export type DataListHeader<T extends DataListObject> = {
 
 export interface DataListSorting {
   readonly key: string;
-  readonly direction: "asc" | "desc";
+  readonly order: "asc" | "desc";
 }
 
 export interface DataListProps<T extends DataListObject> {

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.test.tsx
@@ -5,6 +5,7 @@ import { DataListFilters, InternalDataListFilters } from "./DataListFilters";
 import { CONTAINER_TEST_ID } from "./DataListFilter.const";
 import { defaultValues } from "../../context/DataListContext";
 import * as dataListContext from "../../context/DataListContext/DataListContext";
+import * as useShowHeader from "../../hooks/useShowHeader";
 
 configMocks({ act });
 const observer = mockIntersectionObserver();
@@ -20,10 +21,12 @@ const contextValueWithRenderableChildren = {
     </DataListFilters>
   ),
 };
+const showHeaderSpy = jest.spyOn(useShowHeader, "useShowHeader");
 
 afterEach(() => {
   cleanup();
   spy.mockReset();
+  showHeaderSpy.mockReset();
 });
 
 describe("DataListFilters", () => {
@@ -103,5 +106,32 @@ describe("InternalDataListFilters", () => {
     render(<InternalDataListFilters />);
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  describe("Sort", () => {
+    const mockContextValueWithSorting = {
+      ...contextValueWithRenderableChildren,
+      sorting: { sortable: ["name"], state: undefined, onSort: jest.fn() },
+    };
+
+    it("should render the sort button when the header is not there", () => {
+      spy.mockReturnValue(mockContextValueWithSorting);
+      showHeaderSpy.mockReturnValueOnce(false);
+      render(<InternalDataListFilters />);
+
+      expect(
+        screen.getByRole("button", { name: "Sort by" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should not render the sort button when the header is there", () => {
+      spy.mockReturnValue(mockContextValueWithSorting);
+      showHeaderSpy.mockReturnValueOnce(true);
+      render(<InternalDataListFilters />);
+
+      expect(
+        screen.queryByRole("button", { name: "Sort by" }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
@@ -6,6 +6,7 @@ import { CONTAINER_TEST_ID } from "./DataListFilter.const";
 import { DataListSort } from "./components/DataListSort";
 import { useDataListContext } from "../../context/DataListContext";
 import { getCompoundComponent } from "../../DataList.utils";
+import { useShowHeader } from "../../hooks/useShowHeader";
 
 interface DataListFiltersProps {
   readonly children: ReactElement | ReactElement[];
@@ -22,6 +23,7 @@ export function DataListFilters(_: DataListFiltersProps) {
  */
 export function InternalDataListFilters() {
   const { children: parentChildren } = useDataListContext();
+  const showHeader = useShowHeader();
   const component = getCompoundComponent<DataListFiltersProps>(
     parentChildren,
     DataListFilters,
@@ -47,7 +49,7 @@ export function InternalDataListFilters() {
 
         {children}
 
-        <DataListSort />
+        {!showHeader && <DataListSort />}
 
         <span ref={rightRef} className={styles.overflowTrigger} />
       </div>

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import { useInView } from "@jobber/hooks/useInView";
 import styles from "./DataListFilters.css";
 import { CONTAINER_TEST_ID } from "./DataListFilter.const";
+import { DataListSort } from "./components/DataListSort";
 import { useDataListContext } from "../../context/DataListContext";
 import { getCompoundComponent } from "../../DataList.utils";
 
@@ -45,6 +46,8 @@ export function InternalDataListFilters() {
         <span ref={leftRef} className={styles.overflowTrigger} />
 
         {children}
+
+        <DataListSort />
 
         <span ref={rightRef} className={styles.overflowTrigger} />
       </div>

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.tsx
@@ -24,6 +24,7 @@ export function DataListFilters(_: DataListFiltersProps) {
 export function InternalDataListFilters() {
   const { children: parentChildren } = useDataListContext();
   const showHeader = useShowHeader();
+  const showSortButton = !showHeader;
   const component = getCompoundComponent<DataListFiltersProps>(
     parentChildren,
     DataListFilters,
@@ -32,9 +33,9 @@ export function InternalDataListFilters() {
   const [leftRef, isLeftVisible] = useInView<HTMLSpanElement>();
   const [rightRef, isRightVisible] = useInView<HTMLSpanElement>();
 
-  if (!component) return null;
+  if (!showSortButton && !component) return null;
 
-  const { children } = component.props;
+  const children = component?.props.children;
 
   return (
     <div
@@ -47,9 +48,9 @@ export function InternalDataListFilters() {
       <div className={styles.filterActions}>
         <span ref={leftRef} className={styles.overflowTrigger} />
 
-        {children}
+        {children && children}
 
-        {!showHeader && <DataListSort />}
+        {showSortButton && <DataListSort />}
 
         <span ref={rightRef} className={styles.overflowTrigger} />
       </div>

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  DataListContext,
+  defaultValues,
+} from "@jobber/components/DataList/context/DataListContext";
+import { DataListSorting } from "@jobber/components/DataList/DataList.types";
+import { DataListSort } from "./DataListSort";
+
+const sortableKeys = ["label", "address"] as const;
+const handleSort = jest.fn();
+const mockContextValue = {
+  ...defaultValues,
+  headers: { label: "Label", address: "Address", phone: "Phone" },
+  sorting: {
+    sortable: [...sortableKeys],
+    state: undefined,
+    onSort: handleSort,
+  },
+};
+
+const buttonLabel = "Sort by";
+
+afterEach(() => {
+  handleSort.mockClear();
+});
+
+describe("DataListSort", () => {
+  it("should only render a button", () => {
+    render(
+      <DataListContext.Provider value={mockContextValue}>
+        <DataListSort />
+      </DataListContext.Provider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: buttonLabel }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should not render a button when sorting is undefined", () => {
+    render(
+      <DataListContext.Provider value={defaultValues}>
+        <DataListSort />
+      </DataListContext.Provider>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: buttonLabel }),
+    ).not.toBeInTheDocument();
+  });
+
+  describe("Popover", () => {
+    beforeEach(() => {
+      render(
+        <DataListContext.Provider value={mockContextValue}>
+          <DataListSort />
+        </DataListContext.Provider>,
+      );
+
+      userEvent.click(screen.getByRole("button", { name: buttonLabel }));
+    });
+
+    it("should render a popover when the button is clicked", () => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("should close the popover when the button is clicked again", () => {
+      userEvent.click(screen.getByRole("button", { name: buttonLabel }));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("should close the popover when the close button is pressed", () => {
+      userEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Sort by chips", () => {
+    beforeEach(() => {
+      render(
+        <DataListContext.Provider value={mockContextValue}>
+          <DataListSort />
+        </DataListContext.Provider>,
+      );
+
+      userEvent.click(screen.getByRole("button", { name: buttonLabel }));
+    });
+
+    it.each(sortableKeys)("should render a chip for %s", name => {
+      expect(
+        screen.getByRole("radio", { name: mockContextValue.headers[name] }),
+      ).toBeInTheDocument();
+    });
+
+    it("should render a chip for none", () => {
+      expect(screen.getByRole("radio", { name: "None" })).toBeInTheDocument();
+    });
+
+    it("should render a chip for ascending and descending and they're disabled", () => {
+      const ascendingRadio = screen.getByRole("radio", { name: "Ascending" });
+      expect(ascendingRadio).toBeInTheDocument();
+      expect(ascendingRadio).toBeDisabled();
+
+      const descendingRadio = screen.getByRole("radio", { name: "Descending" });
+      expect(descendingRadio).toBeInTheDocument();
+      expect(descendingRadio).toBeDisabled();
+    });
+  });
+
+  describe("Sorting key change", () => {
+    beforeEach(() => {
+      render(
+        <DataListContext.Provider value={mockContextValue}>
+          <DataListSort />
+        </DataListContext.Provider>,
+      );
+
+      userEvent.click(screen.getByRole("button", { name: buttonLabel }));
+    });
+
+    it.each(sortableKeys)("should call onSort with %s", name => {
+      userEvent.click(
+        screen.getByRole("radio", { name: mockContextValue.headers[name] }),
+      );
+
+      expect(handleSort).toHaveBeenCalledWith({
+        key: name,
+        direction: "asc",
+      });
+    });
+
+    it("should call onSort with undefined when none is clicked", () => {
+      userEvent.click(screen.getByRole("radio", { name: "None" }));
+      expect(handleSort).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe("'Ordered by' change", () => {
+    const initialSortingState: DataListSorting = {
+      key: "label",
+      direction: "asc",
+    };
+
+    beforeEach(() => {
+      render(
+        <DataListContext.Provider
+          value={{
+            ...mockContextValue,
+            sorting: {
+              ...mockContextValue.sorting,
+              state: initialSortingState,
+            },
+          }}
+        >
+          <DataListSort />
+        </DataListContext.Provider>,
+      );
+
+      userEvent.click(
+        screen.getByRole("button", { name: RegExp(buttonLabel, "i") }),
+      );
+    });
+
+    it("should call not call onSort when you're selecting the already selected value", () => {
+      userEvent.click(screen.getByRole("radio", { name: "Ascending" }));
+      expect(handleSort).not.toHaveBeenCalled();
+    });
+
+    it("should call onSort with the new direction", () => {
+      userEvent.click(screen.getByRole("radio", { name: "Descending" }));
+      expect(handleSort).toHaveBeenCalledWith({
+        ...initialSortingState,
+        direction: "desc",
+      });
+    });
+  });
+});

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
@@ -128,7 +128,7 @@ describe("DataListSort", () => {
 
       expect(handleSort).toHaveBeenCalledWith({
         key: name,
-        direction: "asc",
+        order: "asc",
       });
     });
 
@@ -141,7 +141,7 @@ describe("DataListSort", () => {
   describe("'Ordered by' change", () => {
     const initialSortingState: DataListSorting = {
       key: "label",
-      direction: "asc",
+      order: "asc",
     };
 
     beforeEach(() => {
@@ -173,7 +173,7 @@ describe("DataListSort", () => {
       userEvent.click(screen.getByRole("radio", { name: "Descending" }));
       expect(handleSort).toHaveBeenCalledWith({
         ...initialSortingState,
-        direction: "desc",
+        order: "desc",
       });
     });
   });

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
@@ -1,0 +1,93 @@
+import React, { useRef, useState } from "react";
+import { useDataListContext } from "../../../../context/DataListContext";
+import { Button } from "../../../../../Button";
+import { Popover } from "../../../../../Popover";
+import { Content } from "../../../../../Content";
+import { Chip, Chips } from "../../../../../Chips";
+import { Heading } from "../../../../../Heading";
+
+export function DataListSort() {
+  const { sorting, headers } = useDataListContext();
+  const divRef = useRef<HTMLSpanElement>(null);
+  const [showPopover, setShowPopover] = useState(false);
+
+  if (!sorting) return null;
+  const { sortable, state, onSort } = sorting;
+
+  const sortByOptions = getSortByOptions();
+  const canChangeOrder = !state?.key;
+
+  return (
+    <>
+      <span ref={divRef}>
+        <Button
+          {...(!state && { icon: "add", iconOnRight: true })}
+          label={getButtonLabel()}
+          variation="subtle"
+          onClick={() => setShowPopover(!showPopover)}
+        />
+      </span>
+      <Popover
+        attachTo={divRef}
+        open={showPopover}
+        onRequestClose={() => setShowPopover(false)}
+      >
+        <Content>
+          <Heading level={5}>Sort by</Heading>
+          <Chips selected={state?.key || "none"} onChange={handleKeyChange}>
+            {sortByOptions.map(({ label, value }) => (
+              <Chip key={label} label={label} value={value} />
+            ))}
+          </Chips>
+
+          <Heading level={5}>Ordered by</Heading>
+          <Chips selected={state?.direction} onChange={handleSortingChange}>
+            <Chip label="Ascending" value="asc" disabled={canChangeOrder} />
+            <Chip label="Descending" value="desc" disabled={canChangeOrder} />
+          </Chips>
+        </Content>
+      </Popover>
+    </>
+  );
+
+  function getSortByOptions() {
+    const options = sortable.reduce(
+      (acc: Record<"label" | "value", string>[], sort) => {
+        const label = headers[sort];
+        if (!label) return acc;
+
+        acc.push({ label, value: sort.toString() });
+        return acc;
+      },
+      [],
+    );
+
+    // Inject a none option as the first option
+    options.unshift({ label: "None", value: "none" });
+
+    return options;
+  }
+
+  function getButtonLabel() {
+    const label = state && headers[state.key];
+    if (!label) return "Sort by";
+
+    return `Sort by: ${label}, ${state.direction}`;
+  }
+
+  function handleKeyChange(value?: string) {
+    if (value && value !== "none") {
+      onSort({ key: value, direction: state?.direction || "asc" });
+      return;
+    }
+
+    onSort(undefined);
+  }
+
+  function handleSortingChange(value: "asc" | "desc") {
+    if (state?.key) {
+      onSort({ key: state.key, direction: value });
+      return;
+    }
+  }
+}

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
@@ -1,10 +1,10 @@
 import React, { useRef, useState } from "react";
-import { useDataListContext } from "../../../../context/DataListContext";
-import { Button } from "../../../../../Button";
-import { Popover } from "../../../../../Popover";
-import { Content } from "../../../../../Content";
-import { Chip, Chips } from "../../../../../Chips";
-import { Heading } from "../../../../../Heading";
+import { useDataListContext } from "@jobber/components/DataList/context/DataListContext";
+import { Button } from "@jobber/components/Button";
+import { Popover } from "@jobber/components/Popover";
+import { Content } from "@jobber/components/Content";
+import { Chip, Chips } from "@jobber/components/Chips";
+import { Heading } from "@jobber/components/Heading";
 
 export function DataListSort() {
   const { sorting, headers } = useDataListContext();
@@ -85,7 +85,7 @@ export function DataListSort() {
   }
 
   function handleSortingChange(value: "asc" | "desc") {
-    if (state?.key) {
+    if (state?.key && value) {
       onSort({ key: state.key, direction: value });
       return;
     }

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
@@ -41,7 +41,7 @@ export function DataListSort() {
           </Chips>
 
           <Heading level={5}>Ordered by</Heading>
-          <Chips selected={state?.direction} onChange={handleSortingChange}>
+          <Chips selected={state?.order} onChange={handleSortingChange}>
             <Chip label="Ascending" value="asc" disabled={canChangeOrder} />
             <Chip label="Descending" value="desc" disabled={canChangeOrder} />
           </Chips>
@@ -72,12 +72,12 @@ export function DataListSort() {
     const label = state && headers[state.key];
     if (!label) return "Sort by";
 
-    return `Sort by: ${label}, ${state.direction}`;
+    return `Sort by: ${label}, ${state.order}`;
   }
 
   function handleKeyChange(value?: string) {
     if (value && value !== "none") {
-      onSort({ key: value, direction: state?.direction || "asc" });
+      onSort({ key: value, order: state?.order || "asc" });
       return;
     }
 
@@ -86,7 +86,7 @@ export function DataListSort() {
 
   function handleSortingChange(value: "asc" | "desc") {
     if (state?.key && value) {
-      onSort({ key: state.key, direction: value });
+      onSort({ key: state.key, order: value });
       return;
     }
   }

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/index.ts
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/index.ts
@@ -1,0 +1,1 @@
+export { DataListSort } from "./DataListSort";

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -31,19 +31,19 @@ export function DataListHeaderTile<T extends DataListObject>({
     >
       <Text maxLines="single">{headers[headerKey]}</Text>
       {sortingState?.key === headerKey && (
-        <DataListSortingArrows order={sortingState.direction} />
+        <DataListSortingArrows order={sortingState.order} />
       )}
     </Tag>
   );
 
   function toggleSorting(sortingKey: string) {
-    if (sortingState?.direction === "desc") {
+    if (sortingState?.order === "desc") {
       sorting?.onSort(undefined);
       return;
     }
 
     sorting?.onSort({
-      direction: sortingState?.direction === "asc" ? "desc" : "asc",
+      order: sortingState?.order === "asc" ? "desc" : "asc",
       key: sortingKey,
     });
   }

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListHeader.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListHeader.tsx
@@ -11,7 +11,7 @@ import {
   DataListObject,
   DataListProps,
 } from "../../DataList.types";
-import { sortSizeProp } from "../../DataList.utils";
+import { useShowHeader } from "../../hooks/useShowHeader";
 
 interface DataListHeaderProps<T extends DataListObject> {
   readonly layouts: React.ReactElement<DataListLayoutProps<T>>[] | undefined;
@@ -24,20 +24,8 @@ export function DataListHeader<T extends DataListObject>({
   layouts,
   mediaMatches,
   headerData,
-  headerVisibility,
 }: DataListHeaderProps<T>) {
-  const matchingMediaQueries = Object.keys(mediaMatches || {}).filter(
-    (key): key is Breakpoints => !!mediaMatches?.[key as Breakpoints],
-  );
-  const sortedVisibleBreakpoints = sortSizeProp(matchingMediaQueries);
-
-  // Determines if the header should be visible based on the headerVisibility
-  const showHeader = sortedVisibleBreakpoints.reduce(
-    (previousVisibility, breakpoint) => {
-      return headerVisibility[breakpoint] ?? previousVisibility;
-    },
-    true,
-  );
+  const showHeader = useShowHeader();
 
   if (!showHeader || !headerData) return null;
 

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
@@ -4,7 +4,7 @@
 
   position: absolute;
   /* Inputs are off by 1 when put beside a button */
-  top: calc(var(--space-small) - 1px);
+  top: calc(var(--space-small) + 1px);
   right: var(--button-offset);
   visibility: hidden;
   width: 0;

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.tsx
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.tsx
@@ -25,7 +25,8 @@ export function InternalDataListSearch() {
   const inputRef = useRef<InputTextRef>(null);
   const [visible, setVisible] = useState(false);
 
-  const { searchComponent, filterComponent, title } = useDataListContext();
+  const { searchComponent, filterComponent, sorting, title } =
+    useDataListContext();
 
   const debouncedSearch = useCallback(
     debounce(
@@ -39,7 +40,11 @@ export function InternalDataListSearch() {
   const { placeholder } = searchComponent.props;
 
   return (
-    <div className={classNames({ [styles.withNoFilters]: !filterComponent })}>
+    <div
+      className={classNames({
+        [styles.withNoFilters]: !filterComponent && !sorting,
+      })}
+    >
       <div
         data-testid={DATA_LIST_SEARCH_TEST_ID}
         className={classNames(styles.searchInput, {

--- a/packages/components/src/DataList/hooks/useMediaQueries.ts
+++ b/packages/components/src/DataList/hooks/useMediaQueries.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQueries(CSSMediaQuery: string) {
+  const [matches, setMatches] = useState(
+    window.matchMedia(CSSMediaQuery).matches,
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia(CSSMediaQuery);
+
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+
+    const listener = () => setMatches(media.matches);
+    media.addEventListener("change", listener);
+
+    return () => media.removeEventListener("change", listener);
+  }, [CSSMediaQuery]);
+
+  return matches;
+}

--- a/packages/components/src/DataList/hooks/useMediaQuery.ts
+++ b/packages/components/src/DataList/hooks/useMediaQuery.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export function useMediaQueries(CSSMediaQuery: string) {
+export function useMediaQuery(CSSMediaQuery: string) {
   const [matches, setMatches] = useState(
     window.matchMedia(CSSMediaQuery).matches,
   );

--- a/packages/components/src/DataList/hooks/useResponsiveSizing.ts
+++ b/packages/components/src/DataList/hooks/useResponsiveSizing.ts
@@ -1,11 +1,12 @@
-import { useMediaQueries } from "./useMediaQueries";
+import { useMediaQuery } from "./useMediaQuery";
+import { BREAKPOINT_SIZES, Breakpoints } from "../DataList.const";
 
-export function useResponsiveSizing() {
-  const xs = useMediaQueries("(width > 0px)");
-  const sm = useMediaQueries("(width >= 490px)");
-  const md = useMediaQueries("(width >= 768px)");
-  const lg = useMediaQueries("(width >= 1080px)");
-  const xl = useMediaQueries("(width >= 1440px)");
+export function useResponsiveSizing(): Record<Breakpoints, boolean> {
+  const xs = useMediaQuery(`(width > ${BREAKPOINT_SIZES.xs}px)`);
+  const sm = useMediaQuery(`(width >= ${BREAKPOINT_SIZES.sm}px)`);
+  const md = useMediaQuery(`(width >= ${BREAKPOINT_SIZES.md}px)`);
+  const lg = useMediaQuery(`(width >= ${BREAKPOINT_SIZES.lg}px)`);
+  const xl = useMediaQuery(`(width >= ${BREAKPOINT_SIZES.xl}px)`);
 
   return { xs, sm, md, lg, xl };
 }

--- a/packages/components/src/DataList/hooks/useResponsiveSizing.ts
+++ b/packages/components/src/DataList/hooks/useResponsiveSizing.ts
@@ -1,0 +1,11 @@
+import { useMediaQueries } from "./useMediaQueries";
+
+export function useResponsiveSizing() {
+  const xs = useMediaQueries("(width > 0px)");
+  const sm = useMediaQueries("(width >= 490px)");
+  const md = useMediaQueries("(width >= 768px)");
+  const lg = useMediaQueries("(width >= 1080px)");
+  const xl = useMediaQueries("(width >= 1440px)");
+
+  return { xs, sm, md, lg, xl };
+}

--- a/packages/components/src/DataList/hooks/useShowHeader.ts
+++ b/packages/components/src/DataList/hooks/useShowHeader.ts
@@ -1,0 +1,19 @@
+import { useResponsiveSizing } from "./useResponsiveSizing";
+import { useDataListContext } from "../context/DataListContext";
+
+export function useShowHeader(): boolean {
+  const { headerVisibility } = useDataListContext();
+  if (headerVisibility === undefined) return true;
+
+  const sizes = useResponsiveSizing();
+  const sizeKeys = Object.keys(sizes) as (keyof typeof sizes)[];
+
+  const showHeader = sizeKeys.reduce((previous, breakpoint) => {
+    const isHeaderVisible = headerVisibility[breakpoint] || false;
+    const isBreakpointTriggered = sizes[breakpoint];
+
+    return previous || (isBreakpointTriggered && isHeaderVisible);
+  }, false);
+
+  return showHeader;
+}

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -9,6 +9,9 @@
     "paths": {
       "@jobber/hooks/*": [
         "../../packages/hooks/src/*"
+      ],
+      "@jobber/components/*": [
+        "./src/*"
       ]
     }
   },


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We've recently implemented sorting and it is closely tied to the header showing up. Unfortunately, you can hide that header on any breakpoint which removes the sorting capability even if you have implemented it.

This PR moves the sorting capability to a button whenever the header disappears. That way the user have access to it at all times.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Move the sorting capability to a button with the filters when the header is not shown
- Capability to import from `@jobber/components` instead of `../../../../../../../`

### Changed

- Renamed `direction` to `order` since it is more common to hear "sort order" than "sort direction"

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Adjust story size to large mobile <br /> 
![image](https://github.com/GetJobber/atlantis/assets/15986172/2d5ef7ee-117d-4b14-9d39-7b69f49d6f95)
- Click this <br />
![image](https://github.com/GetJobber/atlantis/assets/15986172/8b251855-a67d-46de-b5b5-2fdd9860129d)
  - That should swap between big enough that it's not a button, and small enough that it is a button


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
