### PR TITLE
feat(components): Ability to externally clear combobox selection

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -99,7 +99,10 @@ const ComboboxChip: ComponentStory<typeof Combobox> = args => {
 };
 
 const ComboboxClearSelection: ComponentStory<typeof Combobox> = args => {
-  const [selected, setSelected] = useState<ComboboxOption | null>(null);
+  const [selected, setSelected] = useState<ComboboxOption | null>({
+    id: "1",
+    label: "Bilbo Baggins",
+  });
 
   return (
     <>

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Combobox } from "@jobber/components/Combobox";
+import { Combobox, ComboboxOption } from "@jobber/components/Combobox";
 import { Button as ClearButton } from "@jobber/components/Button";
 
 export default {
@@ -13,7 +13,93 @@ export default {
 } as ComponentMeta<typeof Combobox>;
 
 const ComboboxButton: ComponentStory<typeof Combobox> = args => {
-  const [selected, setSelected] = useState(1);
+  const [selected, setSelected] = useState<ComboboxOption | null>(null);
+  return (
+    <Combobox {...args}>
+      <Combobox.TriggerButton
+        label="Select a teammate"
+        variation="subtle"
+        type="primary"
+        icon="arrowDown"
+        iconOnRight={true}
+      />
+      <Combobox.Content
+        options={[
+          { id: "1", label: "Bilbo Baggins" },
+          { id: "2", label: "Frodo Baggins" },
+          { id: "3", label: "Pippin Took" },
+          { id: "4", label: "Merry Brandybuck" },
+          { id: "5", label: "Sam Gamgee" },
+          { id: "6", label: "Bilbo Baggins2" },
+          { id: "7", label: "Frodo Baggins2" },
+          { id: "8", label: "Pippin Took2" },
+          { id: "9", label: "Merry Brandybuck2" },
+          { id: "10", label: "Sam Gamgee2" },
+          { id: "11", label: "Bilbo Baggins3" },
+          { id: "12", label: "Frodo Baggins3" },
+          { id: "13", label: "Pippin Took3" },
+          { id: "14", label: "Merry Brandybuck3" },
+          { id: "15", label: "Sam Gamgee3" },
+        ]}
+        onSelect={selection => {
+          setSelected(selection);
+        }}
+        selected={selected}
+      >
+        <Combobox.Action
+          label="Add Teammate"
+          onClick={() => {
+            alert("Added a new teammate ✅");
+          }}
+        />
+        <Combobox.Action
+          label="Manage Teammates"
+          onClick={() => {
+            alert("Managed teammates 👍");
+          }}
+        />
+      </Combobox.Content>
+    </Combobox>
+  );
+};
+
+const ComboboxChip: ComponentStory<typeof Combobox> = args => {
+  const [selected, setSelected] = useState<ComboboxOption | null>(null);
+  return (
+    <Combobox {...args}>
+      <Combobox.TriggerChip label="Tags" />
+      <Combobox.Content
+        options={[
+          { id: "1", label: "Bilbo Baggins" },
+          { id: "2", label: "Frodo Baggins" },
+          { id: "3", label: "Pippin Took" },
+          { id: "4", label: "Merry Brandybuck" },
+          { id: "5", label: "Sam Gamgee" },
+        ]}
+        onSelect={selection => {
+          setSelected(selection);
+        }}
+        selected={selected}
+      >
+        <Combobox.Action
+          label="Add Teammate"
+          onClick={() => {
+            alert("Added a new teammate ✅");
+          }}
+        />
+        <Combobox.Action
+          label="Manage Teammates"
+          onClick={() => {
+            alert("Managed teammates 👍");
+          }}
+        />
+      </Combobox.Content>
+    </Combobox>
+  );
+};
+
+const ComboboxClearSelection: ComponentStory<typeof Combobox> = args => {
+  const [selected, setSelected] = useState<ComboboxOption | null>(null);
 
   return (
     <>
@@ -49,7 +135,7 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
             { id: "15", label: "Sam Gamgee3" },
           ]}
           onSelect={selection => {
-            console.log(selection);
+            setSelected(selection);
           }}
           selected={selected}
         >
@@ -71,41 +157,11 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
   );
 };
 
-const ComboboxChip: ComponentStory<typeof Combobox> = args => {
-  return (
-    <Combobox {...args}>
-      <Combobox.TriggerChip label="Tags" />
-      <Combobox.Content
-        options={[
-          { id: "1", label: "Bilbo Baggins" },
-          { id: "2", label: "Frodo Baggins" },
-          { id: "3", label: "Pippin Took" },
-          { id: "4", label: "Merry Brandybuck" },
-          { id: "5", label: "Sam Gamgee" },
-        ]}
-        onSelect={selection => {
-          console.log(selection);
-        }}
-      >
-        <Combobox.Action
-          label="Add Teammate"
-          onClick={() => {
-            alert("Added a new teammate ✅");
-          }}
-        />
-        <Combobox.Action
-          label="Manage Teammates"
-          onClick={() => {
-            alert("Managed teammates 👍");
-          }}
-        />
-      </Combobox.Content>
-    </Combobox>
-  );
-};
-
 export const Button = ComboboxButton.bind({});
 Button.args = {};
 
 export const Chip = ComboboxChip.bind({});
 Chip.args = {};
+
+export const ClearSelection = ComboboxClearSelection.bind({});
+ClearSelection.args = {};

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Combobox } from "@jobber/components/Combobox";
+import { Button as ClearButton } from "@jobber/components/Button";
 
 export default {
   title: "Components/Combobox/Combobox/Web",
@@ -12,52 +13,61 @@ export default {
 } as ComponentMeta<typeof Combobox>;
 
 const ComboboxButton: ComponentStory<typeof Combobox> = args => {
+  const [selected, setSelected] = useState(1);
+
   return (
-    <Combobox {...args}>
-      <Combobox.TriggerButton
-        label="Select a teammate"
-        variation="subtle"
+    <>
+      <ClearButton
+        label="Clear Selection"
         type="primary"
-        icon="arrowDown"
-        iconOnRight={true}
+        onClick={() => setSelected(null)}
       />
-      <Combobox.Content
-        options={[
-          { id: "1", label: "Bilbo Baggins" },
-          { id: "2", label: "Frodo Baggins" },
-          { id: "3", label: "Pippin Took" },
-          { id: "4", label: "Merry Brandybuck" },
-          { id: "5", label: "Sam Gamgee" },
-          { id: "6", label: "Bilbo Baggins2" },
-          { id: "7", label: "Frodo Baggins2" },
-          { id: "8", label: "Pippin Took2" },
-          { id: "9", label: "Merry Brandybuck2" },
-          { id: "10", label: "Sam Gamgee2" },
-          { id: "11", label: "Bilbo Baggins3" },
-          { id: "12", label: "Frodo Baggins3" },
-          { id: "13", label: "Pippin Took3" },
-          { id: "14", label: "Merry Brandybuck3" },
-          { id: "15", label: "Sam Gamgee3" },
-        ]}
-        onSelect={selection => {
-          console.log(selection);
-        }}
-        selected={1}
-      >
-        <Combobox.Action
-          label="Add Teammate"
-          onClick={() => {
-            alert("Added a new teammate ✅");
-          }}
+      <Combobox {...args}>
+        <Combobox.TriggerButton
+          label="Select a teammate"
+          variation="subtle"
+          type="primary"
+          icon="arrowDown"
+          iconOnRight={true}
         />
-        <Combobox.Action
-          label="Manage Teammates"
-          onClick={() => {
-            alert("Managed teammates 👍");
+        <Combobox.Content
+          options={[
+            { id: "1", label: "Bilbo Baggins" },
+            { id: "2", label: "Frodo Baggins" },
+            { id: "3", label: "Pippin Took" },
+            { id: "4", label: "Merry Brandybuck" },
+            { id: "5", label: "Sam Gamgee" },
+            { id: "6", label: "Bilbo Baggins2" },
+            { id: "7", label: "Frodo Baggins2" },
+            { id: "8", label: "Pippin Took2" },
+            { id: "9", label: "Merry Brandybuck2" },
+            { id: "10", label: "Sam Gamgee2" },
+            { id: "11", label: "Bilbo Baggins3" },
+            { id: "12", label: "Frodo Baggins3" },
+            { id: "13", label: "Pippin Took3" },
+            { id: "14", label: "Merry Brandybuck3" },
+            { id: "15", label: "Sam Gamgee3" },
+          ]}
+          onSelect={selection => {
+            console.log(selection);
           }}
-        />
-      </Combobox.Content>
-    </Combobox>
+          selected={selected}
+        >
+          <Combobox.Action
+            label="Add Teammate"
+            onClick={() => {
+              alert("Added a new teammate ✅");
+            }}
+          />
+          <Combobox.Action
+            label="Manage Teammates"
+            onClick={() => {
+              alert("Managed teammates 👍");
+            }}
+          />
+        </Combobox.Content>
+      </Combobox>
+    </>
   );
 };
 

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -225,6 +225,17 @@ describe("ComboboxContent", () => {
 });
 
 describe("Combobox selected value", () => {
+  it("has no selected option when a null selected value is passed", () => {
+    const { getByText } = render(<ClearSelectionCombobox />);
+
+    fireEvent.click(getByText("Button"));
+
+    const option = getByText("Bilbo Baggins");
+    expect(option).toHaveClass("selectedOption");
+    const clearButton = getByText("Clear Selection");
+    fireEvent.click(clearButton);
+    expect(option).not.toHaveClass("selectedOption");
+  });
   it("has a selected option when a selected id is passed as a number and option id is a string", () => {
     const { getByText } = render(
       <Combobox>
@@ -314,3 +325,26 @@ describe("Combobox Zero Index State", () => {
     });
   });
 });
+
+function ClearSelectionCombobox() {
+  const [selected, setSelected] = React.useState<number | null>(1);
+
+  return (
+    <>
+      <button onClick={() => setSelected(null)}>Clear Selection</button>
+      <Combobox>
+        <Combobox.TriggerButton label="Button" />
+        <Combobox.Content
+          options={[
+            { id: "1", label: "Bilbo Baggins" },
+            { id: "2", label: "Frodo Baggins" },
+          ]}
+          onSelect={jest.fn()}
+          selected={selected}
+        >
+          <></>
+        </Combobox.Content>
+      </Combobox>
+    </>
+  );
+}

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -5,6 +5,7 @@ import {
   COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE,
   Combobox,
 } from "./Combobox";
+import { ComboboxOption } from "./Combobox.types";
 
 afterEach(cleanup);
 
@@ -14,7 +15,7 @@ describe("Combobox validation", () => {
       render(
         <Combobox>
           <Combobox.TriggerButton label="Button" />
-          <Combobox.Content options={[]} onSelect={jest.fn()}>
+          <Combobox.Content options={[]} onSelect={jest.fn()} selected={null}>
             <></>
           </Combobox.Content>
         </Combobox>,
@@ -28,7 +29,7 @@ describe("Combobox validation", () => {
     try {
       render(
         <Combobox>
-          <Combobox.Content options={[]} onSelect={jest.fn()}>
+          <Combobox.Content options={[]} onSelect={jest.fn()} selected={null}>
             <></>
           </Combobox.Content>
         </Combobox>,
@@ -48,7 +49,7 @@ describe("Combobox validation", () => {
         <Combobox>
           <Combobox.TriggerButton label="Button" />
           <Combobox.TriggerButton label="Button Again" />
-          <Combobox.Content options={[]} onSelect={jest.fn()}>
+          <Combobox.Content options={[]} onSelect={jest.fn()} selected={null}>
             <></>
           </Combobox.Content>
         </Combobox>,
@@ -68,7 +69,7 @@ describe("Combobox validation", () => {
         <Combobox>
           <Combobox.TriggerButton label="Button" />
           <Combobox.TriggerChip label="Chippy Chip" />
-          <Combobox.Content options={[]} onSelect={jest.fn()}>
+          <Combobox.Content options={[]} onSelect={jest.fn()} selected={null}>
             <></>
           </Combobox.Content>
         </Combobox>,
@@ -135,7 +136,7 @@ describe("ComboboxContent", () => {
     const { getByTestId } = render(
       <Combobox>
         <Combobox.TriggerButton label="Button" />
-        <Combobox.Content options={[]} onSelect={jest.fn()}>
+        <Combobox.Content options={[]} onSelect={jest.fn()} selected={null}>
           <></>
         </Combobox.Content>
       </Combobox>,
@@ -153,6 +154,7 @@ describe("ComboboxContent", () => {
             { id: "2", label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
+          selected={null}
         >
           <></>
         </Combobox.Content>
@@ -180,6 +182,7 @@ describe("ComboboxContent", () => {
             { id: "2", label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
+          selected={null}
         >
           <></>
         </Combobox.Content>
@@ -206,6 +209,7 @@ describe("ComboboxContent", () => {
             { id: "2", label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
+          selected={null}
         >
           <></>
         </Combobox.Content>
@@ -246,7 +250,7 @@ describe("Combobox selected value", () => {
             { id: "2", label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
-          selected={1}
+          selected={{ id: 1, label: "Bilbo Baggins" }}
         >
           <></>
         </Combobox.Content>
@@ -266,7 +270,7 @@ describe("Combobox selected value", () => {
             { id: 2, label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
-          selected={1}
+          selected={{ id: 1, label: "Bilbo Baggins" }}
         >
           <></>
         </Combobox.Content>
@@ -288,6 +292,7 @@ describe("Combobox Zero Index State", () => {
             options={[]}
             onSelect={jest.fn()}
             subjectNoun={subjectNoun}
+            selected={null}
           />
         </Combobox>,
       );
@@ -301,7 +306,7 @@ describe("Combobox Zero Index State", () => {
       const { getByText } = render(
         <Combobox>
           <Combobox.TriggerButton label="Select a tax rate" />
-          <Combobox.Content options={[]} onSelect={jest.fn()} />
+          <Combobox.Content options={[]} onSelect={jest.fn()} selected={null} />
         </Combobox>,
       );
 
@@ -317,6 +322,7 @@ describe("Combobox Zero Index State", () => {
           <Combobox.Content
             options={[{ id: "1", label: "10%" }]}
             onSelect={jest.fn()}
+            selected={null}
           />
         </Combobox>,
       );
@@ -327,7 +333,10 @@ describe("Combobox Zero Index State", () => {
 });
 
 function ClearSelectionCombobox() {
-  const [selected, setSelected] = React.useState<number | null>(1);
+  const [selected, setSelected] = React.useState<ComboboxOption | null>({
+    id: 1,
+    label: "Bilbo Baggins",
+  });
 
   return (
     <>

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -13,6 +13,7 @@ describe("ComboboxContent Search", () => {
             { id: "2", label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
+          selected={null}
         ></Combobox.Content>
         ,
       </MockComboboxProvider>,
@@ -31,6 +32,7 @@ describe("ComboboxContent Search", () => {
             { id: "2", label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
+          selected={null}
         ></Combobox.Content>
       </MockComboboxProvider>,
     );
@@ -51,6 +53,7 @@ describe("ComboboxContent Search", () => {
             { id: "2", label: "Frodo Baggins" },
           ]}
           onSelect={jest.fn()}
+          selected={null}
         ></Combobox.Content>
       </MockComboboxProvider>,
     );
@@ -75,6 +78,7 @@ describe("ComboboxContent Search", () => {
             { id: "2", label: "Jason Vorhees" },
           ]}
           onSelect={jest.fn()}
+          selected={null}
         ></Combobox.Content>
       </MockComboboxProvider>,
     );

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -2,6 +2,7 @@ import React, {
   Dispatch,
   ReactElement,
   SetStateAction,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -41,7 +42,7 @@ interface ComboboxContentProps {
    * @optional
    * @type string
    */
-  readonly selected?: string | number;
+  readonly selected?: string | number | null;
 
   /**
    * The encapsulating noun for the content of the combobox. Used
@@ -185,7 +186,7 @@ function getZeroIndexStateText(subjectNoun?: string) {
 }
 
 function useComboboxContent(
-  selected: string | number | undefined,
+  selected: string | number | undefined | null,
   options: ComboboxOption[],
 ): {
   searchValue: string;
@@ -208,6 +209,10 @@ function useComboboxContent(
   const [selectedOption, setSelectedOption] = useState<ComboboxOption | null>(
     defaultValue || null,
   );
+  useEffect(() => {
+    setSelectedOption(defaultValue || null);
+  }, [selected]);
+
   const { open, setOpen, wrapperRef } = React.useContext(ComboboxContext);
 
   const filteredOptions = options.filter(option =>

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -2,7 +2,6 @@ import React, {
   Dispatch,
   ReactElement,
   SetStateAction,
-  useEffect,
   useRef,
   useState,
 } from "react";
@@ -39,10 +38,9 @@ interface ComboboxContentProps {
   /**
    * pre selected option
    * @default ""
-   * @optional
    * @type string
    */
-  readonly selected?: string | number | null;
+  readonly selected: ComboboxOption | null;
 
   /**
    * The encapsulating noun for the content of the combobox. Used
@@ -55,15 +53,13 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
   const {
     searchValue,
     setSearchValue,
-    selectedOption,
-    setSelectedOption,
     open,
     setOpen,
     popperRef,
     popperStyles,
     attributes,
     filteredOptions,
-  } = useComboboxContent(props.selected, props.options);
+  } = useComboboxContent(props.options);
 
   const optionsExist = props.options.length > 0;
 
@@ -88,7 +84,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
               onClick={() => handleSelection(option)}
               className={classnames(
                 styles.option,
-                option.id.toString() === selectedOption?.id.toString() &&
+                option.id.toString() === props.selected?.id.toString() &&
                   styles.selectedOption,
               )}
             >
@@ -125,7 +121,6 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
   return ReactDOM.createPortal(template, document.body);
 
   function handleSelection(selection: ComboboxOption) {
-    setSelectedOption(selection);
     props.onSelect(selection);
     setSearchValue("");
     setOpen(false);
@@ -185,16 +180,9 @@ function getZeroIndexStateText(subjectNoun?: string) {
   return "No options yet";
 }
 
-function useComboboxContent(
-  selected: string | number | undefined | null,
-  options: ComboboxOption[],
-): {
+function useComboboxContent(options: ComboboxOption[]): {
   searchValue: string;
   setSearchValue: React.Dispatch<React.SetStateAction<string>>;
-  selectedOption: ComboboxOption | null;
-  setSelectedOption: React.Dispatch<
-    React.SetStateAction<ComboboxOption | null>
-  >;
   open: boolean;
   setOpen: (open: boolean) => void;
   popperRef: React.RefObject<HTMLDivElement>;
@@ -202,17 +190,7 @@ function useComboboxContent(
   attributes: { [key: string]: { [key: string]: string } | undefined };
   filteredOptions: ComboboxOption[];
 } {
-  const defaultValue = options.find(
-    option => option.id.toString() === selected?.toString(),
-  );
   const [searchValue, setSearchValue] = useState<string>("");
-  const [selectedOption, setSelectedOption] = useState<ComboboxOption | null>(
-    defaultValue || null,
-  );
-  useEffect(() => {
-    setSelectedOption(defaultValue || null);
-  }, [selected]);
-
   const { open, setOpen, wrapperRef } = React.useContext(ComboboxContext);
 
   const filteredOptions = options.filter(option =>
@@ -245,8 +223,6 @@ function useComboboxContent(
   return {
     searchValue,
     setSearchValue,
-    selectedOption,
-    setSelectedOption,
     open,
     setOpen,
     popperRef,

--- a/packages/components/src/Combobox/index.ts
+++ b/packages/components/src/Combobox/index.ts
@@ -5,3 +5,4 @@ export {
   COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE,
 } from "./Combobox";
 export { ComboboxContextProvider } from "./ComboboxProvider";
+export { ComboboxOption } from "./Combobox.types";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
We want the user who is implementing the combobox to be able to clear the selected value from outside of the component.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
Added the a `useEffect` that will update the `setSelectedOption` value whenever the `selected prop is updated.
I also updated this prop so that it can be set to null. So if the selected value were to be updated and the null value was passed in this should trigger a rerender and clear the selected value for the combobox.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
