### PR TITLE
feat(components): DataList Layout pluggable actions

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -223,6 +223,7 @@ const Template: ComponentStory<typeof DataList> = args => {
             </div>
             {item.tags}
             {item.created}
+            <DataList.LayoutActions />
           </Content>
         )}
       </DataList.Layout>

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -222,8 +222,17 @@ const Template: ComponentStory<typeof DataList> = args => {
               {item.gender}
             </div>
             {item.tags}
-            {item.created}
-            <DataList.LayoutActions />
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "auto max-content",
+                gap: 8,
+                alignItems: "center",
+              }}
+            >
+              {item.created}
+              <DataList.LayoutActions />
+            </div>
           </Content>
         )}
       </DataList.Layout>

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -186,10 +186,40 @@ function InternalDataList() {
   }
 }
 
+/**
+ * Sets the layout that the DataList item and header will use.
+ */
 DataList.Layout = DataListLayout;
+
+/**
+ * By using this component, we can render the actions anywhere in the layout
+ * instead of being added automatically on hover.
+ */
 DataList.LayoutActions = DataListLayoutActions;
+
+/**
+ * When the DataList is either empty and/or filtered, this component will be
+ * rendered.
+ */
 DataList.EmptyState = DataListEmptyState;
+
+/**
+ * Adds the filter components of your choosing to the DataList.
+ */
 DataList.Filters = DataListFilters;
+
+/**
+ * Enables the search functionality of the DataList.
+ */
 DataList.Search = DataListSearch;
+
+/**
+ * Defines the group actions you could do on a single DataList item.
+ */
 DataList.ItemActions = DataListItemActions;
+
+/**
+ * Defines the action in a DataList. This should be used inside the
+ * DataListItemActions component.
+ */
 DataList.Action = DataListAction;

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import styles from "./DataList.css";
 import { DataListTotalCount } from "./components/DataListTotalCount";
 import { DataListLoadingState } from "./components/DataListLoadingState";
@@ -48,8 +48,6 @@ export function DataList<T extends DataListObject>({
   sorting,
   ...props
 }: DataListProps<T>) {
-  const [hasInLayoutActions, setHasInLayoutActions] = useState(false);
-
   const searchComponent = getCompoundComponent<DataListSearchProps>(
     props.children,
     DataListSearch,
@@ -77,8 +75,6 @@ export function DataList<T extends DataListObject>({
         layoutComponents,
         emptyStateComponents,
         itemActionComponent,
-        hasInLayoutActions,
-        setHasInLayoutActions,
         ...props,
         selected: props.selected ?? [],
         // T !== DataListObject

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import styles from "./DataList.css";
 import { DataListTotalCount } from "./components/DataListTotalCount";
 import { DataListLoadingState } from "./components/DataListLoadingState";
@@ -21,6 +21,9 @@ import {
   InternalDataListEmptyState,
 } from "./components/DataListEmptyState";
 import { DataListLoadMore } from "./components/DataListLoadMore";
+import { DataListItemActions } from "./components/DataListItemActions";
+import { DataListAction } from "./components/DataListAction";
+import { DataListLayoutActions } from "./components/DataListLayoutActions";
 import { DataListContext, useDataListContext } from "./context/DataListContext";
 import {
   DataListEmptyStateProps,
@@ -38,8 +41,6 @@ import {
 } from "./DataList.utils";
 import { useLayoutMediaQueries } from "./hooks/useLayoutMediaQueries";
 import { DATA_LIST_FILTERING_SPINNER_TEST_ID } from "./DataList.const";
-import { DataListItemActions } from "./components/DataListItemActions";
-import { DataListAction } from "./components/DataListAction";
 import { Heading } from "../Heading";
 import { Spinner } from "../Spinner";
 
@@ -47,6 +48,8 @@ export function DataList<T extends DataListObject>({
   sorting,
   ...props
 }: DataListProps<T>) {
+  const [hasInLayoutActions, setHasInLayoutActions] = useState(false);
+
   const searchComponent = getCompoundComponent<DataListSearchProps>(
     props.children,
     DataListSearch,
@@ -74,6 +77,8 @@ export function DataList<T extends DataListObject>({
         layoutComponents,
         emptyStateComponents,
         itemActionComponent,
+        hasInLayoutActions,
+        setHasInLayoutActions,
         ...props,
         selected: props.selected ?? [],
         // T !== DataListObject
@@ -182,6 +187,7 @@ function InternalDataList() {
 }
 
 DataList.Layout = DataListLayout;
+DataList.LayoutActions = DataListLayoutActions;
 DataList.EmptyState = DataListEmptyState;
 DataList.Filters = DataListFilters;
 DataList.Search = DataListSearch;

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -192,6 +192,14 @@ export interface DataListContextProps<T extends DataListObject>
   readonly setHasInLayoutActions: (state: boolean) => void;
 }
 
+export interface DataListLayoutContextProps<T extends DataListObject>
+  extends Pick<
+    DataListContextProps<T>,
+    "setHasInLayoutActions" | "hasInLayoutActions"
+  > {
+  readonly activeItem?: T;
+}
+
 type Fragment<T> = T | T[];
 
 export interface DataListItemActionsProps<T extends DataListObject> {

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -182,6 +182,14 @@ export interface DataListContextProps<T extends DataListObject>
   readonly emptyStateComponents?: ReactElement<DataListEmptyStateProps>[];
   readonly layoutComponents?: ReactElement<DataListLayoutProps<T>>[];
   readonly itemActionComponent?: ReactElement<DataListItemActionsProps<T>>;
+
+  /**
+   * Determine if the consumer of the DataList manually added an action to the
+   * layout. This is used to determine if the DataList should render the
+   * action column.
+   */
+  readonly hasInLayoutActions: boolean;
+  readonly setHasInLayoutActions: (state: boolean) => void;
 }
 
 type Fragment<T> = T | T[];

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -182,6 +182,11 @@ export interface DataListContextProps<T extends DataListObject>
   readonly emptyStateComponents?: ReactElement<DataListEmptyStateProps>[];
   readonly layoutComponents?: ReactElement<DataListLayoutProps<T>>[];
   readonly itemActionComponent?: ReactElement<DataListItemActionsProps<T>>;
+}
+
+export interface DataListLayoutContextProps<T extends DataListObject> {
+  readonly isInLayoutProvider: boolean;
+  readonly activeItem?: T;
 
   /**
    * Determine if the consumer of the DataList manually added an action to the
@@ -190,14 +195,6 @@ export interface DataListContextProps<T extends DataListObject>
    */
   readonly hasInLayoutActions: boolean;
   readonly setHasInLayoutActions: (state: boolean) => void;
-}
-
-export interface DataListLayoutContextProps<T extends DataListObject>
-  extends Pick<
-    DataListContextProps<T>,
-    "setHasInLayoutActions" | "hasInLayoutActions"
-  > {
-  readonly activeItem?: T;
 }
 
 type Fragment<T> = T | T[];

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css
@@ -5,6 +5,7 @@
   padding: var(--space-small);
   border: none;
   border-radius: 0;
+  font-size: var(--typography--fontSize-base);
   text-align: left;
   background: none;
   cursor: pointer;

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -41,6 +41,7 @@ export function DataListActionsMenu({
           <div className={styles.overlay} onClick={onRequestClose} />
 
           <motion.div
+            role="menu"
             ref={setRef}
             variants={variants}
             initial="hidden"

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, Variants, motion } from "framer-motion";
 import { useFocusTrap } from "@jobber/hooks/useFocusTrap";
 import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
 import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
+import { createPortal } from "react-dom";
 import styles from "./DataListActionsMenu.css";
 import { TRANSITION_DELAY_IN_SECONDS } from "../../DataList.const";
 
@@ -32,7 +33,7 @@ export function DataListActionsMenu({
   const focusTrapRef = useFocusTrap<HTMLDivElement>(visible);
   useOnKeyDown(onRequestClose, "Escape");
 
-  return (
+  return createPortal(
     <AnimatePresence>
       {visible && (
         <>
@@ -54,7 +55,8 @@ export function DataListActionsMenu({
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 
   function getPositionCssVars() {

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -4,6 +4,7 @@ import { useFocusTrap } from "@jobber/hooks/useFocusTrap";
 import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
 import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
 import { createPortal } from "react-dom";
+import { tokens } from "@jobber/design/foundation";
 import styles from "./DataListActionsMenu.css";
 import { TRANSITION_DELAY_IN_SECONDS } from "../../DataList.const";
 
@@ -75,9 +76,10 @@ export function DataListActionsMenu({
 
     const xIsOffScreen = x + width > window.innerWidth;
     const yIsOffScreen = y + height > window.innerHeight;
+    const xOffSet = x + width - window.innerWidth + tokens["space-base"];
     const yOffSet = y + height - window.innerHeight;
 
-    const newPosX = Math.floor(xIsOffScreen ? x - width : x);
+    const newPosX = Math.floor(xIsOffScreen ? x - xOffSet : x);
     const newPosY = Math.floor(yIsOffScreen ? y - yOffSet : y);
     return { posX: newPosX, posY: newPosY };
   }

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -50,6 +50,7 @@ export function DataListActionsMenu({
             transition={{ duration: TRANSITION_DELAY_IN_SECONDS }}
             className={styles.menu}
             style={getPositionCssVars()}
+            onClick={onRequestClose}
           >
             <div tabIndex={0} ref={focusTrapRef}>
               {children}

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
@@ -49,7 +49,7 @@ export function DataListItemActionsOverflow<T extends DataListObject>({
     setShowMenu(true);
 
     const rect = event.currentTarget.getBoundingClientRect();
-    const posX = rect.x + rect.width;
+    const posX = rect.x;
     const posY = rect.y + rect.height;
 
     setMenuPosition({ x: posX, y: posY });

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActionsOverflow.tsx
@@ -10,7 +10,7 @@ import { InternalDataListAction } from "../DataListAction";
 import { DataListActionsMenu } from "../DataListActionsMenu";
 
 interface DataListItemActionsOverflowProps<T extends DataListObject>
-  extends Pick<InternalDataListActionProps<T>, "item"> {
+  extends Partial<Pick<InternalDataListActionProps<T>, "item">> {
   readonly actions: ReactElement<DataListActionProps<T>>[];
 }
 
@@ -33,15 +33,17 @@ export function DataListItemActionsOverflow<T extends DataListObject>({
         />
       </Tooltip>
 
-      <DataListActionsMenu
-        visible={showMenu}
-        position={menuPosition}
-        onRequestClose={handleClose}
-      >
-        {Children.map(actions, action => (
-          <InternalDataListAction {...action.props} item={item} />
-        ))}
-      </DataListActionsMenu>
+      {item && (
+        <DataListActionsMenu
+          visible={showMenu}
+          position={menuPosition}
+          onRequestClose={handleClose}
+        >
+          {Children.map(actions, action => (
+            <InternalDataListAction {...action.props} item={item} />
+          ))}
+        </DataListActionsMenu>
+      )}
     </>
   );
 

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.css
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.css
@@ -1,0 +1,3 @@
+.hidden {
+  visibility: hidden;
+}

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.css.d.ts
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.css.d.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly "hidden": string;
+};
+export = styles;
+

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.test.tsx
@@ -4,10 +4,12 @@ import { DataListLayoutActions } from "./DataListLayoutActions";
 import { DataListContext, defaultValues } from "../../context/DataListContext";
 import { DataListItemActions } from "../DataListItemActions";
 import { DataListAction } from "../DataListAction";
-import { DataListLayoutContext } from "../../context/DataListLayoutContext";
+import {
+  DataListLayoutContext,
+  defaultValues as layoutDefaultValues,
+} from "../../context/DataListLayoutContext";
 
-const mockMainSetHasInLayoutActions = jest.fn();
-const mockLayoutSetHasInLayoutActions = jest.fn();
+const mockSetHasInLayoutActions = jest.fn();
 const mockItemActionComponent = jest.fn<JSX.Element | undefined, []>(() => (
   <DataListItemActions>
     <DataListAction label="Edit" />
@@ -29,21 +31,15 @@ describe("DataListLayoutActions.test", () => {
   it("should let the layout context know that it can be rendered", () => {
     renderComponent();
 
-    expect(mockLayoutSetHasInLayoutActions).toHaveBeenCalledWith(true);
-  });
-
-  it("should not let the main context know that it can be rendered because that's the layouts job", () => {
-    renderComponent();
-
-    expect(mockMainSetHasInLayoutActions).not.toHaveBeenCalled();
+    expect(mockSetHasInLayoutActions).toHaveBeenCalledWith(true);
   });
 
   it("should let the layout context know that it has been removed", () => {
     const { unmount } = renderComponent();
-    expect(mockLayoutSetHasInLayoutActions).toHaveBeenCalledWith(true);
+    expect(mockSetHasInLayoutActions).toHaveBeenCalledWith(true);
 
     unmount();
-    expect(mockLayoutSetHasInLayoutActions).toHaveBeenCalledWith(false);
+    expect(mockSetHasInLayoutActions).toHaveBeenCalledWith(false);
   });
 
   it("should not render when there's no actions to render", () => {
@@ -69,7 +65,6 @@ function MockMainContextProvider({ children }: PropsWithChildren<object>) {
     <DataListContext.Provider
       value={{
         ...defaultValues,
-        setHasInLayoutActions: mockMainSetHasInLayoutActions,
         itemActionComponent: mockItemActionComponent(),
       }}
     >
@@ -82,8 +77,10 @@ function MocklayoutContextProvider({ children }: PropsWithChildren<object>) {
   return (
     <DataListLayoutContext.Provider
       value={{
-        ...defaultValues,
-        setHasInLayoutActions: mockLayoutSetHasInLayoutActions,
+        ...layoutDefaultValues,
+        isInLayoutProvider: true,
+        hasInLayoutActions: false,
+        setHasInLayoutActions: mockSetHasInLayoutActions,
         activeItem: { id: 1 },
       }}
     >

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.test.tsx
@@ -18,7 +18,7 @@ const mockItemActionComponent = jest.fn<JSX.Element | undefined, []>(() => (
   </DataListItemActions>
 ));
 
-describe("DataListLayoutActions.test", () => {
+describe("DataListLayoutActions", () => {
   it("should render a more action", () => {
     renderComponent();
 

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.test.tsx
@@ -1,0 +1,93 @@
+import React, { PropsWithChildren } from "react";
+import { render, screen } from "@testing-library/react";
+import { DataListLayoutActions } from "./DataListLayoutActions";
+import { DataListContext, defaultValues } from "../../context/DataListContext";
+import { DataListItemActions } from "../DataListItemActions";
+import { DataListAction } from "../DataListAction";
+import { DataListLayoutContext } from "../../context/DataListLayoutContext";
+
+const mockMainSetHasInLayoutActions = jest.fn();
+const mockLayoutSetHasInLayoutActions = jest.fn();
+const mockItemActionComponent = jest.fn<JSX.Element | undefined, []>(() => (
+  <DataListItemActions>
+    <DataListAction label="Edit" />
+    <DataListAction label="Email" />
+    <DataListAction label="Delete" />
+  </DataListItemActions>
+));
+
+describe("DataListLayoutActions.test", () => {
+  it("should render a more action", () => {
+    renderComponent();
+
+    expect(
+      screen.getByRole("button", { name: "More actions" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("should let the layout context know that it can be rendered", () => {
+    renderComponent();
+
+    expect(mockLayoutSetHasInLayoutActions).toHaveBeenCalledWith(true);
+  });
+
+  it("should not let the main context know that it can be rendered because that's the layouts job", () => {
+    renderComponent();
+
+    expect(mockMainSetHasInLayoutActions).not.toHaveBeenCalled();
+  });
+
+  it("should let the layout context know that it has been removed", () => {
+    const { unmount } = renderComponent();
+    expect(mockLayoutSetHasInLayoutActions).toHaveBeenCalledWith(true);
+
+    unmount();
+    expect(mockLayoutSetHasInLayoutActions).toHaveBeenCalledWith(false);
+  });
+
+  it("should not render when there's no actions to render", () => {
+    mockItemActionComponent.mockReturnValueOnce(undefined);
+    const { container } = renderComponent();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+function renderComponent() {
+  return render(
+    <MockMainContextProvider>
+      <MocklayoutContextProvider>
+        <DataListLayoutActions />
+      </MocklayoutContextProvider>
+    </MockMainContextProvider>,
+  );
+}
+
+function MockMainContextProvider({ children }: PropsWithChildren<object>) {
+  return (
+    <DataListContext.Provider
+      value={{
+        ...defaultValues,
+        setHasInLayoutActions: mockMainSetHasInLayoutActions,
+        itemActionComponent: mockItemActionComponent(),
+      }}
+    >
+      {children}
+    </DataListContext.Provider>
+  );
+}
+
+function MocklayoutContextProvider({ children }: PropsWithChildren<object>) {
+  return (
+    <DataListLayoutContext.Provider
+      value={{
+        ...defaultValues,
+        setHasInLayoutActions: mockLayoutSetHasInLayoutActions,
+        activeItem: { id: 1 },
+      }}
+    >
+      {children}
+    </DataListLayoutContext.Provider>
+  );
+}

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
@@ -1,0 +1,23 @@
+import React, { Children, ReactElement, useEffect } from "react";
+import { useDataListContext } from "../../context/DataListContext";
+import { DataListItemActionsOverflow } from "../DataListItemActions/DataListItemActionsOverflow";
+
+export function DataListLayoutActions() {
+  const { setHasInLayoutActions, itemActionComponent } = useDataListContext();
+
+  const { children: actionsChildren } = itemActionComponent?.props || {};
+  const actions = Children.toArray(actionsChildren) as ReactElement[];
+  const hasActions = actions.length > 0;
+
+  useEffect(() => {
+    setHasInLayoutActions(hasActions);
+
+    return () => {
+      setHasInLayoutActions(false);
+    };
+  }, []);
+
+  if (!hasActions) return null;
+
+  return <DataListItemActionsOverflow actions={actions} item={{ id: 1 }} />;
+}

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
@@ -1,4 +1,10 @@
-import React, { Children, ReactElement, useEffect } from "react";
+import React, {
+  Children,
+  PropsWithChildren,
+  ReactElement,
+  useEffect,
+} from "react";
+import styles from "./DataListLayoutActions.css";
 import { useDataListContext } from "../../context/DataListContext";
 import { useDataListLayoutContext } from "../../context/DataListLayoutContext";
 import { DataListItemActionsOverflow } from "../DataListItemActions/DataListItemActionsOverflow";
@@ -21,5 +27,16 @@ export function DataListLayoutActions() {
 
   if (!hasActions) return null;
 
-  return <DataListItemActionsOverflow actions={actions} item={activeItem} />;
+  return (
+    <DataListLayoutActionsWrapper>
+      <DataListItemActionsOverflow actions={actions} item={activeItem} />
+    </DataListLayoutActionsWrapper>
+  );
+}
+
+function DataListLayoutActionsWrapper({ children }: PropsWithChildren<object>) {
+  const { isInLayoutProvider } = useDataListLayoutContext();
+  if (isInLayoutProvider) return <>{children}</>;
+
+  return <div className={styles.hidden}>{children}</div>;
 }

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
@@ -1,6 +1,6 @@
 import React, { Children, ReactElement, useEffect } from "react";
 import { useDataListContext } from "../../context/DataListContext";
-import { useDataListLayoutContext } from "../../context/DataListLayoutContext/DataListLayoutContext";
+import { useDataListLayoutContext } from "../../context/DataListLayoutContext";
 import { DataListItemActionsOverflow } from "../DataListItemActions/DataListItemActionsOverflow";
 
 export function DataListLayoutActions() {

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
@@ -1,9 +1,11 @@
 import React, { Children, ReactElement, useEffect } from "react";
 import { useDataListContext } from "../../context/DataListContext";
+import { useDataListLayoutContext } from "../../context/DataListLayoutContext/DataListLayoutContext";
 import { DataListItemActionsOverflow } from "../DataListItemActions/DataListItemActionsOverflow";
 
 export function DataListLayoutActions() {
-  const { setHasInLayoutActions, itemActionComponent } = useDataListContext();
+  const { itemActionComponent } = useDataListContext();
+  const { setHasInLayoutActions, activeItem } = useDataListLayoutContext();
 
   const { children: actionsChildren } = itemActionComponent?.props || {};
   const actions = Children.toArray(actionsChildren) as ReactElement[];
@@ -19,5 +21,5 @@ export function DataListLayoutActions() {
 
   if (!hasActions) return null;
 
-  return <DataListItemActionsOverflow actions={actions} item={{ id: 1 }} />;
+  return <DataListItemActionsOverflow actions={actions} item={activeItem} />;
 }

--- a/packages/components/src/DataList/components/DataListLayoutActions/index.ts
+++ b/packages/components/src/DataList/components/DataListLayoutActions/index.ts
@@ -1,0 +1,1 @@
+export { DataListLayoutActions } from "./DataListLayoutActions";

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
@@ -7,6 +7,7 @@ import styles from "../../DataList.css";
 import { DataListLayoutProps, DataListObject } from "../../DataList.types";
 import { generateListItemElements } from "../../DataList.utils";
 import { InternalDataListItemActions } from "../DataListItemActions";
+import { useDataListContext } from "../../context/DataListContext";
 
 interface DataListItemsProps<T extends DataListObject> {
   readonly layouts: React.ReactElement<DataListLayoutProps<T>>[] | undefined;
@@ -19,6 +20,7 @@ export function DataListItems<T extends DataListObject>({
   mediaMatches,
   data,
 }: DataListItemsProps<T>) {
+  const { hasInLayoutActions } = useDataListContext();
   const elementData = generateListItemElements(data);
   const [hover, setHover] = useState<T["id"]>();
 
@@ -44,7 +46,7 @@ export function DataListItems<T extends DataListObject>({
                   </DataListItemInternal>
 
                   <AnimatePresence>
-                    {hover === item.id && (
+                    {hover === item.id && !hasInLayoutActions && (
                       <InternalDataListItemActions item={item} />
                     )}
                   </AnimatePresence>

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
@@ -7,7 +7,6 @@ import styles from "../../DataList.css";
 import { DataListLayoutProps, DataListObject } from "../../DataList.types";
 import { generateListItemElements } from "../../DataList.utils";
 import { InternalDataListItemActions } from "../DataListItemActions";
-import { useDataListContext } from "../../context/DataListContext";
 import { DataListLayoutContext } from "../../context/DataListLayoutContext";
 
 interface DataListItemsProps<T extends DataListObject> {
@@ -21,14 +20,19 @@ export function DataListItems<T extends DataListObject>({
   mediaMatches,
   data,
 }: DataListItemsProps<T>) {
-  const { hasInLayoutActions, setHasInLayoutActions } = useDataListContext();
   const elementData = generateListItemElements(data);
+  const [hasInLayoutActions, setHasInLayoutActions] = useState(false);
   const [activeID, setActiveID] = useState<T["id"]>();
   const [activeItem, setActiveItem] = useState<T>();
 
   return (
     <DataListLayoutContext.Provider
-      value={{ hasInLayoutActions, setHasInLayoutActions, activeItem }}
+      value={{
+        isInLayoutProvider: true,
+        hasInLayoutActions,
+        setHasInLayoutActions,
+        activeItem,
+      }}
     >
       <DataListLayoutInternal
         layouts={layouts}

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
@@ -8,7 +8,7 @@ import { DataListLayoutProps, DataListObject } from "../../DataList.types";
 import { generateListItemElements } from "../../DataList.utils";
 import { InternalDataListItemActions } from "../DataListItemActions";
 import { useDataListContext } from "../../context/DataListContext";
-import { DataListLayoutContext } from "../../context/DataListLayoutContext/DataListLayoutContext";
+import { DataListLayoutContext } from "../../context/DataListLayoutContext";
 
 interface DataListItemsProps<T extends DataListObject> {
   readonly layouts: React.ReactElement<DataListLayoutProps<T>>[] | undefined;

--- a/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
+++ b/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import noop from "lodash/noop";
 import { DataListContextProps, DataListObject } from "../../DataList.types";
 
 export const defaultValues: DataListContextProps<DataListObject> = {
@@ -8,7 +9,7 @@ export const defaultValues: DataListContextProps<DataListObject> = {
   children: [],
   selected: [],
   hasInLayoutActions: false,
-  setHasInLayoutActions: () => undefined,
+  setHasInLayoutActions: noop,
 };
 
 export const DataListContext =

--- a/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
+++ b/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
@@ -1,12 +1,14 @@
 import { createContext, useContext } from "react";
 import { DataListContextProps, DataListObject } from "../../DataList.types";
 
-export const defaultValues = {
+export const defaultValues: DataListContextProps<DataListObject> = {
   title: "",
   data: [],
   headers: {},
   children: [],
   selected: [],
+  hasInLayoutActions: false,
+  setHasInLayoutActions: () => undefined,
 };
 
 export const DataListContext =

--- a/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
+++ b/packages/components/src/DataList/context/DataListContext/DataListContext.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext } from "react";
-import noop from "lodash/noop";
 import { DataListContextProps, DataListObject } from "../../DataList.types";
 
 export const defaultValues: DataListContextProps<DataListObject> = {
@@ -8,8 +7,6 @@ export const defaultValues: DataListContextProps<DataListObject> = {
   headers: {},
   children: [],
   selected: [],
-  hasInLayoutActions: false,
-  setHasInLayoutActions: noop,
 };
 
 export const DataListContext =

--- a/packages/components/src/DataList/context/DataListLayoutContext/DataListLayoutContext.tsx
+++ b/packages/components/src/DataList/context/DataListLayoutContext/DataListLayoutContext.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../DataList.types";
 
 export const defaultValues: DataListLayoutContextProps<DataListObject> = {
+  isInLayoutProvider: false,
   hasInLayoutActions: false,
   setHasInLayoutActions: noop,
 };

--- a/packages/components/src/DataList/context/DataListLayoutContext/DataListLayoutContext.tsx
+++ b/packages/components/src/DataList/context/DataListLayoutContext/DataListLayoutContext.tsx
@@ -1,0 +1,18 @@
+import noop from "lodash/noop";
+import { createContext, useContext } from "react";
+import {
+  DataListLayoutContextProps,
+  DataListObject,
+} from "../../DataList.types";
+
+export const defaultValues: DataListLayoutContextProps<DataListObject> = {
+  hasInLayoutActions: false,
+  setHasInLayoutActions: noop,
+};
+
+export const DataListLayoutContext =
+  createContext<DataListLayoutContextProps<DataListObject>>(defaultValues);
+
+export function useDataListLayoutContext() {
+  return useContext(DataListLayoutContext);
+}

--- a/packages/components/src/DataList/context/DataListLayoutContext/index.ts
+++ b/packages/components/src/DataList/context/DataListLayoutContext/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListLayoutContext";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

By default, we have implemented the actions to be triggered by hover. However, we want the freedom to place those actions in any location in the layout. 

For example, we want it to be a hover menu on larger screens. But on smaller screens, we want it to be a part of the layout.

![Sep-21-2023 08-15-43](https://github.com/GetJobber/atlantis/assets/15986172/0d40b92b-fe35-4774-8043-5ab1abb961a6)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Implement the idea of `DataList.LayoutActions` to be used only within `DataList.Layout` to inject it as part of the layout manually.
  - This removes the hover menu whenever you use it on a layout.

### Changed

- Sent the menu to the body

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
