### PR TITLE
refactor(components): Visual updates to chip

### DIFF
--- a/packages/components/src/Chips/InternalChip.css
+++ b/packages/components/src/Chips/InternalChip.css
@@ -16,13 +16,13 @@
   position: relative;
   max-width: 100%;
   box-sizing: border-box;
-  padding: var(--space-small);
-  border: var(--border-base) solid var(--color-border);
-  border-radius: var(--radius-larger);
-  color: var(--color-text--secondary);
+  padding: var(--space-small) var(--space-base);
+  min-height: calc(var(--space-largest) - var(--space-small));
+  border-radius: calc(var(--space-base) + var(--space-smaller));
+  color: var(--color-heading);
   text-align: left;
   vertical-align: middle;
-  background-color: var(--color-surface);
+  background-color: var(--color-surface--background);
   transition: var(--timing-base) ease-in-out;
   transition-property: background-color, box-shadow, color;
   grid-template-columns: max-content;
@@ -30,17 +30,14 @@
   gap: var(--space-small);
 }
 
-.hasPrefix,
-.hasSuffix {
-  padding: calc(var(--space-smaller) + var(--space-smallest)) var(--space-small);
-}
-
 .hasPrefix {
   grid-template-columns: min-content 1fr;
+  padding-left: var(--space-small);
 }
 
-.hasSuffix {
-  grid-template-columns: 1fr min-content;
+.hasSuffix, .active {
+  grid-template-columns: 1fr min-content min-content;
+  padding-right: var(--space-small);
 }
 
 .hasPrefix.hasSuffix {
@@ -49,7 +46,6 @@
 
 .clickable,
 .input ~ .chip {
-  box-shadow: var(--shadow-base);
   cursor: pointer;
   appearance: none;
 }
@@ -67,17 +63,25 @@
 .clickable:hover,
 .input ~ .chip:not(.active):hover,
 .input:focus ~ .chip:not(.active) {
-  background-color: var(--color-surface--hover);
+  background-color: var(--color-surface--background--hover);
 }
 
 /**
  * States
  */
 
-.chip.active {
-  border-color: var(--color-surface--reverse);
-  color: var(--color-text--reverse);
-  background-color: var(--color-surface--reverse);
+.activeIndicator {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-circle);
+  height: var(--space-large);
+  width: var(--space-large);
+  display: none;
+}
+
+.chip.active .activeIndicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .chip.invalid {

--- a/packages/components/src/Chips/InternalChip.css
+++ b/packages/components/src/Chips/InternalChip.css
@@ -4,6 +4,10 @@
  * - InternalChipMultiSelect
  */
 
+:root {
+  --color-surface--background--hover: var(--color-greyBlue--lighter); /* delete once PR 1545 has merged */
+}
+
 .wrapper {
   display: flex;
   gap: var(--space-small);

--- a/packages/components/src/Chips/InternalChip.css.d.ts
+++ b/packages/components/src/Chips/InternalChip.css.d.ts
@@ -3,9 +3,10 @@ declare const styles: {
   readonly "chip": string;
   readonly "hasPrefix": string;
   readonly "hasSuffix": string;
+  readonly "active": string;
   readonly "clickable": string;
   readonly "input": string;
-  readonly "active": string;
+  readonly "activeIndicator": string;
   readonly "invalid": string;
   readonly "disabled": string;
   readonly "button": string;

--- a/packages/components/src/Chips/InternalChip.tsx
+++ b/packages/components/src/Chips/InternalChip.tsx
@@ -5,6 +5,7 @@ import { InternalChipProps } from "./ChipTypes";
 import { InternalChipAffix } from "./InternalChipAffix";
 import { Typography } from "../Typography";
 import { Tooltip } from "../Tooltip";
+import { Icon } from "../Icon";
 
 export function InternalChip({
   label,
@@ -46,6 +47,9 @@ export function InternalChip({
         <span ref={setTruncateRef}>{label}</span>
       </Typography>
       <InternalChipAffix affix={suffix} {...affixProps} />
+      <div className={styles.activeIndicator}>
+        <Icon name="checkmark" color="heading" size="small"></Icon>
+      </div>
     </Tag>
   );
 

--- a/packages/components/src/Chips/InternalChipAffix.tsx
+++ b/packages/components/src/Chips/InternalChipAffix.tsx
@@ -48,7 +48,7 @@ export function InternalChipAffix({
   function getIconColor() {
     if (disabled && !active) return "disabled";
     if (invalid && !disabled) return "critical";
-    if (active) return "white";
+    if (active) return "heading";
     return;
   }
 

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -45,10 +45,9 @@
 
   /* Surfaces and Borders */
   --color-surface: var(--color-white);
-  --color-surface--hover: var(--color-grey--lightest);
+  --color-surface--hover: var(--color-yellow--lightest);
   --color-surface--active: var(--color-green--lightest);
   --color-surface--background: var(--color-grey--lightest);
-  --color-surface--background--hover: var(--color-greyBlue--lighter);
   --color-surface--reverse: var(--color-blue);
 
   --color-border: var(--color-grey--lighter);

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -45,9 +45,10 @@
 
   /* Surfaces and Borders */
   --color-surface: var(--color-white);
-  --color-surface--hover: var(--color-yellow--lightest);
+  --color-surface--hover: var(--color-grey--lightest);
   --color-surface--active: var(--color-green--lightest);
   --color-surface--background: var(--color-grey--lightest);
+  --color-surface--background--hover: var(--color-greyBlue--lighter);
   --color-surface--reverse: var(--color-blue);
 
   --color-border: var(--color-grey--lighter);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To better align the Chip for web with our overall visual direction, stylistic changes are being implemented.

**FOR REVIEW/DISCUSSION/To Be Implemented**

- As Chip does not expose the properties of the `InternalChipAffix` publicly, should that be modified to be `InternalChipPrefix` and the current `activeIndicator` div that's been added turned into an `InternalChipSuffix`?
- Need to get the "activeIndicator" to also accept a `cross` icon, which probably means that "activeIndicator" is the wrong name for it (partially why I'm leaning towards the `InternalChipSuffix` approach above)
- Color changes to the hover state will be realized through #1545 

## Changes

### Added

- a new suffix with a white background that contains an icon, to be used primarily in signifying selection or dismissability

### Changed

- background color of chip for default and hovered states
- text color of chip
- chip no longer changes color when "active", it receives a checkmark icon

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
