### PR TITLE
fix(components): Improve performance on the list item creation

### DIFF
--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -184,9 +184,8 @@ export interface DataListContextProps<T extends DataListObject>
   readonly itemActionComponent?: ReactElement<DataListItemActionsProps<T>>;
 }
 
-export interface DataListLayoutContextProps<T extends DataListObject> {
+export interface DataListLayoutContextProps {
   readonly isInLayoutProvider: boolean;
-  readonly activeItem?: T;
 
   /**
    * Determine if the consumer of the DataList manually added an action to the
@@ -195,6 +194,10 @@ export interface DataListLayoutContextProps<T extends DataListObject> {
    */
   readonly hasInLayoutActions: boolean;
   readonly setHasInLayoutActions: (state: boolean) => void;
+}
+
+export interface DataListLayoutActionsContextProps<T extends DataListObject> {
+  readonly activeItem?: T;
 }
 
 type Fragment<T> = T | T[];

--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -46,38 +46,36 @@ export function getCompoundComponents<T>(
 }
 
 /**
- * Generate the default elements the DataList would use on the data provided.
+ * Generate the default element the DataList would use on the data provided.
  */
-export function generateListItemElements<T extends DataListObject>(data: T[]) {
-  type DataListElements = DataListItemType<typeof data>;
+export function generateListItemElement<T extends DataListObject>(item: T) {
+  type DataListElements = DataListItemType<T[]>;
 
-  return data.map(item =>
-    Object.keys(item).reduce((acc, key: keyof DataListElements) => {
-      const currentItem = item[key];
+  return Object.keys(item).reduce((acc, key: keyof DataListElements) => {
+    const currentItem = item[key];
 
-      if (!currentItem) {
-        return acc;
-      }
-
-      if (key === "tags" && Array.isArray(currentItem)) {
-        acc[key] = <DataListTags items={currentItem} />;
-      } else if (key === "label" && typeof currentItem === "string") {
-        acc[key] = <Heading level={5}>{currentItem}</Heading>;
-      } else if (isValidElement(currentItem)) {
-        acc[key] = currentItem;
-      } else if (currentItem instanceof Date) {
-        acc[key] = (
-          <Text variation="subdued">
-            <FormatDate date={currentItem} />
-          </Text>
-        );
-      } else {
-        acc[key] = <Text variation="subdued">{currentItem}</Text>;
-      }
-
+    if (!currentItem) {
       return acc;
-    }, {} as DataListElements),
-  );
+    }
+
+    if (key === "tags" && Array.isArray(currentItem)) {
+      acc[key] = <DataListTags items={currentItem} />;
+    } else if (key === "label" && typeof currentItem === "string") {
+      acc[key] = <Heading level={5}>{currentItem}</Heading>;
+    } else if (isValidElement(currentItem)) {
+      acc[key] = currentItem;
+    } else if (currentItem instanceof Date) {
+      acc[key] = (
+        <Text variation="subdued">
+          <FormatDate date={currentItem} />
+        </Text>
+      );
+    } else {
+      acc[key] = <Text variation="subdued">{currentItem}</Text>;
+    }
+
+    return acc;
+  }, {} as DataListElements);
 }
 
 /**

--- a/packages/components/src/DataList/__tests__/DataList.utils.test.tsx
+++ b/packages/components/src/DataList/__tests__/DataList.utils.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import {
   generateHeaderElements,
-  generateListItemElements,
+  generateListItemElement,
   getCompoundComponent,
   getCompoundComponents,
   sortSizeProp,
@@ -48,12 +48,12 @@ describe("Datalist utils", () => {
    * 1. If any of the snapshot here needs updating, it's either the code within
    *    the utils have changed or there really is something wrong.
    */
-  describe("generateListItemElements", () => {
+  describe("generateListItemElement", () => {
     it("should generate a Text component for the label key", () => {
-      const elementList = generateListItemElements([{ id: 1, label: "Hello" }]);
+      const elementList = generateListItemElement({ id: 1, label: "Hello" });
 
       // Snapshot needs updating? See comment #1 above the `describe`.
-      expect(elementList[0].label).toMatchInlineSnapshot(`
+      expect(elementList.label).toMatchInlineSnapshot(`
         <Heading
           level={5}
         >
@@ -63,15 +63,13 @@ describe("Datalist utils", () => {
     });
 
     it("should generate a subdued Text component for any random key", () => {
-      const elementList = generateListItemElements([
-        {
-          id: 1,
-          randomKeyThatIsntNormal: "I am a normal text",
-        },
-      ]);
+      const elementList = generateListItemElement({
+        id: 1,
+        randomKeyThatIsntNormal: "I am a normal text",
+      });
 
       // Snapshot needs updating? See comment #1 above the `describe`.
-      expect(elementList[0].randomKeyThatIsntNormal).toMatchInlineSnapshot(`
+      expect(elementList.randomKeyThatIsntNormal).toMatchInlineSnapshot(`
         <Text
           variation="subdued"
         >
@@ -81,12 +79,13 @@ describe("Datalist utils", () => {
     });
 
     it("should generate a list of inline label for the tag key", () => {
-      const elementList = generateListItemElements([
-        { id: 1, tags: ["uno", "dos"] },
-      ]);
+      const elementList = generateListItemElement({
+        id: 1,
+        tags: ["uno", "dos"],
+      });
 
       // Snapshot needs updating? See comment #1 above the `describe`.
-      expect(elementList[0].tags).toMatchInlineSnapshot(`
+      expect(elementList.tags).toMatchInlineSnapshot(`
         <DataListTags
           items={
             [
@@ -99,19 +98,17 @@ describe("Datalist utils", () => {
     });
 
     it("should generate the element passed in on any key", () => {
-      const elementList = generateListItemElements([
-        { id: 1, element: <div /> },
-      ]);
+      const elementList = generateListItemElement({ id: 1, element: <div /> });
 
       // Snapshot needs updating? See comment #1 above the `describe`.
-      expect(elementList[0].element).toMatchInlineSnapshot(`<div />`);
+      expect(elementList.element).toMatchInlineSnapshot(`<div />`);
     });
 
     it("should generate the correct element", () => {
-      const elementList = generateListItemElements([{ id: 1, date }]);
+      const elementList = generateListItemElement({ id: 1, date });
 
       // Snapshot needs updating? See comment #1 above the `describe`.
-      expect(elementList[0].date).toMatchInlineSnapshot(`
+      expect(elementList.date).toMatchInlineSnapshot(`
         <Text
           variation="subdued"
         >

--- a/packages/components/src/DataList/components/DataListItem/DataListItemInternal.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItemInternal.tsx
@@ -1,9 +1,9 @@
-import classNames from "classnames";
 import React from "react";
-import { Checkbox } from "../../../Checkbox";
-import { useDataListContext } from "../../context/DataListContext";
-import styles from "../../DataList.css";
-import { DataListObject } from "../../DataList.types";
+import classNames from "classnames";
+import { Checkbox } from "@jobber/components/Checkbox";
+import { useDataListContext } from "@jobber/components/DataList/context/DataListContext";
+import { DataListObject } from "@jobber/components/DataList/DataList.types";
+import styles from "@jobber/components/DataList/DataList.css";
 
 interface ListItemInternalProps<T extends DataListObject> {
   readonly children: JSX.Element;

--- a/packages/components/src/DataList/components/DataListItem/index.ts
+++ b/packages/components/src/DataList/components/DataListItem/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListItem";

--- a/packages/components/src/DataList/components/DataListItemActions/index.ts
+++ b/packages/components/src/DataList/components/DataListItemActions/index.ts
@@ -1,1 +1,2 @@
 export * from "./DataListItemActions";
+export * from "./DataListItemActionsOverflow";

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutActions.tsx
@@ -4,14 +4,16 @@ import React, {
   ReactElement,
   useEffect,
 } from "react";
+import { useDataListContext } from "@jobber/components/DataList/context/DataListContext";
+import { useDataListLayoutContext } from "@jobber/components/DataList/context/DataListLayoutContext";
+import { DataListItemActionsOverflow } from "@jobber/components/DataList/components/DataListItemActions";
+import { useDataListLayoutActionsContext } from "./DataListLayoutContext";
 import styles from "./DataListLayoutActions.css";
-import { useDataListContext } from "../../context/DataListContext";
-import { useDataListLayoutContext } from "../../context/DataListLayoutContext";
-import { DataListItemActionsOverflow } from "../DataListItemActions/DataListItemActionsOverflow";
 
 export function DataListLayoutActions() {
   const { itemActionComponent } = useDataListContext();
-  const { setHasInLayoutActions, activeItem } = useDataListLayoutContext();
+  const { setHasInLayoutActions } = useDataListLayoutContext();
+  const { activeItem } = useDataListLayoutActionsContext();
 
   const { children: actionsChildren } = itemActionComponent?.props || {};
   const actions = Children.toArray(actionsChildren) as ReactElement[];

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutContext/DataListLayoutContext.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutContext/DataListLayoutContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+import {
+  DataListLayoutActionsContextProps,
+  DataListObject,
+} from "@jobber/components/DataList/DataList.types";
+
+export const DataListLayoutActionsContext = createContext<
+  DataListLayoutActionsContextProps<DataListObject>
+>({ activeItem: undefined });
+
+export function useDataListLayoutActionsContext() {
+  return useContext(DataListLayoutActionsContext);
+}

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutContext/index.ts
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutContext/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListLayoutContext";

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItem.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItem.tsx
@@ -13,6 +13,7 @@ import { DataListActionsMenu } from "../DataListActionsMenu";
 import { InternalDataListAction } from "../DataListAction";
 import { useDataListLayoutContext } from "../../context/DataListLayoutContext";
 import styles from "../../DataList.css";
+import { DataListLayoutActionsContext } from "../DataListLayoutActions/DataListLayoutContext/DataListLayoutContext";
 
 interface DataListItem<T extends DataListObject> {
   readonly item: DataListItemType<T[]>;
@@ -39,44 +40,43 @@ export function DataListItem<T extends DataListObject>({
     showMenu && isContextMenuVisible && Boolean(contextMenuActions);
 
   return (
-    <div
-      // Set the active item whenever the element or any of its
-      // children are clicked
-      onClick={handleShowMenu}
-      onMouseEnter={handleShowMenu}
-      onMouseLeave={handleHideMenu}
-      onContextMenu={handleContextMenu}
-      className={classNames(styles.listItem, {
-        [styles.active]: showMenu && isContextMenuVisible,
-      })}
-      key={rawItem.id}
-    >
-      <DataListItemInternal item={rawItem}>
-        {layout.props.children(item)}
-      </DataListItemInternal>
+    <DataListLayoutActionsContext.Provider value={{ activeItem: rawItem }}>
+      <div
+        onMouseEnter={handleShowMenu}
+        onMouseLeave={handleHideMenu}
+        onContextMenu={handleContextMenu}
+        className={classNames(styles.listItem, {
+          [styles.active]: showMenu && isContextMenuVisible,
+        })}
+        key={rawItem.id}
+      >
+        <DataListItemInternal item={rawItem}>
+          {layout.props.children(item)}
+        </DataListItemInternal>
 
-      <AnimatePresence>
-        {showMenu && !hasInLayoutActions && (
-          <InternalDataListItemActions item={rawItem} />
-        )}
+        <AnimatePresence>
+          {showMenu && !hasInLayoutActions && (
+            <InternalDataListItemActions item={rawItem} />
+          )}
 
-        <DataListActionsMenu
-          key={rawItem.id}
-          visible={shouldShowContextMenu}
-          position={contextPosition || { x: 0, y: 0 }}
-          onRequestClose={() => setContextPosition(undefined)}
-        >
-          {contextMenuActions &&
-            Children.map(contextMenuActions, action => (
-              <InternalDataListAction
-                key={rawItem.id}
-                {...action.props}
-                item={rawItem}
-              />
-            ))}
-        </DataListActionsMenu>
-      </AnimatePresence>
-    </div>
+          <DataListActionsMenu
+            key={rawItem.id}
+            visible={shouldShowContextMenu}
+            position={contextPosition || { x: 0, y: 0 }}
+            onRequestClose={() => setContextPosition(undefined)}
+          >
+            {contextMenuActions &&
+              Children.map(contextMenuActions, action => (
+                <InternalDataListAction
+                  key={rawItem.id}
+                  {...action.props}
+                  item={rawItem}
+                />
+              ))}
+          </DataListActionsMenu>
+        </AnimatePresence>
+      </div>
+    </DataListLayoutActionsContext.Provider>
   );
 
   function handleShowMenu() {

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItem.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItem.tsx
@@ -1,19 +1,19 @@
 import React, { Children, MouseEvent, ReactElement, useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import classNames from "classnames";
-import { DataListItemInternal } from "./DataListItemInternal";
-import { useDataListContext } from "../../context/DataListContext";
+import { useDataListContext } from "@jobber/components/DataList/context/DataListContext";
+import { useDataListLayoutContext } from "@jobber/components/DataList/context/DataListLayoutContext";
 import {
   DataListItemType,
   DataListLayoutProps,
   DataListObject,
-} from "../../DataList.types";
-import { InternalDataListItemActions } from "../DataListItemActions";
-import { DataListActionsMenu } from "../DataListActionsMenu";
-import { InternalDataListAction } from "../DataListAction";
-import { useDataListLayoutContext } from "../../context/DataListLayoutContext";
-import styles from "../../DataList.css";
-import { DataListLayoutActionsContext } from "../DataListLayoutActions/DataListLayoutContext/DataListLayoutContext";
+} from "@jobber/components/DataList/DataList.types";
+import { InternalDataListItemActions } from "@jobber/components/DataList/components/DataListItemActions";
+import { DataListActionsMenu } from "@jobber/components/DataList/components/DataListActionsMenu";
+import { InternalDataListAction } from "@jobber/components/DataList/components/DataListAction";
+import { DataListLayoutActionsContext } from "@jobber/components/DataList/components/DataListLayoutActions/DataListLayoutContext";
+import styles from "@jobber/components/DataList/DataList.css";
+import { DataListItemInternal } from "./DataListItemInternal";
 
 interface DataListItem<T extends DataListObject> {
   readonly item: DataListItemType<T[]>;

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
@@ -29,7 +29,6 @@ export function DataListItems<T extends DataListObject>({
         isInLayoutProvider: true,
         hasInLayoutActions,
         setHasInLayoutActions,
-        activeItem: { id: 1 },
       }}
     >
       <DataListLayoutInternal

--- a/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx
@@ -1,13 +1,12 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
+import { DataListItem } from "@jobber/components/DataList/components/DataListItem";
 import { Breakpoints } from "@jobber/components/DataList/DataList.const";
 import {
   DataListLayoutProps,
   DataListObject,
 } from "@jobber/components/DataList/DataList.types";
-import { generateListItemElements } from "@jobber/components/DataList/DataList.utils";
 import { DataListLayoutContext } from "@jobber/components/DataList/context/DataListLayoutContext";
 import { DataListLayoutInternal } from "./DataListLayoutInternal";
-import { DataListItem } from "./DataListItem";
 
 interface DataListItemsProps<T extends DataListObject> {
   readonly layouts: React.ReactElement<DataListLayoutProps<T>>[] | undefined;
@@ -20,7 +19,6 @@ export function DataListItems<T extends DataListObject>({
   mediaMatches,
   data,
 }: DataListItemsProps<T>) {
-  const elementData = useMemo(() => generateListItemElements(data), [data]);
   const [hasInLayoutActions, setHasInLayoutActions] = useState(false);
 
   return (
@@ -36,7 +34,7 @@ export function DataListItems<T extends DataListObject>({
         mediaMatches={mediaMatches}
         renderLayout={layout => (
           <>
-            {elementData.map((child, i) => (
+            {data.map((child, i) => (
               <DataListItem
                 key={data[i].id}
                 index={i}

--- a/packages/components/src/DataList/context/DataListLayoutContext/DataListLayoutContext.tsx
+++ b/packages/components/src/DataList/context/DataListLayoutContext/DataListLayoutContext.tsx
@@ -1,18 +1,14 @@
 import noop from "lodash/noop";
 import { createContext, useContext } from "react";
-import {
-  DataListLayoutContextProps,
-  DataListObject,
-} from "../../DataList.types";
+import { DataListLayoutContextProps } from "@jobber/components/DataList/DataList.types";
 
-export const defaultValues: DataListLayoutContextProps<DataListObject> = {
+export const defaultValues: DataListLayoutContextProps = {
   isInLayoutProvider: false,
   hasInLayoutActions: false,
   setHasInLayoutActions: noop,
 };
 
-export const DataListLayoutContext =
-  createContext<DataListLayoutContextProps<DataListObject>>(defaultValues);
+export const DataListLayoutContext = createContext(defaultValues);
 
 export function useDataListLayoutContext() {
   return useContext(DataListLayoutContext);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

With the addition of actions and state management around when it opens, it started reinitializing everything the moment you interact with the list. That's due to how we're tracking the state for the menu from the parent instead of for each list.

This PR changes that by introducing the state per each item so the parent doesn't change which stops each data list item from reinitializing (note: I didn't say rerender since it doesn't rerender the element in the DOM). 

Adding a console.log [here](https://github.com/GetJobber/atlantis/blob/462ba662b8856312e33ab613ba51c50864d1aa96/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx#L37) shows you that wIthout these changes the list items get reinitialized on load more and interacting with it with a mouse

![image](https://github.com/GetJobber/atlantis/assets/15986172/d97d728a-9c86-4a71-878b-5c97d3d9ea57)

And more if you keep moving your mouse

Compared to this PR where it stays at that number

![image](https://github.com/GetJobber/atlantis/assets/15986172/a6e5678e-3c9f-4efe-9461-fcad6909d7b3)

Unfortunately, with how react keeps on reacting to changes, it would still try to reinitialize everytime the data changes. This time it only changes things when it needs to.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Componentize the list item
  - Moved to its own folder
- Replaced 1 mega state to track which menu is open to a per item state so it only reinitializes the list item that is changing instead of all
- Only run the generate reducer on item render
  - This will pay off with a performance boost once we have a virtualized list and the reducer won't run for all. Just for the visible items,

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Add a console log [here](https://github.com/GetJobber/atlantis/blob/462ba662b8856312e33ab613ba51c50864d1aa96/packages/components/src/DataList/components/DataListLayoutInternal/DataListItems.tsx#L37) and see how many times the component reinitializes compared to master.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
