### PR TITLE
feat(components): DataList row click and tabbing a11y

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -158,7 +158,7 @@ const Template: ComponentStory<typeof DataList> = args => {
         placeholder="Search characters..."
       />
 
-      <DataList.ItemActions onClick={item => console.log(item)}>
+      <DataList.ItemActions onClick={handleActionClick}>
         <DataList.Action icon="edit" label="Edit" onClick={handleActionClick} />
         <DataList.Action
           icon="sendMessage"

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -158,7 +158,7 @@ const Template: ComponentStory<typeof DataList> = args => {
         placeholder="Search characters..."
       />
 
-      <DataList.ItemActions>
+      <DataList.ItemActions onClick={item => console.log(item)}>
         <DataList.Action icon="edit" label="Edit" onClick={handleActionClick} />
         <DataList.Action
           icon="sendMessage"

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -128,6 +128,11 @@
 }
 
 .listItem .selectable > :first-child {
+  order: 2;
+}
+
+.listItem .selectable > :last-child {
+  order: 1;
   padding-top: var(--space-smaller);
   opacity: 1;
   transition: opacity var(--transition-properties);
@@ -139,9 +144,9 @@
   }
 }
 
-.listItem:hover .selectable > :first-child,
-.listItem:focus-within .selectable > :first-child,
-.listItem .selectable.selected > :first-child {
+.listItem:hover .selectable > :last-child,
+.listItem:focus-within .selectable > :last-child,
+.listItem .selectable.selected > :last-child {
   opacity: 1;
 }
 

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -11,6 +11,10 @@
   flex: 1;
 }
 
+/*
+ * Header
+ */
+
 .titleContainer {
   display: flex;
   position: relative;
@@ -46,6 +50,10 @@
   margin: calc(var(--space-small) * -1) 0;
 }
 
+/*
+ * List Item
+ */
+
 .listItem {
   position: relative;
   padding: var(--space-small);
@@ -53,10 +61,40 @@
   transition: all var(--timing-base);
 }
 
-.listItem.active {
+.listItem.active,
+.listItem:hover,
+.listItem:focus-within {
   --data-list-item-active-color: var(--color-surface--background);
   background-color: var(--data-list-item-active-color);
 }
+
+.listItemClickable {
+  margin: calc(var(--space-small) * -1) 0;
+  padding: var(--space-small) 0;
+  border: none;
+  text-align: left;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+/**
+ * Enable a better hover and focus experience when :has() is supported.
+ * This is a workaround for Firefox where the :has() selector is not supported.
+ */
+@supports selector(*:has(*)) {
+  .listItem:hover,
+  .listItem:focus-within {
+    background-color: transparent;
+  }
+
+  .listItem:has(.listItemClickable:hover, .listItemClickable:focus) {
+    background-color: var(--data-list-item-active-color);
+  }
+}
+
+/*
+ * List Item Selection
+ */
 
 .selectable {
   display: grid;
@@ -104,6 +142,10 @@
 .listItem .selectable.selected > :first-child {
   opacity: 1;
 }
+
+/*
+ * Filters
+ */
 
 .filtering {
   display: flex;

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -69,10 +69,12 @@
 }
 
 .listItemClickable {
+  display: block;
   margin: calc(var(--space-small) * -1) 0;
   padding: var(--space-small) 0;
   border: none;
   text-align: left;
+  text-decoration: none;
   background-color: transparent;
   cursor: pointer;
 }

--- a/packages/components/src/DataList/DataList.css.d.ts
+++ b/packages/components/src/DataList/DataList.css.d.ts
@@ -6,6 +6,7 @@ declare const styles: {
   readonly "headerBatchSelect": string;
   readonly "listItem": string;
   readonly "active": string;
+  readonly "listItemClickable": string;
   readonly "selectable": string;
   readonly "selectAllCheckbox": string;
   readonly "visible": string;

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -210,7 +210,7 @@ export interface DataListItemActionsProps<T extends DataListObject> {
   readonly children?: Fragment<ReactElement<DataListActionProps<T>>>;
 
   readonly onClick?: (item: T) => void;
-  readonly href?: string | ((item: T) => string);
+  readonly url?: string | ((item: T) => string);
   readonly to?: string | ((item: T) => string);
 }
 

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -1,5 +1,6 @@
 import { ReactElement, ReactNode } from "react";
 import { IconNames } from "@jobber/design";
+import { XOR } from "ts-xor";
 import { Breakpoints } from "./DataList.const";
 import { ButtonProps } from "../Button";
 
@@ -202,17 +203,41 @@ export interface DataListLayoutActionsContextProps<T extends DataListObject> {
 
 type Fragment<T> = T | T[];
 
-export interface DataListItemActionsProps<T extends DataListObject> {
+interface BaseDataListItemActionsProps<T extends DataListObject> {
   /**
    * The actions to render for each item in the DataList. This only accepts the
    * DataList.Action component.
    */
   readonly children?: Fragment<ReactElement<DataListActionProps<T>>>;
 
+  /**
+   * Callback when an item is clicked.
+   */
   readonly onClick?: (item: T) => void;
+}
+
+interface DataListItemActionsPropsWithURL<T extends DataListObject>
+  extends BaseDataListItemActionsProps<T> {
+  /**
+   * If a normal page navigation is needed, use this prop to change the element
+   * to an `a` tag with an `href`.
+   */
   readonly url?: string | ((item: T) => string);
+}
+
+interface DataListItemActionsPropsWithTo<T extends DataListObject>
+  extends BaseDataListItemActionsProps<T> {
+  /**
+   * If a React Navigation is needed, use this prop to use the `Link` component
+   * that comes with React Router.
+   */
   readonly to?: string | ((item: T) => string);
 }
+
+export type DataListItemActionsProps<T extends DataListObject> = XOR<
+  DataListItemActionsPropsWithURL<T>,
+  DataListItemActionsPropsWithTo<T>
+>;
 
 export interface DataListActionProps<T extends DataListObject> {
   /**

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -208,6 +208,10 @@ export interface DataListItemActionsProps<T extends DataListObject> {
    * DataList.Action component.
    */
   readonly children?: Fragment<ReactElement<DataListActionProps<T>>>;
+
+  readonly onClick?: (item: T) => void;
+  readonly href?: string | ((item: T) => string);
+  readonly to?: string | ((item: T) => string);
 }
 
 export interface DataListActionProps<T extends DataListObject> {

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.css
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.css
@@ -15,7 +15,10 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: var(--elevation-menu);
+  z-index: calc(var(--elevation-menu) - 1);
   width: 100%;
   height: 100%;
+  padding: 0;
+  border: none;
+  background-color: transparent;
 }

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -37,7 +37,7 @@ export function DataListActionsMenu({
   return createPortal(
     <AnimatePresence>
       {visible && (
-        <>
+        <div ref={focusTrapRef}>
           <motion.div
             role="menu"
             ref={setRef}
@@ -50,9 +50,7 @@ export function DataListActionsMenu({
             style={getPositionCssVars()}
             onClick={onRequestClose}
           >
-            <div tabIndex={0} ref={focusTrapRef}>
-              {children}
-            </div>
+            {children}
           </motion.div>
 
           <button
@@ -60,7 +58,7 @@ export function DataListActionsMenu({
             onClick={onRequestClose}
             aria-label="Close menu"
           />
-        </>
+        </div>
       )}
     </AnimatePresence>,
     document.body,

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -38,8 +38,6 @@ export function DataListActionsMenu({
     <AnimatePresence>
       {visible && (
         <>
-          <div className={styles.overlay} onClick={onRequestClose} />
-
           <motion.div
             role="menu"
             ref={setRef}
@@ -56,6 +54,12 @@ export function DataListActionsMenu({
               {children}
             </div>
           </motion.div>
+
+          <button
+            className={styles.overlay}
+            onClick={onRequestClose}
+            aria-label="Close menu"
+          />
         </>
       )}
     </AnimatePresence>,

--- a/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
@@ -19,6 +19,7 @@ import { InternalDataListAction } from "@jobber/components/DataList/components/D
 import { DataListLayoutActionsContext } from "@jobber/components/DataList/components/DataListLayoutActions/DataListLayoutContext";
 import styles from "@jobber/components/DataList/DataList.css";
 import { DataListItemInternal } from "./DataListItemInternal";
+import { DataListItemClickable } from "./components/DataListItemClickable";
 import { generateListItemElement } from "../../DataList.utils";
 
 interface DataListItem<T extends DataListObject> {
@@ -49,6 +50,8 @@ export function DataListItem<T extends DataListObject>({
       <div
         onMouseEnter={handleShowMenu}
         onMouseLeave={handleHideMenu}
+        onFocus={handleShowMenu}
+        onBlur={handleHideMenu}
         onContextMenu={handleContextMenu}
         className={classNames(styles.listItem, {
           [styles.active]: showMenu && isContextMenuVisible,
@@ -56,7 +59,9 @@ export function DataListItem<T extends DataListObject>({
         key={item.id}
       >
         <DataListItemInternal item={item}>
-          {layout.props.children(generatedItem)}
+          <DataListItemClickable>
+            {layout.props.children(generatedItem)}
+          </DataListItemClickable>
         </DataListItemInternal>
 
         <AnimatePresence>

--- a/packages/components/src/DataList/components/DataListItem/DataListItemInternal.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItemInternal.tsx
@@ -23,11 +23,11 @@ export function DataListItemInternal<T extends DataListObject>({
           [styles.selected]: selected?.length,
         })}
       >
+        {children}
         <Checkbox
           checked={selected?.includes(item.id)}
           onChange={handleChange}
         />
-        {children}
       </div>
     );
   }

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.test.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.test.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BrowserRouter } from "react-router-dom";
+import { DataListObject } from "@jobber/components/DataList/DataList.types";
+import {
+  DataListContext,
+  defaultValues,
+} from "@jobber/components/DataList/context/DataListContext";
+import { DataListItemActions } from "@jobber/components/DataList/components/DataListItemActions";
+import { DataListLayoutActionsContext } from "@jobber/components/DataList/components/DataListLayoutActions/DataListLayoutContext";
+import { DataListItemClickable } from "./DataListItemClickable";
+
+const mockItemActionComponent = jest.fn<JSX.Element | undefined, []>(() => (
+  <DataListItemActions />
+));
+
+const expectedItem = { id: 1 };
+const mockActiveItem = jest.fn<DataListObject | undefined, []>(
+  () => expectedItem,
+);
+
+const handleClick = jest.fn();
+
+afterEach(() => {
+  mockItemActionComponent.mockClear();
+  mockActiveItem.mockClear();
+  handleClick.mockClear();
+});
+
+const content = "Content";
+
+describe("DataListItemClickable", () => {
+  it("should render a div when the list item action doesn't have any prop", () => {
+    renderComponent();
+    expect(screen.getByText(content)).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("should render a div when the list item action doesn't exist", () => {
+    mockItemActionComponent.mockReturnValueOnce(undefined);
+    renderComponent();
+    expect(screen.getByText(content)).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("should render a div when the active item doesn't exist", () => {
+    mockActiveItem.mockReturnValueOnce(undefined);
+    renderComponent();
+    expect(screen.getByText(content)).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("should render a button when there's only an `onClick` prop", () => {
+    mockItemActionComponent.mockReturnValueOnce(
+      <DataListItemActions onClick={handleClick} />,
+    );
+
+    renderComponent();
+
+    const target = screen.getByText(content);
+    expect(target).toBeInstanceOf(HTMLButtonElement);
+
+    userEvent.click(target);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledWith(expectedItem);
+  });
+
+  describe("URL prop", () => {
+    it("should render an `a` tag", () => {
+      mockItemActionComponent.mockReturnValueOnce(
+        <DataListItemActions url="jobber.com" />,
+      );
+
+      renderComponent();
+
+      const target = screen.getByText(content);
+      expect(target).toBeInstanceOf(HTMLAnchorElement);
+      expect(target).toHaveAttribute("href", "jobber.com");
+
+      userEvent.click(target);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it("should render an `a` tag with a callback url", () => {
+      mockItemActionComponent.mockReturnValueOnce(
+        <DataListItemActions url={item => `jobber.com/${item.id}`} />,
+      );
+
+      renderComponent();
+
+      const target = screen.getByText(content);
+      expect(target).toBeInstanceOf(HTMLAnchorElement);
+      expect(target).toHaveAttribute("href", "jobber.com/1");
+    });
+
+    it("should still fire onClick if it exists", () => {
+      mockItemActionComponent.mockReturnValueOnce(
+        <DataListItemActions url="jobber.com" onClick={handleClick} />,
+      );
+
+      renderComponent();
+      const target = screen.getByText(content);
+      expect(target).toBeInstanceOf(HTMLAnchorElement);
+
+      userEvent.click(target);
+      expect(handleClick).toHaveBeenCalledTimes(1);
+      expect(handleClick).toHaveBeenCalledWith(expectedItem);
+    });
+  });
+
+  describe("To prop", () => {
+    it("should render an `a` tag", () => {
+      mockItemActionComponent.mockReturnValueOnce(
+        <DataListItemActions to="/getjobber.com" />,
+      );
+
+      renderComponent();
+
+      const target = screen.getByText(content);
+      expect(target).toBeInstanceOf(HTMLAnchorElement);
+      expect(target).toHaveAttribute("href", "/getjobber.com");
+
+      userEvent.click(target);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it("should render an `a` tag with a callback url", () => {
+      mockItemActionComponent.mockReturnValueOnce(
+        <DataListItemActions to={item => `/getjobber.com/${item.id}`} />,
+      );
+
+      renderComponent();
+
+      const target = screen.getByText(content);
+      expect(target).toBeInstanceOf(HTMLAnchorElement);
+      expect(target).toHaveAttribute("href", "/getjobber.com/1");
+    });
+
+    it("should still fire onClick if it exists", () => {
+      mockItemActionComponent.mockReturnValueOnce(
+        <DataListItemActions to="/getjobber.com" onClick={handleClick} />,
+      );
+
+      renderComponent();
+      const target = screen.getByText(content);
+      expect(target).toBeInstanceOf(HTMLAnchorElement);
+
+      userEvent.click(target);
+      expect(handleClick).toHaveBeenCalledTimes(1);
+      expect(handleClick).toHaveBeenCalledWith(expectedItem);
+    });
+  });
+});
+
+function renderComponent() {
+  return render(
+    <BrowserRouter>
+      <DataListContext.Provider
+        value={{
+          ...defaultValues,
+          itemActionComponent: mockItemActionComponent(),
+        }}
+      >
+        <DataListLayoutActionsContext.Provider
+          value={{ activeItem: mockActiveItem() }}
+        >
+          <DataListItemClickable>{content}</DataListItemClickable>
+        </DataListLayoutActionsContext.Provider>
+      </DataListContext.Provider>
+    </BrowserRouter>,
+  );
+}

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.tsx
@@ -1,22 +1,19 @@
 import React, { PropsWithChildren } from "react";
-import styles from "@jobber/components/DataList/DataList.css";
 import { useDataListContext } from "@jobber/components/DataList/context/DataListContext";
+import { DataListItemClickableInternal } from "./DataListItemClickableInternal";
 import { useDataListLayoutActionsContext } from "../../../DataListLayoutActions/DataListLayoutContext";
 
 export function DataListItemClickable({ children }: PropsWithChildren<object>) {
   const { itemActionComponent } = useDataListContext();
   const { activeItem } = useDataListLayoutActionsContext();
 
-  if (itemActionComponent) {
-    const { onClick } = itemActionComponent.props;
+  if (itemActionComponent && activeItem) {
+    const props = itemActionComponent.props;
 
     return (
-      <button
-        className={styles.listItemClickable}
-        onClick={() => onClick?.(activeItem)}
-      >
+      <DataListItemClickableInternal {...props}>
         {children}
-      </button>
+      </DataListItemClickableInternal>
     );
   }
 

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.tsx
@@ -1,13 +1,11 @@
 import React, { PropsWithChildren } from "react";
 import { useDataListContext } from "@jobber/components/DataList/context/DataListContext";
 import { DataListItemClickableInternal } from "./DataListItemClickableInternal";
-import { useDataListLayoutActionsContext } from "../../../DataListLayoutActions/DataListLayoutContext";
 
 export function DataListItemClickable({ children }: PropsWithChildren<object>) {
   const { itemActionComponent } = useDataListContext();
-  const { activeItem } = useDataListLayoutActionsContext();
 
-  if (itemActionComponent && activeItem) {
+  if (itemActionComponent) {
     const props = itemActionComponent.props;
 
     return (

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.tsx
@@ -1,0 +1,24 @@
+import React, { PropsWithChildren } from "react";
+import styles from "@jobber/components/DataList/DataList.css";
+import { useDataListContext } from "@jobber/components/DataList/context/DataListContext";
+import { useDataListLayoutActionsContext } from "../../../DataListLayoutActions/DataListLayoutContext";
+
+export function DataListItemClickable({ children }: PropsWithChildren<object>) {
+  const { itemActionComponent } = useDataListContext();
+  const { activeItem } = useDataListLayoutActionsContext();
+
+  if (itemActionComponent) {
+    const { onClick } = itemActionComponent.props;
+
+    return (
+      <button
+        className={styles.listItemClickable}
+        onClick={() => onClick?.(activeItem)}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickableInternal.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickableInternal.tsx
@@ -1,0 +1,53 @@
+import React, { PropsWithChildren } from "react";
+import { Link } from "react-router-dom";
+import styles from "@jobber/components/DataList/DataList.css";
+import {
+  DataListItemActionsProps,
+  DataListObject,
+} from "@jobber/components/DataList/DataList.types";
+import { useDataListLayoutActionsContext } from "../../../DataListLayoutActions/DataListLayoutContext";
+
+export function DataListItemClickableInternal<T extends DataListObject>({
+  onClick,
+  url,
+  to,
+  children,
+}: PropsWithChildren<
+  Pick<DataListItemActionsProps<T>, "onClick" | "url" | "to">
+>) {
+  const { activeItem } = useDataListLayoutActionsContext<T>();
+
+  if (!activeItem) return <>{children}</>;
+
+  if (to) {
+    const computedTo = typeof to === "string" ? to : to(activeItem);
+    return (
+      <Link
+        className={styles.listItemClickable}
+        to={computedTo}
+        onClick={handleClick}
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  if (url) {
+    const href = typeof url === "string" ? url : url(activeItem);
+    return (
+      <a className={styles.listItemClickable} href={href} onClick={handleClick}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button className={styles.listItemClickable} onClick={handleClick}>
+      {children}
+    </button>
+  );
+
+  function handleClick() {
+    activeItem && onClick?.(activeItem);
+  }
+}

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickableInternal.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickableInternal.tsx
@@ -41,11 +41,15 @@ export function DataListItemClickableInternal<T extends DataListObject>({
     );
   }
 
-  return (
-    <button className={styles.listItemClickable} onClick={handleClick}>
-      {children}
-    </button>
-  );
+  if (onClick) {
+    return (
+      <button className={styles.listItemClickable} onClick={handleClick}>
+        {children}
+      </button>
+    );
+  }
+
+  return <>{children}</>;
 
   function handleClick() {
     activeItem && onClick?.(activeItem);

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/index.ts
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/index.ts
@@ -1,0 +1,1 @@
+export * from "./DataListItemClickable";

--- a/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutContext/DataListLayoutContext.tsx
+++ b/packages/components/src/DataList/components/DataListLayoutActions/DataListLayoutContext/DataListLayoutContext.tsx
@@ -8,6 +8,8 @@ export const DataListLayoutActionsContext = createContext<
   DataListLayoutActionsContextProps<DataListObject>
 >({ activeItem: undefined });
 
-export function useDataListLayoutActionsContext() {
-  return useContext(DataListLayoutActionsContext);
+export function useDataListLayoutActionsContext<T extends DataListObject>() {
+  return useContext(
+    DataListLayoutActionsContext,
+  ) as DataListLayoutActionsContextProps<T>;
 }

--- a/packages/hooks/src/useFocusTrap/useFocusTrap.ts
+++ b/packages/hooks/src/useFocusTrap/useFocusTrap.ts
@@ -37,8 +37,6 @@ export function useFocusTrap<T extends HTMLElement>(active: boolean) {
   useEffect(() => {
     if (active && ref.current) {
       const { firstElement } = getElements(ref.current);
-      console.log(firstElement);
-
       firstElement.focus();
       ref.current.addEventListener("keydown", handleKeyDown);
     }

--- a/packages/hooks/src/useFocusTrap/useFocusTrap.ts
+++ b/packages/hooks/src/useFocusTrap/useFocusTrap.ts
@@ -35,9 +35,12 @@ export function useFocusTrap<T extends HTMLElement>(active: boolean) {
   }
 
   useEffect(() => {
-    if (active) {
-      ref.current?.focus();
-      ref.current?.addEventListener("keydown", handleKeyDown);
+    if (active && ref.current) {
+      const { firstElement } = getElements(ref.current);
+      console.log(firstElement);
+
+      firstElement.focus();
+      ref.current.addEventListener("keydown", handleKeyDown);
     }
 
     return () => {
@@ -57,8 +60,16 @@ function getElements<T extends HTMLElement>(ref: T) {
     "textarea",
     '[tabindex]:not([tabindex="-1"])',
   ];
-  const elements = ref.querySelectorAll<HTMLElement>(focusables.join(", "));
-  const firstElement = ref;
+  const elements = [
+    ...ref.querySelectorAll<HTMLElement>(focusables.join(", ")),
+  ];
+
+  // If the ref is focusable, ensure it's the first element to be focused.
+  if (ref.getAttribute("tabindex") === "0") {
+    elements.unshift(ref);
+  }
+
+  const firstElement = elements[0];
   const lastElement = elements[elements.length - 1];
   return { firstElement, lastElement };
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We need to allow a row click on the data list. There are 3 classification of an interactable item within DataList (and Jobber)
- normal onClick that is a button
- a link to another page (classic a href tag)
- a route to another page (SPA/PWA/etc)

This PR aims to support those 3.

On top of that, this also adjusts the tabbing experience within the list items.

<img width="1035" alt="image" src="https://github.com/GetJobber/atlantis/assets/15986172/ac039cd0-22ec-4eb4-82a8-e2e6009c8a41">

## Out-of-scope
Voice over accessibility. Is not in this PR. Right now, it is good enough but it could be improved. Infortunately, that involves more thinking around how we handle that so to not block this PR further, we can follow up on that task.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Tabbing order
- Show actions on focus
- A pretty sweet hover interaction (except for firefox)

### Changed

- Updated the focus trap hook to either focus on the parent if it's focusable or focus on the very first focuseable element.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
