### PR TITLE
feat(components): Add multiselect prop to combobox

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -139,7 +139,7 @@ const ComboboxClearSelection: ComponentStory<typeof Combobox> = args => {
         type="primary"
         onClick={() => setSelected(null)}
       />
-      <Combobox {...args}>
+      <Combobox {...args} multiSelect>
         <Combobox.TriggerButton
           label="Select a teammate"
           variation="subtle"

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -29,7 +29,7 @@ export const Combobox = (props: ComboboxProps): JSX.Element => {
     props.children,
   );
   return (
-    <ComboboxContextProvider>
+    <ComboboxContextProvider multiselect={props.multiSelect}>
       {triggerElement}
       {contentElement}
     </ComboboxContextProvider>

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -12,10 +12,9 @@ export interface ComboboxProps {
   readonly children: ReactElement | ReactElement[];
 
   /**
-   * multi select
+   * When `true`, `Combobox` will allow for multiple selections
+   *
    * @default false
-   * @type boolean
-   * @description if true, allows multiple selections
    */
   readonly multiSelect?: boolean;
 }

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -10,6 +10,14 @@ import {
 
 export interface ComboboxProps {
   readonly children: ReactElement | ReactElement[];
+
+  /**
+   * multi select
+   * @default false
+   * @type boolean
+   * @description if true, allows multiple selections
+   */
+  readonly multiSelect?: boolean;
 }
 
 export const COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE =

--- a/packages/components/src/Combobox/ComboboxProvider.tsx
+++ b/packages/components/src/Combobox/ComboboxProvider.tsx
@@ -3,6 +3,7 @@ import styles from "./Combobox.css";
 
 export const ComboboxContext = React.createContext(
   {} as {
+    multiselect: boolean;
     open: boolean;
     setOpen: (open: boolean) => void;
     wrapperRef: RefObject<HTMLDivElement>;
@@ -11,16 +12,20 @@ export const ComboboxContext = React.createContext(
 
 export interface ComboboxProviderProps {
   readonly children: React.ReactNode;
+  readonly multiselect?: boolean;
 }
 
 export function ComboboxContextProvider(
   props: ComboboxProviderProps,
 ): JSX.Element {
+  const multiselect = props.multiselect || false;
   const [open, setOpen] = useState<boolean>(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   return (
-    <ComboboxContext.Provider value={{ open, setOpen, wrapperRef }}>
+    <ComboboxContext.Provider
+      value={{ multiselect, open, setOpen, wrapperRef }}
+    >
       <div ref={wrapperRef}>
         {open && (
           <div

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -295,6 +295,7 @@ function MockComboboxProvider({ children }: { children: React.ReactNode }) {
   return (
     <ComboboxContext.Provider
       value={{
+        multiselect: false,
         open,
         setOpen,
         wrapperRef: { current: null },


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
This PR adds the prop for the multi select functionality for the combobox component.
This is the first step for adding multi select functionality to the combobox. It will allow us to have a variable to hook off of in order to build the following multi select functionality.

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
