### PR TITLE
fix(components): nested button issue on DataList

### DIFF
--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -1,4 +1,9 @@
-import React, { CSSProperties, PropsWithChildren, useState } from "react";
+import React, {
+  CSSProperties,
+  MouseEvent,
+  PropsWithChildren,
+  useState,
+} from "react";
 import { AnimatePresence, Variants, motion } from "framer-motion";
 import { useFocusTrap } from "@jobber/hooks/useFocusTrap";
 import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
@@ -37,7 +42,7 @@ export function DataListActionsMenu({
   return createPortal(
     <AnimatePresence>
       {visible && (
-        <div ref={focusTrapRef}>
+        <div ref={focusTrapRef} onClick={handleClick}>
           <motion.div
             role="menu"
             ref={setRef}
@@ -63,6 +68,12 @@ export function DataListActionsMenu({
     </AnimatePresence>,
     document.body,
   );
+
+  function handleClick(event: MouseEvent<HTMLDivElement>): void {
+    // Prevent menu from firing the parent's onClick event when it is nested
+    // within a clickable list item
+    event.stopPropagation();
+  }
 
   function getPositionCssVars() {
     const { posX, posY } = getPosition();

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.test.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.test.tsx
@@ -48,7 +48,7 @@ describe("DataListItemClickable", () => {
     expect(screen.getByText(content)).toBeInstanceOf(HTMLDivElement);
   });
 
-  it("should render a button when there's only an `onClick` prop", () => {
+  it("should render a div with a role of button when there's only an `onClick` prop", () => {
     mockItemActionComponent.mockReturnValueOnce(
       <DataListItemActions onClick={handleClick} />,
     );
@@ -56,7 +56,8 @@ describe("DataListItemClickable", () => {
     renderComponent();
 
     const target = screen.getByText(content);
-    expect(target).toBeInstanceOf(HTMLButtonElement);
+    expect(target).toBeInstanceOf(HTMLDivElement);
+    expect(target).toHaveAttribute("role", "button");
 
     userEvent.click(target);
     expect(handleClick).toHaveBeenCalledTimes(1);

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.test.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { BrowserRouter } from "react-router-dom";
 import { DataListObject } from "@jobber/components/DataList/DataList.types";
@@ -61,6 +61,24 @@ describe("DataListItemClickable", () => {
 
     userEvent.click(target);
     expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledWith(expectedItem);
+  });
+
+  it("should fire the `onClick` when pressing space or enter", () => {
+    mockItemActionComponent.mockReturnValueOnce(
+      <DataListItemActions onClick={handleClick} />,
+    );
+
+    renderComponent();
+
+    const target = screen.getByText(content);
+
+    fireEvent.keyDown(target, { key: "Enter" });
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledWith(expectedItem);
+
+    fireEvent.keyDown(target, { key: " " });
+    expect(handleClick).toHaveBeenCalledTimes(2);
     expect(handleClick).toHaveBeenCalledWith(expectedItem);
   });
 

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickableInternal.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickableInternal.tsx
@@ -43,9 +43,20 @@ export function DataListItemClickableInternal<T extends DataListObject>({
 
   if (onClick) {
     return (
-      <button className={styles.listItemClickable} onClick={handleClick}>
+      <div
+        role="button"
+        tabIndex={0}
+        className={styles.listItemClickable}
+        onClick={handleClick}
+        onKeyDown={e => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+      >
         {children}
-      </button>
+      </div>
     );
   }
 

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickableInternal.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickableInternal.tsx
@@ -43,6 +43,8 @@ export function DataListItemClickableInternal<T extends DataListObject>({
 
   if (onClick) {
     return (
+      // A button can be nested within the list item. To prevent a button inside
+      // button error, we need to manually declare a div to be a button
       <div
         role="button"
         tabIndex={0}

--- a/packages/components/src/DataList/components/DataListItemActionsOverflow/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActionsOverflow/DataListItemActionsOverflow.tsx
@@ -39,6 +39,10 @@ export function DataListItemActionsOverflow<T extends DataListObject>({
   );
 
   function handleMoreClick(event: MouseEvent<HTMLButtonElement>): void {
+    // Prevent firing the parent's onClick event when it is nested
+    // within a clickable list item
+    event.stopPropagation();
+
     setShowMenu(true);
 
     const rect = event.currentTarget.getBoundingClientRect();


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When the DataList items are clickable, it becomes a button. Unfortunately, you can also add a button inside it, like the layout actions, so it will fire both the item click and the menu/menu item click. 

So you'll have 2 problems
- HTML would throw an error around a button inside a button not allowed
- The item click fires with the menu click

This PR prevents that from happening.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `stopPropagation` on places that need it to prevent event bubbling

### Changed

- The wrapping button to a div with a role of button and acts like a button to avoid the button on button issue

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
