### PR TITLE
chore: enforce a better relative import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,8 @@ const packageAliases = [
 ];
 
 module.exports = {
-  extends: ["@jobber/eslint-config"],
+  plugins: ["monorepo-cop"],
+  extends: ["@jobber/eslint-config", "plugin:monorepo-cop/recommended"],
   root: true,
   settings: {
     "import/ignore": ["react-native/index"],
@@ -21,10 +22,10 @@ module.exports = {
   },
   rules: {
     /*
-      Need to figure out a good way to enforce intra vs inter module import
-      rules. For now, warn on these.
+      Atlantis is a monorepo so we need to use `monorepo-cop` to enforce the
+      relative import rule.
      */
-    "import/no-relative-parent-imports": "warn",
+    "import/no-relative-parent-imports": "off",
     "no-restricted-imports": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-plugin-jest": "^22.6.4",
         "eslint-plugin-mdx": "^1.16.0",
+        "eslint-plugin-monorepo-cop": "^1.0.2",
         "glob": "^7.1.4",
         "graphql": "^15.8.0",
         "graphql-ws": "^5.12.0",
@@ -21529,6 +21530,42 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
+    "node_modules/eslint-plugin-monorepo-cop": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-monorepo-cop/-/eslint-plugin-monorepo-cop-1.0.2.tgz",
+      "integrity": "sha512-jGEbrgW5K+JUxT4OwmVMOxWfR9NJDwmZAXxsGCMYT91p5r3b1IB3jMedLCX+zfAXuPtnLOgo93mALaVymLIX8w==",
+      "dev": true,
+      "dependencies": {
+        "read-pkg-up": "^6.0.0",
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-monorepo-cop/node_modules/read-pkg-up": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
+      "integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0",
+        "read-pkg": "^5.1.1",
+        "type-fest": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-monorepo-cop/node_modules/type-fest": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -39599,6 +39636,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
+      }
     },
     "node_modules/requires-port": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-jest": "^22.6.4",
     "eslint-plugin-mdx": "^1.16.0",
+    "eslint-plugin-monorepo-cop": "^1.0.2",
     "glob": "^7.1.4",
     "graphql": "^15.8.0",
     "graphql-ws": "^5.12.0",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We've always had this warning 

<img width="997" alt="image" src="https://github.com/GetJobber/atlantis/assets/15986172/b5b975a3-d2f4-4d0e-bae7-bbe49984442d">

That was meant to catch people importing between packages via `../` their way in there. That's not good because this is a monorepo and relative paths does not exist after packaged up.

This PR turns that off and replaces it with a package that's made for monorepos and relative packages that throws this error now

<img width="1003" alt="image" src="https://github.com/GetJobber/atlantis/assets/15986172/8bc35ba9-849e-40d2-9769-4c46a75c9937">


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- harder linter on reaching to another package through `../`

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
