### PR TITLE
fix(components): Use button type in Dismissable Chip menu items

### DIFF
--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -106,6 +106,7 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
               <button
                 key={option.value}
                 role="option"
+                type="button"
                 id={generateDescendantId(i)}
                 className={classNames(styles.menuListOption, {
                   [styles.activeOption]: activeIndex === i,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When investigating some flakiness in some internal Jest tests, it was observed that _part_ of the problem was that a page using `Form` with a dismissible `Chips` component was having the Form submit simply by selecting a new item to add to the dismissable chips selection. I'm not sure why we weren't seeing this behaviour in a browser, but the [HTML spec](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type) does say that the default type for a `<button>` element is `submit`, and [jsdom matches that behaviour](https://github.com/jsdom/jsdom/blob/master/lib/jsdom/living/nodes/HTMLButtonElement-impl.js#L52). It doesn't look like that was intentional though; this component is handling it's own activation logic (the `onClick={() => handleSelectOption(option)}` line below) and conceptually it seems strange that selecting an option from a dropdown menu would submit a form. 

This PR just adds `type="button"` to the buttons used in that chip dropdown menu. That gives these buttons the "client code will handle events on this button, don't submit or reset the form owner" signal as per spec. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Buttons in the Dismissable Chip add menu no longer submit ancestor forms

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
