### PR TITLE
feat(components): Adjust Combobox Selected Style

### DIFF
--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -32,6 +32,7 @@ describe("Combobox validation", () => {
   it("throws an error if there is no Trigger element", () => {
     expect.assertions(1);
     let error;
+
     try {
       render(
         <Combobox>
@@ -52,6 +53,7 @@ describe("Combobox validation", () => {
   it("throws an error if there are multiple of the same Trigger element", () => {
     expect.assertions(1);
     let error;
+
     try {
       render(
         <Combobox>
@@ -74,6 +76,7 @@ describe("Combobox validation", () => {
   it("throws an error if there are multiple of various Trigger elements", () => {
     expect.assertions(1);
     let error;
+
     try {
       render(
         <Combobox>
@@ -96,6 +99,7 @@ describe("Combobox validation", () => {
   it("throws an error if there is no Content element", () => {
     expect.assertions(1);
     let error;
+
     try {
       render(
         <Combobox>
@@ -112,6 +116,7 @@ describe("Combobox validation", () => {
   it("throws an error if there is neither a Content nor Trigger element", () => {
     expect.assertions(1);
     let error;
+
     try {
       render(
         <Combobox>
@@ -128,6 +133,7 @@ describe("Combobox validation", () => {
   it("throws an error if there are multiple Trigger elements and no Content", () => {
     expect.assertions(1);
     let error;
+
     try {
       render(
         <Combobox>
@@ -243,11 +249,11 @@ describe("Combobox selected value", () => {
     const option = getByText("Bilbo Baggins");
     const clearButton = getByText("Clear Selection");
 
-    expect(option).toHaveClass("selectedOption");
+    expect(option).toHaveAttribute("aria-selected", "true");
 
     fireEvent.click(clearButton);
     fireEvent.click(getByText("Button"));
-    expect(option).not.toHaveClass("selectedOption");
+    expect(option).not.toHaveAttribute("aria-selected", "true");
   });
 });
 
@@ -290,8 +296,8 @@ describe("Combobox multiselect", () => {
     fireEvent.click(option);
     fireEvent.click(option2);
 
-    expect(option).toHaveClass("selectedOption");
-    expect(option2).toHaveClass("selectedOption");
+    expect(option).toHaveAttribute("aria-selected", "true");
+    expect(option2).toHaveAttribute("aria-selected", "true");
   });
 
   it("should call the onSelect callback upon making selection(s)", () => {
@@ -372,7 +378,7 @@ describe("Combobox multiselect", () => {
 });
 
 function MockMultiSelectOnCloseCombobox(props: {
-  onCloseOverride?: () => void;
+  readonly onCloseOverride?: () => void;
 }): JSX.Element {
   const [selected, setSelected] = React.useState<ComboboxOption[]>([]);
   const callback = props.onCloseOverride || setSelected;
@@ -399,7 +405,7 @@ function MockMultiSelectOnCloseCombobox(props: {
 }
 
 function MockMultiSelectOnSelectCombobox(props: {
-  onSelectOverride?: () => void;
+  readonly onSelectOverride?: () => void;
 }): JSX.Element {
   const [selected, setSelected] = React.useState<ComboboxOption[]>([]);
   const callback = props.onSelectOverride || setSelected;

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxList.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxList.css
@@ -29,7 +29,6 @@
   align-items: center;
 }
 
-.selectedOption,
 .option:hover,
 .option:focus {
   background-color: var(--color-surface--background);

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxList.css.d.ts
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxList.css.d.ts
@@ -2,7 +2,6 @@ declare const styles: {
   readonly "container": string;
   readonly "optionsList": string;
   readonly "option": string;
-  readonly "selectedOption": string;
   readonly "filterMessage": string;
   readonly "emptyStateMessage": string;
 };

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxList.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxList.test.tsx
@@ -121,9 +121,9 @@ describe("ComboboxList", () => {
         searchValue=""
       />,
     );
-    expect(getByText("Michael")).toHaveClass("selectedOption");
-    expect(getByText("Leatherface")).toHaveClass("selectedOption");
-    expect(getByText("Jason")).not.toHaveClass("selectedOption");
+    expect(getByText("Michael")).toHaveAttribute("aria-selected", "true");
+    expect(getByText("Leatherface")).toHaveAttribute("aria-selected", "true");
+    expect(getByText("Jason")).not.toHaveAttribute("aria-selected", "true");
   });
 
   it("should have a selected option when selected id is a number and option id is a string", () => {
@@ -142,8 +142,8 @@ describe("ComboboxList", () => {
         searchValue=""
       />,
     );
-    expect(getByText("Michael")).toHaveClass("selectedOption");
-    expect(getByText("Jason")).not.toHaveClass("selectedOption");
+    expect(getByText("Michael")).toHaveAttribute("aria-selected", "true");
+    expect(getByText("Jason")).not.toHaveAttribute("aria-selected", "true");
   });
 
   it("has no selected option when a null selected value is passed", () => {
@@ -162,7 +162,7 @@ describe("ComboboxList", () => {
         searchValue=""
       />,
     );
-    expect(getByText("Michael")).not.toHaveClass("selectedOption");
-    expect(getByText("Jason")).not.toHaveClass("selectedOption");
+    expect(getByText("Michael")).not.toHaveAttribute("aria-selected", "true");
+    expect(getByText("Jason")).not.toHaveAttribute("aria-selected", "true");
   });
 });

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxList.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxList.tsx
@@ -6,15 +6,17 @@ import styles from "./ComboboxList.css";
 import { ComboboxOption } from "../../Combobox.types";
 
 interface ComboboxListProps {
-  options: ComboboxOption[];
-  showEmptyState: boolean;
-  selected: ComboboxOption[];
-  optionsListRef: React.RefObject<HTMLUListElement>;
-  setFirstSelectedElement: React.Dispatch<SetStateAction<HTMLElement | null>>;
-  selectionHandler: (option: ComboboxOption) => void;
-  searchValue: string;
-  multiselect: boolean;
-  subjectNoun?: string;
+  readonly options: ComboboxOption[];
+  readonly showEmptyState: boolean;
+  readonly selected: ComboboxOption[];
+  readonly optionsListRef: React.RefObject<HTMLUListElement>;
+  readonly setFirstSelectedElement: React.Dispatch<
+    SetStateAction<HTMLElement | null>
+  >;
+  readonly selectionHandler: (option: ComboboxOption) => void;
+  readonly searchValue: string;
+  readonly multiselect: boolean;
+  readonly subjectNoun?: string;
 }
 
 export function ComboboxList(props: ComboboxListProps): JSX.Element {
@@ -48,9 +50,7 @@ export function ComboboxList(props: ComboboxListProps): JSX.Element {
                   role="option"
                   aria-selected={isSelected}
                   onClick={() => props.selectionHandler(option)}
-                  className={classnames(styles.option, {
-                    [styles.selectedOption]: isSelected,
-                  })}
+                  className={classnames(styles.option)}
                 >
                   {option.label}
                   {isSelected && <Icon name="checkmark" color="blue" />}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

While playing around with Combobox in the muliselect case, it felt a bit weird to have multiple selections, click one to unselect it and it would still have the same grey background. Sure the checkmark was gone, but overall it still felt like it was selected-ish because selected, focus, and hover all applied that background.
<img width="354" alt="Components___Selections___Combobox___Web_-_Multi_Select_⋅_Storybook_🔊" src="https://github.com/GetJobber/atlantis/assets/11843215/2b54b66a-e898-4ad8-bcc6-e31c2c3fb2c0">


Thought I'd check out Polaris' implementation. Over there, they only apply the grey background on hover and focus which I like.

Ran this idea by Chris M, and he agreed it looked good.

This approach is great because it's so simple. No complicated logic where we only apply the selected class if it wasn't already selected or anything like that.
## Changes

### Changed

No more extra selected style!

Also, since that style is gone I've had to update the tests that were looking for the style. Instead, we're looking for the `aria-selected` which is a very easy change that I think is pretty stable. I don't see us removing that anytime soon.

## Testing

Tests should still be passing for a green CI.

Aside from that, the only change should be that now the selected state is only represented by the checkmark. That's not to say you cannot have the grey background and the checkmark, since you can still focus or hover a selected item - but there will only be one now. It won't be a bunch of grey items.


![Kapture 2023-10-11 at 15 08 46](https://github.com/GetJobber/atlantis/assets/11843215/c23091d8-d13f-4ab7-9fb3-a6f5fdfe7e52)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
