### PR TITLE
chore: reduce the amount of mocking a consumer would have to do when using DataList

### DIFF
--- a/packages/components/src/DataList/hooks/useMediaQuery.ts
+++ b/packages/components/src/DataList/hooks/useMediaQuery.ts
@@ -1,6 +1,19 @@
 import { useEffect, useState } from "react";
 
 export function useMediaQuery(CSSMediaQuery: string) {
+  /**
+   * matchMedia have had full support for browsers since 2012 but jest, being a
+   * lite version of a DOM, doesn't support it.
+   *
+   * Instead of the consumers mocking matchMedia on every usage of DataList,
+   * we can just return true to mimic the largest screen we support.
+   *
+   * In the event that the consumer wants to test the DataList on different
+   * screen sizes, they can use the `mockViewportWidth` function from
+   * `@jobber/components/useBreakpoints`.
+   */
+  if (window.matchMedia === undefined) return true;
+
   const [matches, setMatches] = useState(
     window.matchMedia(CSSMediaQuery).matches,
   );


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When using DataList in a jest test environment, the test would immediately fail because `matchMedia` doesn't exist there. In turn, the consumers would have to mock `matchMedia` on their tests for not a lot of gain since breakpoint changes are already tested by DataList itself.

If the consumer does need to test a specific viewport–such as testing layouts of different screens–the can use the `mockViewportWidth` function from `@jobber/components/useBreakpoints`. Arguably, the layouts should be componentized and tested on their own, but if this happens, the consumer has a way.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- guard matchMedia on one of DataList's internal hook

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- use DataList in your project and run any test that uses DataList
- It will throw an error regarding `matchMedia` not existing
- This PR should let it pass

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)

JOB-80875