### PR TITLE
fix(components): Avoid rendering DataListItemActions when there's no children

### DIFF
--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "@jobber/components/DataList/context/DataListLayoutContext";
 import { DataListLayoutActionsContext } from "@jobber/components/DataList/components/DataListLayoutActions/DataListLayoutContext";
 import { DataListItemActions, InternalDataListItemActions } from ".";
+import { CONTAINER_TEST_ID } from "../DataListOverflowFade";
 
 const handleEditClick = jest.fn();
 const mockSetHasInLayoutActions = jest.fn().mockReturnValue(true);
@@ -66,6 +67,16 @@ describe("DataListItemActions", () => {
     userEvent.click(screen.getByLabelText("Edit"));
     expect(handleEditClick).toHaveBeenCalledTimes(1);
     expect(handleEditClick).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("should not render the DataListItemActions overlay if there's no children", () => {
+    mockItemActionComponent.mockReturnValueOnce(
+      <DataListItemActions url={"getjobber.com"} />,
+    );
+
+    renderComponent();
+
+    expect(screen.queryByTestId(CONTAINER_TEST_ID)).not.toBeInTheDocument();
   });
 });
 

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
@@ -28,6 +28,8 @@ export function InternalDataListItemActions() {
 
   const { children } = itemActionComponent.props;
 
+  if (!children) return null;
+
   return (
     <motion.div
       variants={variants}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In a case where we want only to use `<DataList.ItemActions onClick={handleActionClick} />`, DataList was still rendering the overlay with the menu of `DataListItemActions`. This PR fixes it.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Avoid rendering `DataListItemActions` when there's no children

### Security

- <!-- in case of vulnerabilities -->

## Testing

#### Before
<img width="934" alt="Screenshot 2023-10-13 at 17 21 20" src="https://github.com/GetJobber/atlantis/assets/12849476/df67c7f8-5d0e-49fa-898b-b7fff3b344ce">

#### After
<img width="920" alt="image" src="https://github.com/GetJobber/atlantis/assets/12849476/2e001bb3-6735-47c6-8066-641269a1948e">


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
