### PR TITLE
docs(components): update usage examples in InlineLabel docs

### DIFF
--- a/docs/components/InlineLabel/InlineLabel.stories.mdx
+++ b/docs/components/InlineLabel/InlineLabel.stories.mdx
@@ -15,15 +15,16 @@ Inline labels can be used fairly broadly, but the application of
 of colour along with a descriptive label can help the user understand the
 meaning of an item's status.
 
-| Color                                                 | Meaning                         |
-| :---------------------------------------------------- | :------------------------------ |
-| <InlineLabel color="red">Past Due</InlineLabel>       | Time-sensitive urgent           |
-| <InlineLabel color="orange">Unscheduled</InlineLabel> | Urgent                          |
-| <InlineLabel color="green">Approved</InlineLabel>     | Ready to action on              |
-| <InlineLabel color="teal">Converted</InlineLabel>     | Successful, no action required  |
-| <InlineLabel color="grey">Draft</InlineLabel>         | Object is in a draft state      |
-| <InlineLabel color="blue">Archived</InlineLabel>      | Object has been archived        |
-| <InlineLabel color="lightBlue">Sample</InlineLabel>   | Object is for learning purposes |
+For simpler mapping of statuses to their semantic colours, use
+[StatusLabel.](../?path=/docs/components-status-and-feedback-statuslabel-docs--page)
+
+| Color                                                                                                             | Meaning     |
+| :---------------------------------------------------------------------------------------------------------------- | :---------- |
+| <InlineLabel color="red">Past due</InlineLabel> <InlineLabel color="red">Changes requested</InlineLabel>          | Critical    |
+| <InlineLabel color="yellow">Unscheduled</InlineLabel> <InlineLabel color="yellow">Awaiting response</InlineLabel> | Warning     |
+| <InlineLabel color="green">Approved</InlineLabel> <InlineLabel color="green">Paid</InlineLabel>                   | Success     |
+| <InlineLabel color="greyBlue">Draft</InlineLabel> <InlineLabel color="greyBlue">Archived</InlineLabel>            | Inactive    |
+| <InlineLabel color="lightBlue">Sent</InlineLabel> <InlineLabel color="lightBlue">Converted</InlineLabel>          | Informative |
 
 ---
 

--- a/docs/components/InlineLabel/InlineLabel.stories.mdx
+++ b/docs/components/InlineLabel/InlineLabel.stories.mdx
@@ -15,9 +15,6 @@ Inline labels can be used fairly broadly, but the application of
 of colour along with a descriptive label can help the user understand the
 meaning of an item's status.
 
-For simpler mapping of statuses to their semantic colours, use
-[StatusLabel.](../?path=/docs/components-status-and-feedback-statuslabel-docs--page)
-
 | Color                                                                                                             | Meaning     |
 | :---------------------------------------------------------------------------------------------------------------- | :---------- |
 | <InlineLabel color="red">Past due</InlineLabel> <InlineLabel color="red">Changes requested</InlineLabel>          | Critical    |
@@ -26,7 +23,10 @@ For simpler mapping of statuses to their semantic colours, use
 | <InlineLabel color="greyBlue">Draft</InlineLabel> <InlineLabel color="greyBlue">Archived</InlineLabel>            | Inactive    |
 | <InlineLabel color="lightBlue">Sent</InlineLabel> <InlineLabel color="lightBlue">Converted</InlineLabel>          | Informative |
 
----
+### Related components
+
+For simpler mapping of statuses to their semantic colours, use
+[StatusLabel.](../?path=/docs/components-status-and-feedback-statuslabel-docs--page)
 
 ## Sizes
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The "Draft" example of the InlineLabel is broken , referencing a color variation (grey) that doesn't exist, so it's just a white rectangle. (This lead to confusion for a designer)

**Before:**
![image](https://github.com/GetJobber/atlantis/assets/39704901/03c30333-83b1-45e5-9919-918436bff423)

**After:**
![image](https://github.com/GetJobber/atlantis/assets/39704901/746ffd23-faa4-4dff-af5b-51fee9ab1a0c)

While fixing that, updated the examples to be more in line with our semantic color standards and added
a reference to StatusLabel, which is better equipped to represent status.

## Changes

### Changed

- usage examples to reflect actual usage

### Fixed

- broken example ("draft")

## Testing

View InlineLabel docs

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
