### PR TITLE
docs(hooks): Example for using breakpoints in tests

### DIFF
--- a/packages/hooks/src/useBreakpoints/useBreakpoints.stories.mdx
+++ b/packages/hooks/src/useBreakpoints/useBreakpoints.stories.mdx
@@ -47,7 +47,10 @@ You can use the `mockViewportWidth` function to mock the window size and trigger
 specific breakpoints.
 
 ```tsx
-import { mockViewportWidth } from "@jobber/hooks/useBreakpoints";
+import {
+  BREAKPOINT_SIZES,
+  mockViewportWidth,
+} from "@jobber/hooks/useBreakpoints";
 
 const { cleanup, setViewportWidth } = mockViewportWidth();
 
@@ -61,5 +64,13 @@ it("should render my element when the viewport size is 500px", () => {
 
   render(<MyComponent />);
   expect(screen.getByText("500px")).toBeInTheDocument();
+});
+
+it("should render my element when the viewport size is large", () => {
+  // Set the viewport width before the component renders
+  setViewportWidth(BREAKPOINT_SIZES.lg);
+
+  render(<MyComponent />);
+  expect(screen.getByText("Large")).toBeInTheDocument();
 });
 ```


### PR DESCRIPTION
## Motivations

While implementing, I learnt about the option to use existing Breakpoint Sizes in my test which was not specified in Atlantic Docs. To make it easier for the next person, I've updated the docs to include it.

## Changes

Added an example for the use of `BREAKPOINT_SIZES` in tests documentation

### Added

n/a

### Changed

- Updated the documentation for `useBreakpoints` to added a test using existing sizes.

### Deprecated

n/a

### Removed

n/a

### Fixed

n/a

### Security

n/a

## Testing

- Run Atlantis locally and visit documentation for `useBreakpoints`

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
