### PR TITLE
feat(components-native): add testID property to Button and default testID values to ButtonGroup

### DIFF
--- a/packages/components-native/src/Button/Button.tsx
+++ b/packages/components-native/src/Button/Button.tsx
@@ -126,7 +126,7 @@ export function Button({
   return (
     <TouchableHighlight
       onPress={onPress}
-      testID={testID || accessibilityLabel || label}
+      testID={buildTestID(testID, label, accessibilityLabel)}
       accessibilityLabel={accessibilityLabel || label}
       accessibilityHint={accessibilityHint}
       accessibilityRole="button"
@@ -226,4 +226,16 @@ function getContentStyles(
     icon && !!label && styles.iconPaddingOffset,
     !!label && styles.contentWithLabel,
   ];
+}
+
+function buildTestID(
+  testID: string | undefined,
+  label: string | undefined,
+  accessibilityLabel: string | undefined,
+): string | undefined {
+  if (testID) {
+    return `ATL-${testID}-Button`;
+  }
+
+  return accessibilityLabel || label;
 }

--- a/packages/components-native/src/Button/Button.tsx
+++ b/packages/components-native/src/Button/Button.tsx
@@ -72,6 +72,11 @@ interface CommonButtonProps {
    * `accessibilityLabel`. **Don't use this for testing purposes.**
    */
   readonly accessibilityLabel?: string;
+
+  /**
+   * Used to locate this view in end-to-end tests.
+   */
+  readonly testID?: string;
 }
 
 interface LabelButton extends CommonButtonProps {
@@ -87,6 +92,7 @@ interface IconButton extends CommonButtonProps {
 }
 
 export type ButtonProps = XOR<LabelButton, IconButton>;
+
 export function Button({
   label,
   onPress,
@@ -100,6 +106,7 @@ export function Button({
   accessibilityLabel,
   accessibilityHint,
   icon,
+  testID,
 }: ButtonProps): JSX.Element {
   const buttonStyle = [
     styles.button,
@@ -119,7 +126,7 @@ export function Button({
   return (
     <TouchableHighlight
       onPress={onPress}
-      testID={accessibilityLabel || label}
+      testID={testID || accessibilityLabel || label}
       accessibilityLabel={accessibilityLabel || label}
       accessibilityHint={accessibilityHint}
       accessibilityRole="button"

--- a/packages/components-native/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components-native/src/ButtonGroup/ButtonGroup.tsx
@@ -50,6 +50,7 @@ export function ButtonGroup({
   const { handlePress } = usePreventTapWhenOffline();
   const secondaryActionsRef = useRef<BottomSheetRef>();
   const { primaryActions, secondaryActions } = getActions(children);
+
   return (
     <View style={styles.buttonGroup}>
       {primaryActions.map((action, index) => {
@@ -75,6 +76,7 @@ export function ButtonGroup({
                 fullHeight={true}
                 icon={icon}
                 loading={loading}
+                testID={`primary-action-${index}`}
               />
             )}
           </View>
@@ -88,6 +90,7 @@ export function ButtonGroup({
             accessibilityLabel={t("more")}
             onPress={handlePress(openBottomSheet)}
             fullHeight={true}
+            testID="secondary-action"
           />
         </View>
       )}

--- a/packages/components-native/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components-native/src/ButtonGroup/ButtonGroup.tsx
@@ -76,7 +76,7 @@ export function ButtonGroup({
                 fullHeight={true}
                 icon={icon}
                 loading={loading}
-                testID={`primary-action-${index}`}
+                testID={`ATL-ButtonGroup-Primary-Action-${index}`}
               />
             )}
           </View>
@@ -90,7 +90,7 @@ export function ButtonGroup({
             accessibilityLabel={t("more")}
             onPress={handlePress(openBottomSheet)}
             fullHeight={true}
-            testID="secondary-action"
+            testID="ATL-ButtonGroup-Secondary-Action"
           />
         </View>
       )}

--- a/packages/components-native/src/Form/components/FormSaveButton/FormSaveButton.tsx
+++ b/packages/components-native/src/Form/components/FormSaveButton/FormSaveButton.tsx
@@ -21,36 +21,34 @@ export function FormSaveButton({
   const buttonActions = useButtonGroupAction(secondaryActions);
 
   return (
-    <>
-      <ButtonGroup
-        onOpenBottomSheet={onOpenBottomSheet}
-        onCloseBottomSheet={onCloseBottomSheet}
-        allowTapWhenOffline={true}
-      >
-        {buttonActions.map((action, index) => {
-          if (index === 0) {
-            return (
-              <ButtonGroup.PrimaryAction
-                key={index}
-                onPress={primaryAction}
-                label={label ?? t("save")}
-                loading={loading}
-              />
-            );
-          } else {
-            return (
-              <ButtonGroup.SecondaryAction
-                key={index}
-                label={action.label}
-                icon={action.icon}
-                onPress={action.onPress}
-                destructive={action.destructive}
-              />
-            );
-          }
-        })}
-      </ButtonGroup>
-    </>
+    <ButtonGroup
+      onOpenBottomSheet={onOpenBottomSheet}
+      onCloseBottomSheet={onCloseBottomSheet}
+      allowTapWhenOffline={true}
+    >
+      {buttonActions.map((action, index) => {
+        if (index === 0) {
+          return (
+            <ButtonGroup.PrimaryAction
+              key={index}
+              onPress={primaryAction}
+              label={label ?? t("save")}
+              loading={loading}
+            />
+          );
+        } else {
+          return (
+            <ButtonGroup.SecondaryAction
+              key={index}
+              label={action.label}
+              icon={action.icon}
+              onPress={action.onPress}
+              destructive={action.destructive}
+            />
+          );
+        }
+      })}
+    </ButtonGroup>
   );
 
   function useButtonGroupAction(
@@ -81,6 +79,7 @@ export function FormSaveButton({
     handleAction: SecondaryActionProp["handleAction"],
   ) {
     let performSubmit = true;
+
     if (handleAction.onBeforeSubmit) {
       performSubmit = await handleAction.onBeforeSubmit();
     }


### PR DESCRIPTION
## Motivations

<!-- Why did you do what you did? -->

As part of the e2e work, we need to modify the Button component to allow passing a testID so the contractors can select elements with language-agnostic unique identifiers. The way it works today, it's using the a11yLabel or label as id for testID and that doesn't work for us because when the app is running the Spanish version the e2e tests written will fail. 

I kept the previous implementation with the addition that now the testID prop will take precedence over the other two fallbacks. I also ended up modifying the ButtonGroup to achieve the same goal with the Form component. I know that we can have multiple ButtonGroup components in the same screen that could have the same testID with the current implementation, but it shouldn’t be a problem because they can always rely on xPath in these scenarios. I'm open to your suggestions too!

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Optional testID prop to the Button component
- Default testID values to the Buttons inside the ButtonGroup component

## Testing

You should be able to check these new testIDs by using Appium Inspector. I have the following video showing how it works. If you want to test by yourself, please get in touch so that I can help with the configuration.

https://github.com/GetJobber/atlantis/assets/98422073/71583587-a369-4658-9783-934430127861

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
