### PR TITLE
feat(hooks): Hook for managing boolean values

### DIFF
--- a/packages/hooks/README.mdx
+++ b/packages/hooks/README.mdx
@@ -5,6 +5,7 @@ Shared hooks for components in Atlantis.
 ## Hooks
 
 - [useAssert](../?path=/docs/hooks-useassert--page)
+- [useBool](../?path=/docs/hooks-usebool--page)
 - [useCollectionQuery](../?path=/docs/hooks-usecollectionquery--use-collection-query)
 - [useFormState](../?path=/docs/hooks-useformstate--use-form-state)
 - [useIsMounted](../?path=/docs/hooks-useismounted--use-is-mounted)

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./useAssert";
+export * from "./useBool";
 export * from "./useBreakpoints";
 export * from "./useCollectionQuery";
 export * from "./useFocusTrap";

--- a/packages/hooks/src/useBool/index.ts
+++ b/packages/hooks/src/useBool/index.ts
@@ -1,0 +1,1 @@
+export { useBool } from "./useBool";

--- a/packages/hooks/src/useBool/useBool.stories.mdx
+++ b/packages/hooks/src/useBool/useBool.stories.mdx
@@ -1,0 +1,32 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+// import { Checkbox } from "@jobber/components/Checkbox";
+// import { Content } from "@jobber/components/Content";
+// import { Button } from "@jobber/components/Button";
+import { useBool } from "./useBool";
+
+<Meta title="Hooks/useBool" />
+
+# UseBool
+
+`useBool` is a simple wrapper around `useState` for managing boolean values. It
+provides a simple API for toggling the value, setting it to true, and setting it
+to false.
+
+```tsx
+import { useBool } from "@jobber/hooks/useBool";
+```
+
+<Canvas>
+  <Story name="useBool">
+    {() => {
+      const [checked, on, off, toggle] = useBool(false);
+      return (
+        <>
+          <Checkbox checked={checked} onChange={toggle} />
+          <Button onClick={on} label={"On"} />
+          <Button onClick={off} label={"Off"} />
+        </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/hooks/src/useBool/useBool.stories.mdx
+++ b/packages/hooks/src/useBool/useBool.stories.mdx
@@ -1,8 +1,8 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
-// import { Checkbox } from "@jobber/components/Checkbox";
-// import { Content } from "@jobber/components/Content";
-// import { Button } from "@jobber/components/Button";
-import { useBool } from "./useBool";
+import { Checkbox } from "@jobber/components/Checkbox";
+import { Content } from "@jobber/components/Content";
+import { Button } from "@jobber/components/Button";
+import * as hooks from "./useBool";
 
 <Meta title="Hooks/useBool" />
 
@@ -19,13 +19,15 @@ import { useBool } from "@jobber/hooks/useBool";
 <Canvas>
   <Story name="useBool">
     {() => {
-      const [checked, on, off, toggle] = useBool(false);
+      const [checked, on, off, toggle] = hooks.useBool(false);
       return (
-        <>
+        <Content>
           <Checkbox checked={checked} onChange={toggle} />
-          <Button onClick={on} label={"On"} />
-          <Button onClick={off} label={"Off"} />
-        </>
+          <br />
+          <Button onClick={on} label={"On"} variation="subtle" />
+          <br />
+          <Button onClick={off} label={"Off"} variabtion="destructive" />
+        </Content>
       );
     }}
   </Story>

--- a/packages/hooks/src/useBool/useBool.test.ts
+++ b/packages/hooks/src/useBool/useBool.test.ts
@@ -1,0 +1,32 @@
+import { act, renderHook } from "@testing-library/react";
+import { useBool } from "./useBool";
+
+describe("useBool, a hook for managing boolean state", () => {
+  it("by default has an initial state that is `false`", () => {
+    const [value] = renderHook(() => useBool()).result.current;
+
+    expect(value).toBe(false);
+  });
+
+  it("can be provided an initial state", () => {
+    const [value] = renderHook(() => useBool(true)).result.current;
+
+    expect(value).toBe(true);
+  });
+
+  it("provides helpful setters and a toggle method", () => {
+    const { result } = renderHook(() => useBool());
+    const value = () => result.current[0];
+    const [, setTrue, setFalse, toggle] = result.current;
+
+    expect(value()).toBe(false);
+    act(setTrue);
+    expect(value()).toBe(true);
+    act(setFalse);
+    expect(value()).toBe(false);
+    act(toggle);
+    expect(value()).toBe(true);
+    act(toggle);
+    expect(value()).toBe(false);
+  });
+});

--- a/packages/hooks/src/useBool/useBool.ts
+++ b/packages/hooks/src/useBool/useBool.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+
+declare const brand: unique symbol;
+
+type Callback = () => void;
+
+export type SetTrue = Callback & {
+  [brand]: "SetTrue";
+};
+
+export type SetFalse = Callback & {
+  [brand]: "SetFalse";
+};
+
+export type Toggle = Callback & {
+  [brand]: "Toggle";
+};
+
+export function useBool(
+  initialState = false,
+): [boolean, SetTrue, SetFalse, Toggle] {
+  const [state, setState] = useState(initialState);
+  const setTrue = useCallback(() => setState(true), []);
+  const setFalse = useCallback(() => setState(false), []);
+  const toggle = useCallback(() => setState(current => !current), []);
+
+  return [state, setTrue as SetTrue, setFalse as SetFalse, toggle as Toggle];
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Working on a different component (InputDate, DatePicker, and CalendarDatePicker) and using this hook in more than one place to track whether an element has focus or is selected.

### Added

#### useBool hook
`useBool` is a simple wrapper around `useState` for managing boolean values. It
provides a simple API for toggling the value, setting it to true, and setting it
to false.

#### Example

```tsx
const [checked, on, off, toggle] = useBool(false);
return (
  <>
    <Checkbox checked={checked} onChange={toggle} />
    <Button onClick={on} label={"On"} />
    <Button onClick={off} label={"Off"} />
  </>
);
```

#### Types
Used branded typing so that hovering over the returned setters doesn show `() => void` but a helpful label:

<img width="458" alt="image" src="https://github.com/GetJobber/atlantis/assets/14314519/1c750b05-3f61-45e4-b65f-ce9d6d0e7c74">

