### PR TITLE
test(components): Upgrade @testing-library/user-events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@testing-library/jest-native": "^5.4.2",
         "@testing-library/react": "^14.0.0",
         "@testing-library/react-native": "^12.0.1",
-        "@testing-library/user-event": "^12.0.2",
+        "@testing-library/user-event": "^14.5.1",
         "@types/history": "^4.7.6",
         "@types/jest": "^29.5.0",
         "@types/lodash": "^4.14.149",
@@ -12946,15 +12946,12 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.6.2.tgz",
-      "integrity": "sha512-4OsiTSo2vbQm+eOnm1un8b9i2Re4mn+D7d7ET6HXtzYKY7vPe3O01iYKRmSW9vS5mNrQcCLwvRhVq1gWs5YGKA==",
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
@@ -46109,7 +46106,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/react-hooks": "^7.0.2",
-        "@testing-library/user-event": "^12.0.2",
+        "@testing-library/user-event": "^14.5.1",
         "@types/glob": "^7.1.1",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
@@ -48432,7 +48429,7 @@
         "@jobber/formatters": "*",
         "@testing-library/react": "^14.0.0",
         "@testing-library/react-hooks": "^7.0.0",
-        "@testing-library/user-event": "^12.0.2",
+        "@testing-library/user-event": "^14.5.1",
         "@types/lodash": "4.14.136",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@testing-library/jest-native": "^5.4.2",
     "@testing-library/react": "^14.0.0",
     "@testing-library/react-native": "^12.0.1",
-    "@testing-library/user-event": "^12.0.2",
+    "@testing-library/user-event": "^14.5.1",
     "@types/history": "^4.7.6",
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.149",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/react-hooks": "^7.0.2",
-    "@testing-library/user-event": "^12.0.2",
+    "@testing-library/user-event": "^14.5.1",
     "@types/glob": "^7.1.1",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",

--- a/packages/components/src/Chips/tests/ChipDismissible.test.tsx
+++ b/packages/components/src/Chips/tests/ChipDismissible.test.tsx
@@ -11,7 +11,7 @@ it("should have a remove action", () => {
 });
 
 describe("on remove click", () => {
-  it("should not fire the onclick prop", () => {
+  it("should not fire the onclick prop", async () => {
     const handleRemove = jest.fn();
     const handleClick = jest.fn();
     render(
@@ -22,7 +22,7 @@ describe("on remove click", () => {
       />,
     );
 
-    userEvent.click(screen.getByTestId("remove-chip-button"));
+    await userEvent.click(screen.getByTestId("remove-chip-button"));
     expect(handleClick).toHaveBeenCalledTimes(0);
     expect(handleRemove).toHaveBeenCalledTimes(1);
   });

--- a/packages/components/src/Chips/tests/InternalChip.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChip.test.tsx
@@ -16,10 +16,10 @@ it("should render a button chip when onClick is not present", () => {
   expect(screen.getByTestId("chip-wrapper")).toBeInstanceOf(HTMLButtonElement);
 });
 
-it("should fire the callback when it's clicked", () => {
+it("should fire the callback when it's clicked", async () => {
   const handleClick = jest.fn();
   render(<InternalChip label="Yo!" onClick={handleClick} />);
-  userEvent.click(screen.getByTestId("chip-wrapper"));
+  await userEvent.click(screen.getByTestId("chip-wrapper"));
   expect(handleClick).toHaveBeenCalledTimes(1);
 });
 
@@ -74,6 +74,7 @@ describe("Chip icon colors depending on state", () => {
         label="Yo!"
       />,
     );
+
     return screen.getByTestId("checkbox").querySelector("path");
   }
 });

--- a/packages/components/src/Chips/tests/InternalChipButton.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipButton.test.tsx
@@ -17,8 +17,8 @@ describe("Interaction", () => {
 
   afterEach(cleanup);
 
-  it("should call the onClick action", () => {
-    userEvent.click(target);
+  it("should call the onClick action", async () => {
+    await userEvent.click(target);
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/components/src/Chips/tests/InternalChipMultiSelect.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipMultiSelect.test.tsx
@@ -43,24 +43,24 @@ it("should show a checkmark on the selected chip", () => {
 });
 
 describe("onChange", () => {
-  it("should trigger the onChange selecting a chip", () => {
+  it("should trigger the onChange selecting a chip", async () => {
     const target = chips[1];
-    userEvent.click(screen.getByLabelText(target));
+    await userEvent.click(screen.getByLabelText(target));
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange).toHaveReturnedWith([...selectedChips, target]);
   });
 
-  it("should trigger the onChange deselecting a chip", () => {
-    userEvent.click(screen.getByLabelText(selectedChips[0]));
+  it("should trigger the onChange deselecting a chip", async () => {
+    await userEvent.click(screen.getByLabelText(selectedChips[0]));
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange).toHaveReturnedWith([]);
   });
 });
 
 describe("onClick", () => {
-  it("should trigger the chip onClick", () => {
+  it("should trigger the chip onClick", async () => {
     const target = chips[2];
-    userEvent.click(screen.getByLabelText(target));
+    await userEvent.click(screen.getByLabelText(target));
     expect(handleClickChip).toHaveBeenCalledTimes(1);
     expect(handleClickChip).toHaveReturnedWith(target);
   });

--- a/packages/components/src/Chips/tests/InternalChipSingleSelect.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipSingleSelect.test.tsx
@@ -44,24 +44,24 @@ it("should have a label and a checkbox", () => {
 });
 
 describe("onChange", () => {
-  it("should trigger the onChange selecting a chip", () => {
+  it("should trigger the onChange selecting a chip", async () => {
     const target = chips[1];
-    userEvent.click(screen.getByLabelText(target));
+    await userEvent.click(screen.getByLabelText(target));
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange).toHaveReturnedWith(target);
   });
 
-  it("should trigger the onChange deselecting a chip", () => {
-    userEvent.click(screen.getByLabelText(selectedChip));
+  it("should trigger the onChange deselecting a chip", async () => {
+    await userEvent.click(screen.getByLabelText(selectedChip));
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange).toHaveReturnedWith(undefined);
   });
 });
 
 describe("onClick", () => {
-  it("should trigger the chip onClick", () => {
+  it("should trigger the chip onClick", async () => {
     const target = chips[2];
-    userEvent.click(screen.getByLabelText(target));
+    await userEvent.click(screen.getByLabelText(target));
     expect(handleClickChip).toHaveBeenCalledTimes(1);
     expect(handleClickChip).toHaveReturnedWith(target);
   });

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -70,7 +70,7 @@ describe("ComboboxContent Search", () => {
     expect(getByText("Frodo Baggins")).toBeInTheDocument();
   });
 
-  it("should clear search when activating the clear button with enter key", () => {
+  it("should clear search when activating the clear button with enter key", async () => {
     const { getByTestId, getByPlaceholderText, getByText } = render(
       <MockComboboxProvider>
         <Combobox.Content
@@ -89,7 +89,7 @@ describe("ComboboxContent Search", () => {
 
     const clearButton = getByTestId("ATL-Combobox-Content-Search-Clear");
 
-    userEvent.type(clearButton, "{enter}");
+    await userEvent.type(clearButton, "{enter}");
 
     expect(searchInput).toHaveValue("");
     expect(getByText("Bilbo Baggins")).toBeInTheDocument();
@@ -300,7 +300,7 @@ describe("ComboboxContent Options", () => {
 
     const content = getByTestId("ATL-Combobox-Content");
 
-    userEvent.type(content, "{arrowdown}");
+    await userEvent.type(content, "{arrowdown}");
 
     await waitFor(() => {
       expect(getByText("Leatherface")).toHaveFocus();
@@ -328,9 +328,9 @@ describe("ComboboxContent Options", () => {
 
     const content = getByTestId("ATL-Combobox-Content");
 
-    userEvent.type(content, "{arrowdown}");
-    userEvent.type(content, "{arrowdown}");
-    userEvent.type(content, "{arrowdown}");
+    await userEvent.type(content, "{arrowdown}");
+    await userEvent.type(content, "{arrowdown}");
+    await userEvent.type(content, "{arrowdown}");
 
     await waitFor(() => {
       expect(getByText("Michael")).toHaveFocus();
@@ -358,13 +358,13 @@ describe("ComboboxContent Options", () => {
 
     const content = getByTestId("ATL-Combobox-Content");
 
-    userEvent.type(content, "{arrowup}");
+    await userEvent.type(content, "{arrowup}");
 
     await waitFor(() => {
       expect(getByText("Leatherface")).toHaveFocus();
     });
   });
-  it("should select option with enter key press", () => {
+  it("should select option with enter key press", async () => {
     const selectHandler = jest.fn();
     const { getByText } = render(
       <Combobox>
@@ -387,12 +387,12 @@ describe("ComboboxContent Options", () => {
 
     const firstOption = getByText("Leatherface");
 
-    userEvent.type(firstOption, "{enter}");
+    await userEvent.type(firstOption, "{enter}");
     expect(selectHandler).toHaveBeenCalledWith([
       { id: 1, label: "Leatherface" },
     ]);
   });
-  it("should close after making a selection with the enter key", () => {
+  it("should close after making a selection with the enter key", async () => {
     const { getByText, getByTestId } = render(
       <Combobox>
         <Combobox.TriggerButton label="Click Me" />
@@ -414,7 +414,7 @@ describe("ComboboxContent Options", () => {
 
     const firstOption = getByText("Leatherface");
 
-    userEvent.type(firstOption, "{enter}");
+    await userEvent.type(firstOption, "{enter}");
     expect(getByTestId("ATL-Combobox-Content")).toHaveClass("hidden");
   });
   describe("with a search entered", () => {
@@ -442,7 +442,7 @@ describe("ComboboxContent Options", () => {
 
       fireEvent.change(searchInput, { target: { value: "Mi" } });
 
-      userEvent.type(content, "{arrowdown}");
+      await userEvent.type(content, "{arrowdown}");
 
       await waitFor(() => {
         expect(getByText("Michael")).toHaveFocus();

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -212,6 +212,7 @@ describe("DataList", () => {
             },
           )?.[0];
           const expectedValue = expectedValues[queryBreakpoint as Breakpoints];
+
           return {
             matches: expectedValue,
             media: query,
@@ -394,7 +395,7 @@ describe("DataList", () => {
     function MockSortingLayout({
       sorting,
     }: {
-      sorting: DataListProps<(typeof mockData)[0]>["sorting"];
+      readonly sorting: DataListProps<(typeof mockData)[0]>["sorting"];
     }) {
       return (
         <DataList data={mockData} headers={mockHeaders} sorting={sorting}>
@@ -562,7 +563,7 @@ describe("DataList", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("should call the scrollIntoView on the target element", () => {
+    it("should call the scrollIntoView on the target element", async () => {
       const scrollIntoViewMock = jest.fn();
       window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
       render(
@@ -578,7 +579,9 @@ describe("DataList", () => {
 
       expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
-      userEvent.click(screen.getByRole("button", { name: "Back to top" }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Back to top" }),
+      );
       expect(scrollIntoViewMock).toHaveBeenCalledWith({
         behavior: "smooth",
         block: "nearest",

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.test.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.test.tsx
@@ -41,20 +41,20 @@ describe("DataListAction", () => {
     expect(button.querySelector("p")).toHaveClass("critical");
   });
 
-  it("should not fire the onClick when the item from the context is undefined", () => {
+  it("should not fire the onClick when the item from the context is undefined", async () => {
     const { button } = renderComponent();
 
-    userEvent.click(button);
+    await userEvent.click(button);
     // ensure item doesn't get passed in
     expect(handleClick).toHaveBeenCalledWith();
   });
 
-  it("should fire the onClick when the item from the context is defined", () => {
+  it("should fire the onClick when the item from the context is defined", async () => {
     const mockItem = { id: "1" };
     mockActiveItemValue.mockReturnValue(mockItem);
     const { button } = renderComponent();
 
-    userEvent.click(button);
+    await userEvent.click(button);
     expect(handleClick).toHaveBeenCalledWith(mockItem);
   });
 });

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.test.tsx
@@ -18,7 +18,7 @@ describe("DataListActions", () => {
     expect(screen.getByLabelText("More actions")).toBeInTheDocument();
   });
 
-  it("should render 2 buttons and collapse the last 2 into More Actions", () => {
+  it("should render 2 buttons and collapse the last 2 into More Actions", async () => {
     renderComponent(2);
     expect(screen.getByLabelText("Edit")).toBeInTheDocument();
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
@@ -26,7 +26,7 @@ describe("DataListActions", () => {
     expect(screen.getByLabelText("More actions")).toBeInTheDocument();
 
     const moreMenuButton = screen.getByLabelText("More actions");
-    userEvent.click(moreMenuButton);
+    await userEvent.click(moreMenuButton);
 
     const menu = screen.getByRole("menu");
     expect(menu).toBeInTheDocument();
@@ -35,7 +35,7 @@ describe("DataListActions", () => {
     expect(within(menu).getAllByRole("button")).toHaveLength(2);
   });
 
-  it("should not render the first 2 actions if the first action doesn't have an icon", () => {
+  it("should not render the first 2 actions if the first action doesn't have an icon", async () => {
     render(
       <DataListActions>
         <DataListAction label="Edit" />
@@ -51,7 +51,7 @@ describe("DataListActions", () => {
     expect(screen.getByLabelText("More actions")).toBeInTheDocument();
 
     const moreMenuButton = screen.getByLabelText("More actions");
-    userEvent.click(moreMenuButton);
+    await userEvent.click(moreMenuButton);
 
     const menu = screen.getByRole("menu");
     expect(menu).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe("DataListActions", () => {
     expect(screen.getByLabelText("More actions")).toBeInTheDocument();
   });
 
-  it("should collapse all actions under More actions if the items to expose is 0", () => {
+  it("should collapse all actions under More actions if the items to expose is 0", async () => {
     renderComponent(0);
     expect(screen.queryByLabelText("Edit")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Email")).not.toBeInTheDocument();
@@ -82,7 +82,7 @@ describe("DataListActions", () => {
     expect(screen.queryByLabelText("Delete")).not.toBeInTheDocument();
 
     const moreMenuButton = screen.getByLabelText("More actions");
-    userEvent.click(moreMenuButton);
+    await userEvent.click(moreMenuButton);
 
     const menu = screen.getByRole("menu");
     expect(menu).toBeInTheDocument();

--- a/packages/components/src/DataList/components/DataListBulkActions/DataListBulkActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListBulkActions/DataListBulkActions.test.tsx
@@ -60,14 +60,14 @@ describe("DataListBulkActions", () => {
     expect(screen.getByLabelText("More actions")).toBeInTheDocument();
   });
 
-  it("should call the onClick handler when clicking the edit button", () => {
+  it("should call the onClick handler when clicking the edit button", async () => {
     renderComponent();
-    userEvent.click(screen.getByLabelText("Edit"));
+    await userEvent.click(screen.getByLabelText("Edit"));
     expect(handleEditClick).toHaveBeenCalledTimes(1);
     expect(handleEditClick).toHaveBeenCalledWith();
   });
 
-  it("should collapse all actions under More actions when breakpoint is smaller than sm", () => {
+  it("should collapse all actions under More actions when breakpoint is smaller than sm", async () => {
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: jest.fn().mockImplementation((query: string) => {
@@ -85,6 +85,7 @@ describe("DataListBulkActions", () => {
           lg: false,
           xl: false,
         }[queryBreakpoint as Breakpoints];
+
         return {
           matches: expectedValue,
           media: query,
@@ -105,7 +106,7 @@ describe("DataListBulkActions", () => {
     expect(screen.queryByLabelText("Note")).not.toBeInTheDocument();
     expect(screen.getByLabelText("More actions")).toBeInTheDocument();
     const moreMenuButton = screen.getByLabelText("More actions");
-    userEvent.click(moreMenuButton);
+    await userEvent.click(moreMenuButton);
 
     const menu = screen.getByRole("menu");
     expect(menu).toBeInTheDocument();

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
@@ -53,40 +53,42 @@ describe("DataListSort", () => {
   });
 
   describe("Popover", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(
         <DataListContext.Provider value={mockContextValue}>
           <DataListSort />
         </DataListContext.Provider>,
       );
 
-      userEvent.click(screen.getByRole("button", { name: buttonLabel }));
+      await userEvent.click(screen.getByRole("button", { name: buttonLabel }));
     });
 
     it("should render a popover when the button is clicked", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
-    it("should close the popover when the button is clicked again", () => {
-      userEvent.click(screen.getByRole("button", { name: buttonLabel }));
+    it("should close the popover when the button is clicked again", async () => {
+      await userEvent.click(screen.getByRole("button", { name: buttonLabel }));
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
-    it("should close the popover when the close button is pressed", () => {
-      userEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+    it("should close the popover when the close button is pressed", async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: "Close dialog" }),
+      );
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 
   describe("Sort by chips", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(
         <DataListContext.Provider value={mockContextValue}>
           <DataListSort />
         </DataListContext.Provider>,
       );
 
-      userEvent.click(screen.getByRole("button", { name: buttonLabel }));
+      await userEvent.click(screen.getByRole("button", { name: buttonLabel }));
     });
 
     it.each(sortableKeys)("should render a chip for %s", name => {
@@ -111,18 +113,18 @@ describe("DataListSort", () => {
   });
 
   describe("Sorting key change", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(
         <DataListContext.Provider value={mockContextValue}>
           <DataListSort />
         </DataListContext.Provider>,
       );
 
-      userEvent.click(screen.getByRole("button", { name: buttonLabel }));
+      await userEvent.click(screen.getByRole("button", { name: buttonLabel }));
     });
 
-    it.each(sortableKeys)("should call onSort with %s", name => {
-      userEvent.click(
+    it.each(sortableKeys)("should call onSort with %s", async name => {
+      await userEvent.click(
         screen.getByRole("radio", { name: mockContextValue.headers[name] }),
       );
 
@@ -132,8 +134,8 @@ describe("DataListSort", () => {
       });
     });
 
-    it("should call onSort with undefined when none is clicked", () => {
-      userEvent.click(screen.getByRole("radio", { name: "None" }));
+    it("should call onSort with undefined when none is clicked", async () => {
+      await userEvent.click(screen.getByRole("radio", { name: "None" }));
       expect(handleSort).toHaveBeenCalledWith(undefined);
     });
   });
@@ -144,7 +146,7 @@ describe("DataListSort", () => {
       order: "asc",
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
       render(
         <DataListContext.Provider
           value={{
@@ -159,18 +161,18 @@ describe("DataListSort", () => {
         </DataListContext.Provider>,
       );
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole("button", { name: RegExp(buttonLabel, "i") }),
       );
     });
 
-    it("should call not call onSort when you're selecting the already selected value", () => {
-      userEvent.click(screen.getByRole("radio", { name: "Ascending" }));
+    it("should call not call onSort when you're selecting the already selected value", async () => {
+      await userEvent.click(screen.getByRole("radio", { name: "Ascending" }));
       expect(handleSort).not.toHaveBeenCalled();
     });
 
-    it("should call onSort with the new direction", () => {
-      userEvent.click(screen.getByRole("radio", { name: "Descending" }));
+    it("should call onSort with the new direction", async () => {
+      await userEvent.click(screen.getByRole("radio", { name: "Descending" }));
       expect(handleSort).toHaveBeenCalledWith({
         ...initialSortingState,
         order: "desc",

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.test.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.test.tsx
@@ -84,7 +84,7 @@ describe("DataListHeaderCheckbox", () => {
     expect(screen.getByText(textToBeFound)).toBeInTheDocument();
   });
 
-  it("should fire the onSelectAll when the checkbox have been clicked", () => {
+  it("should fire the onSelectAll when the checkbox have been clicked", async () => {
     render(
       <DataListContext.Provider value={withSelectedContext}>
         <DataListHeaderCheckbox>
@@ -93,12 +93,12 @@ describe("DataListHeaderCheckbox", () => {
       </DataListContext.Provider>,
     );
 
-    userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.click(screen.getByRole("checkbox"));
 
     expect(handleSelectAll).toHaveBeenCalledTimes(1);
   });
 
-  it("should return an empty array on onSelect when deselect all have been clicked", () => {
+  it("should return an empty array on onSelect when deselect all have been clicked", async () => {
     render(
       <DataListContext.Provider value={withSelectedContext}>
         <DataListHeaderCheckbox>
@@ -107,7 +107,9 @@ describe("DataListHeaderCheckbox", () => {
       </DataListContext.Provider>,
     );
 
-    userEvent.click(screen.getByRole("button", { name: deselectAllLabel }));
+    await userEvent.click(
+      screen.getByRole("button", { name: deselectAllLabel }),
+    );
 
     expect(handleSelect).toHaveBeenCalledTimes(1);
     expect(handleSelect).toHaveBeenCalledWith([]);
@@ -137,6 +139,7 @@ describe("DataListHeaderCheckbox", () => {
           lg: true,
           xl: true,
         }[queryBreakpoint as Breakpoints];
+
         return {
           matches: expectedValue,
           media: query,

--- a/packages/components/src/DataList/components/DataListItem/DataListItem.test.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItem.test.tsx
@@ -46,12 +46,12 @@ describe("DataListItem", () => {
       renderComponent();
 
       const listItemEl = screen.getByText(listItem);
-      userEvent.hover(listItemEl);
+      await userEvent.hover(listItemEl);
 
       const menuButton = screen.getByRole("button", { name: "More actions" });
       expect(menuButton).toBeInTheDocument();
 
-      userEvent.unhover(listItemEl);
+      await userEvent.unhover(listItemEl);
       await waitFor(() => {
         expect(menuButton).not.toBeInTheDocument();
       });
@@ -73,14 +73,14 @@ describe("DataListItem", () => {
       });
     });
 
-    it("should render a context menu when right clicked", () => {
+    it("should render a context menu when right clicked", async () => {
       renderComponent();
 
       const listItemEl = screen.getByText(listItem);
 
       const clientX = 20;
       const clientY = 30;
-      userEvent.hover(listItemEl);
+      await userEvent.hover(listItemEl);
       fireEvent.contextMenu(listItemEl, { clientX, clientY });
 
       const menuElement = screen.getByRole("menu");
@@ -108,18 +108,18 @@ describe("DataListItem", () => {
       ).toBeInTheDocument();
     });
 
-    it("should not fire the parent click when opening the menu", () => {
+    it("should not fire the parent click when opening the menu", async () => {
       const moreAction = screen.getByRole("button", { name: "More actions" });
 
-      userEvent.click(moreAction);
+      await userEvent.click(moreAction);
       expect(handleItemClick).not.toHaveBeenCalled();
     });
 
-    it("should not fire the parent click when clicking one of the menu items", () => {
+    it("should not fire the parent click when clicking one of the menu items", async () => {
       const moreAction = screen.getByRole("button", { name: "More actions" });
 
-      userEvent.click(moreAction);
-      userEvent.click(screen.getByRole("button", { name: "Edit" }));
+      await userEvent.click(moreAction);
+      await userEvent.click(screen.getByRole("button", { name: "Edit" }));
       expect(handleItemClick).not.toHaveBeenCalled();
     });
   });

--- a/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.test.tsx
+++ b/packages/components/src/DataList/components/DataListItem/components/DataListItemClickable/DataListItemClickable.test.tsx
@@ -48,7 +48,7 @@ describe("DataListItemClickable", () => {
     expect(screen.getByText(content)).toBeInstanceOf(HTMLDivElement);
   });
 
-  it("should render a div with a role of button when there's only an `onClick` prop", () => {
+  it("should render a div with a role of button when there's only an `onClick` prop", async () => {
     mockItemActionComponent.mockReturnValueOnce(
       <DataListItemActions onClick={handleClick} />,
     );
@@ -59,7 +59,7 @@ describe("DataListItemClickable", () => {
     expect(target).toBeInstanceOf(HTMLDivElement);
     expect(target).toHaveAttribute("role", "button");
 
-    userEvent.click(target);
+    await userEvent.click(target);
     expect(handleClick).toHaveBeenCalledTimes(1);
     expect(handleClick).toHaveBeenCalledWith(expectedItem);
   });
@@ -83,7 +83,7 @@ describe("DataListItemClickable", () => {
   });
 
   describe("URL prop", () => {
-    it("should render an `a` tag", () => {
+    it("should render an `a` tag", async () => {
       mockItemActionComponent.mockReturnValueOnce(
         <DataListItemActions url="jobber.com" />,
       );
@@ -94,7 +94,7 @@ describe("DataListItemClickable", () => {
       expect(target).toBeInstanceOf(HTMLAnchorElement);
       expect(target).toHaveAttribute("href", "jobber.com");
 
-      userEvent.click(target);
+      await userEvent.click(target);
       expect(handleClick).not.toHaveBeenCalled();
     });
 
@@ -110,7 +110,7 @@ describe("DataListItemClickable", () => {
       expect(target).toHaveAttribute("href", "jobber.com/1");
     });
 
-    it("should still fire onClick if it exists", () => {
+    it("should still fire onClick if it exists", async () => {
       mockItemActionComponent.mockReturnValueOnce(
         <DataListItemActions url="jobber.com" onClick={handleClick} />,
       );
@@ -119,14 +119,14 @@ describe("DataListItemClickable", () => {
       const target = screen.getByText(content);
       expect(target).toBeInstanceOf(HTMLAnchorElement);
 
-      userEvent.click(target);
+      await userEvent.click(target);
       expect(handleClick).toHaveBeenCalledTimes(1);
       expect(handleClick).toHaveBeenCalledWith(expectedItem);
     });
   });
 
   describe("To prop", () => {
-    it("should render an `a` tag", () => {
+    it("should render an `a` tag", async () => {
       mockItemActionComponent.mockReturnValueOnce(
         <DataListItemActions to="/getjobber.com" />,
       );
@@ -137,7 +137,7 @@ describe("DataListItemClickable", () => {
       expect(target).toBeInstanceOf(HTMLAnchorElement);
       expect(target).toHaveAttribute("href", "/getjobber.com");
 
-      userEvent.click(target);
+      await userEvent.click(target);
       expect(handleClick).not.toHaveBeenCalled();
     });
 
@@ -153,7 +153,7 @@ describe("DataListItemClickable", () => {
       expect(target).toHaveAttribute("href", "/getjobber.com/1");
     });
 
-    it("should still fire onClick if it exists", () => {
+    it("should still fire onClick if it exists", async () => {
       mockItemActionComponent.mockReturnValueOnce(
         <DataListItemActions to="/getjobber.com" onClick={handleClick} />,
       );
@@ -162,7 +162,7 @@ describe("DataListItemClickable", () => {
       const target = screen.getByText(content);
       expect(target).toBeInstanceOf(HTMLAnchorElement);
 
-      userEvent.click(target);
+      await userEvent.click(target);
       expect(handleClick).toHaveBeenCalledTimes(1);
       expect(handleClick).toHaveBeenCalledWith(expectedItem);
     });

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.test.tsx
@@ -42,18 +42,18 @@ describe("DataListItemActions", () => {
     expect(screen.getByLabelText("More actions")).toBeInTheDocument();
   });
 
-  it("should only render the first 2 actions", () => {
+  it("should only render the first 2 actions", async () => {
     renderComponent();
     expect(screen.getByLabelText("Edit")).toBeInTheDocument();
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
     expect(screen.queryByLabelText("Note")).not.toBeInTheDocument();
   });
 
-  it("should only render put the remaining actions in the more menu", () => {
+  it("should only render put the remaining actions in the more menu", async () => {
     renderComponent();
 
     const moreMenuButton = screen.getByLabelText("More actions");
-    userEvent.click(moreMenuButton);
+    await userEvent.click(moreMenuButton);
 
     const menu = screen.getByRole("menu");
     expect(menu).toBeInTheDocument();
@@ -62,9 +62,9 @@ describe("DataListItemActions", () => {
     expect(within(menu).getAllByRole("button")).toHaveLength(2);
   });
 
-  it("should call the onClick handler when clicking the edit button", () => {
+  it("should call the onClick handler when clicking the edit button", async () => {
     renderComponent();
-    userEvent.click(screen.getByLabelText("Edit"));
+    await userEvent.click(screen.getByLabelText("Edit"));
     expect(handleEditClick).toHaveBeenCalledTimes(1);
     expect(handleEditClick).toHaveBeenCalledWith({ id: 1 });
   });

--- a/packages/components/src/DataList/components/DataListItems/DataListItems.test.tsx
+++ b/packages/components/src/DataList/components/DataListItems/DataListItems.test.tsx
@@ -59,18 +59,18 @@ describe("DataListItems", () => {
       renderComponent();
 
       const checkbox = screen.getAllByRole("checkbox")[0];
-      userEvent.click(checkbox);
+      await userEvent.click(checkbox);
 
       expect(onSelectMock).toHaveBeenCalledTimes(1);
       expect(onSelectMock).toHaveBeenCalledWith([mockData[0].id]);
     });
 
-    it("should call onSelect with multiple checkboxes selected", () => {
+    it("should call onSelect with multiple checkboxes selected", async () => {
       mockSelectedValue.mockReturnValueOnce([mockData[0].id]);
       renderComponent();
 
       const checkbox = screen.getAllByRole("checkbox")[1];
-      userEvent.click(checkbox);
+      await userEvent.click(checkbox);
 
       expect(onSelectMock).toHaveBeenCalledTimes(1);
       expect(onSelectMock).toHaveBeenCalledWith([
@@ -79,12 +79,12 @@ describe("DataListItems", () => {
       ]);
     });
 
-    it("should call onSelect when a single checkbox is un-selected", () => {
+    it("should call onSelect when a single checkbox is un-selected", async () => {
       mockSelectedValue.mockReturnValueOnce([mockData[0].id, mockData[1].id]);
       renderComponent();
 
       const checkbox = screen.getAllByRole("checkbox")[0];
-      userEvent.click(checkbox);
+      await userEvent.click(checkbox);
 
       expect(onSelectMock).toHaveBeenCalledTimes(1);
       expect(onSelectMock).toHaveBeenCalledWith([mockData[1].id]);
@@ -92,12 +92,12 @@ describe("DataListItems", () => {
   });
 
   describe("Context menu", () => {
-    it("should render context menu when right clicking on a list item", () => {
+    it("should render context menu when right clicking on a list item", async () => {
       renderComponent();
       expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 
       const listItem = screen.getByText(mockData[0].label);
-      userEvent.hover(listItem);
+      await userEvent.hover(listItem);
 
       fireEvent.contextMenu(listItem);
 
@@ -106,10 +106,10 @@ describe("DataListItems", () => {
       expect(within(menuElement).getAllByRole("button")).toHaveLength(3);
     });
 
-    it("should render context menu in the right position when right clicking on a list item", () => {
+    it("should render context menu in the right position when right clicking on a list item", async () => {
       renderComponent();
       const listItem = screen.getByText(mockData[0].label);
-      userEvent.hover(listItem);
+      await userEvent.hover(listItem);
 
       const clientX = 20;
       const clientY = 30;
@@ -122,36 +122,36 @@ describe("DataListItems", () => {
       });
     });
 
-    it("should have the correct item when clicking the edit button", () => {
+    it("should have the correct item when clicking the edit button", async () => {
       renderComponent();
       const selectedItem = mockData[1];
       const listItem = screen.getByText(selectedItem.label);
-      userEvent.hover(listItem);
+      await userEvent.hover(listItem);
       fireEvent.contextMenu(listItem);
 
       const menuElement = screen.getByRole("menu");
       const editButton = within(menuElement).getByText("Edit");
-      userEvent.click(editButton);
+      await userEvent.click(editButton);
       expect(mockEditClick).toHaveBeenCalledWith(selectedItem);
     });
 
-    it("should not render context menu when right clicking on a list item and itemActionComponent is not provided", () => {
+    it("should not render context menu when right clicking on a list item and itemActionComponent is not provided", async () => {
       mockItemActionComponent.mockReturnValueOnce(undefined);
       renderComponent();
       const listItem = screen.getByText(mockData[0].label);
-      userEvent.hover(listItem);
+      await userEvent.hover(listItem);
       fireEvent.contextMenu(listItem);
 
       expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
 
-    it("should not close the menu when hovering out of the target", () => {
+    it("should not close the menu when hovering out of the target", async () => {
       renderComponent();
       const listItem = screen.getByText(mockData[0].label);
-      userEvent.hover(listItem);
+      await userEvent.hover(listItem);
       fireEvent.contextMenu(listItem);
 
-      userEvent.unhover(listItem);
+      await userEvent.unhover(listItem);
 
       expect(screen.getByRole("menu")).toBeInTheDocument();
     });

--- a/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.test.tsx
+++ b/packages/components/src/DataList/components/DataListLoadMore/DataListLoadMore.test.tsx
@@ -56,7 +56,7 @@ describe("DataListLoadMore", () => {
     ).toBeInTheDocument();
   });
 
-  it("should fire the onBackToTop callback", () => {
+  it("should fire the onBackToTop callback", async () => {
     const handleBackToTop = jest.fn();
     render(
       <DataListContext.Provider value={{ ...defaultValues, data: mockData }}>
@@ -64,7 +64,7 @@ describe("DataListLoadMore", () => {
       </DataListContext.Provider>,
     );
 
-    userEvent.click(screen.getByRole("button", { name: "Back to top" }));
+    await userEvent.click(screen.getByRole("button", { name: "Back to top" }));
 
     expect(handleBackToTop).toHaveBeenCalled();
   });

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.test.tsx
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import userEvent, { UserEvent } from "@testing-library/user-event";
 import {
   DATA_LIST_SEARCH_TEST_ID,
   DataListSearch,
@@ -17,8 +17,13 @@ const contextValueWithRenderableChildren: DataListContextProps<DataListObject> =
     searchComponent: <DataListSearch onSearch={jest.fn()} />,
   };
 
+let user: UserEvent;
+
 beforeEach(() => {
   jest.useFakeTimers();
+  user = userEvent.setup({
+    advanceTimers: jest.advanceTimersByTime,
+  });
 });
 
 afterEach(() => {
@@ -74,7 +79,7 @@ describe("InternalDataListSearch", () => {
   });
 
   describe("Toggle search", () => {
-    it("should add the searchInputVisible class name after clicking the search button", () => {
+    it("should add the searchInputVisible class name after clicking the search button", async () => {
       spy.mockReturnValue(contextValueWithRenderableChildren);
       render(<InternalDataListSearch />);
 
@@ -83,11 +88,11 @@ describe("InternalDataListSearch", () => {
 
       expect(input).not.toHaveClass("searchInputVisible");
 
-      userEvent.click(searchButton);
+      await user.click(searchButton);
       expect(input).toHaveClass("searchInputVisible");
     });
 
-    it("should focus on the search input after clicking the search button", () => {
+    it("should focus on the search input after clicking the search button", async () => {
       spy.mockReturnValue(contextValueWithRenderableChildren);
       render(<InternalDataListSearch />);
 
@@ -96,13 +101,13 @@ describe("InternalDataListSearch", () => {
 
       expect(input).not.toHaveFocus();
 
-      userEvent.click(searchButton);
+      await user.click(searchButton);
       jest.runAllTimers();
       expect(input).toHaveFocus();
     });
   });
 
-  it("should debounce the search", () => {
+  it("should debounce the search", async () => {
     const onSearch = jest.fn();
     spy.mockReturnValue({
       ...contextValueWithRenderableChildren,
@@ -113,7 +118,7 @@ describe("InternalDataListSearch", () => {
     const input = screen.getByRole("textbox");
     const searchValue = "search";
     input.focus();
-    userEvent.type(input, searchValue);
+    await user.type(input, searchValue);
 
     expect(onSearch).not.toHaveBeenCalled();
     jest.advanceTimersByTime(200);

--- a/packages/components/src/DataTable/DataTable.test.tsx
+++ b/packages/components/src/DataTable/DataTable.test.tsx
@@ -75,27 +75,27 @@ describe("when using pagination", () => {
     expect(screen.getByLabelText("arrowLeft")).toBeDisabled();
   });
 
-  it("renders updated pagination info of the next page", () => {
+  it("renders updated pagination info of the next page", async () => {
     const arrowRight = screen.getByTestId("arrowRight");
-    userEvent.click(arrowRight);
+    await userEvent.click(arrowRight);
 
     const paginationInfo = screen.getByText(/Showing 6-10 of 13 items/i);
     expect(paginationInfo).toBeInTheDocument();
   });
 
-  it("renders correct number of rows of the next page and previous page", () => {
+  it("renders correct number of rows of the next page and previous page", async () => {
     const arrowRight = screen.getByTestId("arrowRight");
-    userEvent.click(arrowRight);
+    await userEvent.click(arrowRight);
 
     const [, ...bodyRowsPage2] = screen.getAllByRole("row");
     expect(bodyRowsPage2).toHaveLength(5);
 
-    userEvent.click(arrowRight);
+    await userEvent.click(arrowRight);
 
     const [, ...bodyRowsPage3] = screen.getAllByRole("row");
     expect(bodyRowsPage3).toHaveLength(3);
 
-    userEvent.click(screen.getByTestId("arrowLeft"));
+    await userEvent.click(screen.getByTestId("arrowLeft"));
 
     const [, ...bodyRowsFinalPage] = screen.getAllByRole("row");
     expect(bodyRowsFinalPage).toHaveLength(5);
@@ -143,15 +143,15 @@ describe("when using manual pagination", () => {
       />,
     );
   });
-  it("calls the provided callback", () => {
-    userEvent.click(screen.getByLabelText("arrowRight"));
+  it("calls the provided callback", async () => {
+    await userEvent.click(screen.getByLabelText("arrowRight"));
 
     expect(mockedOnPaginationChange).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("when using sorting", () => {
-  it("renders table with clickable headers", () => {
+  it("renders table with clickable headers", async () => {
     render(
       <DataTable
         data={data}
@@ -161,12 +161,12 @@ describe("when using sorting", () => {
     );
     const nameHeader = screen.getByText("Name");
 
-    userEvent.click(nameHeader); // sort to asc
+    await userEvent.click(nameHeader); // sort to asc
 
     const firstBodyRow = screen.getAllByRole("row")[1];
     expect(within(firstBodyRow).getByText("Arya")).toBeInTheDocument();
 
-    userEvent.click(nameHeader); // sort to desc
+    await userEvent.click(nameHeader); // sort to desc
 
     const firstBodyRowUpdated = screen.getAllByRole("row")[1];
     expect(within(firstBodyRowUpdated).getByText("Tommen")).toBeInTheDocument();
@@ -176,7 +176,7 @@ describe("when using sorting", () => {
 describe("when using manual sorting", () => {
   const mockedOnSortingChange = jest.fn();
 
-  it("calls the provided callback", () => {
+  it("calls the provided callback", async () => {
     render(
       <DataTable
         data={data}
@@ -191,7 +191,7 @@ describe("when using manual sorting", () => {
 
     const nameHeader = screen.getByText("Name");
 
-    userEvent.click(nameHeader);
+    await userEvent.click(nameHeader);
 
     expect(mockedOnSortingChange).toHaveBeenCalledTimes(1);
   });
@@ -205,9 +205,9 @@ describe("when using onRowClick", () => {
     );
   });
 
-  it("Executes a callback function", () => {
+  it("Executes a callback function", async () => {
     const firstBodyRow = screen.getAllByRole("row")[1];
-    userEvent.click(firstBodyRow);
+    await userEvent.click(firstBodyRow);
     expect(clickHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/components/src/MultiSelect/MultiSelect.test.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.test.tsx
@@ -113,8 +113,8 @@ describe("when focusing multislect to display the options", () => {
   });
 
   describe("when clicking MultiSelect", () => {
-    it("should display the dropdown menu with the options", () => {
-      userEvent.click(screen.getByTestId("multi-select"));
+    it("should display the dropdown menu with the options", async () => {
+      await userEvent.click(screen.getByTestId("multi-select"));
       const dropDownMenu = screen.getByTestId("dropdown-menu");
 
       expect(dropDownMenu).not.toBeNull();
@@ -126,8 +126,8 @@ describe("when focusing multislect to display the options", () => {
   });
 
   describe("when pressing Spacebar key", () => {
-    it("should display the dropdown menu with the options", () => {
-      userEvent.tab();
+    it("should display the dropdown menu with the options", async () => {
+      await userEvent.tab();
       fireEvent(
         screen.getByTestId("multi-select"),
         new KeyboardEvent("keydown", {
@@ -148,8 +148,8 @@ describe("when focusing multislect to display the options", () => {
   });
 
   describe("when pressing Enter key", () => {
-    it("should display the dropdown menu with the options", () => {
-      userEvent.tab();
+    it("should display the dropdown menu with the options", async () => {
+      await userEvent.tab();
       fireEvent(
         screen.getByTestId("multi-select"),
         new KeyboardEvent("keydown", {
@@ -170,8 +170,8 @@ describe("when focusing multislect to display the options", () => {
   });
 
   describe("when pressing 'Escape' key", () => {
-    it("should hide the dropdown menu", () => {
-      userEvent.click(screen.getByTestId("multi-select"));
+    it("should hide the dropdown menu", async () => {
+      await userEvent.click(screen.getByTestId("multi-select"));
 
       expect(screen.queryByTestId("dropdown-menu")).not.toBeNull();
 
@@ -189,12 +189,12 @@ describe("when focusing multislect to display the options", () => {
   });
 
   describe("when clicking out of the component", () => {
-    it("should hide the dropdown menu", () => {
-      userEvent.click(screen.getByTestId("multi-select"));
+    it("should hide the dropdown menu", async () => {
+      await userEvent.click(screen.getByTestId("multi-select"));
 
       expect(screen.queryByTestId("dropdown-menu")).not.toBeNull();
 
-      userEvent.click(document.body);
+      await userEvent.click(document.body);
 
       expect(screen.queryByTestId("dropdown-menu")).toBeNull();
     });
@@ -207,17 +207,17 @@ describe("when selecting an option", () => {
   });
 
   describe("when using mouse click event", () => {
-    it("should call the provided callback", () => {
-      userEvent.click(screen.getByTestId("multi-select"));
-      userEvent.click(screen.getAllByRole("checkbox")[2]);
+    it("should call the provided callback", async () => {
+      await userEvent.click(screen.getByTestId("multi-select"));
+      await userEvent.click(screen.getAllByRole("checkbox")[2]);
 
       expect(screen.getByLabelText("Warnings")).not.toBeChecked();
     });
   });
 
   describe("when using keyboard navigation", () => {
-    it("should call the provided callback when using arrows and Enter keys", () => {
-      userEvent.click(screen.getByTestId("multi-select"));
+    it("should call the provided callback when using arrows and Enter keys", async () => {
+      await userEvent.click(screen.getByTestId("multi-select"));
 
       fireEvent(
         screen.getByTestId("dropdown-menu"),
@@ -239,10 +239,10 @@ describe("when selecting an option", () => {
       expect(screen.getByLabelText("Errors")).toBeChecked();
     });
 
-    it("should call the provided callback when using tab and spacebar keys", () => {
-      userEvent.click(screen.getByTestId("multi-select"));
+    it("should call the provided callback when using tab and spacebar keys", async () => {
+      await userEvent.click(screen.getByTestId("multi-select"));
 
-      userEvent.tab();
+      await userEvent.tab();
       fireEvent(
         screen.getByTestId("dropdown-menu"),
         new KeyboardEvent("keydown", {

--- a/packages/components/src/Switch/Switch.test.tsx
+++ b/packages/components/src/Switch/Switch.test.tsx
@@ -143,23 +143,23 @@ it("renders a disabled Switch", () => {
   `);
 });
 
-test("it should change the input value on click", () => {
+test("it should change the input value on click", async () => {
   const { getByRole } = render(<Switch ariaLabel="Toggle me" />);
   const element = getByRole("switch");
 
-  userEvent.click(element);
+  await userEvent.click(element);
   expect(element).toHaveAttribute("aria-checked", "true");
 
-  userEvent.click(element);
+  await userEvent.click(element);
   expect(element).toHaveAttribute("aria-checked", "false");
 });
 
-test("it should not change the input value on click", () => {
+test("it should not change the input value on click", async () => {
   const { getByRole } = render(
     <Switch ariaLabel="Can't touch this" value={true} disabled={true} />,
   );
   const element = getByRole("switch");
 
-  userEvent.click(element);
+  await userEvent.click(element);
   expect(element).toHaveAttribute("aria-checked", "true");
 });

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -32,7 +32,7 @@ it("should show up on hover", async () => {
     </Tooltip>,
   );
 
-  userEvent.hover(getByTestId(contentID));
+  await userEvent.hover(getByTestId(contentID));
   expect(getByText(message)).toBeInTheDocument();
   expect(getByText(content)).toBeInTheDocument();
 });
@@ -48,7 +48,7 @@ it("should show the tooltip up on focus", async () => {
     </Tooltip>,
   );
 
-  userEvent.hover(getByTestId(contentID));
+  await userEvent.hover(getByTestId(contentID));
   expect(getByText(message)).toBeInTheDocument();
 });
 
@@ -63,8 +63,8 @@ it("should disappear on blur", async () => {
     </Tooltip>,
   );
 
-  userEvent.hover(getByTestId(contentID));
-  userEvent.unhover(getByTestId(contentID));
+  await userEvent.hover(getByTestId(contentID));
+  await userEvent.unhover(getByTestId(contentID));
 
   await waitFor(() => {
     expect(queryByText(message)).not.toBeInTheDocument();

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -23,7 +23,7 @@
     "@jobber/formatters": "*",
     "@testing-library/react": "^14.0.0",
     "@testing-library/react-hooks": "^7.0.0",
-    "@testing-library/user-event": "^12.0.2",
+    "@testing-library/user-event": "^14.5.1",
     "@types/lodash": "4.14.136",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",

--- a/packages/hooks/src/useFocusTrap/useFocusTrap.test.tsx
+++ b/packages/hooks/src/useFocusTrap/useFocusTrap.test.tsx
@@ -12,28 +12,28 @@ it("should focus on the ref target on mount", () => {
   expect(getByTestId(targetId)).toHaveFocus();
 });
 
-it("should focus on the ref target when tabbing out of the last focusable element and ignore the tabindex'=-1'", () => {
+it("should focus on the ref target when tabbing out of the last focusable element and ignore the tabindex'=-1'", async () => {
   const { getByTestId } = render(<TestComponent />);
   getByTestId(lastFocusableChild).focus();
-  userEvent.tab();
+  await userEvent.tab();
   expect(getByTestId(targetId)).toHaveFocus();
 });
 
-it("should focus on the first focusable element", () => {
+it("should focus on the first focusable element", async () => {
   const { getByTestId } = render(<TestComponent />);
-  userEvent.tab();
+  await userEvent.tab();
   expect(getByTestId(firstFocusableChild)).toHaveFocus();
 });
 
-it("should focus on the last focusable element", () => {
+it("should focus on the last focusable element", async () => {
   const { getByTestId } = render(<TestComponent />);
-  userEvent.tab({ shift: true });
+  await userEvent.tab({ shift: true });
   expect(getByTestId(lastFocusableChild)).toHaveFocus();
 });
 
-it("should not trap the tabbing and focus on the first child node", () => {
+it("should not trap the tabbing and focus on the first child node", async () => {
   const { getByTestId } = render(<TestComponent trap={false} />);
-  userEvent.tab();
+  await userEvent.tab();
   expect(getByTestId(targetId).previousElementSibling).toHaveFocus();
 });
 


### PR DESCRIPTION
## Motivations

I wanted to make use of the latest API for testing using keyboard interactions for the Calendar Date Picker. See https://github.com/GetJobber/atlantis/pull/1601

## Changes
Upgraded the package to the lastest version and adjusted wherever `userEvent` is used as it now returns promises.

Recommended reading for the team: https://testing-library.com/docs/user-event/intro

When using `jest.useFakeTimers` you have to configure _userEvent_:

```ts
const user = user = userEvent.setup({
  advanceTimers: jest.advanceTimersByTime,
});
...
await user.click(..)
await user.keyboard(..)
```

Tests for _DataListSearch_ are a good example here.


[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![image](https://github.com/GetJobber/atlantis/assets/14314519/d9a63afb-3a1d-4e8b-9df8-2ed4c9038036)
