### PR TITLE
feat(components): Alternative design option for the CalendarDatePicker

### DIFF
--- a/packages/components/src/CalendarDatePicker/CalendarDatePicker.tsx
+++ b/packages/components/src/CalendarDatePicker/CalendarDatePicker.tsx
@@ -43,6 +43,7 @@ export interface CalendarDatePickerBaseProps {
   readonly maxDate?: Date;
   readonly weekStartsOnMonday?: boolean;
   readonly focusonSelectedDate?: boolean;
+  readonly alternate?: boolean;
   readonly translations?: {
     readonly previousMonth?: string;
     readonly nextMonth?: string;
@@ -68,6 +69,7 @@ export const CalendarDatePicker = forwardRef(function CalendarDatePicker(
     focusonSelectedDate,
     range,
     multi,
+    alternate,
     translations,
     onChange,
     onMonthChange,
@@ -139,6 +141,7 @@ export const CalendarDatePicker = forwardRef(function CalendarDatePicker(
       weekStartsOnMonday={weekStartsOnMonday}
       range={!!range}
       multi={!!multi}
+      alternate={alternate}
       onChange={onChangeSelection}
       onMonthChange={onMonthChangeInternal}
       onClickOutside={onClickOutside}
@@ -172,6 +175,7 @@ export const CalendarMultiDatePickerComponent = forwardRef<
     weekStartsOnMonday,
     range,
     translations,
+    alternate,
     onChange,
     onMonthChange,
     onClickOutside,
@@ -207,6 +211,7 @@ export const CalendarMultiDatePickerComponent = forwardRef<
         year={viewingDate.getFullYear()}
         onChange={onMonthChange}
         translations={translations}
+        alternate={alternate}
       />
       <div>
         <CalendarDatePickerGrid
@@ -220,6 +225,7 @@ export const CalendarMultiDatePickerComponent = forwardRef<
           onMonthChange={onMonthChange}
           weekStartsOnMonday={!!weekStartsOnMonday}
           translations={translations}
+          alternate={alternate}
         />
       </div>
     </div>

--- a/packages/components/src/CalendarDatePicker/components/CalendarDatePickerGrid.tsx
+++ b/packages/components/src/CalendarDatePicker/components/CalendarDatePickerGrid.tsx
@@ -22,6 +22,7 @@ interface CalendarDatePickerGridProps {
   readonly maxDate?: Date;
   readonly highlightedDates: Date[];
   readonly weekStartsOnMonday: boolean;
+  readonly alternate?: boolean;
   readonly translations?: {
     readonly highlightedLabelSuffix?: string;
     readonly chooseDate?: string;
@@ -43,6 +44,7 @@ export const CalendarDatePickerGrid = ({
   range,
   weekStartsOnMonday,
   translations,
+  alternate,
   onChange,
   onMonthChange,
 }: CalendarDatePickerGridProps): JSX.Element => {
@@ -63,6 +65,7 @@ export const CalendarDatePickerGrid = ({
     maxDate,
     highlightedDates,
     weekStartsOnMonday,
+    alternate,
     range,
     viewingDate,
     focusedDate,
@@ -105,6 +108,7 @@ function useRowsAndCells({
   highlightedDates,
   weekStartsOnMonday,
   highlightedLabelSuffix,
+  alternate,
   range,
   focusedDate,
   onToggle,
@@ -116,6 +120,7 @@ function useRowsAndCells({
   highlightedDates: Date[];
   weekStartsOnMonday: boolean;
   highlightedLabelSuffix: string | undefined;
+  alternate?: boolean;
   range: boolean;
   focusedDate: Date;
   onToggle: (
@@ -125,7 +130,11 @@ function useRowsAndCells({
   ) => void;
 }) {
   const rows = [
-    <DaysOfTheWeekRow key="weekdays" weekStartsOnMonday={weekStartsOnMonday} />,
+    <DaysOfTheWeekRow
+      key="weekdays"
+      weekStartsOnMonday={weekStartsOnMonday}
+      alternate={alternate}
+    />,
   ];
 
   const mapOfHighlightedDates =
@@ -187,6 +196,7 @@ function useRowsAndCells({
           isCurrentDate={isCurrentDate}
           onToggle={onToggleCell}
           highlighted={mapOfHighlightedDates[dateOfCell.getTime()]}
+          alternate={alternate}
           disabled={!!isDisabled}
           highlightedLabelSuffix={highlightedLabelSuffix}
           range={

--- a/packages/components/src/CalendarDatePicker/components/CalendarDatePickerHeader.css
+++ b/packages/components/src/CalendarDatePicker/components/CalendarDatePickerHeader.css
@@ -1,6 +1,5 @@
 .container {
   display: flex;
-  padding-left: var(--space-base);
   background-color: var(--color-surface);
   flex-direction: row;
   justify-content: space-between;
@@ -9,4 +8,22 @@
 
 .label {
   flex: 1;
+}
+
+.alternate {
+  height: 50px;
+  padding-left: 0;
+}
+
+.alternate .label {
+  order: 1;
+  text-align: center;
+}
+
+.alternate button:nth-of-type(1) {
+  order: 0;
+}
+
+.alternate button:nth-of-type(2) {
+  order: 2;
 }

--- a/packages/components/src/CalendarDatePicker/components/CalendarDatePickerHeader.css.d.ts
+++ b/packages/components/src/CalendarDatePicker/components/CalendarDatePickerHeader.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles: {
   readonly "container": string;
   readonly "label": string;
+  readonly "alternate": string;
 };
 export = styles;
 

--- a/packages/components/src/CalendarDatePicker/components/CalendarDatePickerHeader.tsx
+++ b/packages/components/src/CalendarDatePicker/components/CalendarDatePickerHeader.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useMemo } from "react";
+import combineClassNames from "classnames";
+import { Heading } from "@jobber/components/Heading";
 import classNames from "./CalendarDatePickerHeader.css";
 import { Button } from "../../Button";
 import { Typography } from "../../Typography";
@@ -8,6 +10,7 @@ interface CaleanderDatePickerHeaderProps {
   readonly month: number;
   readonly year: number;
   readonly onChange?: (date: Date) => void;
+  readonly alternate?: boolean;
   readonly translations?: {
     readonly previousMonth?: string;
     readonly nextMonth?: string;
@@ -18,6 +21,7 @@ export const CalendarDatePickerHeader = ({
   onChange,
   month,
   year,
+  alternate,
   translations,
 }: CaleanderDatePickerHeaderProps) => {
   const date = useMemo(() => new Date(year, month, 1), [year, month]);
@@ -36,9 +40,20 @@ export const CalendarDatePickerHeader = ({
   }, [onChange, date]);
 
   return (
-    <div className={classNames.container}>
+    <div
+      className={combineClassNames(
+        classNames.container,
+        alternate ? classNames.alternate : undefined,
+      )}
+    >
       <div className={classNames.label} aria-live="polite">
-        <Typography fontWeight="semiBold">{formatter.format(date)}</Typography>
+        {alternate ? (
+          <Heading level={3}>{formatter.format(date)}</Heading>
+        ) : (
+          <Typography fontWeight="semiBold">
+            {formatter.format(date)}
+          </Typography>
+        )}
       </div>
       <Button
         type="tertiary"

--- a/packages/components/src/CalendarDatePicker/components/DayCell.css
+++ b/packages/components/src/CalendarDatePicker/components/DayCell.css
@@ -1,6 +1,6 @@
 .container {
   display: flex;
-  height: 34px;
+  height: calc(var(--typography--fontSize-large) * 2.25);
   border-top: 2px solid var(--color-surface);
   border-bottom: 2px solid var(--color-surface);
   justify-content: center;
@@ -10,8 +10,8 @@
 
 .cell {
   display: flex;
-  width: 32px;
-  height: 32px;
+  width: calc(var(--typography--fontSize-large) * 2);
+  height: calc(var(--typography--fontSize-large) * 2);
   box-sizing: border-box;
   border: 0;
   border-color: transparent;
@@ -22,18 +22,22 @@
   justify-content: center;
 }
 
+.alternate .cell {
+  width: calc(var(--typography--fontSize-large) * 1.75);
+  height: calc(var(--typography--fontSize-large) * 1.75);
+}
+
 .container:focus > .cell:not(.selected),
 .container.focus > .cell:not(.selected) {
   color: var(--color-text);
   background-color: var(--color-surface--hover);
 }
 
-.cell:not(.disabled):not(.selected):not(.outOfRange):hover {
+.container:hover .cell:not(.disabled):not(.selected):not(.outOfRange) {
   background-color: var(--color-surface--hover);
 }
 
 .selected {
-  border-color: var(--color-green);
   color: var(--color-surface);
   background-color: var(--color-green);
 }
@@ -42,10 +46,13 @@
   background-color: var(--color-interactive--hover);
 }
 
-.range-none .highlighted {
+.range-none:not(.alternate) .highlighted {
   border-color: var(--color-green);
   border-style: solid;
   border-width: 1px;
+}
+.range-none.alternate .highlighted {
+  background-color: var(--color-green--lightest);
 }
 
 .range-none .highlighted:hover {

--- a/packages/components/src/CalendarDatePicker/components/DayCell.css.d.ts
+++ b/packages/components/src/CalendarDatePicker/components/DayCell.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles: {
   readonly "container": string;
   readonly "cell": string;
+  readonly "alternate": string;
   readonly "selected": string;
   readonly "focus": string;
   readonly "disabled": string;

--- a/packages/components/src/CalendarDatePicker/components/DayCell.tsx
+++ b/packages/components/src/CalendarDatePicker/components/DayCell.tsx
@@ -35,6 +35,7 @@ interface DayCellProps {
    * Flag indicating if the cell has received focus via keyboard navigation
    */
   readonly hasFocus: boolean;
+  readonly alternate?: boolean;
   /**
    * Callback for clicking the cell
    */
@@ -103,6 +104,7 @@ const GridCell = (props: Omit<DayCellProps, "inMonth">): JSX.Element => {
         classNames.container,
         classNames[`range-${props.range}`],
         props.hasFocus ? classNames.focus : "",
+        props.alternate ? classNames.alternate : "",
       )}
     >
       {cell}

--- a/packages/components/src/CalendarDatePicker/components/DaysOfTheWeekRow.css
+++ b/packages/components/src/CalendarDatePicker/components/DaysOfTheWeekRow.css
@@ -9,3 +9,10 @@
 .row {
   display: flex;
 }
+
+.alternate .cell {
+  height: auto;
+  padding: var(--space-small) 0 var(--space-small) 0;
+  border-bottom: 1px solid var(--color-grey--lighter);
+  text-transform: uppercase;
+}

--- a/packages/components/src/CalendarDatePicker/components/DaysOfTheWeekRow.css.d.ts
+++ b/packages/components/src/CalendarDatePicker/components/DaysOfTheWeekRow.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles: {
   readonly "cell": string;
   readonly "row": string;
+  readonly "alternate": string;
 };
 export = styles;
 

--- a/packages/components/src/CalendarDatePicker/components/DaysOfTheWeekRow.tsx
+++ b/packages/components/src/CalendarDatePicker/components/DaysOfTheWeekRow.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import combineClassNames from "classnames";
 import classNames from "./DaysOfTheWeekRow.css";
 import { Text } from "../../Text";
 import { addDays } from "../utils";
@@ -17,8 +18,10 @@ const getFirstDayOfTheWeekDate = (weekStartsOnMonday: boolean) => {
  */
 export const DaysOfTheWeekRow = ({
   weekStartsOnMonday,
+  alternate,
 }: {
   readonly weekStartsOnMonday?: boolean;
+  readonly alternate?: boolean;
 }): JSX.Element => {
   const formatter = new Intl.DateTimeFormat(navigator.language, {
     weekday: "short",
@@ -28,9 +31,20 @@ export const DaysOfTheWeekRow = ({
 
   const row = Array.from({ length: 7 }).map((_, index) => (
     <div className={classNames.cell} key={index} role="row">
-      <Text>{formatter.format(addDays(firstDayOfTheWeek, index))}</Text>
+      <Text size={alternate ? "small" : "base"}>
+        {formatter.format(addDays(firstDayOfTheWeek, index))}
+      </Text>
     </div>
   ));
 
-  return <div className={classNames.row}>{row}</div>;
+  return (
+    <div
+      className={combineClassNames(
+        classNames.row,
+        alternate ? classNames.alternate : "",
+      )}
+    >
+      {row}
+    </div>
+  );
 };


### PR DESCRIPTION
## Motivations

The  calendar date picker for the scheduling recommendations project has a diverging design that I think is worth considering as an option or replacement.

My personal opinion is that for dialogs I like the design in Figma but for inline maybe prefer @jlelford's take. I wasn't a fan of the highlighted dates being borders vs. background. It felt way to busy on the eyes.

## Changes / Added
Implemented the alternative design and added a prop to enable/disable it.

### Scheduling recommendations with the alternative design
https://github.com/GetJobber/atlantis/assets/14314519/76764110-6d1a-4a04-b257-79145ca1388c

<img width="421" alt="image" src="https://github.com/GetJobber/atlantis/assets/14314519/41e730d5-3848-491f-bb4c-4e514f8f4a4b">

### Scheduling recommendations with the original design

https://github.com/GetJobber/atlantis/assets/14314519/f19adcc1-950d-43f5-bbd1-7c60ab24633b


<img width="392" alt="image" src="https://github.com/GetJobber/atlantis/assets/14314519/92444d9d-ef4e-4a41-9e65-f97863cbe228">

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![image](https://github.com/GetJobber/atlantis/assets/14314519/cac61aa9-29e3-41c6-a203-4bfa9507b3d1)