### PR TITLE
fix(components-native): remove doubled testID prefix for GroupButton

### DIFF
--- a/packages/components-native/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components-native/src/ButtonGroup/ButtonGroup.tsx
@@ -76,7 +76,7 @@ export function ButtonGroup({
                 fullHeight={true}
                 icon={icon}
                 loading={loading}
-                testID={`ATL-ButtonGroup-Primary-Action-${index}`}
+                testID={`ButtonGroup-Primary-Action-${index}`}
               />
             )}
           </View>
@@ -90,7 +90,7 @@ export function ButtonGroup({
             accessibilityLabel={t("more")}
             onPress={handlePress(openBottomSheet)}
             fullHeight={true}
-            testID="ATL-ButtonGroup-Secondary-Action"
+            testID="ButtonGroup-Secondary-Action"
           />
         </View>
       )}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

By mistake, I ended up adding two testID prefix to the ButtonGroup to match the [Atlantis rule](https://jobber.atlassian.net/wiki/spaces/TEAMATL/pages/2476933462/How+should+we+declare+test+ID+s+in+Atlantis+components#Exposing-test-ID-as-a-prop) for that.

![Appium](https://github.com/GetJobber/jobber-mobile/assets/108444/b5f12b24-c97b-4430-a682-1be842a975a2)

## Changes

### Changed

- removed prefix for testID on ButtonGroup

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
