### PR TITLE
fix(hooks): Fix useCollectionQuery error state when fetching more

### DIFF
--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
@@ -274,6 +274,7 @@ describe("useCollectionQuery", () => {
                 },
                 error: mockError,
               },
+              buildListRequestMockForNextPage(query, responseMock),
             ]),
           });
 
@@ -286,6 +287,15 @@ describe("useCollectionQuery", () => {
           await act(wait);
 
           expect(result.current.error).toEqual(mockError);
+
+          // should clear the error after a successful fetch
+          act(() => {
+            result.current.nextPage();
+          });
+
+          await act(wait);
+
+          expect(result.current.error).toBeUndefined();
         });
       });
     });

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.test.tsx
@@ -260,6 +260,34 @@ describe("useCollectionQuery", () => {
           await act(wait);
         });
       });
+
+      describe("when there is an error", () => {
+        it("should update the error state", async () => {
+          const mockError = new Error("Failed to fetch more items");
+          const { result } = renderHook(() => useCollectionQueryHook(query), {
+            wrapper: wrapper([
+              buildListRequestMock(query, responseMock),
+              {
+                request: {
+                  query: query,
+                  variables: { cursor: "MZ" },
+                },
+                error: mockError,
+              },
+            ]),
+          });
+
+          await act(wait);
+
+          act(() => {
+            result.current.nextPage();
+          });
+
+          await act(wait);
+
+          expect(result.current.error).toEqual(mockError);
+        });
+      });
     });
 
     describe("#refresh", () => {

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -152,6 +152,7 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
     }
 
     setLoadingNextPage(true);
+    setHookError(undefined);
 
     fetchMore({
       variables: {
@@ -185,6 +186,9 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
       if (subscription == undefined) return;
 
       const subscriptionOptions = subscription.options || {};
+
+      // Reset this state so we can handle errors from the subscription
+      setHookError(undefined);
 
       return subscribeToMore<TSubscription>({
         ...subscriptionOptions,

--- a/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
+++ b/packages/hooks/src/useCollectionQuery/useCollectionQuery.ts
@@ -107,6 +107,7 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
   const isMounted = useIsMounted();
   const [loadingRefresh, setLoadingRefresh] = useState<boolean>(false);
   const [loadingNextPage, setLoadingNextPage] = useState<boolean>(false);
+  const [hookError, setHookError] = useState<ApolloError | undefined>();
   const loadingInitialContent = loading && !loadingRefresh && !loadingNextPage;
   const isSearching = !!queryOptions?.variables?.searchTerm;
 
@@ -159,7 +160,10 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
       updateQuery: (prev, { fetchMoreResult }) =>
         fetchMoreUpdateQueryHandler(prev, fetchMoreResult, getCollectionByPath),
     })
-      .catch(err => config.errorNotifier("FetchMore Error", err))
+      .catch(err => {
+        config.errorNotifier("FetchMore Error", err);
+        setHookError(err);
+      })
       .finally(() => {
         if (isMounted.current) {
           setLoadingNextPage(false);
@@ -193,7 +197,10 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
             subscriptionData?.data,
             subscription.getNodeByPath,
           ),
-        onError: err => config.errorNotifier("Subscribe to More Error", err),
+        onError: err => {
+          config.errorNotifier("Subscribe to More Error", err);
+          setHookError(err as ApolloError);
+        },
       });
     },
     // Disabling this linter so we can force this only run once. If we didn't
@@ -202,9 +209,11 @@ export function useCollectionQuery<TQuery, TSubscription = undefined>({
     [queryOptions?.variables?.searchTerm],
   );
 
+  const combinedError = error || hookError;
+
   return {
     data,
-    error,
+    error: combinedError,
     refresh,
     loadingRefresh,
     nextPage,
@@ -249,6 +258,7 @@ function fetchMoreUpdateQueryHandler<TQuery>(
       nextCollection.nodes,
     );
   }
+
   if (outputCollection.edges && nextCollection.edges) {
     outputCollection.edges = getUpdatedEdges(
       outputCollection.edges,
@@ -288,6 +298,7 @@ function subscribeToMoreHandler<TQuery, TSubscription>(
       false,
     );
   }
+
   if (outputCollection.edges) {
     outputCollection.edges = getUpdatedEdges(
       outputCollection.edges,
@@ -344,6 +355,7 @@ function getUpdatedEdges(
   const newEdges = appendToEnd
     ? [...prevEdges, ...nextEdges]
     : [...nextEdges, ...prevEdges];
+
   return uniqueEdges(newEdges);
 }
 
@@ -355,5 +367,6 @@ function getUpdatedNodes(
   const newNodes = appendToEnd
     ? [...prevNodes, ...nextNodes]
     : [...nextNodes, ...prevNodes];
+
   return uniqueNodes(newNodes);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Fixing the error state of `useCollectionQuery`. Before, it was just doing a `console.error` when it failed on `fetchMore`. I added a state for the error and updated it when necessary.

I also added a test for this case.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fixed the error state of `useCollectionQuery` when it fails on `fetchMore`

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
