### PR TITLE
fix(components): eliminate Tooltip/activator flicker

### DIFF
--- a/packages/components/src/Tooltip/Tooltip.css
+++ b/packages/components/src/Tooltip/Tooltip.css
@@ -12,6 +12,7 @@
   display: inline-block;
   position: absolute;
   z-index: var(--elevation-tooltip);
+  pointer-events: none;
 }
 
 .tooltip {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In https://github.com/GetJobber/atlantis/pull/1593#issuecomment-1777767499 we uncovered that Tooltip is causing flickers on any activator with a hover state.


https://github.com/GetJobber/atlantis/assets/39704901/f650c880-ae80-4b5b-93fc-5e3208722fd6



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- no more flicker at the edge of a Tooltip activator component

https://github.com/GetJobber/atlantis/assets/39704901/4efda7ee-9217-4b89-8ec4-37b38cb8a638

## Testing

Hover around the edges of an element with a Tooltip

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
