### PR TITLE
fix(components): DataList UI updates

### DIFF
--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -4,6 +4,8 @@
 }
 
 .wrapper {
+  --data-list--minimum-item-height: calc(var(--base-unit) * 3.5);
+
   display: flex;
   flex-direction: column;
   position: relative;
@@ -71,6 +73,14 @@
   transition: all var(--timing-base);
 }
 
+.listItem,
+.listItemClickable {
+  display: grid;
+  grid-template-columns: minmax(0px, auto);
+  min-height: var(--data-list--minimum-item-height);
+  align-items: center;
+}
+
 .listItem.active,
 .listItem:hover,
 .listItem:focus-within {
@@ -79,7 +89,6 @@
 }
 
 .listItemClickable {
-  display: block;
   margin: calc(var(--space-small) * -1) 0;
   padding: var(--space-small) 0;
   border: none;
@@ -87,6 +96,15 @@
   text-decoration: none;
   background-color: transparent;
   cursor: pointer;
+}
+
+/**
+ * Reset CSS properties on focus to ensure we only have the focus state on the
+ * parent .listItem
+ */
+.listItemClickable:focus {
+  outline: none;
+  background-color: transparent;
 }
 
 /**

--- a/packages/components/src/DataList/DataList.css.d.ts
+++ b/packages/components/src/DataList/DataList.css.d.ts
@@ -6,8 +6,8 @@ declare const styles: {
   readonly "batchSelectContainer": string;
   readonly "headerBatchSelect": string;
   readonly "listItem": string;
-  readonly "active": string;
   readonly "listItemClickable": string;
+  readonly "active": string;
   readonly "selectable": string;
   readonly "selectAllCheckbox": string;
   readonly "visible": string;

--- a/packages/components/src/DataList/components/DataListBulkActions/DataListBulkActions.css
+++ b/packages/components/src/DataList/components/DataListBulkActions/DataListBulkActions.css
@@ -1,0 +1,4 @@
+.bulkActions {
+  /* Offset the button's padding so the height of the header bar doesn't change */
+  margin: calc(var(--space-small) * -1) 0;
+}

--- a/packages/components/src/DataList/components/DataListBulkActions/DataListBulkActions.css.d.ts
+++ b/packages/components/src/DataList/components/DataListBulkActions/DataListBulkActions.css.d.ts
@@ -1,9 +1,5 @@
 declare const styles: {
-  readonly "bulkActionsContainer": string;
-  readonly "filters": string;
-  readonly "overflowTrigger": string;
-  readonly "overflowLeft": string;
-  readonly "overflowRight": string;
+  readonly "bulkActions": string;
 };
 export = styles;
 

--- a/packages/components/src/DataList/components/DataListBulkActions/DataListBulkActions.tsx
+++ b/packages/components/src/DataList/components/DataListBulkActions/DataListBulkActions.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styles from "./DataListBulkActions.css";
 import { DataListBulkActionsProps } from "../../DataList.types";
 import { useDataListContext } from "../../context/DataListContext";
 import { DataListActions } from "../DataListActions";
@@ -24,6 +25,10 @@ export function InternalDataListBulkActions() {
   const itemsToExpose = sm ? 3 : 0;
 
   return (
-    <DataListActions itemsToExpose={itemsToExpose}>{children}</DataListActions>
+    <div className={styles.bulkActions}>
+      <DataListActions itemsToExpose={itemsToExpose}>
+        {children}
+      </DataListActions>
+    </div>
   );
 }

--- a/packages/components/src/DataList/components/DataListLoadingState/DataListLoadingState.css
+++ b/packages/components/src/DataList/components/DataListLoadingState/DataListLoadingState.css
@@ -18,7 +18,7 @@
 }
 
 .loadingItem {
-  padding: var(--space-small);
+  padding: var(--space-base) var(--space-small);
 }
 
 .glimmer {

--- a/packages/components/src/DataList/components/DataListLoadingState/DataListLoadingState.tsx
+++ b/packages/components/src/DataList/components/DataListLoadingState/DataListLoadingState.tsx
@@ -18,7 +18,7 @@ export function DataListLoadingState() {
 
   if (!layout) return null;
 
-  const glimmerSize = activeBreakpoint === "xs" ? "small" : "base";
+  const glimmerSize = activeBreakpoint === "xs" ? "small" : "large";
   const glimmersFromHeader = Object.keys(headers).reduce(
     (data: DataListItemType<DataListObject[]>, key) => ({
       ...data,

--- a/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.css
+++ b/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.css
@@ -1,4 +1,7 @@
 .fadeContainer {
+  --overflow-fade--offset: var(--space-smaller);
+  --overflow-fade--negative-offset: calc(var(--overflow-fade--offset) * -1);
+
   align-self: center;
   position: relative;
   min-width: 0;
@@ -6,7 +9,10 @@
 
 .overflowGrid {
   display: grid;
+  margin: var(--overflow-fade--negative-offset);
+  padding: var(--overflow-fade--offset);
   overflow-x: auto;
+  overflow-y: visible;
   grid-auto-flow: column;
   grid-auto-columns: max-content;
   align-items: center;
@@ -36,10 +42,10 @@
 }
 
 .overflowLeft::before {
-  left: 0;
+  left: var(--overflow-fade--negative-offset);
 }
 
 .overflowRight::after {
   --data-list-overflow-shadow-angle: to left;
-  right: 0;
+  right: var(--overflow-fade--negative-offset);
 }

--- a/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.css
+++ b/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.css
@@ -18,8 +18,8 @@
   align-items: center;
 }
 
-.overflowGrid > :nth-child(n + 3):not(:last-child) {
-  margin-left: var(--space-small);
+.overflowGrid > :not(:nth-last-child(2)):not(.overflowTrigger) {
+  margin-right: var(--space-small);
 }
 
 .overflowTrigger {

--- a/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.tsx
+++ b/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.tsx
@@ -11,6 +11,7 @@ interface DataListOverflowFadeProps {
 export function DataListOverflowFade({ children }: DataListOverflowFadeProps) {
   const [leftRef, isLeftVisible] = useInView<HTMLSpanElement>();
   const [rightRef, isRightVisible] = useInView<HTMLSpanElement>();
+
   return (
     <div
       data-testid={CONTAINER_TEST_ID}

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css
@@ -4,6 +4,7 @@
   z-index: var(--elevation-default);
   overflow: hidden;
   gap: var(--space-small);
+  white-space: nowrap;
 }
 
 .tagCount {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There are a few design tweaks we need to do to make the DataList UI more harmonious and polished

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Ensure the height of each item is at a minimum of 56px so we reduce the amount of varying heights
- Remove focus on the clickable row to let the parent handle the styling of it
- Ensure bulk action doesn't change the height of the header
- More spacious loading glimmers
- Larger glimmers on wide screens
- Ensure tags doesn't wrap when there's more than 1 word inside a tag
- Ensure focus doesn't get clipped on filters and batch actiions

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
