### PR TITLE
feat(components-native): add custom testID to Select component

### DIFF
--- a/packages/components-native/src/Select/Select.test.tsx
+++ b/packages/components-native/src/Select/Select.test.tsx
@@ -25,7 +25,6 @@ afterEach(() => {
 
 const defaultPlaceholder = "Select an option";
 
-// eslint-disable-next-line max-statements
 describe("Select", () => {
   it("renders a Select", () => {
     const component = render(
@@ -79,48 +78,6 @@ describe("Select", () => {
     expect(
       getByText(assistiveText, { includeHiddenElements: true }),
     ).toBeDefined();
-  });
-
-  describe("when invalid", () => {
-    const labelText = "labelText";
-
-    it("renders an invalid Select", () => {
-      const { getByText } = render(
-        <Select onChange={onChange} invalid={true} label={labelText}>
-          <Option value={"1"}>1</Option>
-          <Option value={"2"}>2</Option>
-        </Select>,
-      );
-      expect(
-        getByText(labelText, { includeHiddenElements: true }).props.style,
-      ).toContainEqual({
-        color: tokens["color-critical"],
-      });
-    });
-
-    it("renders an invalid Select with placeholder", () => {
-      const placeholder = "Place me in the holder";
-      const { getByText } = render(
-        <Select
-          label={labelText}
-          onChange={onChange}
-          invalid={true}
-          placeholder={placeholder}
-        >
-          <Option value={"1"}>1</Option>
-          <Option value={"2"}>2</Option>
-        </Select>,
-      );
-
-      expect(
-        getByText(placeholder, { includeHiddenElements: true }),
-      ).toBeDefined();
-      expect(
-        getByText(labelText, { includeHiddenElements: true }).props.style,
-      ).toContainEqual({
-        color: tokens["color-critical"],
-      });
-    });
   });
 
   it("renders a disabled Select", () => {
@@ -179,156 +136,160 @@ describe("Select", () => {
     expect(getByTestId(`ATL-${testID}-Select`)).toBeDefined();
   });
 
-  describe("fires the onChange callback", () => {
-    it("fires", () => {
-      const { getByTestId } = render(
-        <Select onChange={onChange} value={"2"}>
-          <Option value={"1"}>1</Option>
-          <Option value={"2"}>2</Option>
+  it("renders an accessibilityLabel if provided", () => {
+    const { getByLabelText } = render(
+      <Select
+        onChange={onChange}
+        label="label"
+        accessibilityLabel="accessibilityLabel"
+      >
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+
+    expect(getByLabelText("accessibilityLabel")).toBeTruthy();
+  });
+  it("fires the onChange callback", () => {
+    const { getByTestId } = render(
+      <Select onChange={onChange} value={"2"}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+
+    const select = getByTestId("ATL-Select").findByType(SelectInternalPicker);
+    expect(select).toBeTruthy();
+    fireEvent(select, "onChange", "1");
+    expect(onChange).toHaveBeenCalledWith("1");
+  });
+});
+
+describe("when Select is invalid", () => {
+  const labelText = "labelText";
+
+  it("renders an invalid Select", () => {
+    const { getByText } = render(
+      <Select onChange={onChange} invalid={true} label={labelText}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+    expect(
+      getByText(labelText, { includeHiddenElements: true }).props.style,
+    ).toContainEqual({
+      color: tokens["color-critical"],
+    });
+  });
+
+  it("renders an invalid Select with placeholder", () => {
+    const placeholder = "Place me in the holder";
+    const { getByText } = render(
+      <Select
+        label={labelText}
+        onChange={onChange}
+        invalid={true}
+        placeholder={placeholder}
+      >
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+
+    expect(
+      getByText(placeholder, { includeHiddenElements: true }),
+    ).toBeDefined();
+    expect(
+      getByText(labelText, { includeHiddenElements: true }).props.style,
+    ).toContainEqual({
+      color: tokens["color-critical"],
+    });
+  });
+});
+
+describe("when validations are passed to the component", () => {
+  describe("validations fail", () => {
+    let tree: RenderAPI;
+    const labelText = "labelText";
+    const errorMsg = "Too short";
+    beforeEach(() => {
+      tree = render(
+        <Select
+          label={labelText}
+          onChange={onChange}
+          value={"Watermelon"}
+          validations={{
+            minLength: { value: 60, message: errorMsg },
+          }}
+        >
+          <Option value={"Apple"}>Apple</Option>
+          <Option value={"Watermelon"}>Watermelon</Option>
         </Select>,
       );
+    });
 
-      const select = getByTestId("ATL-Select").findByType(SelectInternalPicker);
+    it("renders the error message when there is an error", async () => {
+      const select = tree
+        .getByTestId("ATL-Select")
+        .findByType(SelectInternalPicker);
+      fireEvent(select, "onChange", "Apple");
+      expect(
+        await tree.findByText(errorMsg, { includeHiddenElements: true }),
+      ).toBeTruthy();
+    });
+
+    it("shows the invalid colours", async () => {
+      const select = tree
+        .getByTestId("ATL-Select")
+        .findByType(SelectInternalPicker);
+      fireEvent(select, "onChange", "Apple");
+      expect(
+        (await tree.findByText(labelText, { includeHiddenElements: true }))
+          .props.style,
+      ).toContainEqual({
+        color: tokens["color-critical"],
+      });
+    });
+  });
+
+  describe("validations passes", () => {
+    let tree: RenderAPI;
+    const labelText = "labelText";
+    const errorMsg = "Not too short";
+    beforeEach(() => {
+      tree = render(
+        <Select
+          label={labelText}
+          onChange={onChange}
+          value={"Watermelon"}
+          validations={{
+            minLength: { value: 4, message: errorMsg },
+          }}
+        >
+          <Option value={"Apple"}>Apple</Option>
+          <Option value={"Watermelon"}>Watermelon</Option>
+        </Select>,
+      );
+    });
+
+    it("does not render any error messages", () => {
+      const select = tree
+        .getByTestId("ATL-Select")
+        .findByType(SelectInternalPicker);
       expect(select).toBeTruthy();
-      fireEvent(select, "onChange", "1");
-      expect(onChange).toHaveBeenCalledWith("1");
+      fireEvent(select, "onChange", "Apple");
+      expect(tree.queryByText(errorMsg)).toBeNull();
     });
-  });
 
-  describe("Invalid value", () => {
-    it("renders with the empty value option", () => {
-      const { getByText } = render(
-        <Select onChange={onChange} value={"invalid"}>
-          <Option value={"first"}>first</Option>
-          <Option value={"2"}>2</Option>
-        </Select>,
-      );
-
+    it("has non-critical colours", () => {
+      const select = tree
+        .getByTestId("ATL-Select")
+        .findByType(SelectInternalPicker);
+      fireEvent(select, "onChange", "Apple");
       expect(
-        getByText(defaultPlaceholder, { includeHiddenElements: true }),
-      ).toBeDefined();
-    });
-
-    it("renders with the placeholder", () => {
-      const { getByText } = render(
-        <Select
-          onChange={onChange}
-          value={"invalid"}
-          placeholder={"Make a selection"}
-        >
-          <Option value={"1"}>1</Option>
-          <Option value={"2"}>2</Option>
-        </Select>,
-      );
-
-      expect(
-        getByText("Make a selection", { includeHiddenElements: true }),
-      ).toBeDefined();
-    });
-  });
-
-  describe("accessibilityLabel", () => {
-    it("uses accessibilityLabel if specified", () => {
-      const { getByLabelText } = render(
-        <Select
-          onChange={onChange}
-          label="label"
-          accessibilityLabel="accessibilityLabel"
-        >
-          <Option value={"1"}>1</Option>
-          <Option value={"2"}>2</Option>
-        </Select>,
-      );
-
-      expect(getByLabelText("accessibilityLabel")).toBeTruthy();
-    });
-  });
-
-  describe("when validations are passed to the component", () => {
-    describe("validations fail", () => {
-      let tree: RenderAPI;
-      const labelText = "labelText";
-      const errorMsg = "Too short";
-      beforeEach(() => {
-        tree = render(
-          <Select
-            label={labelText}
-            onChange={onChange}
-            value={"Watermelon"}
-            validations={{
-              minLength: { value: 60, message: errorMsg },
-            }}
-          >
-            <Option value={"Apple"}>Apple</Option>
-            <Option value={"Watermelon"}>Watermelon</Option>
-          </Select>,
-        );
-      });
-
-      it("renders the error message when there is an error", async () => {
-        const select = tree
-          .getByTestId("ATL-Select")
-          .findByType(SelectInternalPicker);
-        fireEvent(select, "onChange", "Apple");
-        expect(
-          await tree.findByText(errorMsg, { includeHiddenElements: true }),
-        ).toBeTruthy();
-      });
-
-      it("shows the invalid colours", async () => {
-        const select = tree
-          .getByTestId("ATL-Select")
-          .findByType(SelectInternalPicker);
-        fireEvent(select, "onChange", "Apple");
-        expect(
-          (await tree.findByText(labelText, { includeHiddenElements: true }))
-            .props.style,
-        ).toContainEqual({
-          color: tokens["color-critical"],
-        });
-      });
-    });
-
-    describe("validations passes", () => {
-      let tree: RenderAPI;
-      const labelText = "labelText";
-      const errorMsg = "Not too short";
-      beforeEach(() => {
-        tree = render(
-          <Select
-            label={labelText}
-            onChange={onChange}
-            value={"Watermelon"}
-            validations={{
-              minLength: { value: 4, message: errorMsg },
-            }}
-          >
-            <Option value={"Apple"}>Apple</Option>
-            <Option value={"Watermelon"}>Watermelon</Option>
-          </Select>,
-        );
-      });
-
-      it("does not render any error messages", () => {
-        const select = tree
-          .getByTestId("ATL-Select")
-          .findByType(SelectInternalPicker);
-        expect(select).toBeTruthy();
-        fireEvent(select, "onChange", "Apple");
-        expect(tree.queryByText(errorMsg)).toBeNull();
-      });
-
-      it("has non-critical colours", () => {
-        const select = tree
-          .getByTestId("ATL-Select")
-          .findByType(SelectInternalPicker);
-        fireEvent(select, "onChange", "Apple");
-        expect(
-          tree.getByText(labelText, { includeHiddenElements: true }).props
-            .style,
-        ).toContainEqual({
-          color: tokens["color-text--secondary"],
-        });
+        tree.getByText(labelText, { includeHiddenElements: true }).props.style,
+      ).toContainEqual({
+        color: tokens["color-text--secondary"],
       });
     });
   });

--- a/packages/components-native/src/Select/Select.test.tsx
+++ b/packages/components-native/src/Select/Select.test.tsx
@@ -25,6 +25,7 @@ afterEach(() => {
 
 const defaultPlaceholder = "Select an option";
 
+// eslint-disable-next-line max-statements
 describe("Select", () => {
   it("renders a Select", () => {
     const component = render(
@@ -164,6 +165,18 @@ describe("Select", () => {
     expect(
       getByText(expectedValue, { includeHiddenElements: true }),
     ).toBeDefined();
+  });
+
+  it("renders a Select with custom testID", () => {
+    const testID = "testID";
+    const { getByTestId } = render(
+      <Select onChange={onChange} testID={testID}>
+        <Option value={"1"}>1</Option>
+        <Option value={"2"}>2</Option>
+      </Select>,
+    );
+
+    expect(getByTestId(`ATL-${testID}-Select`)).toBeDefined();
   });
 
   describe("fires the onChange callback", () => {

--- a/packages/components-native/src/Select/Select.tsx
+++ b/packages/components-native/src/Select/Select.tsx
@@ -88,6 +88,11 @@ export interface SelectProps {
    * The validations that will mark this component as invalid
    */
   readonly validations?: RegisterOptions;
+
+  /**
+   * Used to locate this view in end-to-end tests.
+   */
+  readonly testID?: string;
 }
 
 export function Select({
@@ -103,6 +108,7 @@ export function Select({
   validations,
   accessibilityLabel,
   name,
+  testID,
 }: SelectProps): JSX.Element {
   const { field, error } = useFormController({
     name,
@@ -129,7 +135,7 @@ export function Select({
       }}
     >
       <View
-        testID="ATL-Select"
+        testID={getTestID(testID)}
         accessible={true}
         accessibilityLabel={getA11yLabel()}
         accessibilityValue={{ text: getValue() }}
@@ -187,6 +193,7 @@ export function Select({
   function getA11yLabel(): string | undefined {
     let text = [accessibilityLabel || label, assistiveText];
     text = text.filter(Boolean);
+
     return text.join(", ");
   }
 
@@ -219,6 +226,7 @@ export function Select({
     const options = getOptions();
 
     const activeValue = options.find(option => option.isActive);
+
     return activeValue?.label || placeholder || t("Select.emptyValue");
   }
 }
@@ -229,7 +237,16 @@ function getTextVariation({
 }: Pick<SelectProps, "invalid" | "disabled">): TextVariation {
   if (invalid) return "error";
   if (disabled) return "disabled";
+
   return "subdued";
+}
+
+function getTestID(testID?: string): string {
+  if (testID) {
+    return `ATL-${testID}-Select`;
+  }
+
+  return "ATL-Select";
 }
 
 export function Option({ children }: SelectOption): JSX.Element {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Some screens in the app has more than one select and we don’t have way to uniquely identify these components. So following the[ testID recommendations document](https://jobber.atlassian.net/wiki/spaces/TEAMATL/pages/2476933462/How+should+we+declare+test+ID+s+in+Atlantis+components#Exposing-test-ID-as-a-prop), I added a custom testID for the Select.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- new testID property to the Select component

## Testing

You can pass a testID to any component in the app using this version and it should be present with the new pattern: ATL-{customId}-Select. If not present, should just be as it's.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
