### PR TITLE
feat(components): Implement option and deprecate content

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -228,41 +228,39 @@ const ComboboxMultiSelection: ComponentStory<typeof Combobox> = args => {
   const [selected, setSelected] = useState<ComboboxOption[]>([]);
 
   return (
-    <Combobox {...args} multiSelect heading="Teammates">
-      <Combobox.Content
-        options={[
-          { id: "1", label: "Bilbo Baggins" },
-          { id: "2", label: "Frodo Baggins" },
-          { id: "3", label: "Pippin Took" },
-          { id: "4", label: "Merry Brandybuck" },
-          { id: "5", label: "Sam Gamgee" },
-          { id: "6", label: "Aragorn" },
-          { id: "7", label: "Galadriel" },
-          { id: "8", label: "Arwen" },
-          { id: "9", label: "Gandalf" },
-          { id: "10", label: "Legolas" },
-          { id: "11", label: "Gimli" },
-          { id: "12", label: "Samwise Gamgee" },
-          { id: "14", label: "Faramir" },
-        ]}
-        onSelect={selection => {
-          setSelected(selection);
+    <Combobox
+      {...args}
+      multiSelect
+      heading="Teammates"
+      onSelect={setSelected}
+      selected={selected}
+    >
+      <Combobox.Option id="1" label="Bilbo Baggins" />
+      <Combobox.Option id="2" label="Frodo Baggins" />
+      <Combobox.Option id="3" label="Pippin Took" />
+      <Combobox.Option id="4" label="Merry Brandybuck" />
+      <Combobox.Option id="5" label="Sam Gamgee" />
+      <Combobox.Option id="6" label="Aragorn" />
+      <Combobox.Option id="7" label="Galadriel" />
+      <Combobox.Option id="8" label="Arwen" />
+      <Combobox.Option id="9" label="Gandalf" />
+      <Combobox.Option id="10" label="Legolas" />
+      <Combobox.Option id="11" label="Gimli" />
+      <Combobox.Option id="12" label="Samwise Gamgee" />
+      <Combobox.Option id="14" label="Faramir" />
+
+      <Combobox.Action
+        label="Add Teammate"
+        onClick={() => {
+          alert("Added a new teammate ✅");
         }}
-        selected={selected}
-      >
-        <Combobox.Action
-          label="Add Teammate"
-          onClick={() => {
-            alert("Added a new teammate ✅");
-          }}
-        />
-        <Combobox.Action
-          label="Manage Teammates"
-          onClick={() => {
-            alert("Managed teammates 👍");
-          }}
-        />
-      </Combobox.Content>
+      />
+      <Combobox.Action
+        label="Manage Teammates"
+        onClick={() => {
+          alert("Managed teammates 👍");
+        }}
+      />
     </Combobox>
   );
 };

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -21,33 +21,30 @@ const BasicCombobox: ComponentStory<typeof Combobox> = args => {
   const [selected, setSelected] = useState<ComboboxOption[]>([]);
 
   return (
-    <Combobox {...args} heading="Teammates">
-      <Combobox.Content
-        options={[
-          { id: "1", label: "Bilbo Baggins" },
-          { id: "2", label: "Frodo Baggins" },
-          { id: "3", label: "Pippin Took" },
-          { id: "4", label: "Merry Brandybuck" },
-          { id: "5", label: "Sam Gamgee" },
-        ]}
-        onSelect={selection => {
-          setSelected(selection);
+    <Combobox
+      {...args}
+      onSelect={setSelected}
+      selected={selected}
+      heading="Teammates"
+    >
+      <Combobox.Option id="1" label="Bilbo Baggins" />
+      <Combobox.Option id="2" label="Frodo Baggins" />
+      <Combobox.Option id="3" label="Pippin Took" />
+      <Combobox.Option id="4" label="Merry Brandybuck" />
+      <Combobox.Option id="5" label="Sam Gamgee" />
+
+      <Combobox.Action
+        label="Add Teammate"
+        onClick={() => {
+          alert("Added a new teammate ✅");
         }}
-        selected={selected}
-      >
-        <Combobox.Action
-          label="Add Teammate"
-          onClick={() => {
-            alert("Added a new teammate ✅");
-          }}
-        />
-        <Combobox.Action
-          label="Manage Teammates"
-          onClick={() => {
-            alert("Managed teammates 👍");
-          }}
-        />
-      </Combobox.Content>
+      />
+      <Combobox.Action
+        label="Manage Teammates"
+        onClick={() => {
+          alert("Managed teammates 👍");
+        }}
+      />
     </Combobox>
   );
 };

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -16,7 +16,14 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
   const [selected, setSelected] = useState<ComboboxOption[]>([]);
 
   return (
-    <Combobox {...args}>
+    <Combobox
+      {...args}
+      onSelect={selection => {
+        setSelected(selection);
+      }}
+      selected={selected}
+      subjectNoun="teammates"
+    >
       <Combobox.TriggerButton
         label="Select Teammate"
         variation="subtle"
@@ -24,41 +31,33 @@ const ComboboxButton: ComponentStory<typeof Combobox> = args => {
         icon="arrowDown"
         iconOnRight={true}
       />
-      <Combobox.Content
-        options={[
-          { id: "1", label: "Bilbo Baggins" },
-          { id: "2", label: "Frodo Baggins" },
-          { id: "3", label: "Pippin Took" },
-          { id: "4", label: "Merry Brandybuck" },
-          { id: "5", label: "Sam Gamgee" },
-          { id: "6", label: "Aragorn" },
-          { id: "7", label: "Galadriel" },
-          { id: "8", label: "Arwen" },
-          { id: "9", label: "Gandalf" },
-          { id: "10", label: "Legolas" },
-          { id: "11", label: "Gimli" },
-          { id: "12", label: "Samwise Gamgee" },
-          { id: "14", label: "Faramir" },
-        ]}
-        onSelect={selection => {
-          setSelected(selection);
+
+      <Combobox.Option id="1" label="Bilbo Baggins" />
+      <Combobox.Option id="2" label="Frodo Baggins" />
+      <Combobox.Option id="3" label="Pippin Took" />
+      <Combobox.Option id="4" label="Merry Brandybuck" />
+      <Combobox.Option id="5" label="Sam Gamgee" />
+      <Combobox.Option id="6" label="Aragorn" />
+      <Combobox.Option id="7" label="Galadriel" />
+      <Combobox.Option id="8" label="Arwen" />
+      <Combobox.Option id="9" label="Gandalf" />
+      <Combobox.Option id="10" label="Legolas" />
+      <Combobox.Option id="11" label="Gimli" />
+      <Combobox.Option id="12" label="Samwise Gamgee" />
+      <Combobox.Option id="14" label="Faramir" />
+
+      <Combobox.Action
+        label="Add Teammate"
+        onClick={() => {
+          alert("Added a new teammate ✅");
         }}
-        selected={selected}
-        subjectNoun="teammates"
-      >
-        <Combobox.Action
-          label="Add Teammate"
-          onClick={() => {
-            alert("Added a new teammate ✅");
-          }}
-        />
-        <Combobox.Action
-          label="Manage Teammates"
-          onClick={() => {
-            alert("Managed teammates 👍");
-          }}
-        />
-      </Combobox.Content>
+      />
+      <Combobox.Action
+        label="Manage Teammates"
+        onClick={() => {
+          alert("Managed teammates 👍");
+        }}
+      />
     </Combobox>
   );
 };
@@ -67,35 +66,34 @@ const ComboboxChip: ComponentStory<typeof Combobox> = args => {
   const [selected, setSelected] = useState<ComboboxOption[]>([]);
 
   return (
-    <Combobox {...args}>
+    <Combobox
+      {...args}
+      onSelect={selection => {
+        setSelected(selection);
+      }}
+      selected={selected}
+      subjectNoun="teammates"
+    >
       <Combobox.TriggerChip label="Teammates" />
-      <Combobox.Content
-        options={[
-          { id: "1", label: "Bilbo Baggins" },
-          { id: "2", label: "Frodo Baggins" },
-          { id: "3", label: "Pippin Took" },
-          { id: "4", label: "Merry Brandybuck" },
-          { id: "5", label: "Sam Gamgee" },
-        ]}
-        onSelect={selection => {
-          setSelected(selection);
+
+      <Combobox.Option id="1" label="Bilbo Baggins" />
+      <Combobox.Option id="2" label="Frodo Baggins" />
+      <Combobox.Option id="3" label="Pippin Took" />
+      <Combobox.Option id="4" label="Merry Brandybuck" />
+      <Combobox.Option id="5" label="Sam Gamgee" />
+
+      <Combobox.Action
+        label="Add Teammate"
+        onClick={() => {
+          alert("Added a new teammate ✅");
         }}
-        selected={selected}
-        subjectNoun="teammates"
-      >
-        <Combobox.Action
-          label="Add Teammate"
-          onClick={() => {
-            alert("Added a new teammate ✅");
-          }}
-        />
-        <Combobox.Action
-          label="Manage Teammates"
-          onClick={() => {
-            alert("Managed teammates 👍");
-          }}
-        />
-      </Combobox.Content>
+      />
+      <Combobox.Action
+        label="Manage Teammates"
+        onClick={() => {
+          alert("Managed teammates 👍");
+        }}
+      />
     </Combobox>
   );
 };

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -4,7 +4,6 @@ import { ComboboxOption } from "./Combobox.types";
 import { Combobox } from "./Combobox";
 import {
   COMBOBOX_OPTION_AND_CONTENT_EXISTS_ERROR,
-  COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE,
   COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE,
 } from "./hooks/useComboboxValidation";
 import { Chip } from "../Chip";
@@ -125,40 +124,6 @@ describe("Combobox validation", () => {
       );
 
     expect(component).toThrow(COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
-  });
-
-  it("throws an error if there is no Content element", () => {
-    expect.assertions(1);
-    let error;
-
-    try {
-      render(
-        <Combobox>
-          <Combobox.TriggerButton label="Button" />
-        </Combobox>,
-      );
-    } catch (e) {
-      error = e as Error;
-    } finally {
-      expect(error?.message).toBe(COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE);
-    }
-  });
-
-  it("throws an error if there is neither a Content nor Trigger element", () => {
-    expect.assertions(1);
-    let error;
-
-    try {
-      render(
-        <Combobox>
-          <></>
-        </Combobox>,
-      );
-    } catch (e) {
-      error = e as Error;
-    } finally {
-      expect(error?.message).toBe(COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE);
-    }
   });
 
   it("throws an error if there are multiple Trigger elements and no Content", () => {

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
 import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { ComboboxOption } from "./Combobox.types";
 import { Combobox } from "./Combobox";
 import { COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE } from "./hooks/useComboboxValidation";
@@ -88,6 +88,41 @@ describe("Combobox validation", () => {
     } finally {
       expect(error?.message).toBe(COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
     }
+  });
+});
+
+// TODO: Consolidate this with "ComboboxContent" test once we've completely
+// remove Combobox.Content JOB-81416
+describe("Combobox Simplified API", () => {
+  const mockOnSelect = jest.fn();
+  const mockActionClick = jest.fn();
+
+  it("should show the options and actions in the Combobox Content", () => {
+    const triggerLabel = "Button";
+    render(
+      <Combobox onSelect={mockOnSelect} selected={[]}>
+        <Combobox.TriggerButton label={triggerLabel} />
+
+        <Combobox.Option id="1" label="Option 1" />
+        <Combobox.Option id="2" label="Option 2" />
+
+        <Combobox.Action label="Action 1" onClick={mockActionClick} />
+      </Combobox>,
+    );
+
+    const optionOneLabel = screen.getByText("Option 1");
+    const actionLabel = screen.getByLabelText("Action 1");
+
+    fireEvent.click(screen.getByText(triggerLabel));
+    expect(optionOneLabel).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(actionLabel).toBeInTheDocument();
+
+    fireEvent.click(optionOneLabel);
+    expect(mockOnSelect).toHaveBeenCalledWith([{ id: "1", label: "Option 1" }]);
+
+    actionLabel.click();
+    expect(mockActionClick).toHaveBeenCalled();
   });
 });
 

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -2,10 +2,7 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { ComboboxOption } from "./Combobox.types";
 import { Combobox } from "./Combobox";
-import {
-  COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE,
-  COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE,
-} from "./hooks/useComboboxValidation";
+import { COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE } from "./hooks/useComboboxValidation";
 
 // jsdom is missing this implementation
 const scrollIntoViewMock = jest.fn();
@@ -27,27 +24,6 @@ describe("Combobox validation", () => {
         </Combobox>,
       );
     }).not.toThrow();
-  });
-
-  it("throws an error if there is no Trigger element", () => {
-    expect.assertions(1);
-    let error;
-
-    try {
-      render(
-        <Combobox>
-          <Combobox.Content
-            options={[]}
-            onSelect={jest.fn()}
-            selected={[]}
-          ></Combobox.Content>
-        </Combobox>,
-      );
-    } catch (e) {
-      error = e as Error;
-    } finally {
-      expect(error?.message).toBe(COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE);
-    }
   });
 
   it("throws an error if there are multiple of the same Trigger element", () => {
@@ -93,40 +69,6 @@ describe("Combobox validation", () => {
       error = e as Error;
     } finally {
       expect(error?.message).toBe(COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
-    }
-  });
-
-  it("throws an error if there is no Content element", () => {
-    expect.assertions(1);
-    let error;
-
-    try {
-      render(
-        <Combobox>
-          <Combobox.TriggerButton label="Button" />
-        </Combobox>,
-      );
-    } catch (e) {
-      error = e as Error;
-    } finally {
-      expect(error?.message).toBe(COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE);
-    }
-  });
-
-  it("throws an error if there is neither a Content nor Trigger element", () => {
-    expect.assertions(1);
-    let error;
-
-    try {
-      render(
-        <Combobox>
-          <></>
-        </Combobox>,
-      );
-    } catch (e) {
-      error = e as Error;
-    } finally {
-      expect(error?.message).toBe(COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE);
     }
   });
 

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { ComboboxOption } from "./Combobox.types";
 import { Combobox } from "./Combobox";
-import { COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE } from "./hooks/useComboboxValidation";
+import {
+  COMBOBOX_OPTION_AND_CONTENT_EXISTS_ERROR,
+  COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE,
+} from "./hooks/useComboboxValidation";
 
 // jsdom is missing this implementation
 const scrollIntoViewMock = jest.fn();
@@ -123,6 +126,24 @@ describe("Combobox Simplified API", () => {
 
     actionLabel.click();
     expect(mockActionClick).toHaveBeenCalled();
+  });
+
+  it("should throw an error when Option/Action and Content all exist as siblings", () => {
+    const component = () =>
+      render(
+        <Combobox onSelect={mockOnSelect} selected={[]}>
+          <Combobox.TriggerButton label="Button" />
+
+          <Combobox.Content options={[]} onSelect={jest.fn()} selected={[]} />
+
+          <Combobox.Option id="1" label="Option 1" />
+          <Combobox.Option id="2" label="Option 2" />
+
+          <Combobox.Action label="Action 1" onClick={mockActionClick} />
+        </Combobox>,
+      );
+
+    expect(component).toThrow(COMBOBOX_OPTION_AND_CONTENT_EXISTS_ERROR);
   });
 });
 

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -8,6 +8,7 @@ import {
   ComboboxTriggerChip,
 } from "./components/ComboboxTrigger";
 import { useComboboxValidation } from "./hooks/useComboboxValidation";
+import { ComboboxOption } from "./components/ComboboxOption";
 
 export function Combobox({
   selected = [],
@@ -34,6 +35,7 @@ export function Combobox({
           onSelect={props.onSelect}
           onClose={props.onClose}
           selected={selected}
+          subjectNoun={props.subjectNoun}
         >
           {actionElements}
         </ComboboxContent>
@@ -50,3 +52,4 @@ Combobox.TriggerChip = ComboboxTriggerChip;
  */
 Combobox.Content = ComboboxContent;
 Combobox.Action = ComboboxAction;
+Combobox.Option = ComboboxOption;

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -28,12 +28,8 @@ export function Combobox({
       {contentElement}
 
       {Boolean(optionElements.length) && (
-        // @ts-expect-error - Suppress the XOR error with onClose until we finish the refactor on JOB-81416
-        <ComboboxContent
-          onSelect={() => new Error("Add an `onSelect` prop on `Combobox`")}
-          options={buildOptions}
-          {...props}
-        >
+        // @ts-expect-error - Suppress the XOR error with onClose|onSelect until we finish the refactor on JOB-81416
+        <ComboboxContent options={buildOptions} {...props}>
           {actionElements}
         </ComboboxContent>
       )}

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -27,9 +27,8 @@ export function Combobox({
   return (
     <ComboboxContextProvider multiselect={multiSelect}>
       {triggerElement || <ComboboxTrigger heading={props.heading} />}
-      {contentElement}
 
-      {Boolean(optionElements.length) && (
+      {contentElement || (
         // @ts-expect-error - Suppress the XOR error with onClose|onSelect until we finish the refactor on JOB-81416
         <ComboboxContent options={buildOptions} {...props}>
           {actionElements}

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -9,20 +9,44 @@ import {
 } from "./components/ComboboxTrigger";
 import { useComboboxValidation } from "./hooks/useComboboxValidation";
 
-export function Combobox(props: ComboboxProps): JSX.Element {
-  const { contentElement, triggerElement } = useComboboxValidation(
-    props.children,
-  );
+export function Combobox({
+  selected = [],
+  ...props
+}: ComboboxProps): JSX.Element {
+  const { contentElement, triggerElement, optionElements, actionElements } =
+    useComboboxValidation(props.children);
+
+  const getOptions = optionElements.map(option => ({
+    id: option.props.id,
+    label: option.props.label,
+  }));
 
   return (
     <ComboboxContextProvider multiselect={props.multiSelect}>
       {triggerElement}
       {contentElement}
+
+      {Boolean(optionElements.length) && (
+        // @ts-expect-error - XOR issue but since this will be refactored, we
+        // can ignore this for now
+        <ComboboxContent
+          options={getOptions}
+          onSelect={props.onSelect}
+          onClose={props.onClose}
+          selected={selected}
+        >
+          {actionElements}
+        </ComboboxContent>
+      )}
     </ComboboxContextProvider>
   );
 }
 
 Combobox.TriggerButton = ComboboxTriggerButton;
 Combobox.TriggerChip = ComboboxTriggerChip;
+
+/**
+ * @deprecated Use individual Combobox.Option instead
+ */
 Combobox.Content = ComboboxContent;
 Combobox.Action = ComboboxAction;

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -14,6 +14,7 @@ import { ComboboxActivator } from "./components/ComboboxActivator";
 
 export function Combobox({
   multiSelect = false,
+  selected = [],
   ...props
 }: ComboboxProps): JSX.Element {
   const { contentElement, triggerElement, optionElements, actionElements } =
@@ -26,11 +27,13 @@ export function Combobox({
 
   return (
     <ComboboxContextProvider multiselect={multiSelect}>
-      {triggerElement || <ComboboxTrigger heading={props.heading} />}
+      {triggerElement || (
+        <ComboboxTrigger heading={props.heading} selected={selected} />
+      )}
 
       {contentElement || (
         // @ts-expect-error - Suppress the XOR error with onClose|onSelect until we finish the refactor on JOB-81416
-        <ComboboxContent options={buildOptions} {...props}>
+        <ComboboxContent options={buildOptions} selected={selected} {...props}>
           {actionElements}
         </ComboboxContent>
       )}

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -11,31 +11,28 @@ import { useComboboxValidation } from "./hooks/useComboboxValidation";
 import { ComboboxOption } from "./components/ComboboxOption";
 
 export function Combobox({
-  selected = [],
+  multiSelect = false,
   ...props
 }: ComboboxProps): JSX.Element {
   const { contentElement, triggerElement, optionElements, actionElements } =
     useComboboxValidation(props.children);
 
-  const getOptions = optionElements.map(option => ({
+  const buildOptions = optionElements.map(option => ({
     id: option.props.id,
     label: option.props.label,
   }));
 
   return (
-    <ComboboxContextProvider multiselect={props.multiSelect}>
+    <ComboboxContextProvider multiselect={multiSelect}>
       {triggerElement}
       {contentElement}
 
       {Boolean(optionElements.length) && (
-        // @ts-expect-error - XOR issue but since this will be refactored, we
-        // can ignore this for now
+        // @ts-expect-error - Suppress the XOR error with onClose until we finish the refactor on JOB-81416
         <ComboboxContent
-          options={getOptions}
-          onSelect={props.onSelect}
-          onClose={props.onClose}
-          selected={selected}
-          subjectNoun={props.subjectNoun}
+          onSelect={() => new Error("Add an `onSelect` prop on `Combobox`")}
+          options={buildOptions}
+          {...props}
         >
           {actionElements}
         </ComboboxContent>

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -13,6 +13,7 @@ export interface ComboboxProps {
   readonly multiSelect?: boolean;
 
   readonly selected?: ComboboxOption[];
+  readonly subjectNoun?: string;
   readonly onSelect?: (selection: ComboboxOption[]) => void;
   readonly onClose?: (selection: ComboboxOption[]) => void;
 }

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -11,6 +11,10 @@ export interface ComboboxProps {
    * @default false
    */
   readonly multiSelect?: boolean;
+
+  readonly selected?: ComboboxOption[];
+  readonly onSelect?: (selection: ComboboxOption[]) => void;
+  readonly onClose?: (selection: ComboboxOption[]) => void;
 }
 
 export interface ComboboxTriggerProps {

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -2,7 +2,8 @@ import { Dispatch, ReactElement, SetStateAction } from "react";
 import { XOR } from "ts-xor";
 import { ButtonProps } from "../Button";
 
-export interface ComboboxProps {
+export interface ComboboxProps
+  extends Partial<Omit<ComboboxContentBaseProps, "options">> {
   readonly children: ReactElement | ReactElement[];
 
   /**
@@ -12,8 +13,6 @@ export interface ComboboxProps {
    */
   readonly multiSelect?: boolean;
 
-  readonly selected?: ComboboxOption[];
-  readonly subjectNoun?: string;
   readonly onSelect?: (selection: ComboboxOption[]) => void;
   readonly onClose?: (selection: ComboboxOption[]) => void;
 }

--- a/packages/components/src/Combobox/ComboboxProvider.tsx
+++ b/packages/components/src/Combobox/ComboboxProvider.tsx
@@ -1,14 +1,11 @@
 import React, { RefObject, useRef, useState } from "react";
 import styles from "./Combobox.css";
-import { ComboboxOption } from "./Combobox.types";
 
 export const ComboboxContext = React.createContext(
   {} as {
     multiselect: boolean;
     open: boolean;
     setOpen: (open: boolean) => void;
-    selected: ComboboxOption[];
-    setSelected: (open: ComboboxOption[]) => void;
     wrapperRef: RefObject<HTMLDivElement>;
   },
 );
@@ -23,12 +20,11 @@ export function ComboboxContextProvider(
 ): JSX.Element {
   const multiselect = props.multiselect || false;
   const [open, setOpen] = useState<boolean>(false);
-  const [selected, setSelected] = useState<ComboboxOption[]>([]);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   return (
     <ComboboxContext.Provider
-      value={{ multiselect, open, setOpen, wrapperRef, selected, setSelected }}
+      value={{ multiselect, open, setOpen, wrapperRef }}
     >
       <div ref={wrapperRef}>
         {open && (

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import classnames from "classnames";
 import ReactDOM from "react-dom";
 import styles from "./ComboboxContent.css";
@@ -11,12 +11,8 @@ import { useComboboxAccessibility } from "../../hooks/useComboboxAccessibility";
 import { ComboboxContentProps, ComboboxOption } from "../../Combobox.types";
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
-  const { open, setOpen, setSelected, wrapperRef, multiselect } =
+  const { open, setOpen, wrapperRef, multiselect } =
     React.useContext(ComboboxContext);
-
-  useEffect(() => {
-    setSelected(props.selected);
-  }, [props.selected]);
 
   const optionsExist = props.options.length > 0;
 

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.tsx
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.tsx
@@ -1,0 +1,12 @@
+import { useAssert } from "@jobber/hooks/useAssert";
+import { ComboboxOption as ComboboxOptionType } from "../../Combobox.types";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function ComboboxOption(_: ComboboxOptionType) {
+  useAssert(
+    true,
+    "Combobox.Option can only be used inside a Combobox component",
+  );
+
+  return null;
+}

--- a/packages/components/src/Combobox/components/ComboboxOption/index.ts
+++ b/packages/components/src/Combobox/components/ComboboxOption/index.ts
@@ -1,0 +1,1 @@
+export * from "./ComboboxOption";

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
@@ -83,15 +83,13 @@ describe("ComboboxTrigger", () => {
     afterEach(cleanup);
     it("renders a Chip with 'base' variation", () => {
       const { getByRole } = render(
-        <Combobox heading="Teammates">
-          <Combobox.Content
-            options={[
-              { id: "1", label: "Michael" },
-              { id: "2", label: "Jason" },
-            ]}
-            onSelect={jest.fn()}
-            selected={[{ id: "1", label: "Michael" }]}
-          ></Combobox.Content>
+        <Combobox
+          heading="Teammates"
+          onSelect={jest.fn()}
+          selected={[{ id: "1", label: "Michael" }]}
+        >
+          <Combobox.Option id="1" label="Michael" />
+          <Combobox.Option id="2" label="Jason" />
         </Combobox>,
       );
 
@@ -104,15 +102,13 @@ describe("ComboboxTrigger", () => {
     describe("When multiSelect is false", () => {
       it("renders Chip with the selected option as the label", () => {
         const { getByRole } = render(
-          <Combobox heading="Teammates">
-            <Combobox.Content
-              options={[
-                { id: "1", label: "Michael" },
-                { id: "2", label: "Jason" },
-              ]}
-              onSelect={jest.fn()}
-              selected={[{ id: "1", label: "Michael" }]}
-            ></Combobox.Content>
+          <Combobox
+            heading="Teammates"
+            onSelect={jest.fn()}
+            selected={[{ id: "1", label: "Michael" }]}
+          >
+            <Combobox.Option id="1" label="Michael" />
+            <Combobox.Option id="2" label="Jason" />
           </Combobox>,
         );
 
@@ -125,16 +121,15 @@ describe("ComboboxTrigger", () => {
     describe("When multiSelect is true", () => {
       it("renders Chip with a heading and label", () => {
         const { getByRole } = render(
-          <Combobox heading="Teammates" multiSelect>
-            <Combobox.Content
-              options={[
-                { id: "1", label: "Michael" },
-                { id: "2", label: "Jason" },
-                { id: "3", label: "Leatherface" },
-              ]}
-              onSelect={jest.fn()}
-              selected={[{ id: "1", label: "Michael" }]}
-            ></Combobox.Content>
+          <Combobox
+            heading="Teammates"
+            multiSelect
+            onSelect={jest.fn()}
+            selected={[{ id: "1", label: "Michael" }]}
+          >
+            <Combobox.Option id="1" label="Michael" />
+            <Combobox.Option id="2" label="Jason" />
+            <Combobox.Option id="3" label="Leatherface" />
           </Combobox>,
         );
 
@@ -146,19 +141,18 @@ describe("ComboboxTrigger", () => {
 
       it("renders Chip with a label that is the selected options joined by a comma", () => {
         const { getByRole } = render(
-          <Combobox heading="Teammates" multiSelect>
-            <Combobox.Content
-              options={[
-                { id: "1", label: "Michael" },
-                { id: "2", label: "Jason" },
-                { id: "3", label: "Leatherface" },
-              ]}
-              onSelect={jest.fn()}
-              selected={[
-                { id: "1", label: "Michael" },
-                { id: "3", label: "Leatherface" },
-              ]}
-            ></Combobox.Content>
+          <Combobox
+            heading="Teammates"
+            multiSelect
+            onSelect={jest.fn()}
+            selected={[
+              { id: "1", label: "Michael" },
+              { id: "3", label: "Leatherface" },
+            ]}
+          >
+            <Combobox.Option id="1" label="Michael" />
+            <Combobox.Option id="2" label="Jason" />
+            <Combobox.Option id="3" label="Leatherface" />
           </Combobox>,
         );
 
@@ -176,7 +170,7 @@ function TriggerTestWrapper() {
   return (
     <>
       <span data-testid="combobox-state">{open ? "Open" : "Closed"}</span>
-      <ComboboxTrigger heading="Teammates" />
+      <ComboboxTrigger heading="Teammates" selected={[]} />
     </>
   );
 }

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import { Chip } from "@jobber/components/Chip";
 import { Icon } from "@jobber/components/Icon";
 import { ComboboxContext } from "../../ComboboxProvider";
+import { ComboboxContentProps } from "../../Combobox.types";
 
-interface ComboboxTriggerProps {
+interface ComboboxTriggerProps extends Pick<ComboboxContentProps, "selected"> {
   readonly heading: string;
 }
 
-export function ComboboxTrigger(props: ComboboxTriggerProps) {
-  const { open, setOpen, selected, multiselect } =
-    React.useContext(ComboboxContext);
+export function ComboboxTrigger({ selected, ...props }: ComboboxTriggerProps) {
+  const { open, setOpen, multiselect } = React.useContext(ComboboxContext);
 
   const hasSelection = selected.length;
   const selectedLabel = selected.map(option => option.label).join(", ");

--- a/packages/components/src/Combobox/hooks/useComboboxValidation.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxValidation.ts
@@ -17,8 +17,6 @@ export const COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE =
   "Combobox can only have one Trigger or Activator element";
 export const COMBOBOX_OPTION_AND_CONTENT_EXISTS_ERROR =
   "Combobox prefers using Combobox.Option and Combobox.Action as the direct child of Combobox instead of Combobox.Content";
-export const COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE =
-  "Combobox must have a Combobox.Option and/or Combobox.Action element";
 
 export function useComboboxValidation(children: ReactNode): {
   triggerElement: ReactNode;
@@ -59,13 +57,6 @@ export function useComboboxValidation(children: ReactNode): {
   useAssert(
     Boolean((optionElements.length || actionElements.length) && contentElement),
     COMBOBOX_OPTION_AND_CONTENT_EXISTS_ERROR,
-  );
-
-  useAssert(
-    optionElements.length === 0 &&
-      actionElements.length === 0 &&
-      !contentElement,
-    COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE,
   );
 
   return {

--- a/packages/components/src/Combobox/hooks/useComboboxValidation.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxValidation.ts
@@ -1,10 +1,16 @@
+import React, { ReactElement, ReactNode } from "react";
 import { useAssert } from "@jobber/hooks/useAssert";
-import React, { ReactNode } from "react";
 import {
   ComboboxTriggerButton,
   ComboboxTriggerChip,
 } from "../components/ComboboxTrigger";
 import { ComboboxContent } from "../components/ComboboxContent";
+import { ComboboxOption } from "../components/ComboboxOption";
+import {
+  ComboboxActionProps,
+  ComboboxOption as ComboboxOptionProps,
+} from "../Combobox.types";
+import { ComboboxAction } from "../components/ComboboxAction";
 
 export const COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE =
   "Combobox can only have one Trigger element";
@@ -13,11 +19,13 @@ export const COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE =
 
 export function useComboboxValidation(children: ReactNode): {
   triggerElement: ReactNode;
-  contentElement: ReactNode;
+  contentElement: ReactNode | undefined;
+  optionElements: ReactElement<ComboboxOptionProps>[];
+  actionElements: ReactElement<ComboboxActionProps>[];
 } {
   const childrenArray = React.Children.toArray(children);
   let triggerElement: ReactNode,
-    contentElement: ReactNode,
+    contentElement: ReactNode | undefined,
     multipleTriggersFound = false;
 
   childrenArray.forEach(child => {
@@ -33,6 +41,14 @@ export function useComboboxValidation(children: ReactNode): {
     }
   });
 
+  const optionElements = childrenArray.filter(child =>
+    isOptionElement(child),
+  ) as ReactElement<ComboboxOptionProps>[];
+
+  const actionElements = childrenArray.filter(child =>
+    isActionElement(child),
+  ) as ReactElement<ComboboxActionProps>[];
+
   useAssert(multipleTriggersFound, COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
 
   useAssert(
@@ -43,6 +59,8 @@ export function useComboboxValidation(children: ReactNode): {
   return {
     contentElement,
     triggerElement,
+    optionElements,
+    actionElements,
   };
 }
 
@@ -55,4 +73,12 @@ function isTriggerElement(child: ReactNode): boolean {
 
 function isContentElement(child: ReactNode): boolean {
   return React.isValidElement(child) && child.type === ComboboxContent;
+}
+
+function isOptionElement(child: ReactNode): boolean {
+  return React.isValidElement(child) && child.type === ComboboxOption;
+}
+
+function isActionElement(child: ReactNode): boolean {
+  return React.isValidElement(child) && child.type === ComboboxAction;
 }

--- a/packages/components/src/Combobox/hooks/useComboboxValidation.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxValidation.ts
@@ -51,11 +51,6 @@ export function useComboboxValidation(children: ReactNode): {
 
   useAssert(multipleTriggersFound, COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
 
-  useAssert(
-    !triggerElement || !contentElement,
-    COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE,
-  );
-
   return {
     contentElement,
     triggerElement,

--- a/packages/components/src/Combobox/hooks/useComboboxValidation.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxValidation.ts
@@ -14,8 +14,8 @@ import { ComboboxAction } from "../components/ComboboxAction";
 
 export const COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE =
   "Combobox can only have one Trigger element";
-export const COMBOBOX_REQUIRED_CHILDREN_ERROR_MESSAGE =
-  "Combobox must have a Trigger and Combobox.Content element";
+export const COMBOBOX_OPTION_AND_CONTENT_EXISTS_ERROR =
+  "Combobox prefers using Combobox.Option and Combobox.Action as the direct child of Combobox child instead of Combobox.Content";
 
 export function useComboboxValidation(children: ReactNode): {
   triggerElement: ReactNode;
@@ -27,6 +27,8 @@ export function useComboboxValidation(children: ReactNode): {
   let triggerElement: ReactNode,
     contentElement: ReactNode | undefined,
     multipleTriggersFound = false;
+  const optionElements: ReactElement<ComboboxOptionProps>[] = [];
+  const actionElements: ReactElement<ComboboxActionProps>[] = [];
 
   childrenArray.forEach(child => {
     if (isTriggerElement(child)) {
@@ -39,17 +41,21 @@ export function useComboboxValidation(children: ReactNode): {
     if (isContentElement(child)) {
       contentElement = child;
     }
+
+    if (isOptionElement(child)) {
+      optionElements.push(child as ReactElement<ComboboxOptionProps>);
+    }
+
+    if (isActionElement(child)) {
+      actionElements.push(child as ReactElement<ComboboxActionProps>);
+    }
   });
 
-  const optionElements = childrenArray.filter(child =>
-    isOptionElement(child),
-  ) as ReactElement<ComboboxOptionProps>[];
-
-  const actionElements = childrenArray.filter(child =>
-    isActionElement(child),
-  ) as ReactElement<ComboboxActionProps>[];
-
   useAssert(multipleTriggersFound, COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
+  useAssert(
+    Boolean((optionElements.length || actionElements.length) && contentElement),
+    COMBOBOX_OPTION_AND_CONTENT_EXISTS_ERROR,
+  );
 
   return {
     contentElement,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In an effort to simplify the API of Combobox and ensure JO gets a some buffer time before we pull the rug under it this PR is an intermediary state when we do remove the Triggers and Content components within Combobox.

I left the test as is as it is still technically testing what the internal ComboboxContent could do until the refactor comes.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added a Combobox.Option and ensure we only have either the Option or the Content being rendered
- Internalize the logic on building the options

### Changed

- Deprecate Combobox.Content

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
