### PR TITLE
feat(components): Make Combobox heading prop optional

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -25,7 +25,7 @@ const BasicCombobox: ComponentStory<typeof Combobox> = args => {
       {...args}
       onSelect={setSelected}
       selected={selected}
-      heading="Teammates"
+      label="Teammates"
     >
       <Combobox.Option id="1" label="Bilbo Baggins" />
       <Combobox.Option id="2" label="Frodo Baggins" />
@@ -143,7 +143,7 @@ const ComboboxEmptyState: ComponentStory<typeof Combobox> = args => {
   const [selected, setSelected] = useState<ComboboxOption[]>([]);
 
   return (
-    <Combobox {...args} heading="Teammates">
+    <Combobox {...args} label="Teammates">
       <Combobox.Content
         options={[]}
         onSelect={selection => {
@@ -183,7 +183,7 @@ const ComboboxClearSelection: ComponentStory<typeof Combobox> = args => {
         type="primary"
         onClick={() => setSelected([])}
       />
-      <Combobox {...args} heading="Teammates">
+      <Combobox {...args} label="Teammates">
         <Combobox.Content
           options={[
             { id: "1", label: "Bilbo Baggins" },
@@ -231,7 +231,7 @@ const ComboboxMultiSelection: ComponentStory<typeof Combobox> = args => {
     <Combobox
       {...args}
       multiSelect
-      heading="Teammates"
+      label="Teammates"
       onSelect={setSelected}
       selected={selected}
     >

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -11,14 +11,18 @@ import {
 import { useComboboxValidation } from "./hooks/useComboboxValidation";
 import { ComboboxActivator } from "./components/ComboboxActivator";
 
-export function Combobox(props: ComboboxProps): JSX.Element {
+export function Combobox({
+  multiSelect = false,
+  heading = "Select",
+  ...props
+}: ComboboxProps): JSX.Element {
   const { contentElement, triggerElement } = useComboboxValidation(
     props.children,
   );
 
   return (
-    <ComboboxContextProvider multiselect={props.multiSelect}>
-      {triggerElement || <ComboboxTrigger heading={props.heading} />}
+    <ComboboxContextProvider multiselect={multiSelect}>
+      {triggerElement || <ComboboxTrigger heading={heading} />}
       {contentElement}
     </ComboboxContextProvider>
   );

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -14,7 +14,7 @@ import { ComboboxActivator } from "./components/ComboboxActivator";
 
 export function Combobox({
   multiSelect = false,
-  heading = "Select",
+  label = "Select",
   selected = [],
   ...props
 }: ComboboxProps): JSX.Element {
@@ -28,9 +28,7 @@ export function Combobox({
 
   return (
     <ComboboxContextProvider multiselect={multiSelect}>
-      {triggerElement || (
-        <ComboboxTrigger heading={heading} selected={selected} />
-      )}
+      {triggerElement || <ComboboxTrigger label={label} selected={selected} />}
 
       {contentElement || (
         // @ts-expect-error - Suppress the XOR error with onClose|onSelect until we finish the refactor on JOB-81416

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -14,9 +14,9 @@ export interface ComboboxProps
   readonly multiSelect?: boolean;
 
   /**
-   * The Chip heading for the trigger
+   * The label for the Combobox trigger
    */
-  readonly heading?: string;
+  readonly label?: string;
 
   readonly onSelect?: (selection: ComboboxOption[]) => void;
   readonly onClose?: (selection: ComboboxOption[]) => void;

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -15,7 +15,7 @@ export interface ComboboxProps {
   /**
    * The Chip heading for the trigger
    */
-  readonly heading: string;
+  readonly heading?: string;
 }
 
 export interface ComboboxTriggerProps {

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
@@ -60,7 +60,7 @@ describe("ComboboxActivator", () => {
 
   it("renders a ComboboxTrigger with role 'combobox' when no custom activator is provided", () => {
     const { getByRole } = render(
-      <Combobox heading="Teammates">
+      <Combobox label="Teammates">
         <Combobox.Content
           options={[]}
           onSelect={jest.fn()}

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
@@ -46,7 +46,7 @@ describe("ComboboxTrigger", () => {
   });
 
   describe("before selection", () => {
-    it("renders a Chip with a heading", () => {
+    it("renders a ComboboxTrigger with a label", () => {
       const { getByText } = render(
         <ComboboxContextProvider>
           <TriggerTestWrapper />
@@ -56,7 +56,7 @@ describe("ComboboxTrigger", () => {
       expect(getByText("Teammates")).toBeInTheDocument();
     });
 
-    it("renders a Chip with a 'Select' heading if no heading is provided", () => {
+    it("renders a ComboboxTrigger with a 'Select' label if no label is provided", () => {
       const { getByText } = render(
         <Combobox>
           <Combobox.Content
@@ -101,7 +101,7 @@ describe("ComboboxTrigger", () => {
     it("renders a Chip with 'base' variation", () => {
       const { getByRole } = render(
         <Combobox
-          heading="Teammates"
+          label="Teammates"
           onSelect={jest.fn()}
           selected={[{ id: "1", label: "Michael" }]}
         >
@@ -120,7 +120,7 @@ describe("ComboboxTrigger", () => {
       it("renders Chip with the selected option as the label", () => {
         const { getByRole } = render(
           <Combobox
-            heading="Teammates"
+            label="Teammates"
             onSelect={jest.fn()}
             selected={[{ id: "1", label: "Michael" }]}
           >
@@ -136,10 +136,10 @@ describe("ComboboxTrigger", () => {
     });
 
     describe("When multiSelect is true", () => {
-      it("renders Chip with a heading and label", () => {
+      it("renders ComboboxTrigger with a label and selected options", () => {
         const { getByRole } = render(
           <Combobox
-            heading="Teammates"
+            label="Teammates"
             multiSelect
             onSelect={jest.fn()}
             selected={[{ id: "1", label: "Michael" }]}
@@ -156,10 +156,10 @@ describe("ComboboxTrigger", () => {
         expect(trigger).toHaveTextContent("Michael");
       });
 
-      it("renders Chip with a label that is the selected options joined by a comma", () => {
+      it("renders ComboboxTrigger with multiple selected options joined by a comma", () => {
         const { getByRole } = render(
           <Combobox
-            heading="Teammates"
+            label="Teammates"
             multiSelect
             onSelect={jest.fn()}
             selected={[
@@ -187,7 +187,7 @@ function TriggerTestWrapper() {
   return (
     <>
       <span data-testid="combobox-state">{open ? "Open" : "Closed"}</span>
-      <ComboboxTrigger heading="Teammates" selected={[]} />
+      <ComboboxTrigger label="Teammates" selected={[]} />
     </>
   );
 }

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
@@ -56,6 +56,23 @@ describe("ComboboxTrigger", () => {
       expect(getByText("Teammates")).toBeInTheDocument();
     });
 
+    it("renders a Chip with a 'Select' heading if no heading is provided", () => {
+      const { getByText } = render(
+        <Combobox>
+          <Combobox.Content
+            options={[
+              { id: "1", label: "Michael" },
+              { id: "2", label: "Jason" },
+            ]}
+            onSelect={jest.fn()}
+            selected={[]}
+          ></Combobox.Content>
+        </Combobox>,
+      );
+
+      expect(getByText("Select")).toBeInTheDocument();
+    });
+
     it("renders a Chip with a suffix", () => {
       const { getByTestId } = render(
         <ComboboxContextProvider>

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
@@ -5,7 +5,7 @@ import { ComboboxContext } from "../../ComboboxProvider";
 import { ComboboxContentProps } from "../../Combobox.types";
 
 interface ComboboxTriggerProps extends Pick<ComboboxContentProps, "selected"> {
-  readonly heading: string;
+  readonly label: string;
 }
 
 export function ComboboxTrigger({ selected, ...props }: ComboboxTriggerProps) {
@@ -19,7 +19,7 @@ export function ComboboxTrigger({ selected, ...props }: ComboboxTriggerProps) {
     <Chip
       variation={hasSelection ? "base" : "subtle"}
       label={hasSelection ? selectedLabel : ""}
-      heading={renderHeading ? props.heading : ""}
+      heading={renderHeading ? props.label : ""}
       onClick={() => setOpen(!open)}
       role="combobox"
     >


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`heading` prop in `<Combobox>` needs to be optional for flexibility when using either a `Combobox.Activator` or the default `ComboboxTrigger`.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->


### Changed

 <!-- changes in existing functionality -->
`heading` prop on `ComboboxProps` is now optional.

When a consumer of `Combobox` is using using a `Combobox.Activator` as the trigger, they will be able to set the label of the `Button` or `Chip` directly within that component.  This use case does not have a need for a `Combobox` `heading` so to avoid errors, `heading` needs to be optional.

When a consumer does not use a custom activator, `Combobox` will default to using `ComboboxTrigger` which is a Chip.  It is in this implementation, that a `heading` should be set.  We decided to set a default for this Chip heading (`Select`) and then the consumer can use the `heading` prop to change that as they need to.

If a `heading` prop is put on a `Combobox` that is using a `Combobox.Activator`, the label of the activator will remain.  I have decided to include this in the documentation in a later PR.  In my opinion, there doesn't need to be any safe guarding here but if there is a different take on that, I'm happy to hear it!

`<Combobox heading="Teammates">`

![Screenshot 2023-10-30 at 3 04 56 PM](https://github.com/GetJobber/atlantis/assets/104797704/3cbcb75f-527e-4369-b645-2a8903f8c066)

`<Combobox>`

<img width="141" alt="Screenshot 2023-10-30 at 3 05 44 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/e9a44a0b-2f97-409e-97cc-1a51a8ab9423">

## Testing

Make sure `<Combobox>` is not giving an error if there is no `heading`. 
In the Basic Storybook example, remove the `heading="Teammates"` on line 24 to see the Chip heading read `Select` instead.

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
