### PR TITLE
chore: remove testing library cleanup

### DIFF
--- a/packages/components-native/src/AtlantisContext/AtlantisContext.test.tsx
+++ b/packages/components-native/src/AtlantisContext/AtlantisContext.test.tsx
@@ -1,14 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { PropsWithChildren } from "react";
-import { cleanup, renderHook } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react-hooks";
 import {
   AtlantisContext,
   AtlantisContextProps,
   atlantisContextDefaultValues,
   useAtlantisContext,
 } from "./AtlantisContext";
-
-afterEach(cleanup);
 
 const providerValues: AtlantisContextProps = {
   dateFormat: "MM/DD/YYYY",

--- a/packages/components-native/src/Button/components/InternalButtonLoading/InternalButtonLoading.test.tsx
+++ b/packages/components-native/src/Button/components/InternalButtonLoading/InternalButtonLoading.test.tsx
@@ -1,13 +1,11 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react-native";
+import { render } from "@testing-library/react-native";
 import {
   InternalButtonLoading,
   darkPattern,
   lightPattern,
 } from "./InternalButtonLoading";
 import { ButtonType, ButtonVariation } from "../../types";
-
-afterEach(cleanup);
 
 describe("Loading pattern", () => {
   it.each<[string, ButtonType, ButtonVariation]>([

--- a/packages/components-native/src/Checkbox/CheckboxGroup.test.tsx
+++ b/packages/components-native/src/Checkbox/CheckboxGroup.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import {
   RenderAPI,
-  cleanup,
   fireEvent,
   render,
   waitFor,
@@ -30,8 +29,6 @@ interface CheckboxGroupFormOnChangeHandlers {
   ketchup?: (data: boolean) => void;
   all?: (data: CheckboxGroupState) => void;
 }
-
-afterEach(cleanup);
 
 function setup(
   label: string | undefined,
@@ -71,8 +68,8 @@ function SetupWithForm({
   initialValues,
   onChangeHandlers,
 }: {
-  initialValues: CheckboxGroupFormData;
-  onChangeHandlers?: CheckboxGroupFormOnChangeHandlers;
+  readonly initialValues: CheckboxGroupFormData;
+  readonly onChangeHandlers?: CheckboxGroupFormOnChangeHandlers;
 }): JSX.Element {
   const formMethods = useForm({ defaultValues: initialValues });
 
@@ -178,6 +175,7 @@ describe("when all of the checkboxes in a group are checked", () => {
 describe("when the parent checkbox does not have a label", () => {
   it("does not render the parent checkbox", async () => {
     const { checkboxGroup } = setup(undefined);
+
     const findParentCheckbox = () => {
       checkboxGroup.getByLabelText(parentCheckboxLabel);
     };

--- a/packages/components-native/src/Divider/Divider.test.tsx
+++ b/packages/components-native/src/Divider/Divider.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react-native";
+import { render } from "@testing-library/react-native";
 import { Divider } from "./Divider";
 import { styles } from "./Divider.style";
-
-afterEach(cleanup);
 
 const dividerTestId = "Divider";
 

--- a/packages/components-native/src/Form/components/FormErrorBanner/FormErrorBanner.test.tsx
+++ b/packages/components-native/src/Form/components/FormErrorBanner/FormErrorBanner.test.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react-native";
+import { render } from "@testing-library/react-native";
 import { FormErrorBanner } from "./FormErrorBanner";
 import { atlantisContextDefaultValues } from "../../../AtlantisContext";
 import * as atlantisContext from "../../../AtlantisContext/AtlantisContext";
+
+afterEach(jest.clearAllMocks);
 
 describe("FormErrorBanner", () => {
   const atlantisContextSpy = jest.spyOn(atlantisContext, "useAtlantisContext");
@@ -56,6 +58,3 @@ describe("FormErrorBanner", () => {
     expect(queryByText(couldNotSavechanges)).toBeNull();
   });
 });
-
-afterEach(jest.clearAllMocks);
-afterEach(cleanup);

--- a/packages/components-native/src/InputSearch/InputSearch.test.tsx
+++ b/packages/components-native/src/InputSearch/InputSearch.test.tsx
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  waitFor,
-} from "@testing-library/react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import { InputSearch } from "./InputSearch";
 
 const accessibilityLabelSearch = "Search";
@@ -18,7 +13,6 @@ beforeEach(() => {
   mockOnDebouncedChange.mockReset();
   searchValue = "";
 });
-afterEach(cleanup);
 
 function setup() {
   return render(

--- a/packages/components-native/src/InputTime/InputTime.test.tsx
+++ b/packages/components-native/src/InputTime/InputTime.test.tsx
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  waitFor,
-} from "@testing-library/react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import { Host } from "react-native-portalize";
 import { FormProvider, useForm } from "react-hook-form";
 import { InputTime } from "./InputTime";
@@ -12,7 +7,6 @@ import * as atlantisContext from "../AtlantisContext/AtlantisContext";
 import { Button } from "../Button";
 
 afterEach(() => {
-  cleanup();
   jest.spyOn(atlantisContext, "useAtlantisContext").mockRestore();
 });
 
@@ -192,6 +186,7 @@ const mockOnSubmit = jest.fn();
 const saveButtonText = "Submit";
 
 const requiredError = "This is required";
+
 function SimpleFormWithProvider({ children, defaultValues }) {
   const formMethods = useForm({
     reValidateMode: "onChange",

--- a/packages/components-native/src/Select/Select.test.tsx
+++ b/packages/components-native/src/Select/Select.test.tsx
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  RenderAPI,
-  cleanup,
-  fireEvent,
-  render,
-} from "@testing-library/react-native";
+import { RenderAPI, fireEvent, render } from "@testing-library/react-native";
 import { tokens } from "@jobber/design/foundation";
 import { AccessibilityInfo } from "react-native";
 import { Option, Select } from ".";
@@ -19,7 +14,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  cleanup();
   jest.resetAllMocks();
 });
 

--- a/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.test.tsx
+++ b/packages/components-native/src/Select/components/SelectDefaultPicker/SelectDefaultPicker.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 import { AccessibilityInfo, View } from "react-native";
 import { SelectDefaultPicker } from "./SelectDefaultPicker";
 import { Text } from "../../../Text";
@@ -19,11 +19,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  cleanup();
   jest.resetAllMocks();
 });
 
 const childText = "Click me";
+
 function setup() {
   return render(
     <View testID="SelectDefaultPicker">

--- a/packages/components-native/src/Select/components/SelectInternalPicker/SelectInternalPicker.test.tsx
+++ b/packages/components-native/src/Select/components/SelectInternalPicker/SelectInternalPicker.test.tsx
@@ -1,5 +1,5 @@
 import React, { ElementType } from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 import { View } from "react-native";
 import { SelectInternalPicker } from ".";
 import { SelectInternalPickerProps } from "../../types";
@@ -19,7 +19,6 @@ jest.mock("@react-native-picker/picker", () => ({ Picker: MockPicker }));
 MockPicker.Item = MockPickerItem;
 
 afterEach(() => {
-  cleanup();
   jest.resetAllMocks();
 });
 

--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { AnyOption, Autocomplete } from ".";
 import { InputTextRef } from "../InputText";
-
-afterEach(cleanup);
 
 function returnOptions(options: AnyOption[]) {
   return async () => {

--- a/packages/components/src/Avatar/Avatar.test.tsx
+++ b/packages/components/src/Avatar/Avatar.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Avatar } from ".";
-
-afterEach(cleanup);
 
 it("renders a Avatar", () => {
   const { container } = render(

--- a/packages/components/src/Banner/Banner.test.tsx
+++ b/packages/components/src/Banner/Banner.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { Banner } from ".";
-
-afterEach(cleanup);
 
 it("renders a success banner", () => {
   const { container } = render(<Banner type="success">Success</Banner>);

--- a/packages/components/src/ButtonDismiss/ButtonDismiss.test.tsx
+++ b/packages/components/src/ButtonDismiss/ButtonDismiss.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { ButtonDismiss } from ".";
-
-afterEach(cleanup);
 
 it("renders a ButtonDismiss", () => {
   const { container } = render(

--- a/packages/components/src/Checkbox/Checkbox.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { Checkbox } from ".";
 import { Text } from "../Text";
-
-afterEach(cleanup);
 
 it("renders a Checkbox", () => {
   const { getByRole } = render(

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissible.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissible.test.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import {
   act,
-  cleanup,
   fireEvent,
   render,
   screen,
@@ -53,8 +52,6 @@ describe("Basic interaction", () => {
 
     await popperUpdate();
   });
-
-  afterEach(cleanup);
 
   it("should only render the selected chip on the UI", () => {
     const wrapperEl = screen.getByTestId("dismissible-chips");

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  within,
-} from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { InternalChipDismissibleInput } from "../InternalChipDismissibleInput";
 import { ChipProps } from "../../Chip";
 
@@ -49,8 +43,6 @@ beforeEach(async () => {
   );
   rerender = rerenderComponent;
 });
-
-afterEach(cleanup);
 
 describe("Menu closed", () => {
   it("should show a button", () => {

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
@@ -1,8 +1,6 @@
 import { ChangeEvent, KeyboardEvent } from "react";
-import { act, cleanup, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
 import { useInternalChipDismissibleInput } from "../useInternalChipDismissibleInput";
-
-afterEach(cleanup);
 
 const handleOptionSelect = jest.fn(value => value);
 const handleCustomOptionSelect = jest.fn(value => value);
@@ -23,6 +21,7 @@ function setupHook(params?: Partial<typeof hookParams>) {
   const { result } = renderHook(() =>
     useInternalChipDismissibleInput({ ...hookParams, ...params }),
   );
+
   return result;
 }
 

--- a/packages/components/src/Chips/tests/Chip.test.tsx
+++ b/packages/components/src/Chips/tests/Chip.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Chip } from "..";
-
-afterEach(cleanup);
 
 it("should throw error when not wrapped inside `<Chips>`", () => {
   expect(() => render(<Chip value={""} label={""} />)).toThrow(

--- a/packages/components/src/Chips/tests/ChipDismissible.test.tsx
+++ b/packages/components/src/Chips/tests/ChipDismissible.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ChipDismissible } from "..";
-
-afterEach(cleanup);
 
 it("should have a remove action", () => {
   render(<ChipDismissible onRequestRemove={jest.fn()} label="This thing!" />);

--- a/packages/components/src/Chips/tests/InternalChip.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChip.test.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { InternalChip } from "../InternalChip";
 import { Icon } from "../../Icon";
-
-afterEach(cleanup);
 
 it("should render a div chip when onClick is not present", () => {
   render(<InternalChip label="Yo!" />);

--- a/packages/components/src/Chips/tests/InternalChipButton.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipButton.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { InternalChipButton } from "../InternalChipButton";
 
@@ -14,8 +14,6 @@ describe("Interaction", () => {
     );
     target = screen.getByTestId("remove-chip-button");
   });
-
-  afterEach(cleanup);
 
   it("should call the onClick action", async () => {
     await userEvent.click(target);

--- a/packages/components/src/Chips/tests/InternalChipMultiSelect.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipMultiSelect.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { InternalChipMultiSelect } from "../InternalChipMultiSelect";
 import { Chip } from "..";
@@ -25,8 +25,6 @@ beforeEach(() => {
     </InternalChipMultiSelect>,
   );
 });
-
-afterEach(cleanup);
 
 it("should have a label and a checkbox", () => {
   const component = screen.getByTestId("multiselect-chips");

--- a/packages/components/src/Chips/tests/InternalChipSingleSelect.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChipSingleSelect.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  cleanup,
   fireEvent,
   render,
   screen,
@@ -32,8 +31,6 @@ beforeEach(() => {
     </InternalChipSingleSelect>,
   );
 });
-
-afterEach(cleanup);
 
 it("should have a label and a checkbox", () => {
   const component = screen.getByTestId("singleselect-chips");

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { ComboboxOption } from "./Combobox.types";
 import { Combobox } from "./Combobox";
@@ -11,8 +11,6 @@ import { Chip } from "../Chip";
 // jsdom is missing this implementation
 const scrollIntoViewMock = jest.fn();
 window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
-
-afterEach(cleanup);
 
 describe("Combobox validation", () => {
   it("renders without error if the correct count and composition of elements are present", () => {

--- a/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx
+++ b/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx
@@ -4,11 +4,9 @@
  */
 
 import React, { RefObject, useRef } from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { ConfirmationModal, ConfirmationModalRef } from "..";
 import { Button } from "../../Button";
-
-afterEach(cleanup);
 
 test("simple ConfirmationModal should confirm", () => {
   const confirmHandler = jest.fn();
@@ -202,8 +200,8 @@ test("controlled ConfirmationModal should cancel", () => {
 });
 
 interface ControlledConfirmProps {
-  onConfirmMock: jest.Mock;
-  onCancelMock: jest.Mock;
+  readonly onConfirmMock: jest.Mock;
+  readonly onCancelMock: jest.Mock;
 }
 
 function ControlledConfirm({

--- a/packages/components/src/Content/Content.test.tsx
+++ b/packages/components/src/Content/Content.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Content } from ".";
-
-afterEach(cleanup);
 
 it("renders a Content", () => {
   const { queryByText } = render(<Content>Wazaaaaa</Content>);

--- a/packages/components/src/Countdown/Countdown.test.tsx
+++ b/packages/components/src/Countdown/Countdown.test.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { Countdown } from "./Countdown";
 
 jest.useFakeTimers();
-
-afterEach(cleanup);
 
 it(`Shows units`, () => {
   const { container } = render(

--- a/packages/components/src/DataList/components/DataListFilters/DataListFilters.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/DataListFilters.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { configMocks, mockIntersectionObserver } from "jsdom-testing-mocks";
 import { DataListFilters, InternalDataListFilters } from "./DataListFilters";
 import { CONTAINER_TEST_ID } from "../DataListOverflowFade";
@@ -24,7 +24,6 @@ const contextValueWithRenderableChildren = {
 const showHeaderSpy = jest.spyOn(useShowHeader, "useShowHeader");
 
 afterEach(() => {
-  cleanup();
   spy.mockReset();
   showHeaderSpy.mockReset();
 });

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.test.tsx
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 import {
   DATA_LIST_SEARCH_TEST_ID,
@@ -27,7 +27,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  cleanup();
   spy.mockReset();
   jest.useRealTimers();
 });

--- a/packages/components/src/DatePicker/DatePicker.test.tsx
+++ b/packages/components/src/DatePicker/DatePicker.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import ReactDatePicker from "react-datepicker";
 import { DatePicker } from "./DatePicker";
-
-afterEach(cleanup);
 
 beforeEach(() => {
   /**

--- a/packages/components/src/Disclosure/Disclosure.test.tsx
+++ b/packages/components/src/Disclosure/Disclosure.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Disclosure } from ".";
-
-afterEach(cleanup);
 
 it("renders a Disclosure", () => {
   const { container } = render(

--- a/packages/components/src/Divider/Divider.test.tsx
+++ b/packages/components/src/Divider/Divider.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Divider } from ".";
-
-afterEach(cleanup);
 
 describe("Divider", () => {
   it("should render", () => {

--- a/packages/components/src/Drawer/Drawer.test.tsx
+++ b/packages/components/src/Drawer/Drawer.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { Drawer } from ".";
-
-afterEach(cleanup);
 
 describe("Drawer", () => {
   it("should render the drawer", () => {

--- a/packages/components/src/FeatureSwitch/FeatureSwitch.test.tsx
+++ b/packages/components/src/FeatureSwitch/FeatureSwitch.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { FeatureSwitch } from ".";
-
-afterEach(cleanup);
 
 it("renders a full FeatureSwitch", () => {
   const { container } = render(

--- a/packages/components/src/Flex/Flex.test.tsx
+++ b/packages/components/src/Flex/Flex.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Flex } from ".";
-
-afterEach(cleanup);
 
 describe("Flex", () => {
   it("renders the flexible container", () => {

--- a/packages/components/src/Form/Form.test.tsx
+++ b/packages/components/src/Form/Form.test.tsx
@@ -1,11 +1,9 @@
 import React, { MutableRefObject, useRef } from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { useFormState } from "@jobber/hooks/useFormState";
 import { Form, FormRef } from ".";
 import { InputText } from "../InputText";
 import { Text } from "../Text";
-
-afterEach(cleanup);
 
 test("calls the submit handler if the form is valid", async () => {
   const submitHandler = jest.fn();
@@ -175,6 +173,7 @@ interface MockFormValidateProps {
 
 function MockFormValidate({ onSubmit }: MockFormValidateProps) {
   const formRef = useRef() as MutableRefObject<FormRef>;
+
   return (
     <>
       <Form onSubmit={onSubmit} ref={formRef}>

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { FormField } from ".";
-
-afterEach(cleanup);
 
 // eslint-disable-next-line max-statements
 describe("FormField", () => {

--- a/packages/components/src/FormatDate/FormatDate.test.tsx
+++ b/packages/components/src/FormatDate/FormatDate.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { CivilDate } from "@std-proposal/temporal";
 import { FormatDate, strFormatDate } from "./FormatDate";
-
-afterEach(cleanup);
 
 describe("Different date values", () => {
   const dates = {

--- a/packages/components/src/FormatEmail/FormatEmail.test.tsx
+++ b/packages/components/src/FormatEmail/FormatEmail.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { FormatEmail } from ".";
-
-afterEach(cleanup);
 
 it("renders a FormatEmail", () => {
   const { container } = render(<FormatEmail email="email@address.me" />);

--- a/packages/components/src/FormatFile/FormatFile.test.tsx
+++ b/packages/components/src/FormatFile/FormatFile.test.tsx
@@ -1,15 +1,7 @@
 import React from "react";
-import {
-  act,
-  cleanup,
-  fireEvent,
-  render,
-  waitFor,
-} from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { FormatFile } from ".";
 import { GLIMMER_TEST_ID } from "../Glimmer";
-
-afterEach(cleanup);
 
 it("renders a FormatFile", () => {
   const testFile = {

--- a/packages/components/src/FormatTime/FormatTime.test.tsx
+++ b/packages/components/src/FormatTime/FormatTime.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { CivilTime } from "@std-proposal/temporal";
 import { FormatTime } from "./FormatTime";
-
-afterEach(cleanup);
 
 describe("FormatTime", () => {
   describe.each(

--- a/packages/components/src/Gallery/Gallery.test.tsx
+++ b/packages/components/src/Gallery/Gallery.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { Gallery } from ".";
-
-afterEach(cleanup);
 
 const files = [
   {

--- a/packages/components/src/InputAvatar/InputAvatar.test.tsx
+++ b/packages/components/src/InputAvatar/InputAvatar.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { InputAvatar } from ".";
-
-afterEach(cleanup);
 
 const testFile = new File(["🔱 Atlantis"], "atlantis.png", {
   type: "image/png",

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { InputDate } from ".";
 import { Modal } from "../Modal";
 import { Button } from "../Button";
 import { Text } from "../Text";
-
-afterEach(cleanup);
 
 it("renders a blank form by default", () => {
   const { getByDisplayValue, queryByText } = render(
@@ -198,7 +196,7 @@ describe("when InputDate is used within a Modal", () => {
   });
 });
 
-function NestedTestComponent(props: { date: string }): JSX.Element {
+function NestedTestComponent(props: { readonly date: string }): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
   const changeHandler = jest.fn();
 

--- a/packages/components/src/InputEmail/InputEmail.test.tsx
+++ b/packages/components/src/InputEmail/InputEmail.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { InputEmail, validationMessage } from ".";
-
-afterEach(cleanup);
 
 it("shows an error message for an invalid email", async () => {
   const { getByLabelText, getByText } = render(

--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import axios from "axios";
 import { InputFile } from ".";
 
@@ -10,8 +10,6 @@ jest.mock("axios", () => {
 beforeEach(() => {
   (axios.request as jest.Mock).mockReturnValue(Promise.resolve());
 });
-
-afterEach(cleanup);
 
 const testFile = new File(["🔱 Atlantis"], "atlantis.png", {
   type: "image/png",

--- a/packages/components/src/InputGroup/InputGroup.test.tsx
+++ b/packages/components/src/InputGroup/InputGroup.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { InputGroup } from ".";
-
-afterEach(cleanup);
 
 it("renders a vertical InputGroup", () => {
   const { container } = render(

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { InputNumber, InputNumberRef } from ".";
-
-afterEach(cleanup);
 
 it("renders an input type number", () => {
   const { container } = render(<InputNumber value={123} />);

--- a/packages/components/src/InputPassword/InputPassword.test.tsx
+++ b/packages/components/src/InputPassword/InputPassword.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { InputPassword } from ".";
-
-afterEach(cleanup);
 
 describe("<InputPassword />", () => {
   it("renders an input type password", () => {

--- a/packages/components/src/InputTime/InputTime.test.tsx
+++ b/packages/components/src/InputTime/InputTime.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { CivilTime } from "@std-proposal/temporal";
 import { InputTime } from ".";
-
-afterEach(cleanup);
 
 it("renders a InputTime", () => {
   const { container } = render(<InputTime />);

--- a/packages/components/src/LightBox/LightBox.test.tsx
+++ b/packages/components/src/LightBox/LightBox.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { LightBox } from ".";
-
-afterEach(cleanup);
 
 test("Lightbox opens and shows the image", () => {
   const title = "Dis be a title";

--- a/packages/components/src/List/List.test.tsx
+++ b/packages/components/src/List/List.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { List } from ".";
-
-afterEach(cleanup);
 
 it("renders 1 List item with all the props", () => {
   const { container } = render(

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -1,15 +1,8 @@
 import React from "react";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Menu } from ".";
 import { Button } from "../Button";
 
-afterEach(cleanup);
 jest.mock("uuid");
 
 describe("Menu", () => {

--- a/packages/components/src/Modal/Modal.test.tsx
+++ b/packages/components/src/Modal/Modal.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { Modal } from ".";
 import styles from "./Modal.css";
-
-afterEach(cleanup);
 
 test("modal shows the children and a close button", () => {
   const title = "Dis be a title";

--- a/packages/components/src/MultiSelect/MultiSelect.test.tsx
+++ b/packages/components/src/MultiSelect/MultiSelect.test.tsx
@@ -1,15 +1,7 @@
 import React, { useState } from "react";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  within,
-} from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MultiSelect } from ".";
-
-afterEach(cleanup);
 
 const Component = () => {
   const [options, setOptions] = useState([

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { Page } from ".";
 import { SectionProps } from "../Menu";
 
@@ -20,8 +20,6 @@ jest.mock("@jobber/hooks", () => {
     },
   };
 });
-
-afterEach(cleanup);
 
 it("renders a Page", () => {
   const { container } = render(

--- a/packages/components/src/Popover/Popover.test.tsx
+++ b/packages/components/src/Popover/Popover.test.tsx
@@ -1,21 +1,14 @@
 import React, { useRef } from "react";
-import {
-  RenderResult,
-  act,
-  cleanup,
-  fireEvent,
-  render,
-} from "@testing-library/react";
+import { RenderResult, act, fireEvent, render } from "@testing-library/react";
 import { Popover } from ".";
 import { PopoverProps } from "./Popover";
-
-afterEach(cleanup);
 
 let rendered: RenderResult;
 const content = "Test Content";
 
 const PopoverTestComponent = (props: Omit<PopoverProps, "attachTo">) => {
   const divRef = useRef();
+
   return (
     <>
       <div ref={divRef}></div>

--- a/packages/components/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.test.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { RadioGroup, RadioOption } from ".";
-
-afterEach(cleanup);
 
 test("renders a RadioGroup", () => {
   const { container } = render(<MockRadioGroup />);
@@ -109,6 +107,7 @@ interface MockProps {
 function MockRadioGroup({ onChange }: MockProps) {
   const [value, setValue] = useState("one");
   const [valueTwo, setValueTwo] = useState("one");
+
   return (
     <>
       <RadioGroup

--- a/packages/components/src/RecurringSelect/RecurringSelect.test.tsx
+++ b/packages/components/src/RecurringSelect/RecurringSelect.test.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable jest/no-conditional-expect */
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { RecurringSelect } from "./RecurringSelect";
 import { DayOfMonth, DurationPeriod, WeekDay } from "./types";
-
-afterEach(cleanup);
 
 let onChange: jest.Mock;
 

--- a/packages/components/src/RecurringSelect/components/DayOfMonthSelect.test.tsx
+++ b/packages/components/src/RecurringSelect/components/DayOfMonthSelect.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { DayOfMonthSelect } from "./DayOfMonthSelect";
 import { DayOfMonth } from "../types";
-
-afterEach(cleanup);
 
 let onChange: jest.Mock;
 

--- a/packages/components/src/RecurringSelect/components/MonthlyDayOfWeekSelect.test.tsx
+++ b/packages/components/src/RecurringSelect/components/MonthlyDayOfWeekSelect.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { MonthlyDayOfWeekSelect } from "./MonthlyDayOfWeekSelect";
 import { WeekDay } from "../types";
-
-afterEach(cleanup);
 
 let onChange: jest.Mock;
 

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { Option, Select } from ".";
-
-afterEach(cleanup);
 
 it("renders a Select with no options", () => {
   const { container } = render(<Select />);

--- a/packages/components/src/StatusLabel/StatusLabel.test.tsx
+++ b/packages/components/src/StatusLabel/StatusLabel.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { StatusLabel } from ".";
-
-afterEach(cleanup);
 
 it("renders an inactive StatusLabel", () => {
   const { container } = render(<StatusLabel label="Foo" status="inactive" />);

--- a/packages/components/src/Switch/Switch.test.tsx
+++ b/packages/components/src/Switch/Switch.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Switch } from ".";
-
-afterEach(cleanup);
 
 it("renders a Switch", () => {
   const { container } = render(<Switch ariaLabel="Toggle me" />);

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { Tab, Tabs } from ".";
-
-afterEach(cleanup);
 
 let count = 0;
 const omelet = (

--- a/packages/components/src/Toast/Toast.test.tsx
+++ b/packages/components/src/Toast/Toast.test.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  act,
-  cleanup,
-  fireEvent,
-  render,
-  waitFor,
-} from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { showToast } from ".";
 
 jest.mock("framer-motion", () => ({
@@ -28,7 +22,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  cleanup();
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
 });
@@ -126,6 +119,7 @@ it("stops and starts the timer when the item is hover toggled", async () => {
 interface MockToastProps {
   mockAction?(): void;
 }
+
 const MockToast = ({ mockAction }: MockToastProps) => {
   const buttons = [
     {
@@ -157,6 +151,7 @@ const MockToast = ({ mockAction }: MockToastProps) => {
       },
     },
   ];
+
   return (
     <>
       {buttons.map(({ label, onClick }) => (

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Tooltip } from ".";
-
-afterEach(cleanup);
 
 it("shouldn't show the tooltip", async () => {
   const message = "Imma not tip the tool";

--- a/packages/generators/templates/component-native/{{name}}.test.tsx
+++ b/packages/generators/templates/component-native/{{name}}.test.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react-native";
-
-afterEach(cleanup);
-
+import {  render } from "@testing-library/react-native";
 
 it("renders a {{name}}", () => {
   const { getByText } = render(< {{ name }} text = "Foo" />);

--- a/packages/generators/templates/component/{{name}}.test.tsx
+++ b/packages/generators/templates/component/{{name}}.test.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { {{name}} } from ".";
 
-afterEach(cleanup);
 
 it("renders a {{name}}", () => {
   const { container } = render(<{{name}} text="Foo" />);


### PR DESCRIPTION
## Motivations
The need to manually cleanup `@testing-library/react` has long passed, so good riddance.

Reference: https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-cleanup
Reference 2: https://testing-library.com/docs/react-testing-library/api/#cleanup


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed
- Removed manual `cleanup` import from `@testing-library/react` from all test files.
- Some linting changes also came in upon making changes but were limited to adding missing `readonly` types within test files.
