### PR TITLE
fix(components): remove useragent styling from Combobox search [JOB-82086]

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.css
@@ -24,6 +24,7 @@
 }
 
 .clearSearch {
+  display: flex;
   position: absolute;
   top: 50%;
   right: var(--space-base);
@@ -36,6 +37,8 @@
   background-color: var(--color-surface--background);
   cursor: pointer;
   transform: translateY(-50%);
+  justify-content: center;
+  align-items: center;
 }
 
 .clearSearch:focus {

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.css
@@ -12,6 +12,17 @@
   font-size: var(--typography--fontSize-base);
 }
 
+.searchInput::-webkit-search-decoration,
+.searchInput::-webkit-search-cancel-button,
+.searchInput::-webkit-search-results-button,
+.searchInput::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+}
+
+.searchInput:focus {
+  outline: none;
+}
+
 .clearSearch {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Atlantis has resets in the docs site that strip out styling on `input type="search"`, but all sites do not have this.

So, Combobox looks like this in Jobber:

![image](https://github.com/GetJobber/atlantis/assets/39704901/15248932-fca9-4042-9d7c-4631c8c8cc0e)


## Changes

Add styling to remove browser defaults

### Added

- New styling rules for search input
- new styling rules for dismiss button as the `cross` icon could be moved off-center by external styling

### Fixed

- Unwanted browser-provided styling that conflicted with our own

## Testing

Pull pre-release into Jobber

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
