### PR TITLE
feat(components): Optional DataList action

### DIFF
--- a/docs/components/DataList/DataList.stories.mdx
+++ b/docs/components/DataList/DataList.stories.mdx
@@ -104,6 +104,18 @@ action that is related to the item.
 </DataList>
 ```
 
+##### Hiding an action
+
+Hide an action by using the `visible` prop. It accepts a function that has a
+parameter of the item it's related to.
+
+```tsx
+<DataList.ItemAction
+  visible={item => item.status === "Archived"}
+  label="Delete"
+/>
+```
+
 <Tabs>
   <Tab label="DataList.ItemActions">
     <ArgsTable of={DataList.ItemActions} />

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -162,6 +162,7 @@ const Template: ComponentStory<typeof DataList> = args => {
 
       <DataList.ItemActions onClick={handleActionClick}>
         <DataList.ItemAction
+          visible={item => item.species !== "Droid"}
           icon="edit"
           label="Edit"
           onClick={handleActionClick}

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -315,7 +315,7 @@ export interface DataListActionsProps<T extends DataListObject> {
 }
 
 export interface DataListBulkActionProps
-  extends DataListActionProps<DataListObject> {
+  extends Omit<DataListActionProps<DataListObject>, "visible"> {
   /**
    * The callback function when the action is clicked.
    */

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -290,6 +290,11 @@ export interface DataListActionProps<T extends DataListObject> {
   readonly destructive?: boolean;
 
   /**
+   * Determine if the action is visible for a given item.
+   */
+  readonly visible?: (item: T) => boolean;
+
+  /**
    * The callback function when the action is clicked.
    */
   readonly onClick?: (data: T) => void;

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.test.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.test.tsx
@@ -57,6 +57,34 @@ describe("DataListAction", () => {
     await userEvent.click(button);
     expect(handleClick).toHaveBeenCalledWith(mockItem);
   });
+
+  describe("Action visibility", () => {
+    const value = { activeItem: { id: 1 } };
+
+    it("should render the action if the visibility prop is returning true", () => {
+      const mockVisibility = jest.fn(() => true);
+      render(
+        <DataListLayoutActionsContext.Provider value={value}>
+          <DataListAction label={name} visible={mockVisibility} />
+        </DataListLayoutActionsContext.Provider>,
+      );
+
+      expect(screen.getByRole("button", { name })).toBeInTheDocument();
+      expect(mockVisibility).toHaveBeenCalledWith(value.activeItem);
+    });
+
+    it("should not render the action if the visibility prop is returning false", () => {
+      const mockVisibility = jest.fn(() => false);
+      render(
+        <DataListLayoutActionsContext.Provider value={value}>
+          <DataListAction label={name} visible={mockVisibility} />
+        </DataListLayoutActionsContext.Provider>,
+      );
+
+      expect(screen.queryByRole("button", { name })).not.toBeInTheDocument();
+      expect(mockVisibility).toHaveBeenCalledWith(value.activeItem);
+    });
+  });
 });
 
 function renderComponent() {

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
@@ -12,13 +12,20 @@ export function DataListAction<T extends DataListObject>({
   label,
   icon,
   destructive,
+  visible = () => true,
   onClick,
 }: DataListActionProps<T>) {
   const { activeItem } = useDataListLayoutActionsContext<T>();
+
+  // Don't render if the item is not visible
+  if (activeItem && !visible(activeItem)) {
+    return null;
+  }
+
   const color = destructive ? "critical" : "blue";
 
   return (
-    <button className={styles.action} onClick={handleClick}>
+    <button type="button" className={styles.action} onClick={handleClick}>
       {icon && <Icon name={icon} color={color} />}
 
       <Typography textColor={color}>

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.test.tsx
@@ -99,6 +99,38 @@ describe("DataListActions", () => {
 
     expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument();
   });
+
+  describe("Visibility prop", () => {
+    it("should render the action if the visibility prop is not set", () => {
+      render(
+        <DataListActions>
+          <DataListAction icon="edit" label="Edit" />
+        </DataListActions>,
+      );
+
+      expect(screen.getByLabelText("Edit")).toBeInTheDocument();
+    });
+
+    it("should render the action if the visibility prop is returning true", () => {
+      render(
+        <DataListActions>
+          <DataListAction icon="edit" label="Edit" visible={() => true} />
+        </DataListActions>,
+      );
+
+      expect(screen.getByLabelText("Edit")).toBeInTheDocument();
+    });
+
+    it("should not render the action if the visibility prop is returning false", () => {
+      render(
+        <DataListActions>
+          <DataListAction icon="edit" label="Edit" visible={() => false} />
+        </DataListActions>,
+      );
+
+      expect(screen.queryByLabelText("Edit")).not.toBeInTheDocument();
+    });
+  });
 });
 
 function renderComponent(itemsToExpose = 3) {

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
@@ -27,6 +27,7 @@ export function DataListActions<T extends DataListObject>({
   return (
     <DataListOverflowFade>
       {exposedActions.map(({ props }) => {
+        if (props.visible && !props.visible(activeItem)) return null;
         if (!props.icon) return null;
 
         return (

--- a/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
+++ b/packages/components/src/DataList/components/DataListActionsMenu/DataListActionsMenu.tsx
@@ -59,6 +59,7 @@ export function DataListActionsMenu({
           </motion.div>
 
           <button
+            type="button"
             className={styles.overlay}
             onClick={onRequestClose}
             aria-label="Close menu"
@@ -96,6 +97,7 @@ export function DataListActionsMenu({
 
     const newPosX = Math.floor(xIsOffScreen ? x - xOffSet : x);
     const newPosY = Math.floor(yIsOffScreen ? y - yOffSet : y);
+
     return { posX: newPosX, posY: newPosY };
   }
 }

--- a/packages/components/src/DataList/components/DataListItem/DataListItem.test.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItem.test.tsx
@@ -89,6 +89,26 @@ describe("DataListItem", () => {
         "--actions-menu-y": `${clientY}px`,
       });
     });
+
+    it("should not show a context menu when the actions are hidden", async () => {
+      mockItemActionComponent.mockReturnValueOnce(
+        <DataListItemActions onClick={handleItemClick}>
+          <DataListAction label="Edit" visible={() => false} />
+          <DataListAction label="Email" visible={() => false} />
+        </DataListItemActions>,
+      );
+
+      renderComponent();
+
+      const listItemEl = screen.getByText(listItem);
+      await userEvent.hover(listItemEl);
+      fireEvent.contextMenu(listItemEl);
+
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "More actions" }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("In-layout action", () => {

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.test.tsx
@@ -1,35 +1,29 @@
 import React, { PropsWithChildren } from "react";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  DataListContext,
-  defaultValues,
-} from "@jobber/components/DataList/context/DataListContext";
 import { DataListAction } from "@jobber/components/DataList/components/DataListAction";
 import {
   DataListLayoutContext,
   defaultValues as layoutDefaultValues,
 } from "@jobber/components/DataList/context/DataListLayoutContext";
 import { DataListLayoutActionsContext } from "@jobber/components/DataList/components/DataListLayoutActions/DataListLayoutContext";
-import { DataListItemActions, InternalDataListItemActions } from ".";
-import { CONTAINER_TEST_ID } from "../DataListOverflowFade";
+import { InternalDataListItemActions } from ".";
 
 const handleEditClick = jest.fn();
 const mockSetHasInLayoutActions = jest.fn().mockReturnValue(true);
-const mockItemActionComponent = jest.fn().mockReturnValue(
-  <DataListItemActions>
-    <DataListAction icon="edit" label="Edit" onClick={handleEditClick} />
-    <DataListAction icon="email" label="Email" />
-    <DataListAction icon="note" label="Note" />
-    <DataListAction label="Delete" />
-  </DataListItemActions>,
-);
-
-afterEach(() => {
-  mockSetHasInLayoutActions.mockClear();
-  mockItemActionComponent.mockClear();
-  handleEditClick.mockClear();
-});
+const mockActions = jest
+  .fn()
+  .mockReturnValue([
+    <DataListAction
+      key="Edit"
+      icon="edit"
+      label="Edit"
+      onClick={handleEditClick}
+    />,
+    <DataListAction key="Email" icon="email" label="Email" />,
+    <DataListAction key="Note" icon="note" label="Note" />,
+    <DataListAction key="Delete" label="Delete" />,
+  ]);
 
 describe("DataListItemActions", () => {
   it("should render the 3 buttons", () => {
@@ -68,38 +62,13 @@ describe("DataListItemActions", () => {
     expect(handleEditClick).toHaveBeenCalledTimes(1);
     expect(handleEditClick).toHaveBeenCalledWith({ id: 1 });
   });
-
-  it("should not render the DataListItemActions overlay if there's no children", () => {
-    mockItemActionComponent.mockReturnValueOnce(
-      <DataListItemActions url={"getjobber.com"} />,
-    );
-
-    renderComponent();
-
-    expect(screen.queryByTestId(CONTAINER_TEST_ID)).not.toBeInTheDocument();
-  });
 });
 
 function renderComponent() {
   return render(
-    <MockMainContextProvider>
-      <MockLayoutContextProvider>
-        <InternalDataListItemActions />
-      </MockLayoutContextProvider>
-    </MockMainContextProvider>,
-  );
-}
-
-function MockMainContextProvider({ children }: PropsWithChildren<object>) {
-  return (
-    <DataListContext.Provider
-      value={{
-        ...defaultValues,
-        itemActionComponent: mockItemActionComponent(),
-      }}
-    >
-      {children}
-    </DataListContext.Provider>
+    <MockLayoutContextProvider>
+      <InternalDataListItemActions actions={mockActions()} />
+    </MockLayoutContextProvider>,
   );
 }
 

--- a/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
+++ b/packages/components/src/DataList/components/DataListItemActions/DataListItemActions.tsx
@@ -1,8 +1,11 @@
-import React, { MouseEvent } from "react";
+import React, { MouseEvent, ReactElement } from "react";
 import { Variants, motion } from "framer-motion";
 import styles from "./DataListItemActions.css";
-import { useDataListContext } from "../../context/DataListContext";
-import { DataListItemActionsProps, DataListObject } from "../../DataList.types";
+import {
+  DataListActionProps,
+  DataListItemActionsProps,
+  DataListObject,
+} from "../../DataList.types";
 import {
   TRANSITION_DELAY_IN_SECONDS,
   TRANSITION_DURATION_IN_SECONDS,
@@ -22,14 +25,13 @@ const variants: Variants = {
   visible: { opacity: 1, y: 0 },
 };
 
-export function InternalDataListItemActions() {
-  const { itemActionComponent } = useDataListContext();
-  if (!itemActionComponent) return null;
+interface InternalDataListItemActionsProps<T extends DataListObject> {
+  readonly actions: ReactElement<DataListActionProps<T>>[];
+}
 
-  const { children } = itemActionComponent.props;
-
-  if (!children) return null;
-
+export function InternalDataListItemActions<T extends DataListObject>({
+  actions,
+}: InternalDataListItemActionsProps<T>) {
   return (
     <motion.div
       variants={variants}
@@ -43,7 +45,7 @@ export function InternalDataListItemActions() {
       className={styles.menu}
       onContextMenu={handleContextMenu}
     >
-      <DataListActions>{children}</DataListActions>
+      <DataListActions>{actions}</DataListActions>
     </motion.div>
   );
 }

--- a/packages/components/src/DataList/hooks/useGetItemActions.ts
+++ b/packages/components/src/DataList/hooks/useGetItemActions.ts
@@ -1,0 +1,24 @@
+import { Children, ReactElement, isValidElement, useMemo } from "react";
+import { useDataListContext } from "../context/DataListContext";
+import { DataListActionProps, DataListObject } from "../DataList.types";
+
+export function useGetItemActions<T extends DataListObject>(item: T) {
+  const { itemActionComponent } = useDataListContext<T>();
+  const itemActions = itemActionComponent?.props.children || [];
+  const actionsArray = Children.toArray(itemActions);
+
+  const actions = useMemo(() => {
+    return actionsArray.filter(action => {
+      if (isValidElement(action) && action.props.visible) {
+        return action.props.visible(item);
+      }
+
+      return true;
+    });
+  }, [itemActionComponent?.props.children, item]);
+
+  return {
+    actions: actions as ReactElement<DataListActionProps<T>>[],
+    hasActions: Boolean(actions.length),
+  };
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The DataList was initially built to have all of the actions or none of it. This enables a way to hide some actions when it's not valid. For example, you shouldn't have an archive action on an already archived item.

Since DataList actions gets built outside of the template, the `visible` prop needs to be function that has the item it's attached to as the parameter so the consumers can easily determine if it should should up based on the existing data.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `visible` prop on DataList item actions

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
