### PR TITLE
fix(components): Fix Chip gradient on Safari

### DIFF
--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -174,3 +174,8 @@
     rgba(255, 255, 255, 0)
   );
 }
+
+.chipLabelRef {
+  display: inline-block;
+  width: 1px;
+}

--- a/packages/components/src/Chip/Chip.css.d.ts
+++ b/packages/components/src/Chip/Chip.css.d.ts
@@ -11,6 +11,7 @@ declare const styles: {
   readonly "disabled": string;
   readonly "chipContent": string;
   readonly "truncateGradient": string;
+  readonly "chipLabelRef": string;
 };
 export = styles;
 

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -62,14 +62,14 @@ export const Chip = ({
             <>
               <Typography size="base" fontWeight="medium">
                 {heading}
-                <span ref={headingRef} />
+                <span ref={headingRef} className={styles.chipLabelRef} />
               </Typography>
               {label && <span className={styles.chipBar} />}
             </>
           )}
           <Typography size="base">
             {label}
-            <span ref={labelRef} />
+            <span ref={labelRef} className={styles.chipLabelRef} />
           </Typography>
           {!labelFullyVisible && (
             <div


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

While doing some tests on Safari, I noticed that the gradient on Chip was always showing up, even if the label was fully visible. To fix it, I added one pixel to the ref element that is being passed to the hook `useInView` to it can understand the size of the element to handle the intersections

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fixed the gradient of Chip on Safari

### Security

- <!-- in case of vulnerabilities -->

## Testing

### Before
![image](https://github.com/GetJobber/atlantis/assets/12849476/4f167454-2104-442c-8339-d0818fd5aaf5)


### After
![image](https://github.com/GetJobber/atlantis/assets/12849476/c63eb2c6-57ce-420e-8d67-2eaabd76b86d)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
