### PR TITLE
fix(components-native): Update type exports for `Select` and `Text` components

### DIFF
--- a/packages/components-native/src/Select/index.ts
+++ b/packages/components-native/src/Select/index.ts
@@ -1,1 +1,2 @@
-export { Select, Option, SelectOption, SelectProps } from "./Select";
+export { Select, Option } from "./Select";
+export type { SelectOption, SelectProps } from "./Select";

--- a/packages/components-native/src/Text/index.ts
+++ b/packages/components-native/src/Text/index.ts
@@ -1,1 +1,2 @@
-export { Text, TextLevel } from "./Text";
+export { Text } from "./Text";
+export type { TextLevel } from "./Text";


### PR DESCRIPTION
## Motivations

Tried updating native components in Jobber Mobile and was running into:
https://app.circleci.com/pipelines/github/GetJobber/jobber-mobile/50924/workflows/406a5e3f-1e6a-4ead-b79c-195fce6b8966/jobs/406206

### How I got here:
This is for the appium contractors.  We need to get test ids into JM for certain components, so I was trying to update to `"@jobber/components-native": "^0.48.0"` (a version that allows for custom test ids), but when I go to update the native components TS doesn't compile.  The newest Atlantis version isn't looking like it does this, so I made this PR 🤷  

In JM I ended up grouping imports together and that fixed the typescript issue, good to know!  Gonna close the PR!

## Changes

Just updated to export the types separately

### Added

N/A

### Changed

N/A

### Deprecated

N/A

### Removed

N/A

### Fixed

See above

### Security

N/A

## Testing

You could make a pre-release and then brings those changes into JM and use the imports like I do in that PR linked above then do a `npm run typescript:compile`.

Passed tests and compiled in JM with a prerelease 🎉 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

<img src="https://github.com/GetJobber/atlantis/assets/88052089/5284fd2e-2c2d-4e08-b4b8-3218793c5260" width="75%" />

