### PR TITLE
fix: remove @use-it/event-listener dependency and use regular event handler attachment api.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14101,14 +14101,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@use-it/event-listener": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
-      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -46084,7 +46076,6 @@
         "@types/react-router": "5.1.7",
         "@types/react-router-dom": "^5.3.3",
         "@types/uuid": "^8.3.3",
-        "@use-it/event-listener": "^0.1.3",
         "axios": "^0.21.2",
         "classnames": "^2.3.2",
         "color": "^3.1.2",
@@ -48420,7 +48411,6 @@
       "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
-        "@use-it/event-listener": "^0.1.6",
         "lodash": "^4.17.20",
         "resize-observer-polyfill": "^1.5.1",
         "ts-xor": "^1.0.8",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,7 +31,6 @@
     "@types/react-router": "5.1.7",
     "@types/react-router-dom": "^5.3.3",
     "@types/uuid": "^8.3.3",
-    "@use-it/event-listener": "^0.1.3",
     "axios": "^0.21.2",
     "classnames": "^2.3.2",
     "color": "^3.1.2",

--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -63,7 +63,6 @@ export default {
     "uuid",
     new RegExp("lodash/.*"),
     "@std-proposal/temporal",
-    "@use-it/event-listener",
     "@jobber/design",
     "@jobber/design/foundation",
     "@jobber/formatters",

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -1,6 +1,5 @@
 import React, { RefObject, useEffect, useLayoutEffect, useState } from "react";
 import classnames from "classnames";
-import useEventListener from "@use-it/event-listener";
 import { createPortal } from "react-dom";
 import { usePopper } from "react-popper";
 import { AnyOption, Option } from "./Option";
@@ -158,14 +157,17 @@ function useOnKeyDown(
   keyName: string,
   handler: (event: KeyboardEvent) => boolean | void,
 ) {
-  // Pending: https://github.com/donavon/use-event-listener/pull/12
-  // The types in useEventListener mistakenly require a SyntheticEvent for the passed generic.
-  useEventListener("keydown", event => {
-    const newEvent = event as unknown as KeyboardEvent;
-    if (newEvent.key === keyName) {
-      handler(newEvent);
-    }
-  });
+  useEffect(() => {
+    window.addEventListener('keydown', event => {
+      const newEvent = event as unknown as KeyboardEvent;
+      if (newEvent.key === keyName) {
+        handler(newEvent);
+      }
+    });
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, []);
 }
 
 function isGroup(option: AnyOption) {

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -2,6 +2,7 @@ import React, { RefObject, useEffect, useLayoutEffect, useState } from "react";
 import classnames from "classnames";
 import { createPortal } from "react-dom";
 import { usePopper } from "react-popper";
+import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
 import { AnyOption, Option } from "./Option";
 import styles from "./Autocomplete.css";
 import { Text } from "../Text";
@@ -115,7 +116,7 @@ export function Menu({
       });
     }, [highlightedIndex]);
 
-    useOnKeyDown("ArrowDown", (event: KeyboardEvent) => {
+    useOnKeyDown((event: KeyboardEvent) => {
       const indexChange = arrowKeyPress(event, IndexChange.Next);
 
       if (indexChange) {
@@ -123,23 +124,23 @@ export function Menu({
           Math.min(options.length - 1, highlightedIndex + indexChange),
         );
       }
-    });
+    }, "ArrowDown");
 
-    useOnKeyDown("ArrowUp", (event: KeyboardEvent) => {
+    useOnKeyDown((event: KeyboardEvent) => {
       const indexChange = arrowKeyPress(event, IndexChange.Previous);
 
       if (indexChange) {
         setHighlightedIndex(Math.max(0, highlightedIndex + indexChange));
       }
-    });
+    }, "ArrowUp");
 
-    useOnKeyDown("Enter", (event: KeyboardEvent) => {
+    useOnKeyDown((event: KeyboardEvent) => {
       if (!visible) return;
       if (isGroup(options[highlightedIndex])) return;
 
       event.preventDefault();
       onOptionSelect(options[highlightedIndex]);
-    });
+    }, "Enter");
   }
 
   function arrowKeyPress(event: KeyboardEvent, direction: number) {
@@ -155,26 +156,6 @@ export function Menu({
 
 function isOptionSelected(selectedOption: Option | undefined, option: Option) {
   return selectedOption && selectedOption.value === option.value;
-}
-
-// Split this out into a hooks package.
-function useOnKeyDown(
-  keyName: string,
-  handler: (event: KeyboardEvent) => boolean | void,
-) {
-  const newHandler = (event: KeyboardEvent): void => {
-    if (event.key === keyName) {
-      handler(event);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener("keydown", newHandler);
-
-    return () => {
-      window.removeEventListener("keydown", newHandler);
-    };
-  }, [keyName, handler]);
 }
 
 function isGroup(option: AnyOption) {

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -159,9 +159,8 @@ function useOnKeyDown(
 ) {
   useEffect(() => {
     window.addEventListener('keydown', event => {
-      const newEvent = event as unknown as KeyboardEvent;
-      if (newEvent.key === keyName) {
-        handler(newEvent);
+      if (event.key === keyName) {
+        handler(event);
       }
     });
     return () => {

--- a/packages/components/src/Autocomplete/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu.tsx
@@ -65,6 +65,7 @@ export function Menu({
           [styles.active]: index === highlightedIndex,
           [styles.separator]: addSeparators,
         });
+
         if (isGroup(option)) {
           return (
             <div key={option.label} className={styles.heading}>
@@ -72,6 +73,7 @@ export function Menu({
             </div>
           );
         }
+
         return (
           <button
             className={optionClass}
@@ -115,6 +117,7 @@ export function Menu({
 
     useOnKeyDown("ArrowDown", (event: KeyboardEvent) => {
       const indexChange = arrowKeyPress(event, IndexChange.Next);
+
       if (indexChange) {
         setHighlightedIndex(
           Math.min(options.length - 1, highlightedIndex + indexChange),
@@ -124,6 +127,7 @@ export function Menu({
 
     useOnKeyDown("ArrowUp", (event: KeyboardEvent) => {
       const indexChange = arrowKeyPress(event, IndexChange.Previous);
+
       if (indexChange) {
         setHighlightedIndex(Math.max(0, highlightedIndex + indexChange));
       }
@@ -142,6 +146,7 @@ export function Menu({
     if (!visible) return;
     event.preventDefault();
     const requestedIndex = options[highlightedIndex + direction];
+
     return requestedIndex && isGroup(requestedIndex)
       ? direction + direction
       : direction;
@@ -157,20 +162,24 @@ function useOnKeyDown(
   keyName: string,
   handler: (event: KeyboardEvent) => boolean | void,
 ) {
+  const newHandler = (event: KeyboardEvent): void => {
+    if (event.key === keyName) {
+      handler(event);
+    }
+  };
+
   useEffect(() => {
-    window.addEventListener('keydown', event => {
-      if (event.key === keyName) {
-        handler(event);
-      }
-    });
+    window.addEventListener("keydown", newHandler);
+
     return () => {
-      window.removeEventListener('keydown', handler);
+      window.removeEventListener("keydown", newHandler);
     };
-  }, []);
+  }, [keyName, handler]);
 }
 
 function isGroup(option: AnyOption) {
   if (option.options) return true;
+
   return false;
 }
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -34,7 +34,6 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
-    "@use-it/event-listener": "^0.1.6",
     "lodash": "^4.17.20",
     "resize-observer-polyfill": "^1.5.1",
     "ts-xor": "^1.0.8",

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
@@ -1,4 +1,4 @@
-import useEventListener from "@use-it/event-listener";
+import { useEffect } from "react";
 import { XOR } from "ts-xor";
 
 type SimpleKeyComparator = KeyboardEvent["key"];
@@ -18,7 +18,12 @@ export function useOnKeyDown(
   callback: (event: KeyboardEvent) => void,
   keys: KeyComparator[] | KeyComparator,
 ) {
-  useEventListener("keydown", handler);
+  useEffect(() => {
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [handler]);
 
   function handler(event: KeyboardEvent) {
     const keyboardEvent = event as unknown as VerboseKeyComparator;

--- a/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
+++ b/packages/hooks/src/useOnKeyDown/useOnKeyDown.ts
@@ -19,16 +19,19 @@ export function useOnKeyDown(
   keys: KeyComparator[] | KeyComparator,
 ) {
   useEffect(() => {
-    window.addEventListener('keydown', handler);
+    window.addEventListener("keydown", handler);
+
     return () => {
-      window.removeEventListener('keydown', handler);
+      window.removeEventListener("keydown", handler);
     };
   }, [handler]);
 
   function handler(event: KeyboardEvent) {
     const keyboardEvent = event as unknown as VerboseKeyComparator;
+
     if (typeof keys === "string" && keyboardEvent.key === keys) {
       callback(event);
+
       return;
     }
 
@@ -36,12 +39,14 @@ export function useOnKeyDown(
       Array.isArray(keys) &&
       keys.some(item => {
         if (typeof item === "string") return keyboardEvent.key === item;
+
         return Object.keys(item).every(
           index => keyboardEvent[index] === item[index],
         );
       })
     ) {
       callback(event);
+
       return;
     }
 
@@ -51,6 +56,7 @@ export function useOnKeyDown(
       Object.keys(keys).every(index => keyboardEvent[index] === keys[index])
     ) {
       callback(event);
+
       return;
     }
   }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
During the vite migration work we noticed that there was some errors coming from globals that weren't being set. After doing some digging into this we realized that this was related to an issue with the `@use-it/event-listener` dependency.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
- The `@use-it/event-listener` dependency was unnecessary and causing issues. It's better to remove unnecessary dependencies.


### Removed
- We have removed the `@use-it/event-listener` dependency and have updated the code to use the regular event handler attachment api. We also updated the uses to use a shared hook to reduce unnecessary code duplication.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
