### PR TITLE
fix(components): Make pseudo-elements avoid pointer events on Combobox

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
@@ -31,6 +31,7 @@
     rgba(255, 255, 255, 0) 0%,
     rgb(255, 255, 255) 100%
   );
+  pointer-events: none;
 }
 
 .container::before {
@@ -46,4 +47,5 @@
     rgba(255, 255, 255, 1),
     rgba(255, 255, 255, 0)
   );
+  pointer-events: none;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The fade pseudo-elements were blocking the selection of the first and last options of Combobox, making them harder to select. This PR fixes it by adding the `pointer-events: none` on them.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Make pseudo-elements avoid pointer events on Combobox

### Security

- <!-- in case of vulnerabilities -->

## Testing

#### Before
![combobox-before](https://github.com/GetJobber/atlantis/assets/12849476/03172f9b-e2ef-4f5e-ac30-90e635629853)



#### After
![combobox-after](https://github.com/GetJobber/atlantis/assets/12849476/6d5351cf-c934-4676-b340-b98a943f9ca3)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
