### PR TITLE
fix(components): fix Chip, Combobox, and DataList focus states [JOB-82715]

### DIFF
--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -24,7 +24,12 @@
   align-items: center;
 }
 
-.chip:focus {
+.chip:focus,
+.chip:focus-visible {
+  outline: none;
+}
+
+.chip:focus-visible {
   box-shadow: var(--shadow-focus);
 }
 
@@ -48,11 +53,6 @@
   background-color: var(--color-surface);
   align-items: center;
   justify-content: center;
-}
-
-.chip .suffix:hover,
-.chip .prefix:hover {
-  background-color: var(--color-disabled);
 }
 
 .chip .prefix.empty,
@@ -80,17 +80,17 @@
 }
 
 .base:hover,
-.base:focus {
+.base:focus-visible {
   background-color: var(--chip-base--hover);
   --chip--gradient-color-variation--hover: var(--chip-base--hover);
 }
 
 .invalid,
 .invalid:hover,
-.invalid:focus,
+.invalid:focus-visible,
 .subtle.invalid,
 .subtle.invalid:hover,
-.subtle.invalid:focus {
+.subtle.invalid:focus-visible {
   border: var(--border-base) solid var(--color-critical);
   background-color: var(--color-critical--surface);
   --chip--gradient-color-variation: var(--color-critical--surface);
@@ -108,7 +108,7 @@
 * and we want hover to take priority
 */
 
-.subtle:focus {
+.subtle:focus-visible {
   --chip--gradient-color-variation--hover: var(--color-surface);
 }
 
@@ -120,7 +120,7 @@
 
 .disabled,
 .disabled:hover,
-.disabled:focus {
+.disabled:focus-visible {
   border: var(--border-base) solid var(--chip-disabled--bg);
   color: var(--color-disabled);
   background-color: var(--chip-disabled--bg);
@@ -166,7 +166,7 @@
   );
 }
 
-.chip:focus .truncateGradient,
+.chip:focus-visible .truncateGradient,
 .chip:hover .truncateGradient {
   background: linear-gradient(
     to left,

--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.css
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.css
@@ -19,12 +19,17 @@
 }
 
 .actionButton:focus {
-  box-shadow: var(--shadow-focus);
+  outline: none;
+}
+
+.actionButton:hover,
+.actionButton:focus-visible {
+  outline: none;
   background-color: var(--color-surface--background);
 }
 
-.actionButton:hover {
-  background-color: var(--color-surface--background);
+.actionButton:focus-visible {
+  box-shadow: var(--shadow-focus);
 }
 
 .actionButton span {

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
@@ -19,6 +19,15 @@
   visibility: hidden;
 }
 
+.content:focus,
+.content:focus-visible {
+  outline: none;
+}
+
+.content:focus-visible {
+  box-shadow: var(--shadow-focus);
+}
+
 .actions {
   display: flex;
   flex-direction: column;

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.css
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.css
@@ -14,10 +14,15 @@
 }
 
 .option:hover,
-.option:focus {
+.option:focus-visible {
   background-color: var(--color-surface--background);
 }
 
-.option:focus {
+.option:focus,
+.option:focus-visible {
+  outline: none;
+}
+
+.option:focus-visible {
   box-shadow: var(--shadow-focus);
 }

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css
@@ -20,6 +20,15 @@
   background-color: var(--color-surface--hover);
 }
 
+.action:focus,
+.action:focus-visible {
+  outline: none;
+}
+
+.action:focus-visible {
+  box-shadow: var(--shadow-focus);
+}
+
 .label {
   font-weight: 500;
 }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.css
@@ -6,6 +6,15 @@
   background-color: transparent;
 }
 
+.headerLabel:focus,
+.headerLabel:focus-visible {
+  outline: none;
+}
+
+.headerLabel:focus-visible {
+  box-shadow: var(--shadow-focus);
+}
+
 .sortable {
   cursor: pointer;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Upon pulling the DataList and Combobox into Jobber, we found useragent styling on some of our custom-styled `button` and other HTML elements that was being masked by Storybook.

**Chip**

![image](https://github.com/GetJobber/atlantis/assets/39704901/ec4d596c-cedf-4a42-ba0b-17b15b6b0a28)

**Combobox**
![image](https://github.com/GetJobber/atlantis/assets/39704901/6a480daf-782b-418b-bcba-28d1d85307ee)
![image](https://github.com/GetJobber/atlantis/assets/39704901/45a6dd58-507d-44d9-84b1-935545583c6d)
![image](https://github.com/GetJobber/atlantis/assets/39704901/cd007c37-8194-4376-b6b9-1b84fba8476a)

**DataList**
![image](https://github.com/GetJobber/atlantis/assets/39704901/d68adece-69b0-4eac-a8af-d71a980226e7)

It's possible there's a "systemic" fix to this like including a reset for HTML `button` elements in our Atlantis foundations stylesheet, but in service of solving the immediate problem this is my fix.

## Changes

### Changed

- Changed existing focus background and shadow styling to apply to `focus-visible` contexts for a smarter treatment of focus states: keyboard users always get the full focus treatment, pointer users receive what the browser heuristics determine is appropriate.
- Outline has been removed in contexts where we are already adding a focus style

### Fixed

- useragent styling is replaced with Atlantis styling for focus states

## Testing

- pull prerelease into Jobber or a "sandbox" project

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
