### PR TITLE
fix(components): resolve transition flicker on DataList "tag count" element

### DIFF
--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css
@@ -1,27 +1,27 @@
+.tagWrapper {
+  position: relative;
+}
+
 .tags {
   display: flex;
-  position: relative;
   z-index: var(--elevation-default);
   overflow: hidden;
   gap: var(--space-small);
   white-space: nowrap;
+  mask-image: linear-gradient(
+    to left,
+    transparent,
+    transparent var(--space-large),
+    rgba(0, 0, 0, 1) var(--space-largest),
+    rgba(0, 0, 0, 1)
+  );
 }
 
 .tagCount {
-  --overflow-bg: var(--data-list-item-active-color, var(--color-surface));
-
   display: flex;
   position: absolute;
   top: 0;
   right: 0;
   height: 100%;
-  padding-left: var(--space-base);
-  background-image: linear-gradient(
-    90deg,
-    transparent 0,
-    var(--overflow-bg) var(--space-base),
-    var(--overflow-bg) 100%
-  );
   align-items: center;
-  transition: all var(--timing-base);
 }

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css
@@ -8,6 +8,9 @@
   overflow: hidden;
   gap: var(--space-small);
   white-space: nowrap;
+}
+
+.tagsMask {
   mask-image: linear-gradient(
     to left,
     transparent,

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css.d.ts
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css.d.ts
@@ -1,4 +1,5 @@
 declare const styles: {
+  readonly "tagWrapper": string;
   readonly "tags": string;
   readonly "tagCount": string;
 };

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css.d.ts
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles: {
   readonly "tagWrapper": string;
   readonly "tags": string;
+  readonly "tagsMask": string;
   readonly "tagCount": string;
 };
 export = styles;

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -29,13 +29,14 @@ export function DataListTags({ items }: DataListTagsProps) {
   }, [items]);
 
   return (
-    <div className={styles.tags} ref={ref}>
-      {items.filter(Boolean).map((tag, index) => (
-        <div key={tag} data-tag-element={index}>
-          <InlineLabel>{tag}</InlineLabel>
-        </div>
-      ))}
-
+    <div className={styles.tagWrapper} ref={ref}>
+      <div className={styles.tags}>
+        {items.filter(Boolean).map((tag, index) => (
+          <div key={tag} data-tag-element={index}>
+            <InlineLabel>{tag}</InlineLabel>
+          </div>
+        ))}
+      </div>
       {Boolean(visibleItems) && (
         <div className={styles.tagCount}>
           <Text>+{visibleItems}</Text>

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import styles from "./DataListTags.css";
+import classNames from "classnames";
 import { InlineLabel } from "../../../InlineLabel";
 import { Text } from "../../../Text";
 
@@ -11,6 +12,7 @@ export function DataListTags({ items }: DataListTagsProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [visibleIndex, setVisibleIndex] = useState<boolean[]>([]);
   const visibleItems = visibleIndex.filter(Boolean).length;
+  const shouldShowTagCount = Boolean(visibleItems);
 
   useEffect(() => {
     if (!window.IntersectionObserver) return;
@@ -30,14 +32,18 @@ export function DataListTags({ items }: DataListTagsProps) {
 
   return (
     <div className={styles.tagWrapper} ref={ref}>
-      <div className={styles.tags}>
+      <div
+        className={classNames(styles.tags, {
+          [styles.tagsMask]: shouldShowTagCount,
+        })}
+      >
         {items.filter(Boolean).map((tag, index) => (
           <div key={tag} data-tag-element={index}>
             <InlineLabel>{tag}</InlineLabel>
           </div>
         ))}
       </div>
-      {Boolean(visibleItems) && (
+      {shouldShowTagCount && (
         <div className={styles.tagCount}>
           <Text>+{visibleItems}</Text>
         </div>

--- a/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import styles from "./DataListTags.css";
 import classNames from "classnames";
+import styles from "./DataListTags.css";
 import { InlineLabel } from "../../../InlineLabel";
 import { Text } from "../../../Text";
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When hovering the datalist row, the tag count's background gradient has a delay in receiving the new color value, so its' transition is not synced to the background of the row.

To resolve this, we'll get rid of the gradient background and apply a `mask-image` to the tags themselves.

## Changes

### Changed

- tag container is visually truncated by a mask on the container instead of an element with a gradient being positioned above it
- modified DOM structure of the tags + count to add a wrapper and allow the count to sit above the masked container

### Fixed

- tag count does not flicker when the Datalist row is hovered

## Testing

- Hover on a clickable DataList with overflowing tags

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
