### PR TITLE
fix(components): Ensure DataList renders the list item on safari

### DIFF
--- a/packages/components/src/DataList/hooks/useResponsiveSizing.ts
+++ b/packages/components/src/DataList/hooks/useResponsiveSizing.ts
@@ -2,11 +2,14 @@ import { useMediaQuery } from "./useMediaQuery";
 import { BREAKPOINT_SIZES, Breakpoints } from "../DataList.const";
 
 export function useResponsiveSizing(): Record<Breakpoints, boolean> {
-  const xs = useMediaQuery(`(width > ${BREAKPOINT_SIZES.xs}px)`);
-  const sm = useMediaQuery(`(width >= ${BREAKPOINT_SIZES.sm}px)`);
-  const md = useMediaQuery(`(width >= ${BREAKPOINT_SIZES.md}px)`);
-  const lg = useMediaQuery(`(width >= ${BREAKPOINT_SIZES.lg}px)`);
-  const xl = useMediaQuery(`(width >= ${BREAKPOINT_SIZES.xl}px)`);
+  // This was originally written to look for "min-width: 0" which would always
+  // return true no matter what.
+  // So, instead of running media query on it, just set it to true.
+  const xs = true;
+  const sm = useMediaQuery(`(min-width: ${BREAKPOINT_SIZES.sm}px)`);
+  const md = useMediaQuery(`(min-width: ${BREAKPOINT_SIZES.md}px)`);
+  const lg = useMediaQuery(`(min-width: ${BREAKPOINT_SIZES.lg}px)`);
+  const xl = useMediaQuery(`(min-width: ${BREAKPOINT_SIZES.xl}px)`);
 
   return { xs, sm, md, lg, xl };
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Upon further testing, we found out that the list items in the DataList weren't rendering. That was due to the fact that Safari on iOS16 and below prefers the `min-width` pattern instead of the new `width >=` pattern for media queries.

| Before | After |
|--|--|
| ![image](https://github.com/GetJobber/atlantis/assets/15986172/ac20a76b-d9a3-4884-ae96-2b969a7a93fb) | ![image](https://github.com/GetJobber/atlantis/assets/15986172/c3cd57f7-16b0-4bb9-bf4b-7eb2bb08781a) |

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- use `min-width: value` for media queries
- return true for xs always and forever since it is set to trigger at 0px

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
