### PR TITLE
docs: remove warning Banner from Glimmer

### DIFF
--- a/docs/components/Glimmer/Glimmer.stories.mdx
+++ b/docs/components/Glimmer/Glimmer.stories.mdx
@@ -1,18 +1,10 @@
 import { ArgsTable, Canvas, Meta, Source } from "@storybook/addon-docs";
-import { Banner } from "@jobber/components/Banner";
 import { Tab, Tabs } from "@jobber/components/Tabs";
 import { Glimmer } from "@jobber/components/Glimmer";
 
 <Meta title="Components/Status and Feedback/Glimmer/Docs" component={Glimmer} />
 
 # Glimmer
-
-<Banner type="warning" dismissible={false}>
-
-**Experimental component**. This component is subject to change and will have
-**breaking changes**, use at your own risk.
-
-</Banner>
 
 Glimmer is a foundational component that is used to build Skeleton (_coming
 soon_) or other components that invoke loading such as an image waiting to load


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Glimmer is stable

## Changes

### Removed

- warning from Glimmer

## Testing

View docs

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
