### PR TITLE
feat(components): Adding onBlur and onFocus support to Web <Select />

### DIFF
--- a/docs/components/Select/Web.stories.tsx
+++ b/docs/components/Select/Web.stories.tsx
@@ -70,6 +70,21 @@ const InitialValueTemplate: ComponentStory<typeof Select> = args => (
   </Select>
 );
 
+const OnFocusAndBlurTemplate: ComponentStory<typeof Select> = args => (
+  <Select
+    {...args}
+    onFocus={() => {
+      console.log("I have been focused!");
+    }}
+    onBlur={() => console.log("I have been blurred!")}
+  >
+    <Option value="tony">Tony</Option>
+    <Option value="steve">Steve</Option>
+    <Option value="natasha">Natasha</Option>
+    <Option value="bob">Bob</Option>
+  </Select>
+);
+
 export const Basic = BasicTemplate.bind({});
 Basic.args = {
   placeholder: "My best friend",
@@ -91,4 +106,10 @@ Events.args = {
   onChange: (newValue: string) => {
     alert("You picked: " + newValue);
   },
+};
+
+export const OnFocusAndBlur = OnFocusAndBlurTemplate.bind({});
+OnFocusAndBlur.args = {
+  placeholder: "Pick a friend",
+  defaultValue: "bob",
 };

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -104,14 +104,14 @@ export function FormField(props: FormFieldProps) {
           readOnly: readonly,
           inputMode: keyboard,
           onChange: handleChange,
+          onBlur: handleBlur,
+          onFocus: handleFocus,
           ...(description &&
             !inline && { "aria-describedby": descriptionIdentifier }),
         };
 
         const textFieldProps = {
           ...fieldProps,
-          onBlur: handleBlur,
-          onFocus: handleFocus,
           onKeyDown: handleKeyDown,
         };
 
@@ -190,10 +190,15 @@ export function FormField(props: FormFieldProps) {
         }
 
         function handleFocus(
-          event: FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+          event: FocusEvent<
+            HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+          >,
         ) {
           const target = event.currentTarget;
-          setTimeout(() => readonly && target.select());
+
+          if ((target as HTMLInputElement).select) {
+            setTimeout(() => readonly && (target as HTMLInputElement).select());
+          }
           onFocus && onFocus();
         }
 


### PR DESCRIPTION
## Motivations

We had an internal request to add support for onBlur and onFocus to our <Select /> component. Researching why that wasn't already the case turned up just an oversight and not a deliberate decision, so we've gone ahead and added support for those two callback to the `<select>` usage in FormField.

## Changes

Added support for onBlur and onFocus callbacks for the <Select> Web component.

### Added

- support for onBlur and onFocus callbacks for the <Select> Web component.
- Storybook story for this functionality

### Changed

- FormField - passed through onBlur and onFocus to child <select> component.
- FormField - handleFocus function now supports the HTMLSelectElement type as an argument
- FormField - handleFocus function now checks for `select` function being available because it is not present on HTMLSelectElement

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

## Testing

I have included a new story under the Select component that prints messages to the console onFocus and onBlur.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
