### PR TITLE
fix(components-native): add padding horizontal on content overlay title

### DIFF
--- a/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
@@ -34,6 +34,7 @@ export const styles = StyleSheet.create({
     zIndex: tokens["elevation-base"],
     borderTopLeftRadius: modalBorderRadius,
     borderTopRightRadius: modalBorderRadius,
+    minHeight: tokens["space-extravagant"],
   },
 
   headerShadow: {

--- a/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
@@ -58,7 +58,7 @@ export const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "center",
     paddingTop: tokens["space-base"],
-    paddingHorizontal: tokens["space-smaller"],
+    paddingHorizontal: tokens["space-base"],
   },
 
   titleWithDismiss: {

--- a/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
@@ -59,6 +59,7 @@ export const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "center",
     paddingTop: tokens["space-base"],
+    paddingHorizontal: tokens["space-smaller"],
   },
 
   titleWithDismiss: {

--- a/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
@@ -34,7 +34,6 @@ export const styles = StyleSheet.create({
     zIndex: tokens["elevation-base"],
     borderTopLeftRadius: modalBorderRadius,
     borderTopRightRadius: modalBorderRadius,
-    height: tokens["space-extravagant"],
   },
 
   headerShadow: {
@@ -54,7 +53,7 @@ export const styles = StyleSheet.create({
     opacity: 0,
   },
 
-  titleWithoutDimiss: {
+  titleWithoutDismiss: {
     flex: 1,
     flexDirection: "row",
     justifyContent: "center",

--- a/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
@@ -67,6 +67,5 @@ export const styles = StyleSheet.create({
     justifyContent: "center",
     paddingLeft: tokens["space-base"],
     paddingRight: tokens["space-smaller"],
-    flexGrow: 1,
   },
 });

--- a/packages/components-native/src/ContentOverlay/ContentOverlay.tsx
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.tsx
@@ -223,16 +223,20 @@ function ContentOverlayInternal(
         <View style={headerStyles}>
           <View
             style={
-              showDismiss ? styles.titleWithDismiss : styles.titleWithoutDismiss
+              shouldShowDismiss
+                ? styles.titleWithDismiss
+                : styles.titleWithoutDismiss
             }
           >
             <Heading
               level="subtitle"
               variation={loading ? "subdued" : "heading"}
+              align={shouldShowDismiss ? "start" : "center"}
             >
               {title}
             </Heading>
           </View>
+
           {shouldShowDismiss && (
             <View
               style={styles.dismissButton}

--- a/packages/components-native/src/ContentOverlay/ContentOverlay.tsx
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.tsx
@@ -85,6 +85,7 @@ function ContentOverlayInternal(
     if (!modalizeMethods?.open || !modalizeMethods?.close) {
       return {};
     }
+
     return {
       open: modalizeMethods?.open,
       close: modalizeMethods?.close,
@@ -110,9 +111,11 @@ function ContentOverlayInternal(
       return undefined;
     }
     const overlayHeight = headerHeight + childrenHeight;
+
     if (overlayHeight >= windowHeight) {
       return undefined;
     }
+
     return overlayHeight;
   }, [
     fullScreen,
@@ -136,9 +139,11 @@ function ContentOverlayInternal(
   const onCloseController = () => {
     if (!onBeforeExit) {
       internalRef.current?.close();
+
       return true;
     } else {
       onBeforeExit();
+
       return false;
     }
   };
@@ -169,6 +174,7 @@ function ContentOverlayInternal(
           onOpened={() => {
             if (overlayHeader.current) {
               const reactTag = findNodeHandle(overlayHeader.current);
+
               if (reactTag) {
                 AccessibilityInfo.setAccessibilityFocus(reactTag);
               }
@@ -217,7 +223,7 @@ function ContentOverlayInternal(
         <View style={headerStyles}>
           <View
             style={
-              showDismiss ? styles.titleWithDismiss : styles.titleWithoutDimiss
+              showDismiss ? styles.titleWithDismiss : styles.titleWithoutDismiss
             }
           >
             <Heading


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We were told that long titles go edge to edge and it shouldn't be. Found out that there's no padding on it. This puts that padding in there.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Padding horizontal on ContentOverlay title
- Allow title to wrap and get bigger than the set height
- If no dismiss, center align that text so when it wraps it looks center aligned

#### Before

<img width="559" alt="image" src="https://github.com/GetJobber/atlantis/assets/15986172/590c8473-5037-4888-a139-ef359962568e">


#### After

<img width="559" alt="image" src="https://github.com/GetJobber/atlantis/assets/15986172/dce38056-d37b-41ad-b3d9-a14c9b448cfd">


### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
