### PR TITLE
fix(components-native): avoid InputText re-renders

### DIFF
--- a/packages/components-native/src/InputCurrency/InputCurrency.test.tsx
+++ b/packages/components-native/src/InputCurrency/InputCurrency.test.tsx
@@ -82,8 +82,6 @@ describe.each([{ includeATLContext: true }, { includeATLContext: false }])(
       });
 
       fireEvent.changeText(getByLabelText(placeHolder), `${value}`);
-      fireEvent(getByLabelText("Price"), "blur");
-      fireEvent(getByLabelText("Price"), "blur");
 
       await waitFor(() => {
         expect(getByDisplayValue("123.45912")).toBeDefined();
@@ -95,7 +93,6 @@ describe.each([{ includeATLContext: true }, { includeATLContext: false }])(
       const { getByLabelText, getByDisplayValue } = setup({ name: "sample" });
 
       fireEvent.changeText(getByLabelText(placeHolder), `${value}`);
-      fireEvent(getByLabelText("Price"), "blur");
 
       await waitFor(() => {
         expect(getByDisplayValue("123.11")).toBeDefined();
@@ -107,7 +104,6 @@ describe.each([{ includeATLContext: true }, { includeATLContext: false }])(
       const { getByLabelText, getByDisplayValue } = setup({ name: "sample" });
 
       fireEvent.changeText(getByLabelText(placeHolder), `${value}`);
-      fireEvent(getByLabelText("Price"), "blur");
 
       await waitFor(() => {
         expect(getByDisplayValue(`${value}`)).toBeDefined();
@@ -119,7 +115,6 @@ describe.each([{ includeATLContext: true }, { includeATLContext: false }])(
       const { getByLabelText, getByDisplayValue } = setup({ name: "sample" });
 
       fireEvent.changeText(getByLabelText(placeHolder), `${value}`);
-      fireEvent(getByLabelText("Price"), "blur");
 
       await waitFor(() => {
         expect(getByDisplayValue("5,098.543")).toBeDefined();
@@ -142,7 +137,6 @@ describe.each([{ includeATLContext: true }, { includeATLContext: false }])(
       const { getByLabelText, getByDisplayValue } = setup({ name: "sample" });
 
       fireEvent.changeText(getByLabelText(placeHolder), `${value}`);
-      fireEvent(getByLabelText("Price"), "blur");
 
       await waitFor(() => {
         expect(getByDisplayValue("123,456.78999")).toBeDefined();

--- a/packages/components-native/src/InputText/InputText.test.tsx
+++ b/packages/components-native/src/InputText/InputText.test.tsx
@@ -19,6 +19,7 @@ jest.mock("../InputFieldWrapper", () => ({
   ...jest.requireActual("../InputFieldWrapper"),
   InputFieldWrapper: function Mock(props: InputFieldWrapperProps) {
     MockInputFieldWrapper(props);
+
     return jest.requireActual("../InputFieldWrapper").InputFieldWrapper(props);
   },
 }));
@@ -198,20 +199,43 @@ describe("InputText", () => {
         expect(blurCallback).toHaveBeenCalledTimes(1);
       });
 
-      it("trims whitespace on blur", () => {
-        const onChangeHandler = jest.fn();
-        const a11yLabel = "Test InputText";
-        const whiteSpacesValue = "    Hello World    ";
-        const { getByLabelText } = render(
-          <InputText
-            value={whiteSpacesValue}
-            accessibilityLabel={a11yLabel}
-            onChangeText={onChangeHandler}
-          />,
-        );
+      describe("when whitespace is present at the start or end of the value", () => {
+        const value = "    Hello World    ";
 
-        fireEvent(getByLabelText(a11yLabel), "blur");
-        expect(onChangeHandler).toHaveBeenCalledWith("Hello World");
+        it("trims whitespace", () => {
+          const onChangeHandler = jest.fn();
+          const a11yLabel = "Test InputText";
+          const { getByLabelText } = render(
+            <InputText
+              value={value}
+              accessibilityLabel={a11yLabel}
+              onChangeText={onChangeHandler}
+            />,
+          );
+
+          fireEvent(getByLabelText(a11yLabel), "blur");
+          expect(onChangeHandler).toHaveBeenCalledTimes(1);
+          expect(onChangeHandler).toHaveBeenLastCalledWith("Hello World");
+        });
+      });
+
+      describe("when whitespace is not present at the start or end of the value", () => {
+        const value = "Hello World";
+
+        it("does not invoke the onChangeText callback", () => {
+          const onChangeHandler = jest.fn();
+          const a11yLabel = "Test InputText";
+          const { getByLabelText } = render(
+            <InputText
+              value={value}
+              accessibilityLabel={a11yLabel}
+              onChangeText={onChangeHandler}
+            />,
+          );
+
+          fireEvent(getByLabelText(a11yLabel), "blur");
+          expect(onChangeHandler).toHaveBeenCalledTimes(0);
+        });
       });
     });
 

--- a/packages/components-native/src/InputText/InputText.tsx
+++ b/packages/components-native/src/InputText/InputText.tsx
@@ -135,7 +135,7 @@ export interface InputTextProps {
   readonly autoCorrect?: boolean;
 
   /**
-   *  Determines where to autocapitalize
+   * Determines where to autocapitalize
    */
   readonly autoCapitalize?: "characters" | "words" | "sentences" | "none";
 
@@ -456,7 +456,14 @@ function trimWhitespace(
   if (!field.value || !field.value.trim) {
     return;
   }
+
   const trimmedInput = field.value.trim();
+
+  if (trimmedInput === field.value) {
+    // avoid re-renders when nothing changed
+    return;
+  }
+
   onChangeText?.(trimmedInput);
   field.onChange(trimmedInput);
 }


### PR DESCRIPTION
## Motivations

The InputText native component automatically trims whitespace from values.

Currently, the `onChangeText` callback is invoked when the input is blurred regardless of if the value actually changes. This can lead to additional renders, which cause further state-related issues down the line (i.e. when displaying contextual menus, etc.).

## Changes

### Fixed

- The InputText `onChangeText` callback is no longer invoked on blur when the value does not change.

## Testing

1. Use the native `InputText` in a react component.

i.e.

```tsx
import React from "react";
import { InputText } from "@jobber/components-native";

const MyComponent = () => {
  const value = "Testing 🧪";
  
  const onChangeText = (text: string) => {
    console.log(`Text changed to: ${text}`);
  }
  
  return <InputText value={value} onChangeText={onChangeText} />;
};
```

2. Blur the input.

Previously the callback would be called because of whitespace trimming.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
