### PR TITLE
feat(components): Add css changes to show the placeholder label to the form field [JOB-83555]

### DIFF
--- a/docs/components/InputTime/Web.stories.tsx
+++ b/docs/components/InputTime/Web.stories.tsx
@@ -26,13 +26,16 @@ const BasicTemplate: ComponentStory<typeof InputTime> = args => (
 );
 
 const EventTemplate: ComponentStory<typeof InputTime> = args => {
-  const [time, setTime] = useState(new CivilTime(3, 52));
+  const [time, setTime] = useState<CivilTime>();
+
   const resetTime = () => {
     setTime(new CivilTime(3, 52));
   };
+
   const handleChange = (newTime: CivilTime) => {
     setTime(newTime);
   };
+
   return (
     <Content>
       <InputTime {...args} value={time} onChange={handleChange} />
@@ -66,4 +69,6 @@ Invalid.args = {
 };
 
 export const Event = EventTemplate.bind({});
-Event.args = {};
+Event.args = {
+  placeholder: "Start time",
+};

--- a/docs/components/InputTime/Web.stories.tsx
+++ b/docs/components/InputTime/Web.stories.tsx
@@ -29,7 +29,7 @@ const EventTemplate: ComponentStory<typeof InputTime> = args => {
   const [time, setTime] = useState<CivilTime>();
 
   const resetTime = () => {
-    setTime(new CivilTime(3, 52));
+    setTime(undefined);
   };
 
   const handleChange = (newTime: CivilTime) => {

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`it should display headers when headers are passed in 1`] = `
     >
       <div
         class="wrapper"
+        data-testid="Form-Field-Wrapper"
       >
         <div
           class="inputWrapper"
@@ -48,6 +49,7 @@ exports[`renders an Autocomplete 1`] = `
     >
       <div
         class="wrapper"
+        data-testid="Form-Field-Wrapper"
       >
         <div
           class="inputWrapper"

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -70,10 +70,6 @@
   -webkit-text-fill-color: var(--field--background-color);
 }
 
-/* .timeInputLabel input:focus {
-  color: inherit;
-} */
-
 .timeInputLabel:focus-within,
 .miniLabel {
   --field--placeholder-color: var(--color-text--secondary);

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -65,13 +65,14 @@
   box-shadow: var(--shadow-focus);
 }
 
-.timeInputLabel input {
+.timeInputLabel:not(:focus-within) input {
   color: var(--field--background-color);
+  -webkit-text-fill-color: var(--field--background-color);
 }
 
-.timeInputLabel input:focus {
+/* .timeInputLabel input:focus {
   color: inherit;
-}
+} */
 
 .timeInputLabel:focus-within,
 .miniLabel {

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -65,6 +65,15 @@
   box-shadow: var(--shadow-focus);
 }
 
+.timeInputLabel input {
+  color: var(--field--background-color);
+}
+
+.timeInputLabel input:focus {
+  color: inherit;
+}
+
+.timeInputLabel:focus-within,
 .miniLabel {
   --field--placeholder-color: var(--color-text--secondary);
   --field--placeholder-offset: var(--space-smallest);
@@ -73,6 +82,7 @@
   --field--padding-bottom: var(--space-small);
 }
 
+.timeInputLabel.large:focus-within,
 .miniLabel.large {
   --field--padding-top: calc(var(--space-large) + var(--space-smaller));
 }
@@ -220,10 +230,6 @@
   transition: all var(--timing-quick);
 }
 
-.miniLabel .label {
-  font-size: var(--typography--fontSize-small);
-}
-
 .textarea .label {
   /* Changes the width so that the scrollbar on the textarea doesn't get cut off */
   width: calc(100% - var(--field--padding-right));
@@ -233,16 +239,25 @@
   transform: translateY(--field--placeholder-transform);
 }
 
+.miniLabel .label,
+.timeInputLabel:focus-within .label {
+  font-size: var(--typography--fontSize-small);
+}
+
 .textarea.miniLabel .label {
   padding-top: var(--space-smallest);
   background-color: var(--field--background-color);
 }
 
-.small.miniLabel .label {
+.small.miniLabel .label,
+.timeInputLabel.small.miniLabel:focus-within .label {
   display: none;
 }
 
-.large.miniLabel .label {
+/**This is valid cascading order **/
+/* stylelint-disable-next-line no-descending-specificity */
+.large.miniLabel .label,
+.timeInputLabel.large.miniLabel:focus-within .label {
   padding-top: var(--space-small);
 }
 

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles: {
   readonly "container": string;
   readonly "wrapper": string;
+  readonly "timeInputLabel": string;
   readonly "miniLabel": string;
   readonly "large": string;
   readonly "textarea": string;

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { FormField } from ".";
 
 // eslint-disable-next-line max-statements
@@ -18,6 +18,28 @@ describe("FormField", () => {
         <FormField placeholder={placeholder} />,
       );
       expect(getByLabelText(placeholder)).toBeInTheDocument();
+    });
+
+    describe("with type", () => {
+      it("should render input with  timeInputLabel when type = 'time'", () => {
+        const FORM_FIELD_TEST_ID = "Form-Field-Wrapper";
+        const placeholder = "The best placeholder!";
+        render(<FormField placeholder={placeholder} type="time" />);
+        expect(screen.getByLabelText(placeholder)).toBeInTheDocument();
+        expect(screen.getByTestId(FORM_FIELD_TEST_ID)).toHaveClass(
+          "timeInputLabel",
+        );
+      });
+
+      it("should render input without timeInputLabel style when type != 'time'", () => {
+        const FORM_FIELD_TEST_ID = "Form-Field-Wrapper";
+        const placeholder = "The best placeholder!";
+        render(<FormField placeholder={placeholder} type="text" />);
+        expect(screen.getByLabelText(placeholder)).toBeInTheDocument();
+        expect(screen.getByTestId(FORM_FIELD_TEST_ID)).not.toHaveClass(
+          "timeInputLabel",
+        );
+      });
     });
   });
 

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -13,9 +13,9 @@ import { FormFieldDescription } from "./FormFieldDescription";
 import { InputValidation } from "../InputValidation";
 
 interface FormFieldWrapperProps extends FormFieldProps {
-  error: string;
-  identifier: string;
-  descriptionIdentifier: string;
+  readonly error: string;
+  readonly identifier: string;
+  readonly descriptionIdentifier: string;
 }
 
 interface LabelPadding {
@@ -50,7 +50,6 @@ export function FormFieldWrapper({
       [styles.miniLabel]:
         (placeholder && value !== "") ||
         (placeholder && type === "select") ||
-        (placeholder && type === "time") ||
         // Naively assume that if the the type is tel, it is the InputPhoneNumber
         (placeholder && type === "tel"),
       [styles.textarea]: type === "textarea",
@@ -58,6 +57,8 @@ export function FormFieldWrapper({
       [styles.invalid]: invalid ?? error,
       [styles.disabled]: disabled,
       [styles.maxLength]: maxLength,
+      [styles.timeInputLabel]:
+        placeholder && type === "time" && placeholder && value === "",
     },
   );
   const containerClasses = classnames(styles.container, {

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -83,7 +83,11 @@ export function FormFieldWrapper({
 
   return (
     <div className={containerClasses}>
-      <div className={wrapperClasses} style={wrapperInlineStyle}>
+      <div
+        className={wrapperClasses}
+        style={wrapperInlineStyle}
+        data-testid="Form-Field-Wrapper"
+      >
         {prefix?.icon && <AffixIcon {...prefix} size={size} />}
         <div className={styles.inputWrapper}>
           {placeholder && (

--- a/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
+++ b/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`FormField when small renders 1`] = `
   >
     <div
       class="wrapper small"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"
@@ -16,7 +17,7 @@ exports[`FormField when small renders 1`] = `
         >
           <input
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440005"
+            id="123e4567-e89b-12d3-a456-426655440009"
             type="text"
             value=""
           />
@@ -34,6 +35,7 @@ exports[`FormField with no props renders 1`] = `
   >
     <div
       class="wrapper"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -11,6 +11,7 @@ it("renders an input type number", () => {
       >
         <div
           class="wrapper"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"

--- a/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
+++ b/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<InputPassword /> renders an input type password 1`] = `
   >
     <div
       class="wrapper"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -12,6 +12,7 @@ it("renders a regular input for text and numbers", () => {
       >
         <div
           class="wrapper"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"
@@ -50,6 +51,7 @@ it("renders a textarea", () => {
       >
         <div
           class="wrapper textarea"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"
@@ -91,6 +93,7 @@ it("renders a textarea with 4 rows", () => {
       >
         <div
           class="wrapper textarea"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"

--- a/packages/components/src/InputTime/InputTime.test.tsx
+++ b/packages/components/src/InputTime/InputTime.test.tsx
@@ -12,6 +12,7 @@ it("renders a InputTime", () => {
       >
         <div
           class="wrapper"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"
@@ -44,6 +45,7 @@ it("renders an initial time when given 'defaultValue'", () => {
       >
         <div
           class="wrapper"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"
@@ -76,6 +78,7 @@ it("renders correctly in a readonly state", () => {
       >
         <div
           class="wrapper"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"
@@ -109,6 +112,7 @@ it("adds a error border when invalid", () => {
       >
         <div
           class="wrapper"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"
@@ -140,6 +144,7 @@ it("should set the value when given 'value' and 'onChange'", () => {
       >
         <div
           class="wrapper invalid"
+          data-testid="Form-Field-Wrapper"
         >
           <div
             class="inputWrapper"

--- a/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`renders a Select with many options 1`] = `
   >
     <div
       class="wrapper select"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"
@@ -60,6 +61,7 @@ exports[`renders a Select with no options 1`] = `
   >
     <div
       class="wrapper select"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"
@@ -100,6 +102,7 @@ exports[`renders a Select with one option 1`] = `
   >
     <div
       class="wrapper select"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"
@@ -144,6 +147,7 @@ exports[`renders correctly as large 1`] = `
   >
     <div
       class="wrapper large select"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"
@@ -188,6 +192,7 @@ exports[`renders correctly as small 1`] = `
   >
     <div
       class="wrapper small select"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"
@@ -232,6 +237,7 @@ exports[`renders correctly when disabled 1`] = `
   >
     <div
       class="wrapper select disabled"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"
@@ -277,6 +283,7 @@ exports[`renders correctly when invalid 1`] = `
   >
     <div
       class="wrapper select invalid"
+      data-testid="Form-Field-Wrapper"
     >
       <div
         class="inputWrapper"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The InputTime element was not showing the `Placeholder label` when the element was not focussed. SInce incorporating the new InputTime element for our reactified `Scherdule Card`, SPs have provided feedback regarding the InputTime element, stating that the field input seemed mandatory, which it was not. Hence there was a need to show the `Placeholder label` when not focussed.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Added `timeInputLabel` to FormField.css.d.ts
- Updated FormField.css to show `placeholder label` when there is no value in the time field element
- make FormFieldProps `readonly`

## Testing
- [ ] To test this feature, run `npm start` to start `storybook`, navigate to `InputTime` from SearchBox, navigate to `Event`
![image](https://github.com/GetJobber/atlantis/assets/68708089/4a365c4d-328e-4277-8da6-260052b77740)

- [ ] `Start Time` should be displayed in the input element
- [ ] Clicking in (focussing) the input time element should 
  - [ ] replace the `placeholder label` with the `time input`
  - [ ] move the `placeholder label`  to above the `time input`
- [ ] Clicking out (focus out) of the time input element should
  - [ ] show the `placeholder label` instead of the time input
- [ ] To test in `Safari` copy the `Storybook url` into `Safari` address bar, and you should be able to test the above steps
- [ ] To test in mobile / tablet (IOS) start `simulator`, and copy   the `Storybook url` into `Safari` address bar, and you should be able to test the above steps. `NOTE: Simulator will not allow deleting the time`
- [ ] To test locally with `Jobber Online`, go thru the process noted here -> [npm pack](https://atlantis.getjobber.com/?path=/docs/introduction--page#local-testing)

https://github.com/GetJobber/atlantis/assets/68708089/213aab1f-3d73-4b85-a5ac-925a4d49bc59


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
