### PR TITLE
fix(components): Prevent data list from navigating within the link when opening the menu

### DIFF
--- a/packages/components/src/DataList/components/DataListItemActionsOverflow/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActionsOverflow/DataListItemActionsOverflow.tsx
@@ -43,8 +43,8 @@ export function DataListItemActionsOverflow<T extends DataListObject>({
     // within a clickable list item
     event.stopPropagation();
 
-    // This action can be wrapped in a link, which will navigate to the URL
-    // when clicked. The `preventDefault` prevents that from happening
+    // Prevent navigating to the parent's href event when it is nested within a
+    // linked list item
     event.preventDefault();
 
     setShowMenu(true);

--- a/packages/components/src/DataList/components/DataListItemActionsOverflow/DataListItemActionsOverflow.tsx
+++ b/packages/components/src/DataList/components/DataListItemActionsOverflow/DataListItemActionsOverflow.tsx
@@ -43,6 +43,10 @@ export function DataListItemActionsOverflow<T extends DataListObject>({
     // within a clickable list item
     event.stopPropagation();
 
+    // This action can be wrapped in a link, which will navigate to the URL
+    // when clicked. The `preventDefault` prevents that from happening
+    event.preventDefault();
+
     setShowMenu(true);
 
     const rect = event.currentTarget.getBoundingClientRect();


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When working towards implementing `<DataList.LayoutActions />` on Jobber, we found out that if the list item have a URL to another page, it'll get triggered by tapping the more menu that came from `LayoutActions`. In order to prevent that, we should prevent default on the more menu click so it only opens the menu and not do a page navigation.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Prevent default on layout actions more menu click

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

change the action from `onClick` to `url`

```diff
diff --git a/docs/components/DataList/Web.stories.tsx b/docs/components/DataList/Web.stories.tsx
index ae76bc6f..1a28b11a 100644
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -142,7 +142,7 @@ const Template: ComponentStory<typeof DataList> = args => {
         placeholder="Search characters..."
       />

-      <DataList.ItemActions onClick={handleActionClick}>
+      <DataList.ItemActions url="/">
         <DataList.ItemAction
           visible={item => item.species !== "Droid"}
           icon="edit"

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)

JOB-83680