### PR TITLE
feat(components): Add functionality to clear input [JOB-83557]

### DIFF
--- a/packages/components/src/InputTime/InputTime.test.tsx
+++ b/packages/components/src/InputTime/InputTime.test.tsx
@@ -27,6 +27,30 @@ it("renders a InputTime", () => {
               />
             </div>
           </div>
+          <div
+            class="affixIcon suffix hasAction"
+          >
+            <button
+              aria-label="clear time"
+              class="button base onlyIcon subtle tertiary"
+              type="button"
+            >
+              <svg
+                class="Z6OfUI2sH34- TphtDHcwxDc-"
+                data-testid="remove"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class=""
+                  d="M12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 0 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12l5.293-5.293a1 1 0 1 0-1.414-1.414L12 10.586Z"
+                />
+              </svg>
+              <span
+                class="base extraBold base base"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -58,6 +82,30 @@ it("renders an initial time when given 'defaultValue'", () => {
                 value="11:23"
               />
             </div>
+          </div>
+          <div
+            class="affixIcon suffix hasAction"
+          >
+            <button
+              aria-label="clear time"
+              class="button base onlyIcon subtle tertiary"
+              type="button"
+            >
+              <svg
+                class="Z6OfUI2sH34- TphtDHcwxDc-"
+                data-testid="remove"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class=""
+                  d="M12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 0 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12l5.293-5.293a1 1 0 1 0-1.414-1.414L12 10.586Z"
+                />
+              </svg>
+              <span
+                class="base extraBold base base"
+              />
+            </button>
           </div>
         </div>
       </div>
@@ -92,6 +140,30 @@ it("renders correctly in a readonly state", () => {
               />
             </div>
           </div>
+          <div
+            class="affixIcon suffix hasAction"
+          >
+            <button
+              aria-label="clear time"
+              class="button base onlyIcon subtle tertiary"
+              type="button"
+            >
+              <svg
+                class="Z6OfUI2sH34- TphtDHcwxDc-"
+                data-testid="remove"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class=""
+                  d="M12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 0 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12l5.293-5.293a1 1 0 1 0-1.414-1.414L12 10.586Z"
+                />
+              </svg>
+              <span
+                class="base extraBold base base"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -125,6 +197,30 @@ it("adds a error border when invalid", () => {
               />
             </div>
           </div>
+          <div
+            class="affixIcon suffix hasAction"
+          >
+            <button
+              aria-label="clear time"
+              class="button base onlyIcon subtle tertiary"
+              type="button"
+            >
+              <svg
+                class="Z6OfUI2sH34- TphtDHcwxDc-"
+                data-testid="remove"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class=""
+                  d="M12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 0 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12l5.293-5.293a1 1 0 1 0-1.414-1.414L12 10.586Z"
+                />
+              </svg>
+              <span
+                class="base extraBold base base"
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -154,6 +250,30 @@ it("should set the value when given 'value' and 'onChange'", () => {
                 value=""
               />
             </div>
+          </div>
+          <div
+            class="affixIcon suffix hasAction"
+          >
+            <button
+              aria-label="clear time"
+              class="button base onlyIcon subtle tertiary"
+              type="button"
+            >
+              <svg
+                class="Z6OfUI2sH34- TphtDHcwxDc-"
+                data-testid="remove"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class=""
+                  d="M12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 0 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12l5.293-5.293a1 1 0 1 0-1.414-1.414L12 10.586Z"
+                />
+              </svg>
+              <span
+                class="base extraBold base base"
+              />
+            </button>
           </div>
         </div>
       </div>

--- a/packages/components/src/InputTime/InputTime.test.tsx
+++ b/packages/components/src/InputTime/InputTime.test.tsx
@@ -27,30 +27,6 @@ it("renders a InputTime", () => {
               />
             </div>
           </div>
-          <div
-            class="affixIcon suffix hasAction"
-          >
-            <button
-              aria-label="clear time"
-              class="button base onlyIcon subtle tertiary"
-              type="button"
-            >
-              <svg
-                class="Z6OfUI2sH34- TphtDHcwxDc-"
-                data-testid="remove"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  class=""
-                  d="M12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 0 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12l5.293-5.293a1 1 0 1 0-1.414-1.414L12 10.586Z"
-                />
-              </svg>
-              <span
-                class="base extraBold base base"
-              />
-            </button>
-          </div>
         </div>
       </div>
     </div>
@@ -82,30 +58,6 @@ it("renders an initial time when given 'defaultValue'", () => {
                 value="11:23"
               />
             </div>
-          </div>
-          <div
-            class="affixIcon suffix hasAction"
-          >
-            <button
-              aria-label="clear time"
-              class="button base onlyIcon subtle tertiary"
-              type="button"
-            >
-              <svg
-                class="Z6OfUI2sH34- TphtDHcwxDc-"
-                data-testid="remove"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  class=""
-                  d="M12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 0 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12l5.293-5.293a1 1 0 1 0-1.414-1.414L12 10.586Z"
-                />
-              </svg>
-              <span
-                class="base extraBold base base"
-              />
-            </button>
           </div>
         </div>
       </div>
@@ -144,7 +96,7 @@ it("renders correctly in a readonly state", () => {
             class="affixIcon suffix hasAction"
           >
             <button
-              aria-label="clear time"
+              aria-label="clear undefined"
               class="button base onlyIcon subtle tertiary"
               type="button"
             >
@@ -201,7 +153,7 @@ it("adds a error border when invalid", () => {
             class="affixIcon suffix hasAction"
           >
             <button
-              aria-label="clear time"
+              aria-label="clear undefined"
               class="button base onlyIcon subtle tertiary"
               type="button"
             >
@@ -250,30 +202,6 @@ it("should set the value when given 'value' and 'onChange'", () => {
                 value=""
               />
             </div>
-          </div>
-          <div
-            class="affixIcon suffix hasAction"
-          >
-            <button
-              aria-label="clear time"
-              class="button base onlyIcon subtle tertiary"
-              type="button"
-            >
-              <svg
-                class="Z6OfUI2sH34- TphtDHcwxDc-"
-                data-testid="remove"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  class=""
-                  d="M12 10.586 6.707 5.293a1 1 0 0 0-1.414 1.414L10.586 12l-5.293 5.293a1 1 0 0 0 1.414 1.414L12 13.414l5.293 5.293a1 1 0 0 0 1.414-1.414L13.414 12l5.293-5.293a1 1 0 1 0-1.414-1.414L12 10.586Z"
-                />
-              </svg>
-              <span
-                class="base extraBold base base"
-              />
-            </button>
           </div>
         </div>
       </div>

--- a/packages/components/src/InputTime/InputTime.tsx
+++ b/packages/components/src/InputTime/InputTime.tsx
@@ -25,11 +25,13 @@ export function InputTime({
       onClick: event => (event.currentTarget as HTMLInputElement).showPicker(),
       ...(defaultValue && { defaultValue: civilTimeToHTMLTime(defaultValue) }),
       ...(!defaultValue && { value: civilTimeToHTMLTime(value) }),
-      suffix: {
-        ariaLabel: "clear time",
-        icon: "remove",
-        onClick: () => handleChange(""),
-      },
+      ...(value && {
+        suffix: {
+          ariaLabel: "clear " + params.placeholder,
+          icon: "remove",
+          onClick: () => handleChange(""),
+        },
+      }),
       ...params,
     };
 

--- a/packages/components/src/InputTime/InputTime.tsx
+++ b/packages/components/src/InputTime/InputTime.tsx
@@ -25,6 +25,11 @@ export function InputTime({
       onClick: event => (event.currentTarget as HTMLInputElement).showPicker(),
       ...(defaultValue && { defaultValue: civilTimeToHTMLTime(defaultValue) }),
       ...(!defaultValue && { value: civilTimeToHTMLTime(value) }),
+      suffix: {
+        ariaLabel: "clear time",
+        icon: "remove",
+        onClick: () => handleChange(""),
+      },
       ...params,
     };
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

With [PR](https://github.com/GetJobber/atlantis/pull/1654) - I added the placeholder text, with [PR](https://github.com/GetJobber/atlantis/pull/1655) - I added the timepicker when clicking into the field. Now with this PR - I have added the functionality to clear the time input.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Added `suffix` as a parameter when calling `FormField` from `InputTime` component

## Testing

- [ ] To test this feature, run `npm start` to start `storybook`, navigate to `InputTime` from SearchBox, navigate to `Event`
![image](https://github.com/GetJobber/atlantis/assets/68708089/4a365c4d-328e-4277-8da6-260052b77740)
- [ ] Click in the input time element and select a time from the `time picker`
- [ ] Clicking the `X` should clear the input time

https://github.com/GetJobber/atlantis/assets/68708089/099081a1-af66-48f0-a75b-99226ac8b33b


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
