### PR TITLE
Add functionality to clear timeinput

### DIFF
--- a/docs/components/InputTime/Web.stories.tsx
+++ b/docs/components/InputTime/Web.stories.tsx
@@ -72,3 +72,9 @@ export const Event = EventTemplate.bind({});
 Event.args = {
   placeholder: "Start time",
 };
+
+export const Clearable = EventTemplate.bind({});
+Clearable.args = {
+  defaultValue: new CivilTime(2, 35),
+  clearable: "always",
+};

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -325,3 +325,21 @@
 .description {
   margin-top: var(--space-smaller);
 }
+
+.clearInput {
+  display: flex;
+  position: absolute;
+  top: 50%;
+  right: var(--space-base);
+  z-index: var(--elevation-tooltip);
+  width: var(--space-large);
+  height: var(--space-large);
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-circle);
+  background-color: var(--color-surface--background);
+  cursor: pointer;
+  transform: translateY(-50%);
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -23,6 +23,7 @@ declare const styles: {
   readonly "hasAction": string;
   readonly "affixLabel": string;
   readonly "description": string;
+  readonly "clearInput": string;
 };
 export = styles;
 

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -3,6 +3,8 @@ import { RegisterOptions } from "react-hook-form";
 import { XOR } from "ts-xor";
 import { IconNames } from "../Icon";
 
+export type Clearable = "never" | "while-editing" | "always";
+
 export type FormFieldTypes =
   | "text"
   | "password"
@@ -113,6 +115,15 @@ export interface CommonFormFieldProps {
    * Set the component to the given value.
    */
   readonly value?: string | number | Date;
+
+  /**
+   * Add a clear action on the input that clears the value.
+   *
+   * You should always use `while-editing` if you want the input to be
+   * clearable. if the input value isn't editable (i.e. `InputDateTime`) you can
+   * set it to `always`.
+   */
+  readonly clearable?: Clearable;
 }
 
 export interface FormFieldProps extends CommonFormFieldProps {

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -11,6 +11,7 @@ import styles from "./FormField.css";
 import { AffixIcon, AffixLabel } from "./FormFieldAffix";
 import { FormFieldDescription } from "./FormFieldDescription";
 import { InputValidation } from "../InputValidation";
+import { Icon } from "../Icon";
 
 interface FormFieldWrapperProps extends FormFieldProps {
   readonly error: string;
@@ -41,6 +42,8 @@ export function FormFieldWrapper({
   disabled,
   inline,
   identifier,
+  clearable,
+  onChange,
 }: PropsWithChildren<FormFieldWrapperProps>) {
   const wrapperClasses = classnames(
     styles.wrapper,
@@ -112,6 +115,17 @@ export function FormFieldWrapper({
         </div>
         {suffix?.icon && (
           <AffixIcon {...suffix} variation="suffix" size={size} />
+        )}
+        {clearable && value && (
+          <button
+            className={styles.clearInput}
+            onClick={onChange && (() => onChange(""))}
+            type="button"
+            data-testid="ATL-Input-Time-Clear"
+            aria-label="Clear input"
+          >
+            <Icon name="remove" size="small" />
+          </button>
         )}
       </div>
       {description && !inline && (

--- a/packages/components/src/InputTime/InputTimeProps.tsx
+++ b/packages/components/src/InputTime/InputTimeProps.tsx
@@ -14,6 +14,7 @@ export interface InputTimeProps
       | "onValidation"
       | "placeholder"
       | "size"
+      | "clearable"
     >,
     Pick<
       FormFieldProps,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

With [PR](https://github.com/GetJobber/atlantis/pull/1654) - I added the placeholder text, with [PR](https://github.com/GetJobber/atlantis/pull/1655) - I added the timepicker when clicking into the field. Now with this PR - I have added the functionality to clear the time input.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Added `suffix` as a parameter when calling `FormField` from `InputTime` component

## Testing

- [ ] To test this feature, run `npm start` to start `storybook`, navigate to `InputTime` from SearchBox, navigate to `Event`
![image](https://github.com/GetJobber/atlantis/assets/68708089/4a365c4d-328e-4277-8da6-260052b77740)
- [ ] select a time from the `time picker` or input the time
- [ ] Clicking the `X` should clear the input time

https://github.com/GetJobber/atlantis/assets/68708089/099081a1-af66-48f0-a75b-99226ac8b33b


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)