### PR TITLE
refactor(components): swap icon and label placement in DataList context menu

### DIFF
--- a/packages/components/src/DataList/components/DataListAction/DataListAction.css
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.css
@@ -12,6 +12,7 @@
   transition: background var(--timing-base) ease;
   appearance: none;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-small);
 }
 

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
@@ -22,15 +22,15 @@ export function DataListAction<T extends DataListObject>({
     return null;
   }
 
-  const color = destructive ? "critical" : "blue";
+  const color = destructive ? "critical" : "heading";
 
   return (
     <button type="button" className={styles.action} onClick={handleClick}>
-      {icon && <Icon name={icon} color={color} />}
-
       <Typography textColor={color}>
         <span className={styles.label}>{label}</span>
       </Typography>
+
+      {icon && <Icon name={icon} color={color} />}
     </button>
   );
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The context menu of the DataList is heavily influenced by the mobile Menu - this aligns the two styles, and avoids alignment conflict when one item has an icon and the other does not.

**Before**
![image](https://github.com/GetJobber/atlantis/assets/39704901/a773f3fc-ba8e-49a2-8f8a-6e8eabd36268)

**After**
![image](https://github.com/GetJobber/atlantis/assets/39704901/23023ea4-b66e-4b41-9a9a-4312fb5a2669)

## Changes

### Changed

- The label comes before the icon in the DataList context menu now

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
