### PR TITLE
fix(components): Fix stepped variation of progress bar

### DIFF
--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -39,6 +39,6 @@ progress.SteppedProgressBar[value]::-webkit-progress-value {
 .wrapper {
   display: flex;
   flex-direction: row;
-  flex: 1;
+  width: 100%;
   gap: var(--space-small);
 }

--- a/packages/components/src/ProgressBar/ProgressBar.css
+++ b/packages/components/src/ProgressBar/ProgressBar.css
@@ -39,5 +39,6 @@ progress.SteppedProgressBar[value]::-webkit-progress-value {
 .wrapper {
   display: flex;
   flex-direction: row;
+  flex: 1;
   gap: var(--space-small);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
- Noticed that the stepped variation wasn't rendering when imported to JO.

### Before
<img width="1840" alt="image" src="https://github.com/GetJobber/atlantis/assets/82672426/c0c838da-c905-4dce-8574-ed1a0db73cde">

### After
<img width="1840" alt="image" src="https://github.com/GetJobber/atlantis/assets/82672426/178a0869-b8e4-4cf1-bcf4-a8380493d43c">

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed
- Fixed rendering of stepped variation of progress bar.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
