### PR TITLE
refactor(components) Add callback to ItemAction label

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -151,7 +151,7 @@ const Template: ComponentStory<typeof DataList> = args => {
         />
         <DataList.ItemAction
           icon="sendMessage"
-          label="Message"
+          label={item => `Message ${item.label}`}
           onClick={handleActionClick}
         />
         <DataList.ItemAction

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -306,7 +306,7 @@ export interface DataListActionProps<T extends DataListObject> {
   /**
    * The label of the action
    */
-  readonly label: string;
+  readonly label: string | ((item: T) => string);
 
   /**
    * The icon beside the label

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.test.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.test.tsx
@@ -58,6 +58,20 @@ describe("DataListAction", () => {
     expect(handleClick).toHaveBeenCalledWith(mockItem);
   });
 
+  it("should render the correct label when a callback is passed", async () => {
+    const value = { activeItem: { id: 1 } };
+    const mockLabel = jest.fn(() => "Edit");
+
+    render(
+      <DataListLayoutActionsContext.Provider value={value}>
+        <DataListAction label={mockLabel} />
+      </DataListLayoutActionsContext.Provider>,
+    );
+
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(mockLabel).toHaveBeenCalledWith(value.activeItem);
+  });
+
   describe("Action visibility", () => {
     const value = { activeItem: { id: 1 } };
 

--- a/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
+++ b/packages/components/src/DataList/components/DataListAction/DataListAction.tsx
@@ -24,10 +24,13 @@ export function DataListAction<T extends DataListObject>({
 
   const color = destructive ? "critical" : "heading";
 
+  const actionLabel =
+    typeof label === "function" && activeItem ? label(activeItem) : label;
+
   return (
     <button type="button" className={styles.action} onClick={handleClick}>
       <Typography textColor={color}>
-        <span className={styles.label}>{label}</span>
+        <span className={styles.label}>{actionLabel as string}</span>
       </Typography>
 
       {icon && <Icon name={icon} color={color} />}

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
@@ -30,11 +30,16 @@ export function DataListActions<T extends DataListObject>({
         if (props.visible && !props.visible(activeItem)) return null;
         if (!props.icon) return null;
 
+        const actionLabel =
+          typeof props.label === "function"
+            ? props.label(activeItem)
+            : props.label;
+
         return (
-          <Tooltip key={props.label} message={props.label}>
+          <Tooltip key={actionLabel} message={actionLabel}>
             <Button
               icon={props.icon}
-              ariaLabel={props.label}
+              ariaLabel={actionLabel}
               onClick={() => {
                 if (activeItem) {
                   props.onClick?.(activeItem);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To make label more flexible by passing the `activeItem` to a callback on the `label` prop of `ItemAction`

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `DataListAction` now supports a callback on the `label` prop

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
