### PR TITLE
docs(components): Fixing old links (and a bad rebase)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -150,7 +150,7 @@ follow the following format.
 `<TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>`
 
 Want help with your pull request title? We have a
-[tool to help](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page).
+[tool to help](https://atlantis.getjobber.com/?path=/docs/guides-pull-request-title-generator--page).
 
 ##### Requesting review
 

--- a/docs/components/InputPassword/InputPassword.stories.mdx
+++ b/docs/components/InputPassword/InputPassword.stories.mdx
@@ -14,4 +14,4 @@ password.
 If you are building an experience for authentication that does not require
 character-masking or are looking for more information regarding `validations`,
 refer to
-[InputText](../?path=/docs/components-forms-and-inputs-inputtext-docs--page#validation-message).
+[InputText](https://atlantis.getjobber.com/?path=/docs/components-forms-and-inputs-inputtext-docs--page#validation-message).

--- a/packages/components/src/InputAvatar/InputAvatar.tsx
+++ b/packages/components/src/InputAvatar/InputAvatar.tsx
@@ -11,7 +11,7 @@ interface InputAvatarProps extends Omit<AvatarProps, "size"> {
    * to upload the file.
    *
    * More info is available at:
-   * https://atlantis.getjobber.com/components/input-file#getuploadparams
+   * https://atlantis.getjobber.com/?path=/docs/components-forms-and-inputs-inputfile-docs--page#getuploadparams
    */
   getUploadParams(file: File): UploadParams | Promise<UploadParams>;
 

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -120,7 +120,7 @@ interface InputFileProps {
    * to upload the file.
    *
    * More info is available at:
-   * https://atlantis.getjobber.com/components/input-file#getuploadparams
+   * https://atlantis.getjobber.com/?path=/docs/components-forms-and-inputs-inputfile-docs--page#getuploadparams
    */
   getUploadParams(file: File): UploadParams | Promise<UploadParams>;
 

--- a/packages/components/src/InputGroup/InputGroup.tsx
+++ b/packages/components/src/InputGroup/InputGroup.tsx
@@ -18,6 +18,7 @@ export function InputGroup({
   if (isInvalidGroupNesting(children)) return <></>;
 
   const className = classnames(styles.inputGroup, styles[flowDirection]);
+
   return <div className={className}>{children}</div>;
 }
 
@@ -29,8 +30,9 @@ function isInvalidGroupNesting(childs: ReactElement | ReactElement[]): boolean {
     ) {
       console.error(
         `ERROR: InputGroup not rendered: nesting 'flowDirection="vertical"' columns not supported.`,
-        `https://atlantis.getjobber.com/components/input-group#nested-example`,
+        `https://atlantis.getjobber.com/?path=/story/components-forms-and-inputs-inputgroup-web--nested`,
       );
+
       return true;
     }
 

--- a/packages/generators/templates/docs/{{name}}.stories.{{mdx}}
+++ b/packages/generators/templates/docs/{{name}}.stories.{{mdx}}
@@ -24,7 +24,7 @@ The {{name}} will... _Add a brief description of the design and usage of the com
   What type of content does this component present (documents, text, images, other components)?
   What is the recommended, or expected, amount of content? What is the components’ behaviour when
   the provided content diverges from what is expected (image aspect ratio, amount of text, video
-  vs audio, filesize)? Are there any important references to the [Product Vocabulary](https://atlantis.getjobber.com/guides/product-vocabulary)
+  vs audio, filesize)? Are there any important references to the [Product Vocabulary](https://atlantis.getjobber.com/?path=/docs/content-product-vocabulary--page)
   that should be made regarding this component? What happens when content is unavailable or unreliable
   (poor connection, empty states, flaky GPS data?)
 -->


### PR DESCRIPTION
## Motivations

Back in March Rodrigo identified some bad links in our documentation. Today when I tried to bring that branch up to date with master so we could get it merged I broke the branch. 

So this PR is me replaying Rodrigo's work (and Chris' comment) from March against our mainline branch so we can get these links fixed! :)

## Changes

- Fixed broken links in documentation + code

### Changed

- Documentation Links

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
