### PR TITLE
feat(components): expose search term on combobox action

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -262,6 +262,32 @@ const ComboboxSingleSelection: ComponentStory<typeof Combobox> = args => {
   );
 };
 
+const DynamicButton: ComponentStory<typeof Combobox> = args => {
+  const [selected, setSelected] = useState<ComboboxOption[]>([]);
+
+  return (
+    <Combobox
+      {...args}
+      onSelect={setSelected}
+      selected={selected}
+      label="Teammates"
+    >
+      <Combobox.Option id="1" label="Search" />
+      <Combobox.Option id="2" label="Something" />
+      <Combobox.Option id="3" label="That's not" />
+      <Combobox.Option id="4" label="There" />
+
+      <Combobox.Action
+        visible={({ searchValue }) => Boolean(searchValue)}
+        label={({ searchValue }) => `Add ${searchValue} as teammate`}
+        onClick={(_, { searchValue }) => {
+          alert(`Added ${searchValue} as teammate`);
+        }}
+      />
+    </Combobox>
+  );
+};
+
 export const ClearSelection = ComboboxClearSelection.bind({});
 ClearSelection.args = {};
 
@@ -275,4 +301,7 @@ export const MultiSelect = ComboboxMultiSelection.bind({});
 MultiSelect.args = {};
 
 export const SingleSelect = ComboboxSingleSelection.bind({});
+SingleSelect.args = {};
+
+export const DynamicAction = DynamicButton.bind({});
 SingleSelect.args = {};

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -213,7 +213,12 @@ describe("Actions", () => {
     await userEvent.click(screen.getByRole("combobox"));
     await userEvent.type(screen.getByPlaceholderText("Search"), "Bilbo");
 
-    expect(screen.getByText("Add Bilbo")).toBeInTheDocument();
+    const action = screen.getByText("Add Bilbo");
+    expect(action).toBeInTheDocument();
+    await userEvent.click(action);
+    expect(handleAction).toHaveBeenCalledWith(expect.anything(), {
+      searchValue: "Bilbo",
+    });
   });
 
   it("should not show the action when there is no search value", async () => {
@@ -222,6 +227,7 @@ describe("Actions", () => {
     await userEvent.click(screen.getByRole("combobox"));
 
     expect(screen.queryByText("Add Bilbo")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add ")).not.toBeInTheDocument();
   });
 });
 

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -206,6 +206,25 @@ describe("Combobox Single Select", () => {
   });
 });
 
+describe("Actions", () => {
+  it("should show the action when there is a search value", async () => {
+    renderCombobox();
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.type(screen.getByPlaceholderText("Search"), "Bilbo");
+
+    expect(screen.getByText("Add Bilbo")).toBeInTheDocument();
+  });
+
+  it("should not show the action when there is no search value", async () => {
+    renderCombobox();
+
+    await userEvent.click(screen.getByRole("combobox"));
+
+    expect(screen.queryByText("Add Bilbo")).not.toBeInTheDocument();
+  });
+});
+
 describe("Combobox Multiselect", () => {
   it("should not close the menu when selecting the value", async () => {
     renderMultiSelectCombobox();
@@ -416,6 +435,11 @@ function renderCombobox() {
       <Combobox.Option id="1" label="Bilbo Baggins" />
       <Combobox.Option id="2" label="Frodo Baggins" />
       <Combobox.Action label="Add Teammate" onClick={handleAction} />
+      <Combobox.Action
+        visible={({ searchValue }) => Boolean(searchValue)}
+        label={({ searchValue }) => `Add ${searchValue}`}
+        onClick={handleAction}
+      />
     </Combobox>,
   );
 }

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -49,6 +49,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
       setOpen={setOpen}
       handleClose={handleClose}
       shouldScroll={shouldScroll}
+      searchValue={searchValue}
     >
       <div ref={wrapperRef} className={styles.wrapper}>
         {open && (

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -217,5 +217,9 @@ export interface ComboboxActionProps {
   /**
    * The label text of the action.
    */
-  readonly label: string;
+  readonly label: string | ((param: ComboboxActionLabelParam) => string);
+}
+
+export interface ComboboxActionLabelParam {
+  readonly searchValue: string;
 }

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -217,9 +217,16 @@ export interface ComboboxActionProps {
   /**
    * The label text of the action.
    */
-  readonly label: string | ((param: ComboboxActionLabelParam) => string);
+  readonly label: string | ((param: ComboboxActionCallbackParam) => string);
+
+  /**
+   * Determine if the action is visible for a given item.
+   */
+  readonly visible?:
+    | boolean
+    | ((param: ComboboxActionCallbackParam) => boolean);
 }
 
-export interface ComboboxActionLabelParam {
+export interface ComboboxActionCallbackParam {
   readonly searchValue: string;
 }

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -212,21 +212,24 @@ export interface ComboboxActionProps {
   /**
    * The function to call when the action is clicked.
    */
-  onClick(event: React.MouseEvent<HTMLButtonElement>): void;
+  onClick(
+    event: React.MouseEvent<HTMLButtonElement>,
+    options: ComboboxActionCallbackOptions,
+  ): void;
 
   /**
    * The label text of the action.
    */
-  readonly label: string | ((param: ComboboxActionCallbackParam) => string);
+  readonly label: string | ((options: ComboboxActionCallbackOptions) => string);
 
   /**
    * Determine if the action is visible for a given item.
    */
   readonly visible?:
     | boolean
-    | ((param: ComboboxActionCallbackParam) => boolean);
+    | ((options: ComboboxActionCallbackOptions) => boolean);
 }
 
-export interface ComboboxActionCallbackParam {
+export interface ComboboxActionCallbackOptions {
   readonly searchValue: string;
 }

--- a/packages/components/src/Combobox/ComboboxProvider.tsx
+++ b/packages/components/src/Combobox/ComboboxProvider.tsx
@@ -1,17 +1,6 @@
 import React, { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { ComboboxOption } from "./Combobox.types";
 
-export const ComboboxContext = React.createContext(
-  {} as {
-    open: boolean;
-    setOpen: (open: boolean) => void;
-    selected: ComboboxOption[];
-    selectionHandler: (option: ComboboxOption) => void;
-    handleClose: () => void;
-    shouldScroll: MutableRefObject<boolean>;
-  },
-);
-
 export interface ComboboxProviderProps {
   readonly children: React.ReactNode;
   readonly selected: ComboboxOption[];
@@ -20,23 +9,20 @@ export interface ComboboxProviderProps {
   readonly setOpen: Dispatch<SetStateAction<boolean>>;
   readonly handleClose: () => void;
   readonly shouldScroll: MutableRefObject<boolean>;
+  readonly searchValue: string;
 }
 
-export function ComboboxContextProvider(
-  props: ComboboxProviderProps,
-): JSX.Element {
+export const ComboboxContext = React.createContext(
+  {} as Omit<ComboboxProviderProps, "children">,
+);
+
+export function ComboboxContextProvider({
+  children,
+  ...props
+}: ComboboxProviderProps): JSX.Element {
   return (
-    <ComboboxContext.Provider
-      value={{
-        open: props.open,
-        setOpen: props.setOpen,
-        selected: props.selected,
-        selectionHandler: props.selectionHandler,
-        handleClose: props.handleClose,
-        shouldScroll: props.shouldScroll,
-      }}
-    >
-      {props.children}
+    <ComboboxContext.Provider value={props}>
+      {children}
     </ComboboxContext.Provider>
   );
 }

--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
@@ -30,7 +30,7 @@ export function ComboboxAction(props: ComboboxActionProps) {
         <Typography
           element="span"
           size="base"
-          textColor="green"
+          textColor="interactive"
           fontWeight="semiBold"
         >
           {computedLabel}

--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
@@ -4,18 +4,27 @@ import { Typography } from "../../../Typography";
 import { ComboboxActionProps } from "../../Combobox.types";
 import { ComboboxContext } from "../../ComboboxProvider";
 
-export function ComboboxAction(props: ComboboxActionProps): JSX.Element {
+export function ComboboxAction(props: ComboboxActionProps) {
   const { searchValue } = useContext(ComboboxContext);
+
+  if (props.visible) {
+    const isVisible =
+      typeof props.visible === "function" && !props.visible({ searchValue });
+
+    if (isVisible || !props.visible) {
+      return null;
+    }
+  }
+
+  const options = { searchValue };
   const computedLabel =
-    typeof props.label === "string"
-      ? props.label
-      : props.label({ searchValue });
+    typeof props.label === "string" ? props.label : props.label(options);
 
   return (
     <div className={styles.actionContainer}>
       <button
         className={styles.actionButton}
-        onClick={props.onClick}
+        onClick={e => props.onClick(e, options)}
         type="button"
       >
         <Typography

--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
@@ -1,16 +1,22 @@
-import React from "react";
+import React, { useContext } from "react";
 import styles from "./ComboboxAction.css";
 import { Typography } from "../../../Typography";
 import { ComboboxActionProps } from "../../Combobox.types";
+import { ComboboxContext } from "../../ComboboxProvider";
 
 export function ComboboxAction(props: ComboboxActionProps): JSX.Element {
+  const { searchValue } = useContext(ComboboxContext);
+  const computedLabel =
+    typeof props.label === "string"
+      ? props.label
+      : props.label({ searchValue });
+
   return (
     <div className={styles.actionContainer}>
       <button
         className={styles.actionButton}
         onClick={props.onClick}
         type="button"
-        aria-label={props.label}
       >
         <Typography
           element="span"
@@ -18,7 +24,7 @@ export function ComboboxAction(props: ComboboxActionProps): JSX.Element {
           textColor="green"
           fontWeight="semiBold"
         >
-          {props.label}
+          {computedLabel}
         </Typography>
       </button>
     </div>

--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
@@ -30,7 +30,7 @@ export function ComboboxAction(props: ComboboxActionProps) {
         <Typography
           element="span"
           size="base"
-          textColor="interactive"
+          textColor="green"
           fontWeight="semiBold"
         >
           {computedLabel}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There are instances where the action would need to
- Only show up when there's a search term
- Base the label via the search term
- Know the search term on click

This PR enables all of that.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added a `visible` prop
- Exposes the search term on actions

| Empty search term | With search term |
|--|--|
| ![image](https://github.com/GetJobber/atlantis/assets/15986172/b488e12f-c5f0-4fd3-94a7-bb4cedfa3fed) | ![image](https://github.com/GetJobber/atlantis/assets/15986172/3c1e8a44-6059-4556-a2c8-32c675cb536b) |

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
