### PR TITLE
fix(components): update spacing of DataList bulk header actions

### DIFF
--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -42,7 +42,9 @@
 }
 
 .batchSelectContainer {
+  --data-list--header-actions-gap: var(--space-small);
   display: flex;
+  gap: var(--data-list--header-actions-gap);
 
   @media (--small-screens-and-below) {
     justify-content: space-between;
@@ -59,7 +61,7 @@
   display: flex;
   margin: calc(var(--space-small) * -1) 0;
   align-items: center;
-  gap: var(--space-smaller);
+  gap: var(--data-list--header-actions-gap);
 }
 
 /*


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When focused on the `Deselect all` header action, there is noticeable overlap between the focus ring and the adjacent elements.

**Before**
![image](https://github.com/GetJobber/atlantis/assets/39704901/720e3c66-75be-4a85-ae99-92aaa06c022d)

**After**
![image](https://github.com/GetJobber/atlantis/assets/39704901/10c50bd8-090d-4c67-bceb-f4bd6671a247)

## Changes

### Changed

- standardized gaps across the header action layout elements

### Fixed

- no more overlap

## Testing

View [DataList in Storybook](https://give-datalist-bulk-actions-s.atlantis.pages.dev/?path=/story/components-lists-and-tables-datalist-web--basic) with >=1 item selected, tab to Deselect All button

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
