### PR TITLE
feat(components): Add clearable prop to inputs

### DIFF
--- a/docs/components/InputText/Web.stories.tsx
+++ b/docs/components/InputText/Web.stories.tsx
@@ -38,3 +38,9 @@ Loading.args = {
   name: "phoneNumber",
   loading: true,
 };
+
+export const Clearable = BasicTemplate.bind({});
+Clearable.args = {
+  name: "name",
+  clearable: "always",
+};

--- a/docs/components/InputTime/Web.stories.tsx
+++ b/docs/components/InputTime/Web.stories.tsx
@@ -72,3 +72,9 @@ export const Event = EventTemplate.bind({});
 Event.args = {
   placeholder: "Start time",
 };
+
+export const Clearable = EventTemplate.bind({});
+Clearable.args = {
+  placeholder: "Start Time",
+  clearable: "always",
+};

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -380,4 +380,22 @@ describe("FormField", () => {
       });
     });
   });
+
+  describe("when clearable", () => {
+    it("should clear the search when the clear is used", () => {
+      const setValue = jest.fn();
+
+      const { getByTestId } = render(
+        <FormField
+          placeholder={"I am a placeholder"}
+          value={"I am a value"}
+          clearable="always"
+          onChange={setValue}
+        />,
+      );
+      const clearButton = getByTestId("ATL-Input-Clear");
+      fireEvent.click(clearButton);
+      expect(setValue).toHaveBeenCalledWith("");
+    });
+  });
 });

--- a/packages/components/src/FormField/FormField.test.tsx
+++ b/packages/components/src/FormField/FormField.test.tsx
@@ -385,7 +385,7 @@ describe("FormField", () => {
     it("should clear the search when the clear is used", () => {
       const setValue = jest.fn();
 
-      const { getByTestId } = render(
+      const { getByLabelText } = render(
         <FormField
           placeholder={"I am a placeholder"}
           value={"I am a value"}
@@ -393,7 +393,7 @@ describe("FormField", () => {
           onChange={setValue}
         />,
       );
-      const clearButton = getByTestId("ATL-Input-Clear");
+      const clearButton = getByLabelText("Clear input");
       fireEvent.click(clearButton);
       expect(setValue).toHaveBeenCalledWith("");
     });

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -14,7 +14,8 @@ import styles from "./FormField.css";
 import { FormFieldWrapper } from "./FormFieldWrapper";
 import { FormFieldPostFix } from "./FormFieldPostFix";
 
-// eslint-disable-next-line max-statements
+// Added 13th statement to accommodate getErrorMessage function
+/*eslint max-statements: ["error", 13]*/
 export function FormField(props: FormFieldProps) {
   const {
     actionsRef,

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -9,7 +9,6 @@ import React, {
 } from "react";
 import { v1 as uuidv1 } from "uuid";
 import { Controller, useForm, useFormContext } from "react-hook-form";
-import { useShowClear } from "@jobber/hooks";
 import { FormFieldProps } from "./FormFieldTypes";
 import styles from "./FormField.css";
 import { FormFieldWrapper } from "./FormFieldWrapper";
@@ -57,7 +56,6 @@ export function FormField(props: FormFieldProps) {
 
   const [identifier] = useState(uuidv1());
   const [descriptionIdentifier] = useState(`descriptionUUID--${uuidv1()}`);
-  const [focused, setFocused] = useState(false);
   /**
    * Generate a name if one is not supplied, this is the name
    * that will be used for react-hook-form and not neccessarily
@@ -73,8 +71,6 @@ export function FormField(props: FormFieldProps) {
     }
   }, [value, watch(controlledName)]);
 
-  const fieldValue = watch(controlledName);
-
   useImperativeHandle(actionsRef, () => ({
     setValue: newValue => {
       setValue(controlledName, newValue, { shouldValidate: true });
@@ -84,14 +80,6 @@ export function FormField(props: FormFieldProps) {
   const message = errors[controlledName]?.message;
   const error = getErrorMessage();
   useEffect(() => handleValidation(), [error]);
-
-  const showClear = useShowClear({
-    clearable,
-    multiline: false,
-    focused,
-    hasValue: Boolean(fieldValue),
-    disabled,
-  });
 
   return (
     <Controller
@@ -134,7 +122,7 @@ export function FormField(props: FormFieldProps) {
             error={error}
             identifier={identifier}
             descriptionIdentifier={descriptionIdentifier}
-            showClear={showClear}
+            clearable={clearable}
             onClear={handleClear}
           >
             {renderField()}
@@ -181,6 +169,7 @@ export function FormField(props: FormFieldProps) {
           handleBlur();
           setValue(controlledName, undefined, { shouldValidate: true });
           onChange && onChange("");
+          inputRef?.current?.focus();
         }
 
         function handleChange(
@@ -220,14 +209,12 @@ export function FormField(props: FormFieldProps) {
             setTimeout(() => readonly && (target as HTMLInputElement).select());
           }
 
-          setFocused(true);
           onFocus && onFocus();
         }
 
         function handleBlur() {
           onBlur && onBlur();
           onControllerBlur();
-          setFocused(false);
         }
       }}
     />

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -1,7 +1,6 @@
 import { ChangeEvent, ReactNode, RefObject } from "react";
 import { RegisterOptions } from "react-hook-form";
 import { XOR } from "ts-xor";
-import { Clearable } from "@jobber/hooks";
 import { IconNames } from "../Icon";
 
 export type FormFieldTypes =
@@ -122,7 +121,7 @@ export interface CommonFormFieldProps {
    * clearable. if the input value isn't editable (i.e. `InputTime`) you can
    * set it to `always`.
    */
-  readonly clearable?: Clearable;
+  readonly clearable?: "never" | "always";
 }
 
 export interface FormFieldProps extends CommonFormFieldProps {

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -119,7 +119,7 @@ export interface CommonFormFieldProps {
    * Add a clear action on the input that clears the value.
    *
    * You should always use `while-editing` if you want the input to be
-   * clearable. if the input value isn't editable (i.e. `InputDateTime`) you can
+   * clearable. if the input value isn't editable (i.e. `InputTime`) you can
    * set it to `always`.
    */
   readonly clearable?: Clearable;

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -1,6 +1,7 @@
 import { ChangeEvent, ReactNode, RefObject } from "react";
 import { RegisterOptions } from "react-hook-form";
 import { XOR } from "ts-xor";
+import { Clearable } from "@jobber/hooks";
 import { IconNames } from "../Icon";
 
 export type FormFieldTypes =
@@ -113,6 +114,15 @@ export interface CommonFormFieldProps {
    * Set the component to the given value.
    */
   readonly value?: string | number | Date;
+
+  /**
+   * Add a clear action on the input that clears the value.
+   *
+   * You should always use `while-editing` if you want the input to be
+   * clearable. if the input value isn't editable (i.e. `InputDateTime`) you can
+   * set it to `always`.
+   */
+  readonly clearable?: Clearable;
 }
 
 export interface FormFieldProps extends CommonFormFieldProps {

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from "react";
 import classnames from "classnames";
+import { Clearable, useShowClear } from "@jobber/hooks";
 import { FormFieldProps } from "./FormFieldTypes";
 import styles from "./FormField.css";
 import { AffixIcon, AffixLabel } from "./FormFieldAffix";
@@ -17,7 +18,7 @@ interface FormFieldWrapperProps extends FormFieldProps {
   readonly error: string;
   readonly identifier: string;
   readonly descriptionIdentifier: string;
-  readonly showClear: boolean | undefined;
+  readonly clearable: Clearable;
   readonly onClear: () => void;
 }
 
@@ -44,7 +45,7 @@ export function FormFieldWrapper({
   disabled,
   inline,
   identifier,
-  showClear = false,
+  clearable,
   onClear,
 }: PropsWithChildren<FormFieldWrapperProps>) {
   const wrapperClasses = classnames(
@@ -86,8 +87,30 @@ export function FormFieldWrapper({
     setLabelStyle(getAffixPaddding);
   }, [value]);
 
+  const [focused, setFocused] = useState(false);
+
+  const showClear = useShowClear({
+    clearable,
+    multiline: type === "textarea",
+    focused,
+    hasValue: Boolean(value),
+    disabled,
+  });
+
   return (
-    <div className={containerClasses}>
+    <div
+      className={containerClasses}
+      onFocus={() => setFocused(true)}
+      onBlur={() => {
+        // Uses the nextTick to check if the clear button is focused.
+        // Otherwise, it will say that the body is the activeElement.
+        setTimeout(() => {
+          if (document.activeElement?.ariaLabel === "Clear input") return;
+
+          setFocused(false);
+        });
+      }}
+    >
       <div
         className={wrapperClasses}
         style={wrapperInlineStyle}

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -17,8 +17,8 @@ interface FormFieldWrapperProps extends FormFieldProps {
   readonly error: string;
   readonly identifier: string;
   readonly descriptionIdentifier: string;
-  readonly showClear?: boolean;
-  readonly onClear?: () => void;
+  readonly showClear: boolean | undefined;
+  readonly onClear: () => void;
 }
 
 interface LabelPadding {
@@ -44,7 +44,7 @@ export function FormFieldWrapper({
   disabled,
   inline,
   identifier,
-  showClear,
+  showClear = false,
   onClear,
 }: PropsWithChildren<FormFieldWrapperProps>) {
   const wrapperClasses = classnames(
@@ -115,7 +115,7 @@ export function FormFieldWrapper({
         {suffix?.label && (
           <AffixLabel {...suffix} labelRef={suffixRef} variation="suffix" />
         )}
-        {showClear && <ClearAction onClick={() => onClear && onClear()} />}
+        {showClear && <ClearAction onClick={onClear} />}
         {suffix?.icon && (
           <AffixIcon {...suffix} variation="suffix" size={size} />
         )}

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -10,12 +10,15 @@ import { FormFieldProps } from "./FormFieldTypes";
 import styles from "./FormField.css";
 import { AffixIcon, AffixLabel } from "./FormFieldAffix";
 import { FormFieldDescription } from "./FormFieldDescription";
+import { ClearAction } from "./components/ClearAction";
 import { InputValidation } from "../InputValidation";
 
 interface FormFieldWrapperProps extends FormFieldProps {
   readonly error: string;
   readonly identifier: string;
   readonly descriptionIdentifier: string;
+  readonly showClear?: boolean;
+  readonly onClear?: () => void;
 }
 
 interface LabelPadding {
@@ -41,6 +44,8 @@ export function FormFieldWrapper({
   disabled,
   inline,
   identifier,
+  showClear,
+  onClear,
 }: PropsWithChildren<FormFieldWrapperProps>) {
   const wrapperClasses = classnames(
     styles.wrapper,
@@ -106,10 +111,11 @@ export function FormFieldWrapper({
 
           {prefix?.label && <AffixLabel {...prefix} labelRef={prefixRef} />}
           <div className={styles.childrenWrapper}>{children}</div>
-          {suffix?.label && (
-            <AffixLabel {...suffix} labelRef={suffixRef} variation="suffix" />
-          )}
         </div>
+        {suffix?.label && (
+          <AffixLabel {...suffix} labelRef={suffixRef} variation="suffix" />
+        )}
+        {showClear && <ClearAction onClick={() => onClear && onClear()} />}
         {suffix?.icon && (
           <AffixIcon {...suffix} variation="suffix" size={size} />
         )}

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import classnames from "classnames";
-import { Clearable, useShowClear } from "@jobber/hooks";
+import { useShowClear } from "@jobber/hooks";
 import { FormFieldProps } from "./FormFieldTypes";
 import styles from "./FormField.css";
 import { AffixIcon, AffixLabel } from "./FormFieldAffix";
@@ -18,7 +18,7 @@ interface FormFieldWrapperProps extends FormFieldProps {
   readonly error: string;
   readonly identifier: string;
   readonly descriptionIdentifier: string;
-  readonly clearable: Clearable;
+  readonly clearable: "never" | "always";
   readonly onClear: () => void;
 }
 
@@ -101,15 +101,7 @@ export function FormFieldWrapper({
     <div
       className={containerClasses}
       onFocus={() => setFocused(true)}
-      onBlur={() => {
-        // Uses the nextTick to check if the clear button is focused.
-        // Otherwise, it will say that the body is the activeElement.
-        setTimeout(() => {
-          if (document.activeElement?.ariaLabel === "Clear input") return;
-
-          setFocused(false);
-        });
-      }}
+      onBlur={() => setFocused(false)}
     >
       <div
         className={wrapperClasses}

--- a/packages/components/src/FormField/components/ClearAction.css
+++ b/packages/components/src/FormField/components/ClearAction.css
@@ -20,6 +20,16 @@
   align-items: center;
 }
 
-.addedMargin {
-  margin-right: var(--space-large);
+.clearInput:focus {
+  outline: none;
+}
+
+.clearInput:hover,
+.clearInput:focus-visible {
+  outline: none;
+  background-color: var(--color-surface--background);
+}
+
+.clearInput:focus-visible {
+  box-shadow: var(--shadow-focus);
 }

--- a/packages/components/src/FormField/components/ClearAction.css
+++ b/packages/components/src/FormField/components/ClearAction.css
@@ -1,0 +1,25 @@
+.clearContainer {
+  display: flex;
+  align-items: center;
+  padding-left: var(--space-small);
+}
+
+.clearInput {
+  display: flex;
+  position: relative;
+  right: var(--space-base);
+  z-index: var(--elevation-tooltip);
+  width: var(--space-large);
+  height: var(--space-large);
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-circle);
+  background-color: var(--color-surface--background);
+  cursor: pointer;
+  justify-content: center;
+  align-items: center;
+}
+
+.addedMargin {
+  margin-right: var(--space-large);
+}

--- a/packages/components/src/FormField/components/ClearAction.css.d.ts
+++ b/packages/components/src/FormField/components/ClearAction.css.d.ts
@@ -1,0 +1,7 @@
+declare const styles: {
+  readonly "clearContainer": string;
+  readonly "clearInput": string;
+  readonly "addedMargin": string;
+};
+export = styles;
+

--- a/packages/components/src/FormField/components/ClearAction.css.d.ts
+++ b/packages/components/src/FormField/components/ClearAction.css.d.ts
@@ -1,7 +1,6 @@
 declare const styles: {
   readonly "clearContainer": string;
   readonly "clearInput": string;
-  readonly "addedMargin": string;
 };
 export = styles;
 

--- a/packages/components/src/FormField/components/ClearAction.tsx
+++ b/packages/components/src/FormField/components/ClearAction.tsx
@@ -18,7 +18,6 @@ export function ClearAction({ onClick }: ClearActionProps): JSX.Element {
         onMouseDown={event => event.preventDefault()}
         onClick={onClick}
         type="button"
-        data-testid="ATL-Input-Clear"
         aria-label="Clear input"
       >
         <Icon name="remove" size="small" />

--- a/packages/components/src/FormField/components/ClearAction.tsx
+++ b/packages/components/src/FormField/components/ClearAction.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import styles from "./ClearAction.css";
+import { Icon } from "../../Icon";
+
+interface ClearActionProps {
+  /**
+   * Click handler
+   */
+  readonly onClick: () => void;
+}
+
+export function ClearAction({ onClick }: ClearActionProps): JSX.Element {
+  return (
+    <div className={styles.clearContainer}>
+      <button
+        className={styles.clearInput}
+        // Prevent the input from losing focus when the clear button is clicked
+        onMouseDown={event => event.preventDefault()}
+        onClick={onClick}
+        type="button"
+        data-testid="ATL-Input-Clear"
+        aria-label="Clear input"
+      >
+        <Icon name="remove" size="small" />
+      </button>
+    </div>
+  );
+}

--- a/packages/components/src/FormField/components/ClearAction.tsx
+++ b/packages/components/src/FormField/components/ClearAction.tsx
@@ -14,8 +14,6 @@ export function ClearAction({ onClick }: ClearActionProps): JSX.Element {
     <div className={styles.clearContainer}>
       <button
         className={styles.clearInput}
-        // Prevent the input from losing focus when the clear button is clicked
-        onMouseDown={event => event.preventDefault()}
         onClick={onClick}
         type="button"
         aria-label="Clear input"

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -10,7 +10,7 @@ import {
 import { DatePicker } from "../DatePicker";
 
 interface InputDateProps
-  extends CommonFormFieldProps,
+  extends Omit<CommonFormFieldProps, "clearable">,
     Pick<
       FormFieldProps,
       | "readonly"
@@ -42,6 +42,7 @@ interface InputDateProps
 
 export function InputDate(inputProps: InputDateProps) {
   const formFieldActionsRef = useRef<FieldActionsRef>(null);
+
   return (
     <DatePicker
       selected={inputProps.value}

--- a/packages/components/src/InputTime/InputTimeProps.tsx
+++ b/packages/components/src/InputTime/InputTimeProps.tsx
@@ -14,6 +14,7 @@ export interface InputTimeProps
       | "onValidation"
       | "placeholder"
       | "size"
+      | "clearable"
     >,
     Pick<
       FormFieldProps,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Adding the clearable prop to inputs, except for `InputDate,` because I hit a blocker where `react-datepicker` requires the event when changing the input value for some reason, and I can't mimic it when setting the value directly to an empty string.

I tried to follow the same names and conventions we have on `@jobber/components` name.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added the `clearable` prop to inputs, except for `InputDate`.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
