### PR TITLE
fix(components): remove gradient on scroll from top and bottom of Combobox [JOB-79443]

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
@@ -18,34 +18,42 @@
   padding: var(--space-small) var(--space-base);
 }
 
+.container::before,
 .container::after {
   content: "";
   display: block;
   position: absolute;
   right: 0;
-  bottom: var(--space-small);
   left: 0;
   height: var(--space-base);
+  pointer-events: none;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.container::after {
+  bottom: var(--space-small);
   background: linear-gradient(
     180deg,
     rgba(255, 255, 255, 0) 0%,
     rgb(255, 255, 255) 100%
   );
-  pointer-events: none;
 }
 
 .container::before {
-  content: "";
-  display: block;
-  position: absolute;
   top: var(--space-small);
-  right: 0;
-  left: 0;
-  height: var(--space-base);
   background: linear-gradient(
     to bottom,
     rgba(255, 255, 255, 1),
     rgba(255, 255, 255, 0)
   );
-  pointer-events: none;
+}
+
+.scrollTop::before,
+.scrollNone::before {
+  opacity: 0;
+}
+
+.scrollBottom::after,
+.scrollNone::after {
+  opacity: 0;
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css.d.ts
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css.d.ts
@@ -3,6 +3,9 @@ declare const styles: {
   readonly "optionsList": string;
   readonly "filterMessage": string;
   readonly "emptyStateMessage": string;
+  readonly "scrollTop": string;
+  readonly "scrollNone": string;
+  readonly "scrollBottom": string;
 };
 export = styles;
 

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
@@ -1,12 +1,57 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import classnames from "classnames";
 import { Text } from "@jobber/components/Text";
 import styles from "./ComboboxContentList.css";
 import { ComboboxListProps } from "../../../Combobox.types";
 import { ComboboxOption } from "../../ComboboxOption/ComboboxOption";
 
 export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
+  const [listScrollState, setlistScrollState] = useState("");
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (props.optionsListRef.current) {
+        const { scrollTop, clientHeight, scrollHeight } =
+          props.optionsListRef.current;
+
+        if (scrollHeight === clientHeight) {
+          setlistScrollState("scrollNone");
+        } else if (scrollTop === 0) {
+          setlistScrollState("scrollTop");
+        } else if (scrollTop + clientHeight === scrollHeight) {
+          setlistScrollState("scrollBottom");
+        } else {
+          setlistScrollState("");
+        }
+      }
+    };
+
+    if (!props.showEmptyState && props.options.length === 0) {
+      handleScroll();
+    }
+
+    if (props.optionsListRef.current) {
+      props.optionsListRef.current.addEventListener("scroll", handleScroll);
+      handleScroll();
+    }
+
+    return () => {
+      if (props.optionsListRef.current) {
+        props.optionsListRef.current.removeEventListener(
+          "scroll",
+          handleScroll,
+        );
+      }
+    };
+  }, [props.options]);
+
   return (
-    <div className={styles.container}>
+    <div
+      className={classnames(
+        styles.container,
+        styles[listScrollState as keyof typeof styles],
+      )}
+    >
       {!props.showEmptyState && props.options.length > 0 && (
         <ul
           className={styles.optionsList}


### PR DESCRIPTION
## Motivations

When scrolling to the top or bottom of a Combobox list the gradients used as a visual cue that the combo list can be inline scrolled doesn't disappear, which can be misleading and generally doesn't look good. 

### Changed

#### Before 
![beforefixedblur](https://github.com/GetJobber/atlantis/assets/937953/37f2dca6-87ca-49f1-93e8-ac2cd123bc9e)

#### After
![fixedblur](https://github.com/GetJobber/atlantis/assets/937953/122140fb-b422-4806-b7ab-90079fa6f1ec)

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
