### PR TITLE
fix(components): Clean up interactive state colors in combobox

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.css
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.css
@@ -25,7 +25,7 @@
 .actionButton:hover,
 .actionButton:focus-visible {
   outline: none;
-  background-color: var(--color-surface--background);
+  background-color: var(--color-surface--hover);
 }
 
 .actionButton:focus-visible {

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.css
@@ -42,5 +42,9 @@
 }
 
 .clearSearch:focus {
+  outline: transparent;
+}
+
+.clearSearch:focus-visible {
   box-shadow: var(--shadow-focus);
 }

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.css
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.css
@@ -15,7 +15,7 @@
 
 .option:hover,
 .option:focus-visible {
-  background-color: var(--color-surface--background);
+  background-color: var(--color-surface--hover);
 }
 
 .option:focus,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Combobox was using `surface--background` as proxy for our new hover color before that new hover color existed.

Now it just uses the new hover color!

![image](https://github.com/GetJobber/atlantis/assets/39704901/dd51491d-8951-4374-973e-e71480e0b97d)
![image](https://github.com/GetJobber/atlantis/assets/39704901/cae165d6-9f28-4c35-b115-038c6527a54a)

## Changes

### Changed

- using `hover` color for hover and focus states instead of `surface--background` color

### Fixed

- useragent styling leaking into combobox clear-search action

## Testing

View in Storybook

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
