### PR TITLE
fix(components): Always show sort icons on Datalist [JOB-82902]

### DIFF
--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -13,11 +13,7 @@ import {
   DATA_LOAD_MORE_TEST_ID,
   EMPTY_FILTER_RESULTS_MESSAGE,
 } from "./DataList.const";
-import {
-  DataListItemType,
-  DataListProps,
-  DataListSorting,
-} from "./DataList.types";
+import { DataListItemType, DataListProps } from "./DataList.types";
 import { DATALIST_TOTALCOUNT_TEST_ID } from "./components/DataListTotalCount";
 import {
   DATALIST_LOADINGSTATE_ROW_TEST_ID,
@@ -409,14 +405,9 @@ describe("DataList", () => {
       );
     }
 
-    it("should show the sorting arrows when the header is clicked", () => {
+    it("should show always show sorting arrows", () => {
       const mockOnSort = jest.fn();
-      const expectedSorting: DataListSorting = {
-        order: "asc",
-        key: "name",
-      };
-
-      const { rerender } = render(
+      render(
         <MockSortingLayout
           sorting={{
             sortable: ["name"],
@@ -425,26 +416,6 @@ describe("DataList", () => {
           }}
         />,
       );
-
-      expect(
-        screen.queryByTestId(SORTING_ICON_TEST_ID),
-      ).not.toBeInTheDocument();
-
-      const nameHeader = screen.getByText(mockHeaders.name);
-      fireEvent.click(nameHeader);
-
-      expect(mockOnSort).toHaveBeenCalledWith(expectedSorting);
-
-      rerender(
-        <MockSortingLayout
-          sorting={{
-            sortable: ["name"],
-            onSort: mockOnSort,
-            state: expectedSorting,
-          }}
-        />,
-      );
-
       expect(screen.queryByTestId(SORTING_ICON_TEST_ID)).toBeInTheDocument();
     });
   });

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -30,9 +30,11 @@ export function DataListHeaderTile<T extends DataListObject>({
       onClick={handleOnClick}
     >
       <Text maxLines="single">{headers[headerKey]}</Text>
-      {sortingState?.key === headerKey && (
+      {sortingState?.key === headerKey ? (
         <DataListSortingArrows order={sortingState.order} />
-      )}
+      ) : sortingState?.key !== headerKey && isSortable ? (
+        <DataListSortingArrows order="none" />
+      ) : null}
     </Tag>
   );
 

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css
@@ -16,3 +16,8 @@
 .sortIcon path.inactive {
   fill: var(--color-inactive--surface);
 }
+
+.sortIcon:hover path {
+  fill: var(--color-interactive--subtle);
+  transition: all var(--timing-base) ease;
+}

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import styles from "./DataListSortingArrows.css";
 
 interface DataListSortingArrowsProps {
-  readonly order?: "asc" | "desc";
+  readonly order?: "asc" | "desc" | "none";
 }
 
 export const SORTING_ICON_TEST_ID = "ATL-DataList-Sorting-Icon";
+
 export function DataListSortingArrows({ order }: DataListSortingArrowsProps) {
   return (
     <div className={styles.sortIcon} data-testid={SORTING_ICON_TEST_ID}>


### PR DESCRIPTION
## Motivations

Working theory: not surfacing the sort arrows until the user has clicked a sortable heading is a hard way for the user to learn that they need to click that heading. It’s also hard to tell which columns are in fact sortable. This is also inconsistent with DataTable, which surfaces sort permanently.

This PR shows the sort arrows permanently for any column that can be sorted on Datalist. It also adds a subtle rollover effect to the sorting arrows.

## Changes

![Screenshot 2023-12-08 at 2 09 18 PM](https://github.com/GetJobber/atlantis/assets/937953/6cb8258c-9ae5-49d1-b8dd-16fa9e533116)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
