### PR TITLE
fix(components): Fix DataList hidden tags sliver showing up

### DIFF
--- a/packages/components/src/DataList/components/DataListTags/DataListTags.css
+++ b/packages/components/src/DataList/components/DataListTags/DataListTags.css
@@ -4,7 +4,7 @@
 
 .tags {
   --inline-label-height: calc(
-    var(--typography--fontSize-small) * 1.5 + calc(var(--space-smaller) * 1.5) *
+    var(--typography--fontSize-small) * 1.5 + calc(var(--space-smaller) * 1.25) *
       2
   );
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

After we changed the `gap` between tags to `space-smaller`, it had a little space to render the tags at the bottom that should not be showing up after it breaks into two lines. This PR reduces the space a little bit to render just the correct height that we need.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- A small part of the hidden tags on DataList was showing up.

### Security

- <!-- in case of vulnerabilities -->

## Testing

### Before
![image](https://github.com/GetJobber/atlantis/assets/12849476/404ff0d7-920e-491a-8c40-bcfb164738a4)


### After
![image](https://github.com/GetJobber/atlantis/assets/12849476/5352e245-18f8-4052-82ea-70d592005ff6)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
