### PR TITLE
refactor(components): expose input tokens on root [JOB-84547]

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -8,7 +8,7 @@
   --public-field--bottom-left-radius: var(--radius-base);
   --public-field--bottom-right-radius: var(--radius-base);
 
-  --field--placeholder-color: var(--color-text--secondary);
+  --field--placeholder-color: var(--color-greyBlue--light);
   --field--value-color: var(--color-heading);
   --field--border-color: var(--color-border);
 }

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -7,6 +7,10 @@
   --public-field--top-right-radius: var(--radius-base);
   --public-field--bottom-left-radius: var(--radius-base);
   --public-field--bottom-right-radius: var(--radius-base);
+
+  --field--placeholder-color: var(--color-text--secondary);
+  --field--value-color: var(--color-heading);
+  --field--border-color: var(--color-border);
 }
 
 .container {
@@ -17,7 +21,6 @@
  * Wrapper
  **/
 .wrapper {
-  --field--placeholder-color: var(--color-greyBlue--light);
   --field--placeholder-offset: 50%;
   --field--placeholder-transform: -50%;
 
@@ -30,10 +33,8 @@
   --field--padding-left: var(--space-base);
   --field--padding-right: var(--space-base);
 
-  --field--value-color: var(--color-heading);
   --field--value-lineHeight: calc(var(--base-unit) * 1.25);
 
-  --field--border-color: var(--color-border);
   --field--background-color: var(--color-surface);
 
   --field--base-elevation: var(--elevation-base);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To allow for extending inputs within a consuming product, exposing commonly manipulated variables at `:root`.

## Changes

### Changed

- Vars are now exposed on root and can be overwritten with local CSS targeting the respective custom properties
![image](https://github.com/GetJobber/atlantis/assets/39704901/cd16fad0-e8c6-4f62-897a-0f822285dead)

## Testing

- Ensure focus states, border-color change on invalid, etc are still working
- Manipulate the vars with custom CSS and observe they change

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
