### PR TITLE
chore(components): prep modal for retheme

### DIFF
--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -82,6 +82,7 @@
 
 :global(.jobber-retheme) .header h3 {
   font-size: var(--typography--fontSize-largest);
+  font-family: var(--typography--fontFamily-normal);
 }
 
 /**

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -80,6 +80,10 @@
   background-color: transparent;
 }
 
+:global(.jobber-retheme) h3 {
+  font-size: var(--typography--fontSize-largest);
+}
+
 /**
  * Ensure there's no extra padding top on the next element. This mostly negates
  * the <Content /> padding

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -10,7 +10,7 @@
   }
 }
 
-:root :global(.jobber_retheme) {
+:root :global(.jobber-retheme) {
   --modal--shadow: var(--shadow-base);
 
   @media (--medium-screens-and-up) {
@@ -76,7 +76,7 @@
   background-color: var(--color-surface--background);
 }
 
-:global(.jobber_retheme) .header {
+:global(.jobber-retheme) .header {
   background-color: transparent;
 }
 
@@ -85,7 +85,7 @@
  * the <Content /> padding
  */
 
-:global(.jobber_retheme) .header + * {
+:global(.jobber-retheme) .header + * {
   padding-top: 0;
 }
 

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -81,8 +81,8 @@
 }
 
 :global(.jobber-retheme) .header h3 {
-  font-size: var(--typography--fontSize-largest);
   font-family: var(--typography--fontFamily-normal);
+  font-size: var(--typography--fontSize-largest);
 }
 
 /**

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -80,7 +80,7 @@
   background-color: transparent;
 }
 
-:global(.jobber-retheme) h3 {
+:global(.jobber-retheme) .header h3 {
   font-size: var(--typography--fontSize-largest);
 }
 

--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -10,6 +10,17 @@
   }
 }
 
+:root :global(.jobber_retheme) {
+  --modal--shadow: var(--shadow-base);
+
+  @media (--medium-screens-and-up) {
+    --modal--padding-horizontal: var(--space-large);
+    --modal--padding-vertical: var(--space-large);
+    --modal--padding: var(--modal--padding-vertical)
+      var(--modal--padding-horizontal);
+  }
+}
+
 .container {
   display: flex;
   flex-direction: column;
@@ -33,14 +44,15 @@
 
 .modal {
   position: relative;
-  flex: 0 0 auto;
   width: 100%;
   max-width: var(--modal--width);
+  box-shadow: var(--modal--shadow);
   margin: auto;
   border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
-  outline-color: var(--color-focus);
   background-color: var(--color-surface);
+  flex: 0 0 auto;
+  outline-color: var(--color-focus);
 }
 
 /* Adjust `Content` and `Tab` components public padding to match the modal */
@@ -62,6 +74,19 @@
   align-items: center;
   padding: var(--modal--padding);
   background-color: var(--color-surface--background);
+}
+
+:global(.jobber_retheme) .header {
+  background-color: transparent;
+}
+
+/**
+ * Ensure there's no extra padding top on the next element. This mostly negates
+ * the <Content /> padding
+ */
+
+:global(.jobber_retheme) .header + * {
+  padding-top: 0;
 }
 
 .closeButton {
@@ -95,6 +120,8 @@
   order: 2; /* 1 */
 }
 
+/* This is in a correct position and order */
+/* stylelint-disable-next-line no-descending-specificity */
 .rightAction > * {
   margin-left: var(--space-small);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This allows us to split off the styling of the modal when `jobber_retheme` class names exists on the body

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- styling that only exists for `jobber_retheme`

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Add the `jobber-retheme` class name on the body within the preview iframe

![image](https://github.com/GetJobber/atlantis/assets/15986172/051d5206-4b89-456f-89ca-94ba9aafe6e8)




---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
