### PR TITLE
chore(components): prep card for retheme

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -77,5 +77,6 @@
 }
 
 :global(.jobber-retheme) .header h3 {
+  font-family: var(--typography--fontFamily-normal);
   font-size: var(--typography--fontSize-largest);
 }

--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -19,9 +19,13 @@
 }
 
 :root :global(.jobber-retheme) .card:not(.clickable) {
-  --card--base-padding: 0;
+  --card--base-padding: var(--space-base);
   --card--border: none;
   --card--header-background: transparent;
+
+  @media (--medium-screens-and-up) {
+    --card--base-padding: 0;
+  }
 }
 
 /* Adjust `Content` components public padding to match the cards */
@@ -73,7 +77,12 @@
 }
 
 :global(.jobber-retheme) .header {
-  padding: var(--space-base) 0;
+  padding: var(--card--base-padding);
+  padding-bottom: 0;
+
+  @media (--medium-screens-and-up) {
+    padding: var(--space-base) 0;
+  }
 }
 
 :global(.jobber-retheme) .header h3 {

--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -1,16 +1,27 @@
 :root {
   --card--accent-color: var(--color-grey);
   --card--base-padding: var(--space-base);
+  --card--border: var(--border-base) solid var(--color-border);
+  --card--header-background: var(--color-surface--background);
 }
 
 .card {
-  --card--border-color: var(--color-border);
   display: block;
   width: 100%;
-  border: var(--border-base) solid var(--card--border-color);
+  border: var(--card--border);
   border-radius: var(--radius-base);
   outline-color: var(--color-focus);
   background-color: var(--color-surface);
+}
+
+.card:active {
+  outline: 0;
+}
+
+:root :global(.jobber-retheme) .card:not(.clickable) {
+  --card--base-padding: 0;
+  --card--border: none;
+  --card--header-background: transparent;
 }
 
 /* Adjust `Content` components public padding to match the cards */
@@ -23,10 +34,6 @@
 
 .card > * > * {
   --public-content--padding: 0;
-}
-
-.card:active {
-  outline: 0;
 }
 
 .accent {
@@ -42,7 +49,8 @@
 }
 
 .clickable {
-  --card--border-color: transparent;
+  --card--border: none;
+
   box-shadow: var(--shadow-base);
   color: inherit;
   text-decoration: inherit;
@@ -58,8 +66,16 @@
 .header {
   display: flex;
   padding: var(--card--base-padding);
-  background-color: var(--color-surface--background);
+  background-color: var(--card--header-background);
   justify-content: space-between;
   align-items: flex-start;
   gap: var(--space-small);
+}
+
+:global(.jobber-retheme) .header {
+  padding: var(--space-base) 0;
+}
+
+:global(.jobber-retheme) .header h3 {
+  font-size: var(--typography--fontSize-largest);
 }

--- a/packages/components/src/Card/Card.css.d.ts
+++ b/packages/components/src/Card/Card.css.d.ts
@@ -1,7 +1,7 @@
 declare const styles: {
   readonly "card": string;
-  readonly "accent": string;
   readonly "clickable": string;
+  readonly "accent": string;
   readonly "header": string;
 };
 export = styles;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Same as modal, retheme cards. This allows us to split off the styling of the modal when `jobber-retheme` class names exists on the body

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- styling that only exists for `jobber-retheme`

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Add the `jobber-retheme` class name on the body within the preview iframe

![image](https://github.com/GetJobber/atlantis/assets/15986172/051d5206-4b89-456f-89ca-94ba9aafe6e8)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
