### PR TITLE
refactor(components): update checkbox styling with re-theme flag [JOB-84551]

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.css
+++ b/packages/components/src/Checkbox/Checkbox.css
@@ -1,5 +1,10 @@
 .checkbox {
+  --checkbox-size: var(--space-base);
   display: inline-block;
+}
+
+:global(.jobber-retheme) .checkbox {
+  --checkbox-size: calc(var(--space-base) + var(--space-smaller));
 }
 
 .wrapper {
@@ -30,19 +35,27 @@
 
 .checkBox {
   display: flex;
-  width: var(--space-base);
-  height: var(--space-base);
+  width: var(--checkbox-size);
+  height: var(--checkbox-size);
   box-sizing: border-box;
   border: var(--border-thick) solid var(--color-interactive);
   border-radius: var(--radius-base);
   background-color: var(--color-surface);
-  transition: all 200ms;
+  transition: all var(--timing-quick) ease-out;
   justify-content: center;
   align-items: center;
 }
 
 .disabled .checkBox {
   border-color: var(--color-disabled--secondary);
+}
+
+:global(.jobber-retheme) .checkBox {
+  border-color: var(--color-border);
+}
+
+:global(.jobber-retheme) .checkBox:hover {
+  border-color: var(--color-interactive);
 }
 
 .disabled p {
@@ -78,7 +91,11 @@
   margin: 0 var(--space-small);
 }
 
+:global(.jobber-retheme) .label {
+  margin-top: var(--space-smallest);
+}
+
 .description {
   margin-bottom: var(--space-small);
-  padding-left: var(--space-large);
+  padding-left: calc(var(--checkbox-size) + var(--space-small));
 }

--- a/packages/components/src/Checkbox/Checkbox.css
+++ b/packages/components/src/Checkbox/Checkbox.css
@@ -52,6 +52,7 @@
 
 :global(.jobber-retheme) .checkBox {
   border-color: var(--color-border);
+  border-radius: calc(var(--radius-base) / 2);
 }
 
 :global(.jobber-retheme) .checkBox:hover {

--- a/packages/components/src/Checkbox/Checkbox.css
+++ b/packages/components/src/Checkbox/Checkbox.css
@@ -52,10 +52,21 @@
 
 :global(.jobber-retheme) .checkBox {
   border-color: var(--color-border);
-  border-radius: calc(var(--radius-base) / 2);
+  border-radius: var(--radius-small);
 }
 
-:global(.jobber-retheme) .checkBox:hover {
+.input.indeterminate + .checkBox,
+.input:checked + .checkBox {
+  border-color: var(--color-interactive);
+  background-color: var(--color-interactive);
+}
+
+.input:focus-visible + .checkBox {
+  box-shadow: var(--shadow-focus);
+}
+
+:global(.jobber-retheme) .checkBox:hover,
+:global(.jobber-retheme) .checkbox:hover .checkBox {
   border-color: var(--color-interactive);
 }
 
@@ -65,16 +76,6 @@
 
 .disabled .checkBox > * {
   opacity: 0;
-}
-
-.input.indeterminate + .checkBox,
-.input:checked + .checkBox {
-  border-color: var(--color-interactive);
-  background-color: var(--color-interactive);
-}
-
-.input:focus + .checkBox {
-  box-shadow: var(--shadow-focus);
 }
 
 .disabled .input.indeterminate + .checkBox,

--- a/packages/design/src/radii.css
+++ b/packages/design/src/radii.css
@@ -1,4 +1,5 @@
 :root {
+  --radius-small: var(--space-minuscule);
   --radius-base: var(--space-smallest);
   --radius-large: var(--space-smaller);
   --radius-larger: var(--space-small);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Allow checkbox to be re-styled when a given class is present

## Changes

### Changed

- Enable checkbox to be re-themed and create alternate styling for re-theme

## Testing

Apply the `jobber-retheme` class to the Storybook iframe `body`

- [ ] With `jobber-retheme`, should look different
- [ ] Without `jobber-retheme`, should look the same

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
