### PR TITLE
refactor(components): update Button for retheme [JOB-84545]

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -134,6 +134,13 @@ a.button:active {
   fill: var(--button--color-variation--hover);
 }
 
+:global(.jobber-retheme) .secondary:hover,
+:global(.jobber-retheme) .subtle.primary:hover,
+:global(.jobber-retheme) .secondary:focus-visible,
+:global(.jobber-retheme) .subtle.primary:focus-visible {
+  border-color: var(--button--color-variation--hover);
+}
+
 .subtle.secondary {
   background-color: var(--button--color-surface);
 }
@@ -157,6 +164,17 @@ a.tertiary:focus-visible,
 a.subtle.secondary:hover,
 a.subtle.secondary:focus-visible {
   border-color: transparent;
+}
+
+:global(.jobber-retheme) .tertiary:hover,
+:global(.jobber-retheme) .tertiary:focus-visible,
+:global(.jobber-retheme) a.tertiary:hover,
+:global(.jobber-retheme) a.tertiary:focus-visible,
+:global(.jobber-retheme) .subtle.secondary:hover,
+:global(.jobber-retheme) .subtle.secondary:focus-visible,
+:global(.jobber-retheme) a.subtle.secondary:hover,
+:global(.jobber-retheme) a.subtle.secondary:focus-visible {
+  border-color: var(--button--color-variation--hover);
 }
 
 .subtle.tertiary {

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -23,7 +23,7 @@
   vertical-align: middle;
   background-color: var(--button--color-surface);
   cursor: pointer;
-  transition: all var(--timing-base);
+  transition: all var(--timing-base) ease-out;
   appearance: none;
   fill: var(--button--color-variation);
   align-items: center;

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -43,7 +43,7 @@
 :global(.jobber-retheme) .button * {
   font-weight: 600 !important;
   line-height: 1;
-  letter-spacing: none;
+  letter-spacing: 0;
   /* post-retheme this can move into the TSX on L177 */
 }
 

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -2,8 +2,8 @@
   --button--color-variation: var(--color-interactive);
   --button--color-variation--hover: var(--color-interactive--hover);
   --button--color-surface: var(--color-surface);
-  --button--color-surface--hover: var(--color-surface--background);
-  --button--color-primaryLabel: var(--color-white);
+  --button--color-surface--hover: var(--color-surface--hover);
+  --button--color-primaryLabel: var(--color-surface);
 
   --button--duration-loading: var(--timing-loading--extended);
 }
@@ -17,7 +17,7 @@
   border-radius: var(--radius-base);
   color: var(--button--color-variation);
   -webkit-font-smoothing: antialiased;
-  letter-spacing: var(--typography--letterSpacing-loose);
+  line-height: 1;
   text-align: center;
   text-decoration: none;
   vertical-align: middle;
@@ -30,16 +30,26 @@
   justify-content: center;
 }
 
+:global(.jobber-retheme) .button {
+  min-height: calc(var(--base-unit) * 2.5);
+}
+
 .button * {
   color: inherit;
   fill: inherit !important;
   /* required to over-ride very specific fill from <Icon> */
 }
 
+:global(.jobber-retheme) .button * {
+  font-weight: 600 !important;
+  line-height: 1;
+  /* post-retheme this can move into the TSX on L177 */
+}
+
 .button:hover,
 a.button:hover,
-.button:focus,
-a.button:focus,
+.button:focus-visible,
+a.button:focus-visible,
 .button:active,
 a.button:active {
   border-color: var(--button--color-variation--hover);
@@ -48,12 +58,12 @@ a.button:active {
   background-color: var(--button--color-surface--hover);
 }
 
-.button:focus,
-a.button:focus,
+.button:focus-visible,
+a.button:focus-visible,
 .button:active,
 a.button:active {
   box-shadow: var(--shadow-focus);
-  outline: none;
+  outline: transparent;
 }
 
 /* Variation */
@@ -64,8 +74,8 @@ a.button:active {
 }
 
 .learning {
-  --button--color-variation: var(--color-informative);
-  --button--color-variation--hover: var(--color-informative--onSurface);
+  --button--color-variation: var(--color-interactive--subtle);
+  --button--color-variation--hover: var(--color-interactive--subtle--hover);
 }
 
 .destructive {
@@ -84,14 +94,14 @@ a.button:active {
 
 .primary:not(.subtle, .disabled),
 .primary:not(.subtle, .disabled):hover,
-.primary:not(.subtle, .disabled):focus {
+.primary:not(.subtle, .disabled):focus-visible {
   color: var(--button--color-primaryLabel);
   background-color: var(--button--color-variation);
   fill: var(--button--color-primaryLabel);
 }
 
 .primary:not(.subtle, .disabled):hover,
-.primary:not(.subtle, .disabled):focus {
+.primary:not(.subtle, .disabled):focus-visible {
   background-color: var(--button--color-variation--hover);
 }
 
@@ -103,11 +113,11 @@ a.button:active {
 
 .secondary,
 .subtle.primary {
-  border-color: var(--button--color-variation);
+  border-color: var(--color-border);
 }
 
 .subtle.primary:hover,
-.subtle.primary:focus {
+.subtle.primary:focus-visible {
   color: var(--button--color-variation--hover);
   background-color: var(--button--color-surface--hover);
   fill: var(--button--color-variation--hover);
@@ -123,18 +133,18 @@ a.button:active {
 }
 
 .subtle.secondary:hover,
-.subtle.secondary:focus {
+.subtle.secondary:focus-visible {
   background-color: var(--button--color-surface--hover);
 }
 
 .tertiary:hover,
-.tertiary:focus,
+.tertiary:focus-visible,
 a.tertiary:hover,
-a.tertiary:focus,
+a.tertiary:focus-visible,
 .subtle.secondary:hover,
-.subtle.secondary:focus,
+.subtle.secondary:focus-visible,
 a.subtle.secondary:hover,
-a.subtle.secondary:focus {
+a.subtle.secondary:focus-visible {
   border-color: transparent;
 }
 
@@ -144,9 +154,9 @@ a.subtle.secondary:focus {
 }
 
 .subtle.tertiary:hover,
-.subtle.tertiary:focus,
+.subtle.tertiary:focus-visible,
 a.subtle.tertiary:hover,
-a.subtle.tertiary:focus {
+a.subtle.tertiary:focus-visible {
   border-color: transparent;
   color: var(--color-interactive--subtle--hover);
   fill: var(--color-interactive--subtle--hover);
@@ -171,13 +181,20 @@ a.button.disabled:hover {
 
 .small {
   min-height: calc(var(--base-unit) * 1.5);
-  padding: 0 var(--space-small);
+  padding: 0 calc(var(--space-base) - var(--space-smaller));
   letter-spacing: 0;
 }
 
+:global(.jobber-retheme) .small {
+  padding: calc(var(--space-base) - var(--space-smaller));
+}
+
 .base {
-  min-height: calc(var(--base-unit) * 2.25);
-  padding: 0 calc(var(--space-base) - 4px);
+  padding: 0 calc(var(--space-base) - var(--space-smaller));
+}
+
+:global(.jobber-retheme) .base {
+  padding: 0 var(--space-base);
 }
 
 .large {
@@ -185,7 +202,15 @@ a.button.disabled:hover {
   padding: 0 var(--space-base);
 }
 
+:global(.jobber-retheme) .large {
+  padding: 0 calc(var(--space-base) + var(--space-smaller));
+}
+
 /* Icon */
+
+.button svg {
+  flex-shrink: 0;
+}
 
 .onlyIcon {
   width: calc(var(--base-unit) * 2.25);
@@ -200,6 +225,10 @@ a.button.disabled:hover {
   width: calc(var(--space-base) * 2.25);
 }
 
+:global(.jobber-retheme) .onlyIcon.base {
+  width: calc(var(--space-base) * 2.5);
+}
+
 .onlyIcon.large {
   width: calc(var(--space-large) * 2);
 }
@@ -208,6 +237,8 @@ a.button.disabled:hover {
   width: auto;
 }
 
+/* Don't want to move things that will update after re-theme */
+/* stylelint-disable-next-line no-descending-specificity */
 .hasIconAndLabel > * {
   text-align: start;
 }

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -43,6 +43,7 @@
 :global(.jobber-retheme) .button * {
   font-weight: 600 !important;
   line-height: 1;
+  letter-spacing: none;
   /* post-retheme this can move into the TSX on L177 */
 }
 
@@ -196,6 +197,7 @@ a.button.disabled:hover {
 }
 
 :global(.jobber-retheme) .small {
+  min-height: calc(var(--base-unit) * 1.5);
   padding: 0 calc(var(--space-base) - var(--space-smaller));
 }
 
@@ -213,6 +215,7 @@ a.button.disabled:hover {
 }
 
 :global(.jobber-retheme) .large {
+  min-height: calc(var(--base-unit) * 3);
   padding: 0 calc(var(--space-base) + var(--space-smaller));
 }
 
@@ -245,6 +248,11 @@ a.button.disabled:hover {
 
 .hasIconAndLabel {
   width: auto;
+  gap: var(--space-small);
+}
+
+:global(.jobber-retheme) .hasIconAndLabel {
+  gap: var(--space-smaller);
 }
 
 /* Don't want to move things that will update after re-theme */
@@ -253,15 +261,17 @@ a.button.disabled:hover {
   text-align: start;
 }
 
-.hasIconAndLabel > *:first-child {
-  flex-shrink: 0;
-  margin-right: var(--space-small);
+.iconOnRight > *:first-child {
+  order: 1;
 }
 
-.iconOnRight > *:first-child {
-  margin-left: var(--space-small);
-  margin-right: 0;
-  order: 1;
+:global(.jobber-retheme) .hasIconAndLabel > *:first-child {
+  margin-left: calc(var(--space-smaller) * -1);
+}
+
+:global(.jobber-retheme) .iconOnRight > *:first-child {
+  margin-left: 0;
+  margin-right: calc(var(--space-smaller) * -1);
 }
 
 .fullWidth {

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -17,7 +17,7 @@
   border-radius: var(--radius-base);
   color: var(--button--color-variation);
   -webkit-font-smoothing: antialiased;
-  line-height: 1;
+  letter-spacing: var(--typography--letterSpacing-loose);
   text-align: center;
   text-decoration: none;
   vertical-align: middle;
@@ -74,6 +74,11 @@ a.button:active {
 }
 
 .learning {
+  --button--color-variation: var(--color-informative);
+  --button--color-variation--hover: var(--color-informative--onSurface);
+}
+
+:global(.jobber-retheme) .learning {
   --button--color-variation: var(--color-interactive--subtle);
   --button--color-variation--hover: var(--color-interactive--subtle--hover);
 }
@@ -113,6 +118,11 @@ a.button:active {
 
 .secondary,
 .subtle.primary {
+  border-color: var(--button--color-variation);
+}
+
+:global(.jobber-retheme) .secondary,
+:global(.jobber-retheme) .subtle.primary {
   border-color: var(--color-border);
 }
 
@@ -181,12 +191,12 @@ a.button.disabled:hover {
 
 .small {
   min-height: calc(var(--base-unit) * 1.5);
-  padding: 0 calc(var(--space-base) - var(--space-smaller));
+  padding: 0 var(--space-small);
   letter-spacing: 0;
 }
 
 :global(.jobber-retheme) .small {
-  padding: calc(var(--space-base) - var(--space-smaller));
+  padding: 0 calc(var(--space-base) - var(--space-smaller));
 }
 
 .base {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Allow Button to be re-styled when a given class is present

## Changes

### Changed

- Enable Button to be re-themed and create alternate styling for re-theme
- For both modes, set focus to be on `:focus-visible` to follow browser heuristics on when to show focus ring

## Testing

Apply the `jobber-retheme` class to the Storybook iframe `body`

- [ ] With `jobber-retheme`, should look different
- [ ] Without `jobber-retheme`, should look the same except for focus no longer persists after you've clicked the button with a pointer

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
