### PR TITLE
refactor(components): Separating Chip and Chips (for real this time)

### DIFF
--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -2,9 +2,7 @@ import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Content } from "@jobber/components/Content";
 import { Chip, Chips } from "@jobber/components/Chips";
-import { Icon } from "@jobber/components/Icon";
 import { Text } from "@jobber/components/Text";
-import { Avatar } from "@jobber/components/Avatar";
 import { useFakeOptionQuery } from "./utils/storyUtils";
 
 export default {
@@ -32,22 +30,15 @@ const BasicTemplate: ComponentStory<typeof Chips> = args => {
       <Text>
         You are <u>{selected ? selected : "_______"}</u>
       </Text>
-      <Chips {...args} selected={selected} onChange={setSelected}>
-        <Chip
-          prefix={<Avatar initials="AZ" />}
-          label="Amazing"
-          value="Amazing"
-        />
-        <Chip
-          prefix={<Icon name="video" />}
-          label="Wonderful"
-          value="Wonderful"
-        />
-        <Chip
-          prefix={<Icon name="starFill" />}
-          label="Brilliant"
-          value="Brilliant"
-        />
+      <Chips
+        {...args}
+        selected={selected}
+        onChange={setSelected}
+        type="singleselect"
+      >
+        <Chip label="Amazing" value="Amazing" />
+        <Chip label="Wonderful" value="Wonderful" />
+        <Chip label="Brilliant" value="Brilliant" />
         <Chip label="Magnificent" value="Magnificent" />
       </Chips>
     </Content>
@@ -97,6 +88,7 @@ const SelectionTemplate: ComponentStory<typeof Chips> = args => {
   return (
     <Chips
       {...args}
+      type="dismissible"
       selected={selected}
       onChange={handleSelect}
       onCustomAdd={handleCustomAdd}

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -8,11 +8,11 @@
   --chip-radius: 20px;
   --chip-base-bg: var(--color-surface--background);
   --chip-base--hover: var(--color-surface--background--hover);
-  display: flex;
+  display: inline-flex;
   position: relative;
   height: var(--chip-height);
   min-width: 0;
-  padding: var(--space-small) var(--base-unit);
+  padding: 0 var(--base-unit);
   border: var(--border-base) solid transparent;
   border-radius: var(--chip-radius);
   color: var(--color-heading);
@@ -77,8 +77,7 @@
   --chip--gradient-color-variation: var(--chip-base-bg);
 }
 
-.base:hover,
-.base:focus-visible {
+.base:hover {
   background-color: var(--chip-base--hover);
   --chip--gradient-color-variation--hover: var(--chip-base--hover);
 }

--- a/packages/components/src/Chip/Chip.test.tsx
+++ b/packages/components/src/Chip/Chip.test.tsx
@@ -49,13 +49,7 @@ describe("Chip", () => {
 
   it("should have a role of button when role not provided", () => {
     const { getByRole } = render(<Chip label="Test Chip" />);
-    expect(getByRole("button")).toBeInstanceOf(HTMLButtonElement);
-  });
-
-  it("should have a tabIndex of zero if one is not provided", () => {
-    const { getByRole } = render(<Chip label="Test Chip" />);
-
-    expect(getByRole("button")).toHaveAttribute("tabIndex", "0");
+    expect(getByRole("button")).toBeInstanceOf(HTMLDivElement);
   });
 
   it("should set aria-label if one is provided", () => {
@@ -64,12 +58,6 @@ describe("Chip", () => {
     );
 
     expect(getByRole("button")).toHaveAttribute("aria-label", "Test Label");
-  });
-
-  it("should default aria-label to provided label if not provided", () => {
-    const { getByRole } = render(<Chip label="Test Chip" />);
-
-    expect(getByRole("button")).toHaveAttribute("aria-label", "Test Chip");
   });
 });
 

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -16,11 +16,12 @@ export const Chip = ({
   invalid,
   label,
   value,
+  dataTestID,
   onClick,
   onKeyDown,
   children,
   role = "button",
-  tabIndex = 0,
+  tabIndex,
   variation = "base",
 }: ChipProps): JSX.Element => {
   const classes = classnames(styles.chip, {
@@ -41,19 +42,21 @@ export const Chip = ({
     label,
     heading,
   );
+  const Tag = onClick ? "button" : "div";
 
   return (
-    <Tooltip message={tooltipMessage}>
-      <button
+    <Tooltip message={tooltipMessage} setTabIndex={false}>
+      <Tag
         className={classes}
-        onClick={(ev: React.MouseEvent<HTMLButtonElement>) =>
+        onClick={(ev: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) =>
           onClick && onClick(value, ev)
         }
         tabIndex={tabIndex}
         onKeyDown={onKeyDown}
-        aria-label={ariaLabel || label}
+        aria-label={ariaLabel}
         disabled={disabled}
         role={role}
+        data-testid={dataTestID}
         type="button"
       >
         {prefix}
@@ -79,7 +82,7 @@ export const Chip = ({
           )}
         </div>
         {suffix}
-      </button>
+      </Tag>
     </Tooltip>
   );
 };

--- a/packages/components/src/Chip/Chip.types.d.ts
+++ b/packages/components/src/Chip/Chip.types.d.ts
@@ -7,6 +7,11 @@ export interface ChipProps extends PropsWithChildren {
   readonly ariaLabel?: string;
 
   /**
+   * The testing id for the chip if necessary. Defaults to `chip-wrapper`.
+   */
+  dataTestID?: string;
+
+  /**
    * Disables both mouse and keyboard functionality, and updates the visual style of the Chip to appear disabled.
    */
   readonly disabled?: boolean;
@@ -53,13 +58,15 @@ export interface ChipProps extends PropsWithChildren {
    */
   readonly onClick?: (
     value: string | number | undefined,
-    ev: React.MouseEvent<HTMLButtonElement>,
+    ev: React.MouseEvent<HTMLButtonElement | HTMLDivElement>,
   ) => void;
 
   /**
    * Callback. Called when you keydown on Chip. Ships the event, so you can get the key pushed.
    */
-  readonly onKeyDown?: (ev: React.KeyboardEvent<HTMLButtonElement>) => void;
+  readonly onKeyDown?: (
+    ev: React.KeyboardEvent<HTMLButtonElement | HTMLDivElement>,
+  ) => void;
 }
 
 export type ChipVariations = "subtle" | "base";

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -1,13 +1,19 @@
 import React, { PropsWithChildren } from "react";
 import classNames from "classnames";
 import { Icon } from "@jobber/components/Icon";
+import { InternalChipButton } from "@jobber/components/Chips/InternalChipButton";
 import { useChildComponent } from "../../hooks";
 import styles from "../../Chip.css";
 
 export function ChipSuffix({ children, className }: ChipSuffixProps) {
-  let singleChild = useChildComponent(children, d => d.type === Icon);
+  let singleChild = useChildComponent(
+    children,
+    d => d.type === Icon || d.type == InternalChipButton,
+  );
 
-  if (!allowedSuffixIcons.includes(singleChild?.props?.name)) {
+  const iconName = singleChild?.props?.name || singleChild?.props?.icon;
+
+  if (!allowedSuffixIcons.includes(iconName)) {
     singleChild = undefined;
   }
 
@@ -28,4 +34,10 @@ export interface ChipSuffixProps extends PropsWithChildren {
   readonly className?: string;
 }
 
-export const allowedSuffixIcons = ["cross", "add", "checkmark", "arrowDown"];
+export const allowedSuffixIcons = [
+  "cross",
+  "add",
+  "checkmark",
+  "remove",
+  "arrowDown",
+];

--- a/packages/components/src/Chips/ChipsTypes.tsx
+++ b/packages/components/src/Chips/ChipsTypes.tsx
@@ -1,5 +1,4 @@
 import { MouseEvent, ReactElement } from "react";
-import { XOR } from "ts-xor";
 import { ChipProps } from "./Chip";
 
 interface ChipFoundationProps {
@@ -62,7 +61,7 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
   /**
    * Use a custom activator to trigger the Chip option selector
    */
-  readonly activator?: ReactElement;
+  readonly activator?: ReactElement | undefined;
 
   /**
    * Adds a loading indicator
@@ -96,7 +95,6 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
   onLoadMore?(searchValue: string): void;
 }
 
-export type ChipsProps = XOR<
-  ChipSingleSelectProps,
-  XOR<ChipMultiSelectProps, ChipDismissibleProps>
->;
+export type ChipsProps =
+  | ChipSingleSelectProps
+  | (ChipMultiSelectProps | ChipDismissibleProps);

--- a/packages/components/src/Chips/ChipsTypes.tsx
+++ b/packages/components/src/Chips/ChipsTypes.tsx
@@ -61,7 +61,7 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
   /**
    * Use a custom activator to trigger the Chip option selector
    */
-  readonly activator?: ReactElement | undefined;
+  readonly activator?: ReactElement;
 
   /**
    * Adds a loading indicator

--- a/packages/components/src/Chips/InternalChip.css
+++ b/packages/components/src/Chips/InternalChip.css
@@ -59,11 +59,16 @@
  */
 
 .chip:focus,
-.input:focus ~ .chip {
+.input:focus-visible ~ div[role="button"] {
   box-shadow: var(--shadow-focus);
   outline: none;
 }
 
+.chip:focus,
+.input:focus-visible ~ div[role="option"] {
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}
 .clickable:hover,
 .input ~ .chip:not(.active):hover,
 .input:focus ~ .chip:not(.active) {

--- a/packages/components/src/Chips/InternalChip.tsx
+++ b/packages/components/src/Chips/InternalChip.tsx
@@ -1,14 +1,9 @@
-import React, { useState } from "react";
-import classnames from "classnames";
-import styles from "./InternalChip.css";
+import React from "react";
 import { InternalChipProps } from "./ChipTypes";
-import { InternalChipAffix } from "./InternalChipAffix";
-import { Typography } from "../Typography";
-import { Tooltip } from "../Tooltip";
+import { Chip } from "../Chip";
 
 export function InternalChip({
   label,
-  active = false,
   disabled = false,
   invalid = false,
   prefix,
@@ -18,35 +13,21 @@ export function InternalChip({
   onClick,
   onKeyDown,
 }: InternalChipProps) {
-  const [truncateRef, setTruncateRef] = useState<HTMLElement | null>();
-  const isClickable = onClick && !disabled;
-  const classNames = classnames(styles.chip, {
-    [styles.clickable]: isClickable,
-    [styles.active]: active,
-    [styles.disabled]: disabled,
-    [styles.invalid]: invalid,
-    [styles.hasPrefix]: prefix,
-    [styles.hasSuffix]: suffix,
-  });
-  const affixProps = { active, invalid, disabled };
-  const Tag = onClick ? "button" : "div";
-
-  const chip = (
-    <Tag
-      className={classNames}
-      {...(isClickable && { onClick, disabled })}
+  return (
+    <Chip
+      disabled={disabled}
+      invalid={invalid}
       onKeyDown={onKeyDown}
-      data-testid="chip-wrapper"
-      aria-label={ariaLabel}
+      dataTestID="chip-wrapper"
+      ariaLabel={ariaLabel}
       tabIndex={tabIndex}
       role={tabIndex !== undefined ? "option" : undefined}
+      onClick={onClick ? (_, ev) => onClick(ev) : undefined}
+      label={label}
     >
-      <InternalChipAffix affix={prefix} {...affixProps} />
-      <Typography element="span" numberOfLines={1} size="base">
-        <span ref={setTruncateRef}>{label}</span>
-      </Typography>
-      <InternalChipAffix affix={suffix} {...affixProps} />
-    </Tag>
+      {prefix && <Chip.Prefix>{prefix}</Chip.Prefix>}
+      {suffix && <Chip.Suffix>{suffix}</Chip.Suffix>}
+    </Chip>
   );
 
   return isTruncated() ? <Tooltip message={label}>{chip}</Tooltip> : chip;

--- a/packages/components/src/Chips/InternalChipButton.tsx
+++ b/packages/components/src/Chips/InternalChipButton.tsx
@@ -39,7 +39,7 @@ export function InternalChipButton({
       aria-disabled={disabled}
       data-testid="remove-chip-button"
     >
-      <Icon name={icon} color={getColor()} />
+      <Icon size="small" name={icon} color={getColor()} />
     </div>
   );
 

--- a/packages/components/src/Chips/InternalChipMultiSelect.tsx
+++ b/packages/components/src/Chips/InternalChipMultiSelect.tsx
@@ -33,7 +33,9 @@ export function InternalChipMultiSelect({
             <InternalChip
               {...chip.props}
               active={isChipActive}
-              suffix={checkmarkIcon(isChipActive)}
+              {...(isChipActive
+                ? { suffix: <Icon size="small" name="checkmark" /> }
+                : {})}
             />
           </label>
         );

--- a/packages/components/src/Chips/InternalChipSingleSelect.tsx
+++ b/packages/components/src/Chips/InternalChipSingleSelect.tsx
@@ -2,6 +2,7 @@ import React, { KeyboardEvent, MouseEvent, useId } from "react";
 import styles from "./InternalChip.css";
 import { InternalChip } from "./InternalChip";
 import { ChipSingleSelectProps } from "./ChipsTypes";
+import { Icon } from "../Icon";
 
 type InternalChipChoiceProps = Pick<
   ChipSingleSelectProps,
@@ -34,7 +35,15 @@ export function InternalChipSingleSelect({
               }}
               disabled={child.props.disabled}
             />
-            <InternalChip {...child.props} active={isSelected} />
+            <InternalChip
+              {...child.props}
+              {...(isSelected
+                ? {
+                    suffix: <Icon size="small" name="checkmark" />,
+                  }
+                : {})}
+              active={isSelected}
+            />
           </label>
         );
       })}

--- a/packages/components/src/Chips/tests/InternalChip.test.tsx
+++ b/packages/components/src/Chips/tests/InternalChip.test.tsx
@@ -22,33 +22,9 @@ it("should fire the callback when it's clicked", async () => {
 });
 
 describe("Chip icon colors depending on state", () => {
-  it("should be red when it's invalid", () => {
-    expect(mockChip({ invalid: true })).toHaveStyle({
-      fill: "var(--color-critical)",
-    });
-  });
-
-  it("should be red when it's invalid and active", () => {
-    expect(mockChip({ invalid: true, active: true })).toHaveStyle({
-      fill: "var(--color-critical)",
-    });
-  });
-
-  it("should be grey when it's disabled", () => {
-    expect(mockChip({ disabled: true })).toHaveStyle({
-      fill: "var(--color-disabled)",
-    });
-  });
-
-  it("should be grey when it's disabled and invalid", () => {
-    expect(mockChip({ disabled: true, invalid: true })).toHaveStyle({
-      fill: "var(--color-disabled)",
-    });
-  });
-
-  it("should be white when it's active", () => {
+  it("should be green when it's active", () => {
     expect(mockChip({ active: true })).toHaveStyle({
-      fill: "var(--color-white)",
+      fill: "var(--color-success)",
     });
   });
 
@@ -63,37 +39,16 @@ describe("Chip icon colors depending on state", () => {
     disabled = false,
     active = false,
   }: MockChipProps) {
-    render(
+    const { getByTestId } = render(
       <InternalChip
         invalid={invalid}
         disabled={disabled}
         active={active}
-        prefix={<Icon name="checkbox" />}
+        prefix={<Icon name="checkmark" />}
         label="Yo!"
       />,
     );
 
-    return screen.getByTestId("checkbox").querySelector("path");
+    return getByTestId("checkmark").querySelector("path");
   }
-});
-
-// TODO: Figure out why this is always passing
-
-describe.skip("When the chip is disabled and invalid", () => {
-  it("should still look disabled but have a border of red", () => {
-    render(<InternalChip disabled invalid label="Yo!" />);
-    expect(screen.getByTestId("chip-wrapper")).toHaveStyle({
-      borderColor: "var(--color-critical)",
-      backgroundColor: "var(--color-disabled--secondary)",
-    });
-  });
-});
-
-describe.skip("When the chip is disabled and active", () => {
-  it("should be a darker chip but still grey", async () => {
-    render(<InternalChip disabled active label="Yo!" />);
-    expect(screen.getByTestId("chip-wrapper")).toHaveStyle(`
-        background-color: var(--color-disabled);
-      `);
-  });
 });

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
@@ -17,7 +17,7 @@ export function ComboboxTrigger({
     <Chip
       variation={hasSelection ? "base" : "subtle"}
       label={hasSelection ? selectedLabel : ""}
-      ariaLabel={label}
+      ariaLabel={hasSelection ? selectedLabel : ""}
       heading={label}
       onClick={() => {
         if (open) {

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -24,12 +24,15 @@ interface TooltipProps {
    * @default 'top'
    */
   readonly preferredPlacement?: Placement;
+
+  readonly setTabIndex?: boolean;
 }
 
 export function Tooltip({
   message,
   children,
   preferredPlacement = "top",
+  setTabIndex = true,
 }: TooltipProps) {
   const [show, setShow] = useState(false);
 
@@ -106,7 +109,10 @@ export function Tooltip({
         // This is to avoid having to add those attribute as a prop on every
         // component we have.
         activator.setAttribute("aria-description", message);
-        activator.setAttribute("tabindex", "0"); // enable focus
+
+        if (setTabIndex) {
+          activator.setAttribute("tabindex", "0"); // enable focus
+        }
       }
     };
 


### PR DESCRIPTION
## Motivations

We needed a standalone Chip for DataList/ClientList/Combobox. Since our existing implementation required a group of chips, an effort began to redesign Chip, implement that new Chip, and then decouple Chip from Chips. We've already redesigned and implemented the new Chip, this is the final step, decoupling Chip from Chips.

The original version of this PR made a critical mistake early on, deleting the InternalChip file instead of using it to properly integrate the new Chip component. This version of the PR corrects that mistake, and as a result this is a drastically simpler PR, with less breaking changes.

## Changes

Chips no longer has its own internal implementation of a Chip, instead using the decoupled/unopinionated `<Chip>` that is also available to all consumers of Atlantis.

#### Previous Chips Single Select
![image](https://github.com/GetJobber/atlantis/assets/145565743/3adcca27-56a0-4f98-b7b9-b4d7682f16c9)

#### New Chips Single Select
![image](https://github.com/GetJobber/atlantis/assets/145565743/5668a46a-59ca-4481-9c90-3658590625e5)

#### Previous Chips Multi Select
![image](https://github.com/GetJobber/atlantis/assets/145565743/6ddd9b46-8fc5-4b1c-b5f7-b3f3a7d80a4a)

#### New Chips Multi Select
![image](https://github.com/GetJobber/atlantis/assets/145565743/3c414623-3f8f-405e-ba67-305bef07407b)

#### Previous Chips Selection
![image](https://github.com/GetJobber/atlantis/assets/145565743/b8af47ae-5d0a-4189-8118-56e676da217d)

#### New Chips Selection
![image](https://github.com/GetJobber/atlantis/assets/145565743/3424696e-93f4-418f-90b6-bfd129046601)


### Added

- No net new development

### Changed

- There should be no noticeable changes by consumers of Atlantis other than the design of Chips is now in line with `Chip`. 

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

## Testing

1. Ensured all existing functionality in storybook is preserved.
1. Ensured all existing unit tests pass with the changes.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
