### PR TITLE
refactor(components): Update menu and popover for retheme [JOB-84566]

### DIFF
--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -64,7 +64,7 @@
 
 .section {
   padding: var(--space-small) 0;
-  border-bottom: var(--border-base) dotted var(--color-border);
+  border-bottom: var(--border-base) solid var(--color-border);
 }
 
 .section:first-of-type {
@@ -80,8 +80,22 @@
   padding: var(--space-small);
 }
 
+:global(.jobber-retheme) .sectionHeader {
+  display: flex;
+  align-items: center;
+  min-height: var(--space-largest);
+  padding: var(--space-small) var(--space-base);
+}
+
+:global(.jobber-retheme) .sectionHeader h6 {
+  font-size: var(--typography--fontSize-base);
+  font-weight: 600;
+  text-transform: none;
+}
+
 .action {
   display: flex;
+  gap: var(--space-base);
   width: 100%;
   padding: var(--space-small);
   border: none;
@@ -91,14 +105,23 @@
   align-items: center;
 }
 
+:global(.jobber-retheme) .action {
+  gap: var(--space-small);
+  padding: var(--space-small) calc(var(--space-small) + var(--space-smaller));
+}
+
 .action:hover,
-.action:focus {
+.action:focus-visible {
   background-color: var(--color-surface--hover);
   outline-color: var(--color-focus);
 }
 
-.icon {
-  margin-right: var(--space-base);
+:global(.jobber-retheme) .action span {
+  font-weight: 600;
+}
+
+:global(.jobber-retheme) .icon svg {
+  fill: var(--color-interactive--subtle);
 }
 
 .overlay {

--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -3,6 +3,8 @@
 }
 
 .wrapper {
+  --menu-space: var(--space-small);
+  --menu-offset: var(--space-smallest);
   display: inline-block;
   position: relative;
 }
@@ -14,8 +16,8 @@
   z-index: var(--elevation-menu);
   width: 100%;
   max-height: 72vh;
-  padding: var(--space-small);
-  padding-bottom: calc(env(safe-area-inset-bottom) + var(--space-small));
+  padding: var(--menu-space);
+  padding-bottom: calc(env(safe-area-inset-bottom) + var(--menu-space));
   border-radius: var(--radius-base) var(--radius-base) 0 0;
   -webkit-overflow-scrolling: touch;
   overflow-y: scroll;
@@ -26,7 +28,7 @@
     left: auto;
     width: calc(var(--base-unit) * 12.5);
     box-shadow: var(--shadow-base);
-    padding: var(--space-small);
+    padding: var(--menu-space);
     border: var(--border-base) solid var(--color-border);
     border-radius: var(--radius-base);
     overflow: auto;
@@ -36,7 +38,7 @@
 .above {
   @media (--small-screens-and-up) {
     bottom: 100%;
-    margin-bottom: var(--space-smallest);
+    margin-bottom: var(--menu-offset);
   }
 }
 
@@ -44,7 +46,7 @@
   @media (--small-screens-and-up) {
     top: 100%;
     bottom: auto;
-    margin-top: var(--space-smallest);
+    margin-top: var(--menu-offset);
   }
 }
 
@@ -63,7 +65,7 @@
 }
 
 .section {
-  padding: var(--space-small) 0;
+  padding: var(--menu-space) 0;
   border-bottom: var(--border-base) solid var(--color-border);
 }
 
@@ -77,20 +79,19 @@
 }
 
 .sectionHeader {
-  padding: var(--space-small);
+  padding: var(--menu-space);
 }
 
 :global(.jobber-retheme) .sectionHeader {
   display: flex;
   align-items: center;
-  min-height: var(--space-largest);
-  padding: var(--space-small) var(--space-base);
+  padding: calc(var(--menu-space) * 1.5) var(--menu-space);
 }
 
 :global(.jobber-retheme) .sectionHeader h6 {
   /* can move into the Typography component post re-theme */
   font-size: var(--typography--fontSize-base);
-  font-weight: 600;
+  font-weight: 400;
   text-transform: none;
 }
 
@@ -98,7 +99,7 @@
   display: flex;
   gap: var(--space-base);
   width: 100%;
-  padding: var(--space-small);
+  padding: var(--menu-space);
   border: none;
   border-radius: var(--radius-base);
   background-color: transparent;
@@ -107,8 +108,7 @@
 }
 
 :global(.jobber-retheme) .action {
-  gap: var(--space-small);
-  padding: var(--space-small) calc(var(--space-small) + var(--space-smaller));
+  gap: var(--menu-space);
 }
 
 .action:hover,
@@ -119,6 +119,7 @@
 
 :global(.jobber-retheme) .action span {
   /* can move into the Typography component post re-theme */
+  color: var(--color-text--secondary);
   font-weight: 600;
 }
 

--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -88,6 +88,7 @@
 }
 
 :global(.jobber-retheme) .sectionHeader h6 {
+  /* can move into the Typography component post re-theme */
   font-size: var(--typography--fontSize-base);
   font-weight: 600;
   text-transform: none;
@@ -117,10 +118,12 @@
 }
 
 :global(.jobber-retheme) .action span {
+  /* can move into the Typography component post re-theme */
   font-weight: 600;
 }
 
 :global(.jobber-retheme) .icon svg {
+  /* can move into the Icon component post re-theme */
   fill: var(--color-interactive--subtle);
 }
 

--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -35,6 +35,9 @@
   --public-content--padding: var(--card--base-padding);
 }
 
+/* post-retheme this entire arrow section can be deleted
+ * as it should be removed from the TSX file */
+
 .arrow {
   visibility: hidden;
 }

--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -56,6 +56,10 @@
   clip-path: polygon(-4px -4px, 15.3px 0, 0 15.3px);
 }
 
+:global(.jobber-retheme) .arrow {
+  display: none;
+}
+
 .popover[data-popper-placement^="top"] > .arrow {
   bottom: -5px;
 }

--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -35,9 +35,6 @@
   --public-content--padding: var(--card--base-padding);
 }
 
-/* post-retheme this entire arrow section can be deleted
- * as it should be removed from the TSX file */
-
 .arrow {
   visibility: hidden;
 }

--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -59,10 +59,6 @@
   clip-path: polygon(-4px -4px, 15.3px 0, 0 15.3px);
 }
 
-:global(.jobber-retheme) .arrow {
-  display: none;
-}
-
 .popover[data-popper-placement^="top"] > .arrow {
   bottom: -5px;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To enable the menu and popover components to handle alternate styling base on a retheme classname.

## Changes

### Changed

- using gap instead of margin in both existing and retheme style to determine spacing between icon and label
- alternate styling available when `jobber-retheme` class is present on the body
  - spacing and typographic styles change on Menu
  - Popover has no arrow

## Testing

Add `jobber-retheme` class to the "story" iframe in the DOM

### Popover
- [ ] Looks correct _with_ retheme class
- [ ] Looks correct _without_ retheme class

### Menu

#### Small screens
- [ ] Looks correct _with_ retheme class
- [ ] Looks correct _without_ retheme class

#### Medium+ screens
- [ ] Looks correct _with_ retheme class
- [ ] Looks correct _without_ retheme class

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
