### PR TITLE
fix(components): wrap DataTable empty state in valid DOM elements

### DIFF
--- a/packages/components/src/DataTable/Body.tsx
+++ b/packages/components/src/DataTable/Body.tsx
@@ -5,10 +5,10 @@ import styles from "./DataTable.css";
 import { BodyLoading } from "./BodyLoading";
 
 interface BodyProps<T> {
-  table: Table<T>;
-  onRowClick?: (row: Row<T>) => void;
-  emptyState?: ReactNode | ReactNode[];
-  loading: boolean;
+  readonly table: Table<T>;
+  readonly onRowClick?: (row: Row<T>) => void;
+  readonly emptyState?: ReactNode | ReactNode[];
+  readonly loading: boolean;
 }
 
 export function Body<T extends object>({
@@ -64,7 +64,16 @@ export function Body<T extends object>({
           })}
         </tbody>
       ) : (
-        <div className={classNames(styles.emptyState)}>{emptyState}</div>
+        <tbody>
+          <tr className={bodyRowClasses}>
+            <td
+              colSpan={table.getAllColumns().length}
+              className={classNames(styles.emptyState)}
+            >
+              {emptyState}
+            </td>
+          </tr>
+        </tbody>
       )}
     </>
   );


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
I am super tired of the console warnings telling me (correctly) that a `<div>` cannot be the child of a `<table>`. 

### Fixed

- Wrapped the  `DataTable` empty state in a `<tr>` and `<td>`. 

## Testing

<!-- How to test your changes. -->
Check the data table empty state example and make sure there's no more console error. 
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![image](https://github.com/GetJobber/atlantis/assets/10996915/a30d3194-5b92-42cf-9495-b3afe468cb2e)

