### PR TITLE
fix(components): Fix th cell padding in DataTable

### DIFF
--- a/packages/components/src/DataTable/Header.tsx
+++ b/packages/components/src/DataTable/Header.tsx
@@ -6,10 +6,10 @@ import styles from "./DataTable.css";
 import { SortingType } from "./types";
 
 interface HeaderProps<T> {
-  table: Table<T>;
-  stickyHeader?: boolean;
-  sorting?: SortingType;
-  onRowClick?: (row: Row<T>) => void;
+  readonly table: Table<T>;
+  readonly stickyHeader?: boolean;
+  readonly sorting?: SortingType;
+  readonly onRowClick?: (row: Row<T>) => void;
 }
 
 export function Header<T extends object>({
@@ -19,12 +19,23 @@ export function Header<T extends object>({
   onRowClick,
 }: HeaderProps<T>) {
   const stickyClass = classNames({ [styles.stickyHeader]: stickyHeader });
+
   return (
     <thead className={stickyClass}>
       {table.getHeaderGroups().map(headerGroup => (
         <tr key={headerGroup.id}>
           {headerGroup.headers.map(header => {
             const isSorting = sorting && header.column.getCanSort();
+            const headingCellInlineStyle: React.CSSProperties = {
+              width: header.getSize(),
+              minWidth: header.column.columnDef.minSize,
+              maxWidth: header.column.columnDef.maxSize,
+            };
+
+            if (isSorting) {
+              headingCellInlineStyle.paddingRight = 0;
+            }
+
             return (
               <th
                 key={header.id}
@@ -39,26 +50,19 @@ export function Header<T extends object>({
                 onClick={
                   sorting ? header.column.getToggleSortingHandler() : undefined
                 }
-                style={{
-                  width: header.getSize(),
-                  minWidth: header.column.columnDef.minSize,
-                  maxWidth: header.column.columnDef.maxSize,
-                  paddingRight: isSorting ? 0 : "inherit",
-                }}
+                style={headingCellInlineStyle}
               >
                 {header.isPlaceholder ? null : (
                   <div>
-                    <>
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+                    {header.column.getCanSort() &&
+                      sorting &&
+                      !header.column.getIsSorted() && (
+                        <SortIcon direction={SortDirection.equilibrium} />
                       )}
-                      {header.column.getCanSort() &&
-                        sorting &&
-                        !header.column.getIsSorted() && (
-                          <SortIcon direction={SortDirection.equilibrium} />
-                        )}
-                    </>
                     {
                       {
                         asc: <SortIcon direction={SortDirection.ascending} />,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Our team has a design debt ticket that led us to discover this.

In DataTable all of the table body cells (`tbody > tr > td`) have space-base for the cell padding on all sides. However, for table headers (`thead > tr > th`) we have an inline style that is overriding `padding-right`. This is in place to override to `0` if we are manually sorting the columns (to make room for the sorting control). However, if manual sorting is falsy our fallback is `padding-right: inherit` which I believe was meant to fallback on the default padding set on the th. 

Unfortunately that's not quite how inherit works. Inherit instead tells the cascade to fallback on the defined default in the **parent** element or the browser default if no parent default is found. So we end up with `padding-right: 0` either way. In order to fix this, I moved the inline style override into an object and then if we are manually sorting I add the padding right override. This way when we aren't manually sorting, there's no inline style to contend with. 

Before:
<img width="161" alt="Screenshot 2023-12-21 at 7 32 54 AM" src="https://github.com/GetJobber/atlantis/assets/10996915/40808a4f-d2f0-460f-b915-53bef3fd6985">
<img width="193" alt="Screenshot 2023-12-21 at 7 33 03 AM" src="https://github.com/GetJobber/atlantis/assets/10996915/5f001c86-f614-492a-959f-4f033d97fbdc">

After:
<img width="180" alt="Screenshot 2023-12-21 at 7 24 34 AM" src="https://github.com/GetJobber/atlantis/assets/10996915/b24c4780-4573-422a-a09b-93170f4c329f">
<img width="198" alt="Screenshot 2023-12-21 at 7 24 38 AM" src="https://github.com/GetJobber/atlantis/assets/10996915/947f01ae-34e8-4a2a-be3a-baf880f7c253">
<img width="327" alt="Screenshot 2023-12-21 at 7 25 50 AM" src="https://github.com/GetJobber/atlantis/assets/10996915/18120bf6-f699-4eae-a7f1-85fe90d79415">
<img width="201" alt="Screenshot 2023-12-21 at 7 25 59 AM" src="https://github.com/GetJobber/atlantis/assets/10996915/127cbdab-713e-4178-946c-7f0021659ef3">


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Incorrect table heading cell padding

## Testing

<!-- How to test your changes. -->
Check padding without manual sorting. Check padding wtih manual sorting.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![image](https://github.com/GetJobber/atlantis/assets/10996915/79a0591b-0f15-441f-a53e-8110ba3a7b83)

