### PR TITLE
fix(components): Attemping to fix typing issues for Vue-based Atlantis consumption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13050,6 +13050,15 @@
       "integrity": "sha512-hzzTS+X9EqDhx4vwdch/DOZci/bfh5J6Nyz8lqvyfBg2ROx2fPafX+LpDfpVgSvQKj0EYkwTYpBO3z2etwbkOw==",
       "dev": true
     },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -39597,6 +39606,82 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-copy": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.5.0.tgz",
+      "integrity": "sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^8.0.1",
+        "colorette": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "10.0.1",
+        "is-plain-object": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/globby": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/is-plain-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/rollup-plugin-copy/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/rollup-plugin-multi-input": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-multi-input/-/rollup-plugin-multi-input-1.4.1.tgz",
@@ -45684,6 +45769,7 @@
         "postcss-import": "^12.0.1",
         "postcss-preset-env": "^8.3.0",
         "rollup": "^2.79.1",
+        "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-multi-input": "^1.4.1",
         "rollup-plugin-postcss": "^4.0.2",
         "typed-css-modules": "^0.7.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -70,6 +70,7 @@
     "rollup": "^2.79.1",
     "rollup-plugin-multi-input": "^1.4.1",
     "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-copy": "^3.4.0",
     "typed-css-modules": "^0.7.0",
     "typescript": "^4.9.5",
     "uuid": "^8.3.2"

--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -3,6 +3,7 @@ import multiInput from "rollup-plugin-multi-input";
 import typescript from "@rollup/plugin-typescript";
 import postcss from "rollup-plugin-postcss";
 import commonjs from "@rollup/plugin-commonjs";
+import copy from "rollup-plugin-copy";
 
 export default {
   input: `src/*/index.{ts,tsx}`,
@@ -36,6 +37,62 @@ export default {
     }),
     commonjs({
       ignore: ["time-input-polyfill", "time-input-polyfill/supportsTime"],
+    }),
+    copy({
+      targets: [
+        { src: "src/Card/colors.css.d.ts", dest: "dist/Card" },
+        { src: "src/Content/Spacing.css.d.ts", dest: "dist/Content" },
+        { src: "src/Gallery/Gallery.css.d.ts", dest: "dist/Gallery" },
+        { src: "src/Grid/GridAlign.css.d.ts", dest: "dist/Grid" },
+        { src: "src/Modal/Sizes.css.d.ts", dest: "dist/Modal" },
+        { src: "src/ProgressBar/Sizes.css.d.ts", dest: "dist/ProgressBar" },
+        {
+          src: "src/Typography/css/Emphasis.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        {
+          src: "src/Typography/css/FontFamilies.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        {
+          src: "src/Typography/css/FontSizes.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        {
+          src: "src/Typography/css/FontWeights.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        {
+          src: "src/Typography/css/TextAlignment.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        {
+          src: "src/Typography/css/TextCases.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        {
+          src: "src/Typography/css/TextColors.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        {
+          src: "src/Typography/css/Truncate.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        {
+          src: "src/Typography/css/Typography.css.d.ts",
+          dest: "dist/Typography/css",
+        },
+        { src: "src/Glimmer/style/Shape.css.d.ts", dest: "dist/Glimmer/style" },
+        { src: "src/Glimmer/style/Sizes.css.d.ts", dest: "dist/Glimmer/style" },
+        {
+          src: "src/Glimmer/style/Timing.css.d.ts",
+          dest: "dist/Glimmer/style",
+        },
+        {
+          src: "src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContent.css.d.ts",
+          dest: "dist/Combobox/components/ComboboxContent/ComboboxContentList",
+        },
+      ],
     }),
   ],
   output: [


### PR DESCRIPTION
## Motivations

We've had reports that users building with Vue are seeing props typing issues with Atlantis components that generate acceptable prop values from css files.

The solution presented in this PR is a bit crude, but it does solve the issue in local testing with no changes to the core build process + local dev experience (the css.d.ts files are currently generated files and removing that step from the build process opened up a small can of worms). 

This PR will have a preview build generated from it so Vue consumers can verify that our local testing success can be replicated in other environments.

## Changes

- Updated library build process to copy specific css.d.ts files to the `dist` folder

### Fixed

- Vue-based Atlantis consumers should no longer receive errors when attempting to use specific props on certain components, and additionally gain autocomplete on the previously errored props.

## Testing

- Consume Atlantis in a Vue based environment, and attempt to use the `accent` prop on the `Card` component and you should see a full list of available accent colours instead of an error.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
