### PR TITLE
feat: Add support for providing your own of acceptable file types to upload for InputFile

### DIFF
--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -42,8 +42,7 @@ describe("Post Requests", () => {
   it("renders an InputFile with custom accepted MIME types", () => {
     const { container } = render(
       <InputFile
-        allowedTypes="custom"
-        acceptedMIMETypes={["image/png", "image/jpg", "application/pdf"]}
+        allowedTypes={["image/png", "image/jpg", "application/pdf"]}
         getUploadParams={fetchUploadParams}
       />,
     );

--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -39,6 +39,17 @@ describe("Post Requests", () => {
     expect(container).toMatchSnapshot();
   });
 
+  it("renders an InputFile with custom accepted MIME types", () => {
+    const { container } = render(
+      <InputFile
+        allowedTypes="custom"
+        acceptedMIMETypes={["image/png", "image/jpg", "application/pdf"]}
+        getUploadParams={fetchUploadParams}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   it("renders an InputFile with only images allowed", () => {
     const { container } = render(
       <InputFile allowedTypes="images" getUploadParams={fetchUploadParams} />,

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -103,18 +103,11 @@ interface InputFileProps {
    *
    * @param "images" - only accepts all types of image
    * @param "basicImages" - only accepts png, jpg and jpeg
-   * @param "custom" - uses `acceptedMIMETypes` as the list of allowed types
+   * @param "string[]" - accept a specific list of MIME types
    *
    * @default "all"
    */
-  readonly allowedTypes?: "all" | "images" | "basicImages" | "custom";
-
-  /**
-   * List of allowed MIME types.
-   *
-   * @default [] (empty array) - pass in the list of allowed MIME types when using `allowedTypes="custom"`
-   */
-  readonly acceptedMIMETypes?: string[];
+  readonly allowedTypes?: "all" | "images" | "basicImages" | string[];
 
   /**
    * Allow for multiple files to be selected for upload.
@@ -169,7 +162,6 @@ export function InputFile({
   buttonLabel: providedButtonLabel,
   allowMultiple = false,
   allowedTypes = "all",
-  acceptedMIMETypes = [],
   getUploadParams,
   onUploadStart,
   onUploadProgress,
@@ -184,8 +176,8 @@ export function InputFile({
     options.accept = "image/*";
   } else if (allowedTypes === "basicImages") {
     options.accept = "image/png, image/jpg, image/jpeg";
-  } else if (allowedTypes === "custom") {
-    options.accept = acceptedMIMETypes.join(",");
+  } else if (Array.isArray(allowedTypes)) {
+    options.accept = allowedTypes.join(",");
   }
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone(options);
@@ -306,7 +298,7 @@ function createAxiosConfig({
 function getLabels(
   providedButtonLabel: string | undefined,
   multiple: boolean,
-  allowedTypes: string,
+  allowedTypes: string | string[],
 ) {
   let buttonLabel = multiple ? "Upload Files" : "Upload File";
   let hintText = multiple

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -103,10 +103,18 @@ interface InputFileProps {
    *
    * @param "images" - only accepts all types of image
    * @param "basicImages" - only accepts png, jpg and jpeg
+   * @param "custom" - uses `acceptedMIMETypes` as the list of allowed types
    *
    * @default "all"
    */
-  readonly allowedTypes?: "all" | "images" | "basicImages";
+  readonly allowedTypes?: "all" | "images" | "basicImages" | "custom";
+
+  /**
+   * List of allowed MIME types.
+   *
+   * @default [] (empty array) - pass in the list of allowed MIME types when using `allowedTypes="custom"`
+   */
+  readonly acceptedMIMETypes?: string[];
 
   /**
    * Allow for multiple files to be selected for upload.
@@ -161,6 +169,7 @@ export function InputFile({
   buttonLabel: providedButtonLabel,
   allowMultiple = false,
   allowedTypes = "all",
+  acceptedMIMETypes = [],
   getUploadParams,
   onUploadStart,
   onUploadProgress,
@@ -175,7 +184,10 @@ export function InputFile({
     options.accept = "image/*";
   } else if (allowedTypes === "basicImages") {
     options.accept = "image/png, image/jpg, image/jpeg";
+  } else if (allowedTypes === "custom") {
+    options.accept = acceptedMIMETypes.join(",");
   }
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone(options);
 
   const { buttonLabel, hintText } = getLabels(

--- a/packages/components/src/InputFile/__snapshots__/InputFile.test.tsx.snap
+++ b/packages/components/src/InputFile/__snapshots__/InputFile.test.tsx.snap
@@ -36,6 +36,43 @@ exports[`Post Requests renders an InputFile 1`] = `
 </div>
 `;
 
+exports[`Post Requests renders an InputFile with custom accepted MIME types 1`] = `
+<div>
+  <div
+    class="dropZoneBase dropZone"
+    role="button"
+    tabindex="0"
+  >
+    <input
+      accept="image/png,image/jpg,application/pdf"
+      autocomplete="off"
+      style="display: none;"
+      tabindex="-1"
+      type="file"
+    />
+    <div
+      class="padded small"
+    >
+      <button
+        class="button small work secondary"
+        type="button"
+      >
+        <span
+          class="base extraBold small base"
+        >
+          Upload File
+        </span>
+      </button>
+      <p
+        class="base regular small textSecondary"
+      >
+        or drag a file here to upload
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Post Requests renders an InputFile with multiple images allowed 1`] = `
 <div>
   <div


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release


  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

feat(components): I want to be able to provide a list of acceptable MIME types such that I can restrict what the user should be able to upload.  

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
- Added another option for `allowedTypes` called `custom`. When this option is selected it will look at `acceptedMIMETypes` as the source of what MIME types the user can upload. 
- An additional prop called `acceptedMIMETypes`. This is prop expects a list of MIMETypes which will be passed down to the `useDropzone` hook. 


## Testing
Here we are setting the MIME type as `image/heic`. For a list of MIME types we can refer to either the [MDN web docs])https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) or [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)

<img width="715" alt="image" src="https://github.com/GetJobber/atlantis/assets/13531657/ce0f948f-1eb5-404b-be16-23ddabbd1b6f">

This alerts the file selector that we are looking for a HEIF image and everything else is greyed out.
<img width="841" alt="image" src="https://github.com/GetJobber/atlantis/assets/13531657/40a890cc-88cf-4b1a-8663-d04a3ad688fa">

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
