### PR TITLE
feat: Added Error State and onErrorCallback for InputFile

### DIFF
--- a/docs/components/InputFile/InputFile.stories.mdx
+++ b/docs/components/InputFile/InputFile.stories.mdx
@@ -66,22 +66,25 @@ reject or accept file uploads based on your needs. The value of the function
 must accept a File and return `null` when it is accepted or an error object when
 rejected.
 
-For example, the code below only accepts .PNG files that are less than 2MB in
-size.
+For example, the code below only accepts files that are less than 2MB in size.
 
 ```ts
 function pngFileValidator(file: File) {
-  if (!file.name.endsWith(".png")) {
-    return {
-      code: "wrong-file-type",
-      message: "Only .png files are allowed",
-    };
-  } else if (file.size > 2000000) {
+  if (file.size > 2000000) {
     return {
       code: "file-too-big",
       message: "The file is too big. Try using a smaller image",
     };
   }
+
   return null;
 }
 ```
+
+#### Notes
+
+If you would like to restrict specific file types, it is advised that you use
+the `allowedTypes` property instead of the `validator` property. Using
+`allowTypes` will allow the OS know what type of files the uploader is expecting
+before the user can upload their file. The invalid files will be shown as
+greyed-out as a result of this behaviour.

--- a/docs/components/InputFile/InputFile.stories.mdx
+++ b/docs/components/InputFile/InputFile.stories.mdx
@@ -69,7 +69,7 @@ rejected.
 For example, the code below only accepts files that are less than 2MB in size.
 
 ```ts
-function pngFileValidator(file: File) {
+function fileSizeValidator(file: File) {
   if (file.size > 2000000) {
     return {
       code: "file-too-big",

--- a/docs/components/InputFile/InputFile.stories.mdx
+++ b/docs/components/InputFile/InputFile.stories.mdx
@@ -58,3 +58,30 @@ updating an array of `FileUpload`s based on their `key` as uploads progress.
  */
 export function updateFiles(updatedFile: FileUpload, files: FileUpload[]);
 ```
+
+### validator
+
+InputFile can accept a `validator` function as a prop. This will allow you to
+reject or accept file uploads based on your needs. The value of the function
+must accept a File and return `null` when it is accepted or an error object when
+rejected.
+
+For example, the code below only accepts .PNG files that are less than 2MB in
+size.
+
+```ts
+function pngFileValidator(file: File) {
+  if (!file.name.endsWith(".png")) {
+    return {
+      code: "wrong-file-type",
+      message: "Only .png files are allowed",
+    };
+  } else if (file.size > 2000000) {
+    return {
+      code: "file-too-big",
+      message: "The file is too big. Try using a smaller image",
+    };
+  }
+  return null;
+}
+```

--- a/docs/components/InputFile/InputFile.stories.mdx
+++ b/docs/components/InputFile/InputFile.stories.mdx
@@ -84,7 +84,4 @@ function fileSizeValidator(file: File) {
 #### Notes
 
 If you would like to restrict specific file types, it is advised that you use
-the `allowedTypes` property instead of the `validator` property. Using
-`allowTypes` will allow the OS know what type of files the uploader is expecting
-before the user can upload their file. The invalid files will be shown as
-greyed-out as a result of this behaviour.
+the `allowedTypes` property instead of the `validator` property.

--- a/packages/components/src/InputAvatar/InputAvatar.tsx
+++ b/packages/components/src/InputAvatar/InputAvatar.tsx
@@ -13,7 +13,7 @@ interface InputAvatarProps extends Omit<AvatarProps, "size"> {
    * More info is available at:
    * https://atlantis.getjobber.com/?path=/docs/components-forms-and-inputs-inputfile-docs--page#getuploadparams
    */
-  getUploadParams(file: File): Promise<UploadParams>;
+  getUploadParams(file: File): UploadParams | Promise<UploadParams>;
 
   /**
    * Triggered when an image is changed.

--- a/packages/components/src/InputAvatar/InputAvatar.tsx
+++ b/packages/components/src/InputAvatar/InputAvatar.tsx
@@ -13,7 +13,7 @@ interface InputAvatarProps extends Omit<AvatarProps, "size"> {
    * More info is available at:
    * https://atlantis.getjobber.com/?path=/docs/components-forms-and-inputs-inputfile-docs--page#getuploadparams
    */
-  getUploadParams(file: File): UploadParams | Promise<UploadParams>;
+  getUploadParams(file: File): Promise<UploadParams>;
 
   /**
    * Triggered when an image is changed.

--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -23,6 +23,10 @@
   background-color: var(--color-surface--hover);
 }
 
+.dropZone.error {
+  border: var(--color-critical) dashed var(--border-thick);
+}
+
 .validationErrors {
   display: flex;
   justify-content: center;

--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -29,6 +29,5 @@
 
 .validationErrors {
   display: flex;
-  justify-content: center;
   flex-direction: column;
 }

--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -26,4 +26,5 @@
 .validationErrors {
   display: flex;
   justify-content: center;
+  flex-direction: column;
 }

--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -24,7 +24,7 @@
 }
 
 .dropZone.error {
-  border: var(--color-critical) dashed var(--border-thick);
+  border-color: var(--color-critical);
 }
 
 .validationErrors {

--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -22,3 +22,8 @@
   border-color: var(--color-focus);
   background-color: var(--color-surface--hover);
 }
+
+.validationErrors {
+  display: flex;
+  justify-content: center;
+}

--- a/packages/components/src/InputFile/InputFile.css.d.ts
+++ b/packages/components/src/InputFile/InputFile.css.d.ts
@@ -2,6 +2,7 @@ declare const styles: {
   readonly "dropZoneBase": string;
   readonly "dropZone": string;
   readonly "active": string;
+  readonly "validationErrors": string;
 };
 export = styles;
 

--- a/packages/components/src/InputFile/InputFile.css.d.ts
+++ b/packages/components/src/InputFile/InputFile.css.d.ts
@@ -2,6 +2,7 @@ declare const styles: {
   readonly "dropZoneBase": string;
   readonly "dropZone": string;
   readonly "active": string;
+  readonly "error": string;
   readonly "validationErrors": string;
 };
 export = styles;

--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -178,6 +178,35 @@ describe("Post Requests", () => {
       });
     });
   });
+
+  describe("when a validator is provided and validation fails", () => {
+    it("shows the validation message", async () => {
+      function pngFileValidator(file: File) {
+        if (file.name.endsWith(".png")) {
+          return {
+            code: "wrong-file-type",
+            message: "Only .png files are allowed",
+          };
+        }
+
+        return null;
+      }
+
+      const { container } = render(
+        <InputFile
+          getUploadParams={fetchUploadParams}
+          validator={pngFileValidator}
+        />,
+      );
+      const input = container.querySelector("input[type=file]");
+
+      fireEvent.change(input, { target: { files: [testFile] } });
+
+      await waitFor(() => {
+        expect(container).toContainHTML("Only .png files are allowed");
+      });
+    });
+  });
 });
 
 describe("PUT requests", () => {

--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -136,6 +136,48 @@ describe("Post Requests", () => {
       expect(handleComplete).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("when component fails to get upload params", () => {
+    it("calls onError callback", async () => {
+      const fetchParams = jest.fn(() => Promise.reject("error"));
+      const handleError = jest.fn();
+
+      const { container } = render(
+        <InputFile getUploadParams={fetchParams} onUploadError={handleError} />,
+      );
+      const input = container.querySelector("input[type=file]");
+
+      fireEvent.change(input, { target: { files: [testFile] } });
+
+      await waitFor(() => {
+        expect(handleError).toHaveBeenCalledWith(
+          new Error("Failed to get upload params"),
+        );
+      });
+    });
+  });
+
+  describe("when the component fails to upload", () => {
+    it("calls onError callback", async () => {
+      const fetchParams = jest.fn(fetchUploadParams);
+      const handleError = jest.fn();
+
+      (axios.request as jest.Mock).mockReturnValue(Promise.reject("error"));
+
+      const { container } = render(
+        <InputFile getUploadParams={fetchParams} onUploadError={handleError} />,
+      );
+      const input = container.querySelector("input[type=file]");
+
+      fireEvent.change(input, { target: { files: [testFile] } });
+
+      await waitFor(() => {
+        expect(handleError).toHaveBeenCalledWith(
+          new Error("Failed to upload file"),
+        );
+      });
+    });
+  });
 });
 
 describe("PUT requests", () => {

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -138,6 +138,11 @@ interface InputFileProps {
    * Upload event handler. Triggered on upload completion.
    */
   onUploadComplete?(file: FileUpload): void;
+
+  /**
+   *  Upload event handler. Triggered on upload error.
+   */
+  onUploadError?(error: Error): void;
 }
 
 interface CreateAxiosConfigParams extends Omit<UploadParams, "key"> {
@@ -165,6 +170,7 @@ export function InputFile({
   onUploadStart,
   onUploadProgress,
   onUploadComplete,
+  onUploadError,
 }: InputFileProps) {
   const options: DropzoneOptions = {
     multiple: allowMultiple,
@@ -229,7 +235,9 @@ export function InputFile({
       key = uuidv1(),
       fields = {},
       httpMethod = "POST",
-    } = await getUploadParams(file);
+    } = await getUploadParams(file).catch((e: Error) => {
+      onUploadError && onUploadError(e);
+    });
 
     const fileUpload = getFileUpload(file, key, url);
     onUploadStart && onUploadStart({ ...fileUpload });
@@ -254,7 +262,7 @@ export function InputFile({
       file,
       handleUploadProgress,
     });
-    axios.request(axiosConfig).then(handleUploadComplete);
+    axios.request(axiosConfig).then(handleUploadComplete).catch(onUploadError);
   }
 }
 

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -168,17 +168,6 @@ interface CreateAxiosConfigParams extends Omit<UploadParams, "key"> {
   handleUploadProgress(progress: any): void;
 }
 
-function pngFileValidator(file: File) {
-  if (!file.name.endsWith(".png")) {
-    return {
-      code: "wrong-file-type",
-      message: "Only .png files are allowed",
-    };
-  }
-
-  return null;
-}
-
 export function InputFile({
   variation = "dropzone",
   size = "base",
@@ -190,7 +179,7 @@ export function InputFile({
   onUploadProgress,
   onUploadComplete,
   onUploadError,
-  validator = pngFileValidator,
+  validator,
 }: InputFileProps) {
   const options: DropzoneOptions = {
     multiple: allowMultiple,
@@ -241,7 +230,9 @@ export function InputFile({
               {hintText}
             </Typography>
           )}
-          {validationErrors}
+          {fileRejections?.length > 0 && (
+            <div className={styles.validationErrors}>{validationErrors}</div>
+          )}
         </Content>
       )}
 

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -202,7 +202,7 @@ export function InputFile({
     return errors.map(error => {
       return (
         <InputValidation
-          message={file.name + "\n" + error.message}
+          message={`${file.name} ${error.message}`}
           key={`${file.name}${error.code}`}
         />
       );

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -217,38 +217,41 @@ export function InputFile({
   const dropZone = classnames(styles.dropZoneBase, {
     [styles.dropZone]: variation === "dropzone",
     [styles.active]: isDragActive,
+    [styles.error]: fileRejections?.length > 0,
   });
 
   return (
-    <div
-      {...getRootProps({ className: dropZone })}
-      tabIndex={variation === "button" ? -1 : 0}
-    >
-      <input {...getInputProps()} />
+    <>
+      <div
+        {...getRootProps({ className: dropZone })}
+        tabIndex={variation === "button" ? -1 : 0}
+      >
+        <input {...getInputProps()} />
 
-      {variation === "dropzone" && (
-        <Content spacing="small">
-          <Button label={buttonLabel} size="small" type="secondary" />
-          {size === "base" && (
-            <Typography size="small" textColor="textSecondary">
-              {hintText}
-            </Typography>
-          )}
-          {fileRejections?.length > 0 && (
-            <div className={styles.validationErrors}>{validationErrors}</div>
-          )}
-        </Content>
-      )}
+        {variation === "dropzone" && (
+          <Content spacing="small">
+            <Button label={buttonLabel} size="small" type="secondary" />
+            {size === "base" && (
+              <Typography size="small" textColor="textSecondary">
+                {hintText}
+              </Typography>
+            )}
+          </Content>
+        )}
 
-      {variation === "button" && (
-        <Button
-          label={buttonLabel}
-          size={size}
-          type="secondary"
-          fullWidth={true}
-        />
+        {variation === "button" && (
+          <Button
+            label={buttonLabel}
+            size={size}
+            type="secondary"
+            fullWidth={true}
+          />
+        )}
+      </div>
+      {fileRejections?.length > 0 && (
+        <div className={styles.validationErrors}>{validationErrors}</div>
       )}
-    </div>
+    </>
   );
 
   function handleDrop(acceptedFiles: File[]) {

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -124,7 +124,7 @@ interface InputFileProps {
    * More info is available at:
    * https://atlantis.getjobber.com/?path=/docs/components-forms-and-inputs-inputfile-docs--page#getuploadparams
    */
-  getUploadParams(file: File): Promise<UploadParams>;
+  getUploadParams(file: File): UploadParams | Promise<UploadParams>;
 
   /**
    * Upload event handler. Triggered on upload start.
@@ -184,7 +184,7 @@ export function InputFile({
 }: InputFileProps) {
   const options: DropzoneOptions = {
     multiple: allowMultiple,
-    onDrop: useCallback(handleDrop, []),
+    onDrop: useCallback(handleDrop, [uploadFile]),
     validator: validator && useCallback(validator, []),
   };
 
@@ -203,7 +203,7 @@ export function InputFile({
       return (
         <InputValidation
           message={file.name + "\n" + error.message}
-          key={file.name}
+          key={`${file.name}${error.code}`}
         />
       );
     });


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
I notice that it was possible for the input file to fail in two places. The first place is when the component requests for upload params and the second place. when the file is being uploaded. The lack of having an onError callbacks makes it difficult for the consumer of the component to know if something went wrong.

We also allowed the option to pass down a validator for the files to be rejected. When the file is rejected, the UI will update with a validation error message that was provided by the validator method. 

## Changes
- Added an onUploadError callback which will be trigger when the component fails to fetch the upload params or when the upload process fails.
- Added error state to the component
- 
## Testing

For testing the validator method I used the following function and assigned it to the validator property.
```
function pngFileValidator(file: File) {
  if (!file.name.endsWith(".png")) {
    return {
      code: "wrong-file-type",
      message: "Only .png files are allowed",
    };
  }
  return null;
}
```

![image](https://github.com/GetJobber/atlantis/assets/13531657/2f74962f-a0ca-4cd9-8d33-8ca392e666f7)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
