### PR TITLE
refactor(components): Radius adjustments for retheme

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.css
+++ b/packages/components/src/Autocomplete/Autocomplete.css
@@ -45,7 +45,6 @@
   align-items: center;
   padding: var(--space-small);
   border: none;
-  border-radius: var(--radius-base);
   text-align: left;
   list-style: none;
   background-color: transparent;

--- a/packages/components/src/StatusLabel/StatusLabel.css
+++ b/packages/components/src/StatusLabel/StatusLabel.css
@@ -14,7 +14,7 @@
   width: var(--statusLabel-icon-diameter);
   height: var(--statusLabel-icon-diameter);
   margin-top: var(--space-minuscule);
-  border-radius: var(--radius-base);
+  border-radius: 3px;
   background-color: var(--color-success);
   flex-shrink: 0;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When global tokens like radius change in the retheme, it exposes some un-needed radii being used in our components.

Why do these options need to be rounded?
![image](https://github.com/GetJobber/atlantis/assets/39704901/302debf6-c5c5-42e8-8548-25021aa02bd7)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- AutoComplete option never needed a radius, now it has none
- StatusLabel is 1px rounder (otherwise it becomes a full on circle when larger radius tokens are applied)

## Testing

- View components in Storybook
- You can also go into the inspector and override the `--radius-base` property and see that nothing wild happens to the Autocomplete options, and the StatusLabel stays the same roundness.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
