### PR TITLE
feat(components): Add better typescript types for to prop on Button

### DIFF
--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
-import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
+import {
+  Route,
+  RouteChildrenProps,
+  BrowserRouter as Router,
+  Switch,
+} from "react-router-dom";
 import { Button } from ".";
 
 it("renders a Button", () => {
@@ -141,42 +146,82 @@ it("renders button type='submit'", () => {
   const button = container.querySelector("button[type='submit']");
   expect(button).toBeInstanceOf(HTMLButtonElement);
 });
+describe("react router dom", () => {
+  it("routes when buttons are clicked", () => {
+    const { getByText, queryByText } = render(
+      <Router>
+        <Button label="One" to="/" />
+        <Button label="Two" to="/two" />
+        <Button label="Three" to="/three" />
+        <Switch>
+          <Route exact path="/">
+            Uno
+          </Route>
+          <Route exact path="/two">
+            Dos
+          </Route>
+          <Route exact path="/three">
+            Tres
+          </Route>
+        </Switch>
+      </Router>,
+    );
 
-it("routes when buttons are clicked", () => {
-  const { getByText, queryByText } = render(
-    <Router>
-      <Button label="One" to="/" />
-      <Button label="Two" to="/two" />
-      <Button label="Three" to="/three" />
-      <Switch>
-        <Route exact path="/">
-          Uno
-        </Route>
-        <Route exact path="/two">
-          Dos
-        </Route>
-        <Route exact path="/three">
-          Tres
-        </Route>
-      </Switch>
-    </Router>,
-  );
+    expect(queryByText("Uno")).toBeInstanceOf(HTMLElement);
+    expect(queryByText("Dos")).not.toBeInstanceOf(HTMLElement);
+    expect(queryByText("Tres")).not.toBeInstanceOf(HTMLElement);
 
-  expect(queryByText("Uno")).toBeInstanceOf(HTMLElement);
-  expect(queryByText("Dos")).not.toBeInstanceOf(HTMLElement);
-  expect(queryByText("Tres")).not.toBeInstanceOf(HTMLElement);
+    fireEvent.click(getByText("Two"));
 
-  fireEvent.click(getByText("Two"));
+    expect(queryByText("Uno")).not.toBeInstanceOf(HTMLElement);
+    expect(queryByText("Dos")).toBeInstanceOf(HTMLElement);
+    expect(queryByText("Tres")).not.toBeInstanceOf(HTMLElement);
 
-  expect(queryByText("Uno")).not.toBeInstanceOf(HTMLElement);
-  expect(queryByText("Dos")).toBeInstanceOf(HTMLElement);
-  expect(queryByText("Tres")).not.toBeInstanceOf(HTMLElement);
+    fireEvent.click(getByText("Three"));
 
-  fireEvent.click(getByText("Three"));
+    expect(queryByText("Uno")).not.toBeInstanceOf(HTMLElement);
+    expect(queryByText("Dos")).not.toBeInstanceOf(HTMLElement);
+    expect(queryByText("Tres")).toBeInstanceOf(HTMLElement);
+  });
 
-  expect(queryByText("Uno")).not.toBeInstanceOf(HTMLElement);
-  expect(queryByText("Dos")).not.toBeInstanceOf(HTMLElement);
-  expect(queryByText("Tres")).toBeInstanceOf(HTMLElement);
+  it("routes with when buttons include link state", () => {
+    interface LocationStateTest {
+      locationStateTest: string;
+    }
+
+    function Test2(
+      props: RouteChildrenProps<
+        Record<string, string | undefined>,
+        LocationStateTest
+      >,
+    ) {
+      return <span>{props.location?.state?.locationStateTest}</span>;
+    }
+    const { getByText } = render(
+      <Router>
+        <Button label="One" to="/" />
+        <Button
+          label="Two"
+          to={{
+            pathname: "/two",
+            state: { locationStateTest: "This is state" },
+          }}
+        />
+        <Button label="Three" to="/three" />
+        <Switch>
+          <Route exact path="/">
+            Uno
+          </Route>
+          <Route path="/two" component={Test2}></Route>
+          <Route exact path="/three">
+            Tres
+          </Route>
+        </Switch>
+      </Router>,
+    );
+    fireEvent.click(getByText("Two"));
+    expect(getByText("This is state")).toBeDefined();
+  });
 });
 
 describe("Button role", () => {

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import { XOR } from "ts-xor";
-import { Link } from "react-router-dom";
+import { Link, LinkProps } from "react-router-dom";
 import { IconNames } from "@jobber/design";
 import styles from "./Button.css";
 import { Icon } from "../Icon";
@@ -51,11 +51,11 @@ interface ButtonAnchorProps extends ButtonFoundationProps {
   readonly url?: string;
 }
 
-interface ButtonLinkProps extends ButtonFoundationProps {
+interface ButtonLinkProps<S = unknown> extends ButtonFoundationProps {
   /**
    * Used for client side routing. Only use when inside a routed component.
    */
-  readonly to?: string;
+  readonly to?: LinkProps<S>["to"];
 }
 
 interface BaseActionProps extends ButtonFoundationProps {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Currently the `to` prop in button only supports a new path while react-router-dom allows more customization. This PR updates the `to` prop to also adds the ability to use the other features. See: https://v5.reactrouter.com/web/api/Link


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added ability to use the full `to` options provided by react-router in the button component

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Verify Button `to` works when it is just a string
- Verify other options work [small code sandbox](https://codesandbox.io/p/sandbox/empty-water-vndrrr?file=%2FExample.tsx)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

<img width="310" alt="image" src="https://github.com/GetJobber/atlantis/assets/17303106/a8bf330e-e469-46bb-85f4-b4aed8e7c2e3">

