### PR TITLE
fix(components): DataTable empty state should span full width with pinFirstColumn enabled [85639]

### DIFF
--- a/packages/components/src/DataTable/Body.tsx
+++ b/packages/components/src/DataTable/Body.tsx
@@ -68,9 +68,9 @@ export function Body<T extends object>({
           <tr className={bodyRowClasses}>
             <td
               colSpan={table.getAllColumns().length}
-              className={classNames(styles.emptyState)}
+              className={styles.emptyStateCell}
             >
-              {emptyState}
+              <div className={styles.emptyState}>{emptyState}</div>
             </td>
           </tr>
         </tbody>

--- a/packages/components/src/DataTable/DataTable.css
+++ b/packages/components/src/DataTable/DataTable.css
@@ -60,6 +60,11 @@
   background-color: var(--color-surface);
 }
 
+.pinFirstColumn tbody tr td.emptyStateCell {
+  display: table-cell;
+  position: initial;
+}
+
 .pinFirstColumn th:first-child::after,
 .pinFirstColumn td:first-child::after {
   content: "";

--- a/packages/components/src/DataTable/DataTable.css.d.ts
+++ b/packages/components/src/DataTable/DataTable.css.d.ts
@@ -3,6 +3,7 @@ declare const styles: {
   readonly "tableContainer": string;
   readonly "table": string;
   readonly "pinFirstColumn": string;
+  readonly "emptyStateCell": string;
   readonly "stickyHeader": string;
   readonly "pinFirstHeaderSortable": string;
   readonly "sortableColumn": string;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
My [previous PR](https://github.com/GetJobber/atlantis/pull/1698) introduced a bug where the empty state wouldn't span the full table width in `pinFirstColumn` due to positioning resets. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- added a div container for width and an empty state cell class to override `pinFirstColumn` cell styles

**Before**
Janky
![Screenshot 2024-01-10 at 12 37 14 PM](https://github.com/GetJobber/atlantis/assets/10996915/03bc8047-c420-4c64-a860-801ec57325c2)

**After**
Beautiful
![Screenshot 2024-01-10 at 12 37 10 PM](https://github.com/GetJobber/atlantis/assets/10996915/26fb4d8a-cf19-4709-ad4a-6897efacdeed)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![image](https://github.com/GetJobber/atlantis/assets/10996915/790e933e-a570-4d7b-bf60-b2e1e3bc366a)
