### PR TITLE
fix: align center banner icon on retheme

### DIFF
--- a/packages/components/src/Banner/Banner.css
+++ b/packages/components/src/Banner/Banner.css
@@ -80,3 +80,14 @@
   outline: none;
   background: rgba(0, 0, 0, 0.05);
 }
+
+.iconWrapper {
+  display: inline-flex;
+  padding: var(--space-smaller);
+  border-radius: var(--radius-circle);
+  background-color: var(--color-surface--background);
+}
+
+:global(.jobber-retheme) .medium .iconWrapper {
+  align-self: center;
+}

--- a/packages/components/src/Banner/Banner.css.d.ts
+++ b/packages/components/src/Banner/Banner.css.d.ts
@@ -5,6 +5,7 @@ declare const styles: {
   readonly "medium": string;
   readonly "bannerAction": string;
   readonly "closeButton": string;
+  readonly "iconWrapper": string;
 };
 export = styles;
 

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -104,6 +104,7 @@ export function Banner({
 
       {dismissible && (
         <button
+          type="button"
           className={styles.closeButton}
           onClick={handleClose}
           aria-label="Close this notification"

--- a/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`renders a banner with a primary 'learning' action when the type is 'not
     <button
       aria-label="Close this notification"
       class="closeButton"
+      type="button"
     >
       <svg
         class="Z6OfUI2sH34- TphtDHcwxDc-"
@@ -89,6 +90,7 @@ exports[`renders a banner with a primary action 1`] = `
     <button
       aria-label="Close this notification"
       class="closeButton"
+      type="button"
     >
       <svg
         class="Z6OfUI2sH34- TphtDHcwxDc-"
@@ -128,6 +130,7 @@ exports[`renders a notice banner 1`] = `
     <button
       aria-label="Close this notification"
       class="closeButton"
+      type="button"
     >
       <svg
         class="Z6OfUI2sH34- TphtDHcwxDc-"
@@ -167,6 +170,7 @@ exports[`renders a success banner 1`] = `
     <button
       aria-label="Close this notification"
       class="closeButton"
+      type="button"
     >
       <svg
         class="Z6OfUI2sH34- TphtDHcwxDc-"
@@ -206,6 +210,7 @@ exports[`renders a warning banner 1`] = `
     <button
       aria-label="Close this notification"
       class="closeButton"
+      type="button"
     >
       <svg
         class="Z6OfUI2sH34- TphtDHcwxDc-"

--- a/packages/components/src/Banner/components/BannerIcon/BannerIcon.css
+++ b/packages/components/src/Banner/components/BannerIcon/BannerIcon.css
@@ -1,14 +1,3 @@
-.wrapper {
-  display: inline-flex;
-  padding: var(--space-smaller);
-  border-radius: var(--radius-circle);
-  background-color: var(--color-surface--background);
-}
-
-:global(.jobber-retheme) .wrapper {
-  align-self: center;
-}
-
 .success {
   background-color: var(--color-success);
 }

--- a/packages/components/src/Banner/components/BannerIcon/BannerIcon.css
+++ b/packages/components/src/Banner/components/BannerIcon/BannerIcon.css
@@ -5,6 +5,10 @@
   background-color: var(--color-surface--background);
 }
 
+:global(.jobber-retheme) .wrapper {
+  align-self: center;
+}
+
 .success {
   background-color: var(--color-success);
 }

--- a/packages/components/src/Banner/components/BannerIcon/BannerIcon.css.d.ts
+++ b/packages/components/src/Banner/components/BannerIcon/BannerIcon.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "wrapper": string;
   readonly "success": string;
   readonly "error": string;
   readonly "warning": string;

--- a/packages/components/src/Banner/components/BannerIcon/BannerIcon.tsx
+++ b/packages/components/src/Banner/components/BannerIcon/BannerIcon.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { IconNames } from "@jobber/design";
 import classNames from "classnames";
 import { getAtlantisConfig } from "@jobber/components/utils/getAtlantisConfig";
-import styles from "./BannerIcon.css";
+import iconStyles from "./BannerIcon.css";
+import bannerStyles from "../../Banner.css";
 import { Icon } from "../../../Icon";
 import { BannerType } from "../../Banner.types";
 
@@ -16,7 +17,7 @@ export function BannerIcon({ icon, type }: BannerIconProps) {
 
   if (JOBBER_RETHEME) {
     return (
-      <span className={classNames(styles.wrapper, styles[type])}>
+      <span className={classNames(bannerStyles.iconWrapper, iconStyles[type])}>
         <Icon name={icon} color={"white"} size="small" />
       </span>
     );


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Noticed the banner icons aren't aligned properly on the retheme styling

![image](https://github.com/GetJobber/atlantis/assets/15986172/3b0983b9-c513-4fe3-9e91-10a4b5cce87b)


This fixes that

![image](https://github.com/GetJobber/atlantis/assets/15986172/aa4603bf-d95d-46f6-865a-5d3d9ae3c4aa)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- align self center on the banner icon

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

add this on preview.tsx

```
document.body.classList.add("jobber-retheme");
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
