### PR TITLE
fix(components): Bring back card border and padding for retheme

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -19,13 +19,7 @@
 }
 
 :root :global(.jobber-retheme) .card:not(.clickable) {
-  --card--base-padding: var(--space-base);
-  --card--border: none;
   --card--header-background: transparent;
-
-  @media (--medium-screens-and-up) {
-    --card--base-padding: 0;
-  }
 }
 
 /* Adjust `Content` components public padding to match the cards */
@@ -44,12 +38,20 @@
   border-top-width: 0;
 }
 
+:global(.jobber-retheme) .accent {
+  border-top-width: 1px;
+}
+
 .accent::before {
   content: " ";
   display: block;
   margin: 0 calc(-1 * var(--border-base));
   border-top: 0.5rem solid var(--card--accent-color);
   border-radius: var(--radius-base) var(--radius-base) 0 0;
+}
+
+:global(.jobber-retheme) .accent::before {
+  display: none;
 }
 
 .clickable {
@@ -77,12 +79,7 @@
 }
 
 :global(.jobber-retheme) .header {
-  padding: var(--card--base-padding);
   padding-bottom: 0;
-
-  @media (--medium-screens-and-up) {
-    padding: var(--space-base) 0;
-  }
 }
 
 :global(.jobber-retheme) .header h3 {


### PR DESCRIPTION
## Motivations

Didn't look good so needed to revert the border change back

## Changes

Added spacing and borders back and made sure the accent colours don't appear

### Before
![image](https://github.com/GetJobber/atlantis/assets/10064579/17a36b65-4956-4ed1-86c9-30a9df0bb16f)

### After
![image](https://github.com/GetJobber/atlantis/assets/10064579/1ba90906-9715-48aa-a9ee-5099424d04d8)

## Testing

Import into rails app and borders should be back on cards with less space between header and content

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
