### PR TITLE
fix(components): Fix DataList Small Breakpoint DataListHeader Visibility

### DIFF
--- a/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
@@ -18,15 +18,14 @@ export function DataListHeader() {
     headers,
     layoutBreakpoints,
   } = useDataListContext();
-  const { selectedIDs } = useBatchSelect();
+  const { hasAtLeastOneSelected } = useBatchSelect();
 
   const size = getVisibleSize();
   const { layout } = useActiveLayout();
 
   const visible = headerVisibility[size];
-  const noItemsSelected = selectedIDs?.length === 0;
 
-  if ((!visible && noItemsSelected) || !layout) return null;
+  if ((!visible && !hasAtLeastOneSelected) || !layout) return null;
 
   const headerData = generateHeaderElements(headers);
   if (!headerData) return null;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The batch/bulk actions header isn't showing up on mobile when we would like it to

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

fix the header not showing when **all** selected. previously it would only show if you had more than zero selected, but less than **all** which is treated differently

now it will show even if you have all selected

**BEFORE**

<img width="373" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/f34d564c-adb8-4589-a610-22f8e55d41f2">


**AFTOR**

<img width="373" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/b7f93a70-ad55-46c9-9a2b-3e27e1fe8e8d">


## Testing

you'll need a DataList with everything including a DataListHeader plus batch setup, and then view it on a small resolution screen

this might be a lot to set up, I've been testing it on the new Client index page via `npm run pack @jobber/components` in Atlantis to make the local package that has this version and then installing that in Jobber and trying it out

you should be able to use the generated preview version from this PR though, I think

medium/large screen should remain the same since it is `visible` and thus won't meet the second `&&`'ed condition paired with this fix

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
