### PR TITLE
fix(components): Hide anything overflowing the dataTable

### DIFF
--- a/packages/components/src/DataTable/DataTable.css
+++ b/packages/components/src/DataTable/DataTable.css
@@ -2,6 +2,7 @@
   position: relative;
   border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
+  overflow: hidden;
 }
 
 .tableContainer {


### PR DESCRIPTION
## Motivations

When we change the roundness of the dataTable elements that are within it that don't follow that same roundness end up breaking outside the container.

## Changes

Added overflow: hidden to hide elements that break outside the bounds. 

### Added

- <!-- new features -->

### Changed

Before
![image](https://github.com/GetJobber/atlantis/assets/10064579/54b40ab7-2253-4dc9-8cef-40944151c16b)
![image](https://github.com/GetJobber/atlantis/assets/10064579/e19b8c60-b3d6-47e6-b47c-c2814cf9df2d)

After
![image](https://github.com/GetJobber/atlantis/assets/10064579/622e7216-13ea-4b5e-9385-4d1f13a13ec3)
![image](https://github.com/GetJobber/atlantis/assets/10064579/8982bc63-df99-479b-b905-029249de8f92)

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
