### PR TITLE
fix(components): Adapt toast and menu for retheme [JOB-86410]

### DIFF
--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -16,6 +16,7 @@
   z-index: var(--elevation-menu);
   width: 100%;
   max-height: 72vh;
+  box-shadow: var(--shadow-base);
   padding: var(--menu-space);
   padding-bottom: calc(env(safe-area-inset-bottom) + var(--menu-space));
   border-radius: var(--radius-base) var(--radius-base) 0 0;
@@ -27,7 +28,6 @@
     position: absolute;
     left: auto;
     width: calc(var(--base-unit) * 12.5);
-    box-shadow: var(--shadow-base);
     padding: var(--menu-space);
     border: var(--border-base) solid var(--color-border);
     border-radius: var(--radius-base);

--- a/packages/components/src/Toast/Toast.css
+++ b/packages/components/src/Toast/Toast.css
@@ -46,6 +46,14 @@
   margin-left: var(--space-base);
 }
 
+:global(.jobber-retheme) .button svg path {
+  fill: var(--color-greyBlue--light);
+}
+
+:global(.jobber-retheme) .button:hover svg path {
+  fill: var(--color-greyBlue);
+}
+
 .action {
   margin-left: var(--space-small);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Some elements of Toast and Menu need a bit of love to work nicely in the retheme

## Changes

### Changed

![image](https://github.com/GetJobber/atlantis/assets/39704901/69df38f6-bf64-466c-8790-5bccb1840674)

- Menu body now has a shadow even on small screens (retheme and non-retheme)

### Fixed

![image](https://github.com/GetJobber/atlantis/assets/39704901/58d5fcd5-3a59-4fbd-b707-e529b0d2fbcf)

- Toast dismiss button is now visible in retheme

## Testing

To test the Toast changes, add the `.jobber-retheme` class to the body of the Storybook "story" iframe

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
