### PR TITLE
feat(components): onSearch Callback Prop for Combobox

### DIFF
--- a/docs/components/Combobox/Combobox.stories.mdx
+++ b/docs/components/Combobox/Combobox.stories.mdx
@@ -122,6 +122,28 @@ activator. The data will still be returned via callback.
 When using a custom activator, the selections will only be returned as data
 keeping the choice of how to display the data flexible.
 
+### Custom onSearch
+
+The `onSearch` prop allows you to hook into the Combobox's search input and
+receive what the user has typed. This callback is debounced by 300ms by default
+but can be configured with the `onSearchDebounce` prop.
+
+When using this callback, we no longer filter the options as a user types.
+Everything is left up to the `onSearch` callback and accompanying code to
+implement.
+
+An example use case here would be using the search term to fire off a request to
+fetch the appropriate data for that term. It is recommended to use the `loading`
+prop while fetching & filtering the new data. The loading state will display a
+static amount of `Glimmer` components. Then updating `loading` once the new data
+has been fetched and the `Combobox.Option`s have been replaced with the new
+ones.
+
+Note that the component does not cache the initial options when using
+`onSearch`. If new data was fetched and replaced the inital options on search
+then a user clears the search, either with the clear button or deleting the
+term, the initial options would need to be restored manually.
+
 ## Content guidelines
 
 Combobox is designed to handle lists of selectable options, so the component is

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -303,12 +303,16 @@ const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
   const mockQuery = (query: string) => {
     return new Promise<ComboboxOption[]>(resolve => {
       setTimeout(() => {
-        resolve([
-          { id: "5", label: `Patrick ${query}` },
-          { id: "6", label: `Roland ${query}` },
-          { id: "7", label: `Twyla ${query}` },
-          { id: "8", label: `Stevie ${query}` },
-        ]);
+        if (query === "no") {
+          resolve([]);
+        } else {
+          resolve([
+            { id: "5", label: `Patrick ${query}` },
+            { id: "6", label: `Roland ${query}` },
+            { id: "7", label: `Twyla ${query}` },
+            { id: "8", label: `Stevie ${query}` },
+          ]);
+        }
       }, 500);
     });
   };
@@ -319,6 +323,8 @@ const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
       onSelect={setSelected}
       selected={selected}
       label="Teammates"
+      multiSelect
+      hadInitalOptions={initialOptions.length > 0}
       onSearchChange={async (term: string) => {
         setLoading(true);
 
@@ -363,7 +369,7 @@ export const SingleSelect = ComboboxSingleSelection.bind({});
 SingleSelect.args = {};
 
 export const DynamicAction = DynamicButton.bind({});
-SingleSelect.args = {};
+DynamicAction.args = {};
 
 export const CustomSearch = ComboboxCustomSearch.bind({});
-SingleSelect.args = {};
+CustomSearch.args = {};

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -303,12 +303,16 @@ const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
   const mockQuery = (query: string) => {
     return new Promise<ComboboxOption[]>(resolve => {
       setTimeout(() => {
-        resolve([
-          { id: "5", label: `Patrick ${query}` },
-          { id: "6", label: `Roland ${query}` },
-          { id: "7", label: `Twyla ${query}` },
-          { id: "8", label: `Stevie ${query}` },
-        ]);
+        if (query === "no") {
+          resolve([]);
+        } else {
+          resolve([
+            { id: "5", label: `Patrick ${query}` },
+            { id: "6", label: `Roland ${query}` },
+            { id: "7", label: `Twyla ${query}` },
+            { id: "8", label: `Stevie ${query}` },
+          ]);
+        }
       }, 500);
     });
   };

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -239,7 +239,6 @@ const ComboboxSingleSelection: ComponentStory<typeof Combobox> = args => {
       onSelect={setSelected}
       selected={selected}
       label="Teammates"
-      onSearchChange={searchValue => console.log("SEARCH VALUE " + searchValue)}
     >
       <Combobox.Option id="1" label="Bilbo Baggins" />
       <Combobox.Option id="2" label="Frodo Baggins" />

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -324,7 +324,6 @@ const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
       selected={selected}
       label="Teammates"
       multiSelect
-      hadInitalOptions={initialOptions.length > 0}
       onSearch={async (term: string) => {
         setLoading(true);
 

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -303,16 +303,12 @@ const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
   const mockQuery = (query: string) => {
     return new Promise<ComboboxOption[]>(resolve => {
       setTimeout(() => {
-        if (query === "no") {
-          resolve([]);
-        } else {
-          resolve([
-            { id: "5", label: `Patrick ${query}` },
-            { id: "6", label: `Roland ${query}` },
-            { id: "7", label: `Twyla ${query}` },
-            { id: "8", label: `Stevie ${query}` },
-          ]);
-        }
+        resolve([
+          { id: "5", label: `Patrick ${query}` },
+          { id: "6", label: `Roland ${query}` },
+          { id: "7", label: `Twyla ${query}` },
+          { id: "8", label: `Stevie ${query}` },
+        ]);
       }, 500);
     });
   };

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -325,7 +325,7 @@ const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
       label="Teammates"
       multiSelect
       hadInitalOptions={initialOptions.length > 0}
-      onSearchChange={async (term: string) => {
+      onSearch={async (term: string) => {
         setLoading(true);
 
         if (term == "") {

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -288,6 +288,65 @@ const DynamicButton: ComponentStory<typeof Combobox> = args => {
   );
 };
 
+const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
+  const initialOptions: ComboboxOption[] = [
+    { id: "1", label: "David" },
+    { id: "2", label: "Johnny" },
+    { id: "3", label: "Moira" },
+    { id: "4", label: "Alexis" },
+  ];
+  const [selected, setSelected] = useState<ComboboxOption[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [displayOptions, setDisplayOptions] =
+    useState<ComboboxOption[]>(initialOptions);
+
+  const mockQuery = (query: string) => {
+    return new Promise<ComboboxOption[]>(resolve => {
+      setTimeout(() => {
+        resolve([
+          { id: "5", label: `Patrick ${query}` },
+          { id: "6", label: `Roland ${query}` },
+          { id: "7", label: `Twyla ${query}` },
+          { id: "8", label: `Stevie ${query}` },
+        ]);
+      }, 500);
+    });
+  };
+
+  return (
+    <Combobox
+      {...args}
+      onSelect={setSelected}
+      selected={selected}
+      label="Teammates"
+      onSearchChange={async (term: string) => {
+        setLoading(true);
+
+        if (term == "") {
+          setDisplayOptions(initialOptions);
+        } else {
+          const results = await mockQuery(term);
+
+          setDisplayOptions(results);
+        }
+
+        setLoading(false);
+      }}
+      loading={loading}
+    >
+      {displayOptions.map(option => {
+        return (
+          <Combobox.Option
+            key={option.id}
+            id={option.id}
+            label={option.label}
+          />
+        );
+      })}
+    </Combobox>
+  );
+};
+
 export const ClearSelection = ComboboxClearSelection.bind({});
 ClearSelection.args = {};
 
@@ -304,4 +363,7 @@ export const SingleSelect = ComboboxSingleSelection.bind({});
 SingleSelect.args = {};
 
 export const DynamicAction = DynamicButton.bind({});
+SingleSelect.args = {};
+
+export const CustomSearch = ComboboxCustomSearch.bind({});
 SingleSelect.args = {};

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -239,6 +239,7 @@ const ComboboxSingleSelection: ComponentStory<typeof Combobox> = args => {
       onSelect={setSelected}
       selected={selected}
       label="Teammates"
+      onSearchChange={searchValue => console.log("SEARCH VALUE " + searchValue)}
     >
       <Combobox.Option id="1" label="Bilbo Baggins" />
       <Combobox.Option id="2" label="Frodo Baggins" />

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -464,6 +464,7 @@ describe("Combobox Custom onSearch", () => {
 
     await user.type(screen.getByPlaceholderText("Search"), "Val");
     jest.advanceTimersByTime(300);
+    expect(mockOnSearch).toHaveBeenLastCalledWith("Val");
     await user.click(screen.getByTestId("ATL-Combobox-Content-Search-Clear"));
     jest.advanceTimersByTime(300);
 
@@ -491,9 +492,6 @@ describe("Combobox Custom onSearch", () => {
 
     expect(screen.queryAllByTestId("ATL-Glimmer")).toHaveLength(0);
   });
-
-  // implement me once bug is fixed
-  // it("should show the correct header when searching and no results found", () => {});
 
   it("should show the correct message when searching, and no options present", async () => {
     renderCustomOnSearchCombobox(false, true);

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -437,6 +437,7 @@ function renderCombobox() {
       multiSelect={mockMultiSelectValue()}
       selected={mockSelectedValue()}
       onSelect={handleSelect}
+      debounce={0}
     >
       <Combobox.Option id="1" label="Bilbo Baggins" />
       <Combobox.Option id="2" label="Frodo Baggins" />

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -446,7 +446,7 @@ describe("Combobox Custom onSearch", () => {
     mockOnSearch.mockClear();
   });
   it("should only call the debounced onSearch one, with the correct value", async () => {
-    renderCustomOnSearchCombobox(false, true);
+    renderCustomOnSearchCombobox(false);
 
     await user.type(screen.getByPlaceholderText("Search"), "V");
     await user.type(screen.getByPlaceholderText("Search"), "a");
@@ -460,7 +460,7 @@ describe("Combobox Custom onSearch", () => {
   });
 
   it("should call the debounced onSearch with an empty string when cleared with the clear button", async () => {
-    renderCustomOnSearchCombobox(false, true);
+    renderCustomOnSearchCombobox(false);
 
     await user.type(screen.getByPlaceholderText("Search"), "Val");
     jest.advanceTimersByTime(300);
@@ -471,7 +471,7 @@ describe("Combobox Custom onSearch", () => {
   });
 
   it("should not have option filtering behavior out of the box like the non custom onSearch version", async () => {
-    renderCustomOnSearchCombobox(false, true);
+    renderCustomOnSearchCombobox(false);
 
     await user.type(screen.getByPlaceholderText("Search"), "Value 1");
     jest.advanceTimersByTime(300);
@@ -481,13 +481,13 @@ describe("Combobox Custom onSearch", () => {
   });
 
   it("should show the correct amount of loading glimmers when loading is true", () => {
-    renderCustomOnSearchCombobox(true, true);
+    renderCustomOnSearchCombobox(true);
 
     expect(screen.getAllByTestId("ATL-Glimmer")).toHaveLength(5);
   });
 
   it("should not show the loading glimmers when loading is false", () => {
-    renderCustomOnSearchCombobox(false, true);
+    renderCustomOnSearchCombobox(false);
 
     expect(screen.queryAllByTestId("ATL-Glimmer")).toHaveLength(0);
   });
@@ -495,8 +495,8 @@ describe("Combobox Custom onSearch", () => {
   // implement me once bug is fixed
   // it("should show the correct header when searching and no results found", () => {});
 
-  it("should show the correct message when searching, no results found and opitions existed", async () => {
-    renderCustomOnSearchCombobox(false, true, true);
+  it("should show the correct message when searching, and no options present", async () => {
+    renderCustomOnSearchCombobox(false, true);
 
     await user.type(screen.getByPlaceholderText("Search"), "Value 4");
     jest.advanceTimersByTime(300);
@@ -505,17 +505,8 @@ describe("Combobox Custom onSearch", () => {
     expect(screen.getByText("No results for “Value 4”")).toBeInTheDocument();
   });
 
-  it("should show the correct message when no options provided and searching", async () => {
-    renderCustomOnSearchCombobox(false, false);
-
-    await user.type(screen.getByPlaceholderText("Search"), "Value 1");
-    jest.advanceTimersByTime(300);
-
-    expect(screen.getByText("No options yet")).toBeInTheDocument();
-  });
-
-  it("should show the correct message when no options provided and not searching", () => {
-    renderCustomOnSearchCombobox(false, false, true);
+  it("should show the correct message when no options present and not searching", () => {
+    renderCustomOnSearchCombobox(false, true);
 
     expect(screen.getByText("No options yet")).toBeInTheDocument();
   });
@@ -523,7 +514,6 @@ describe("Combobox Custom onSearch", () => {
 
 function renderCustomOnSearchCombobox(
   loading: boolean,
-  hadInitalOptions: boolean,
   renderWithoutOptions = false,
 ) {
   const options = renderWithoutOptions
@@ -540,7 +530,6 @@ function renderCustomOnSearchCombobox(
       onSelect={handleSelect}
       onSearch={mockOnSearch}
       loading={loading}
-      hadInitalOptions={hadInitalOptions}
     >
       {options.map(option => (
         <Combobox.Option id={option.id} label={option.label} key={option.id} />

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -80,6 +80,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           setOpen={setOpen}
           options={filteredOptions}
           hadInitialOptions={options.length > 0}
+          loading={props.loading}
         />
       </div>
     </ComboboxContextProvider>

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -80,7 +80,9 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           open={open}
           setOpen={setOpen}
           options={props.onSearchChange ? options : internalFilteredOptions}
-          hadInitialOptions={options.length > 0}
+          showNoResults={
+            props.showNoResults ? props.showNoResults : options.length > 0
+          }
           loading={props.loading}
           handleSearchChange={handleSearchChange}
         />

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -35,6 +35,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
     handleClose,
     handleSelection,
     filteredOptions,
+    handleSearchChange,
   } = useCombobox(
     props.selected,
     props.onSelect,
@@ -81,6 +82,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           options={filteredOptions}
           hadInitialOptions={options.length > 0}
           loading={props.loading}
+          handleSearchChange={handleSearchChange}
         />
       </div>
     </ComboboxContextProvider>

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -42,8 +42,8 @@ export function Combobox(props: ComboboxProps): JSX.Element {
     options,
     props.onClose,
     props.multiSelect,
-    props.onSearchChange,
-    props.debounce,
+    props.onSearch,
+    props.onSearchDebounce,
   );
 
   return (
@@ -79,7 +79,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           wrapperRef={wrapperRef}
           open={open}
           setOpen={setOpen}
-          options={props.onSearchChange ? options : internalFilteredOptions}
+          options={props.onSearch ? options : internalFilteredOptions}
           hadInitialOptions={
             props.hadInitalOptions !== undefined
               ? props.hadInitalOptions

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -80,11 +80,6 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           open={open}
           setOpen={setOpen}
           options={props.onSearch ? options : internalFilteredOptions}
-          hadInitialOptions={
-            props.hadInitalOptions !== undefined
-              ? props.hadInitalOptions
-              : options.length > 0
-          }
           loading={props.loading}
           handleSearchChange={handleSearchChange}
         />

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -80,9 +80,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           open={open}
           setOpen={setOpen}
           options={props.onSearchChange ? options : internalFilteredOptions}
-          showNoResults={
-            props.showNoResults ? props.showNoResults : options.length > 0
-          }
+          hadInitialOptions={options.length > 0}
           loading={props.loading}
           handleSearchChange={handleSearchChange}
         />

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -80,7 +80,11 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           open={open}
           setOpen={setOpen}
           options={props.onSearchChange ? options : internalFilteredOptions}
-          hadInitialOptions={options.length > 0}
+          hadInitialOptions={
+            props.hadInitalOptions !== undefined
+              ? props.hadInitalOptions
+              : options.length > 0
+          }
           loading={props.loading}
           handleSearchChange={handleSearchChange}
         />

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -34,7 +34,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
     setOpen,
     handleClose,
     handleSelection,
-    filteredOptions,
+    internalFilteredOptions,
     handleSearchChange,
   } = useCombobox(
     props.selected,
@@ -79,7 +79,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           wrapperRef={wrapperRef}
           open={open}
           setOpen={setOpen}
-          options={filteredOptions}
+          options={props.onSearchChange ? options : internalFilteredOptions}
           hadInitialOptions={options.length > 0}
           loading={props.loading}
           handleSearchChange={handleSearchChange}

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -34,9 +34,11 @@ export function Combobox(props: ComboboxProps): JSX.Element {
     setOpen,
     handleClose,
     handleSelection,
+    filteredOptions,
   } = useCombobox(
     props.selected,
     props.onSelect,
+    options,
     props.onClose,
     props.multiSelect,
     props.onSearchChange,
@@ -76,7 +78,8 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           wrapperRef={wrapperRef}
           open={open}
           setOpen={setOpen}
-          options={options}
+          options={filteredOptions}
+          hadInitialOptions={options.length > 0}
         />
       </div>
     </ComboboxContextProvider>

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -39,6 +39,8 @@ export function Combobox(props: ComboboxProps): JSX.Element {
     props.onSelect,
     props.onClose,
     props.multiSelect,
+    props.onSearchChange,
+    props.debounce,
   );
 
   return (

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -132,6 +132,11 @@ export interface ComboboxContentProps {
    * The full set of options for the Combobox in the shape of data, not elements.
    */
   readonly options: ComboboxOption[];
+
+  /**
+   * Was the Combobox provided with initial options, prior to filtering.
+   */
+  readonly hadInitialOptions: boolean;
 }
 
 export interface ComboboxSearchProps {

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -120,6 +120,11 @@ export interface ComboboxContentProps {
   readonly setSearchValue: Dispatch<SetStateAction<string>>;
 
   /**
+   * Function called when search input changes.
+   */
+  readonly handleSearchChange: (value: string) => void;
+
+  /**
    * Reference to the wrapping div element of all the Combobox pieces
    */
   readonly wrapperRef: React.RefObject<HTMLDivElement>;
@@ -170,6 +175,11 @@ export interface ComboboxSearchProps {
    * Setter for the search input value.
    */
   setSearchValue: Dispatch<SetStateAction<string>>;
+
+  /**
+   * Function called when search input changes.
+   */
+  readonly handleSearchChange: (value: string) => void;
 }
 
 export interface ComboboxHeaderProps {

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -50,14 +50,10 @@ export interface ComboboxProps {
   readonly label?: string;
 
   /**
-   * Should the Combobox display the loading state. Only needed when providing custom onSearchChange.
+   * Should the Combobox display the loading state. Primarily used in conjunction with async operations and
+   * onSearchChange fetching options.
    */
   readonly loading?: boolean;
-
-  /**
-   * Should the Combobox display the no search results state over the unpopulated options list state. Only needed when providing custom onSearchChange.
-   */
-  readonly showNoResults?: boolean;
 }
 
 export interface ComboboxActivatorProps {
@@ -149,9 +145,9 @@ export interface ComboboxContentProps {
   readonly options: ComboboxOption[];
 
   /**
-   * Should the Combobox display the no results state over the unpopulated options list state.
+   * Was the Combobox provided with initial options, prior to filtering.
    */
-  readonly showNoResults: boolean;
+  readonly hadInitialOptions: boolean;
 
   /**
    * Should loading state be shown.

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -35,6 +35,16 @@ export interface ComboboxProps {
   readonly onClose?: () => void;
 
   /**
+   * Callback function invoked on Combobox search input change. Receives the current search value as an argument.
+   */
+  readonly onSearchChange?: (searchValue: string) => void;
+
+  /**
+   * The amount of time in ms to debounce the search input change. Defaults to 300ms.
+   */
+  readonly debounce?: number;
+
+  /**
    * The Chip heading for the trigger
    */
   readonly label?: string;

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -40,7 +40,7 @@ export interface ComboboxProps {
   readonly onSearchChange?: (searchValue: string) => void;
 
   /**
-   * The amount of time in ms to debounce the search input change. Defaults to 300ms.
+   * The amount of time in ms to debounce the onSearchChange callback. Defaults to 300ms.
    */
   readonly debounce?: number;
 

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -53,11 +53,6 @@ export interface ComboboxProps {
    * Should the Combobox display the loading state, only needed when providing custom onSearch that has async loading behavior.
    */
   readonly loading?: boolean;
-
-  /**
-   * Did the Combobox have initial options, only needed when providing custom onSearch that can alter the passed in options.
-   */
-  readonly hadInitalOptions?: boolean;
 }
 
 export interface ComboboxActivatorProps {
@@ -149,11 +144,6 @@ export interface ComboboxContentProps {
   readonly options: ComboboxOption[];
 
   /**
-   * Was the Combobox provided with initial options, prior to filtering.
-   */
-  readonly hadInitialOptions: boolean;
-
-  /**
    * Should loading state be shown.
    */
   readonly loading?: boolean;
@@ -216,11 +206,6 @@ export interface ComboboxListProps {
    * The options to display in the list. May be the full set of the Combobox or could be filtered.
    */
   readonly options: ComboboxOption[];
-
-  /**
-   * Used to determine if the empty state should be shown and given priority over the options list.
-   */
-  readonly showEmptyState: boolean;
 
   /**
    * The currently selected options.

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -35,7 +35,7 @@ export interface ComboboxProps {
   readonly onClose?: () => void;
 
   /**
-   * Callback function invoked on Combobox search input change. Receives the current search value as an argument.
+   * Debounced callback function invoked on Combobox search input change. Receives the current search value as an argument.
    */
   readonly onSearchChange?: (searchValue: string) => void;
 
@@ -50,10 +50,14 @@ export interface ComboboxProps {
   readonly label?: string;
 
   /**
-   * Should the Combobox display the loading state. Primarily used in conjunction with async operations and
-   * onSearchChange fetching options.
+   * Should the Combobox display the loading state, only needed when providing custom onSearchChange that has async loading behavior.
    */
   readonly loading?: boolean;
+
+  /**
+   * Did the Combobox have initial options, only needed when providing custom onSearchChange that can alter the passed in options.
+   */
+  readonly hadInitalOptions?: boolean;
 }
 
 export interface ComboboxActivatorProps {

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -37,12 +37,12 @@ export interface ComboboxProps {
   /**
    * Debounced callback function invoked on Combobox search input change. Receives the current search value as an argument.
    */
-  readonly onSearchChange?: (searchValue: string) => void;
+  readonly onSearch?: (searchValue: string) => void;
 
   /**
-   * The amount of time in ms to debounce the onSearchChange callback. Defaults to 300ms.
+   * The amount of time in ms to debounce the onSearch callback. Defaults to 300ms.
    */
-  readonly debounce?: number;
+  readonly onSearchDebounce?: number;
 
   /**
    * The Chip heading for the trigger
@@ -50,12 +50,12 @@ export interface ComboboxProps {
   readonly label?: string;
 
   /**
-   * Should the Combobox display the loading state, only needed when providing custom onSearchChange that has async loading behavior.
+   * Should the Combobox display the loading state, only needed when providing custom onSearch that has async loading behavior.
    */
   readonly loading?: boolean;
 
   /**
-   * Did the Combobox have initial options, only needed when providing custom onSearchChange that can alter the passed in options.
+   * Did the Combobox have initial options, only needed when providing custom onSearch that can alter the passed in options.
    */
   readonly hadInitalOptions?: boolean;
 }

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -48,6 +48,12 @@ export interface ComboboxProps {
    * The Chip heading for the trigger
    */
   readonly label?: string;
+
+  /**
+   * Should the Combobox display the loading state. Primarily used in conjunction with async operations and
+   * onSearchChange fetching options.
+   */
+  readonly loading?: boolean;
 }
 
 export interface ComboboxActivatorProps {
@@ -137,6 +143,11 @@ export interface ComboboxContentProps {
    * Was the Combobox provided with initial options, prior to filtering.
    */
   readonly hadInitialOptions: boolean;
+
+  /**
+   * Should loading state be shown.
+   */
+  readonly loading?: boolean;
 }
 
 export interface ComboboxSearchProps {
@@ -221,6 +232,11 @@ export interface ComboboxListProps {
    * The noun to be used in the empty state message.
    */
   readonly subjectNoun?: string;
+
+  /**
+   * Should loading state be shown.
+   */
+  readonly loading?: boolean;
 }
 
 export interface ComboboxActionProps {

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -50,7 +50,7 @@ export interface ComboboxProps {
   readonly label?: string;
 
   /**
-   * Should the Combobox display the loading state, only needed when providing custom onSearch that has async loading behavior.
+   * Should the Combobox display the loading state.
    */
   readonly loading?: boolean;
 }

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -50,10 +50,14 @@ export interface ComboboxProps {
   readonly label?: string;
 
   /**
-   * Should the Combobox display the loading state. Primarily used in conjunction with async operations and
-   * onSearchChange fetching options.
+   * Should the Combobox display the loading state. Only needed when providing custom onSearchChange.
    */
   readonly loading?: boolean;
+
+  /**
+   * Should the Combobox display the no search results state over the unpopulated options list state. Only needed when providing custom onSearchChange.
+   */
+  readonly showNoResults?: boolean;
 }
 
 export interface ComboboxActivatorProps {
@@ -145,9 +149,9 @@ export interface ComboboxContentProps {
   readonly options: ComboboxOption[];
 
   /**
-   * Was the Combobox provided with initial options, prior to filtering.
+   * Should the Combobox display the no results state over the unpopulated options list state.
    */
-  readonly hadInitialOptions: boolean;
+  readonly showNoResults: boolean;
 
   /**
    * Should loading state be shown.

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
@@ -77,10 +77,10 @@ function renderComboboxActivator(child: ReactElement, open: boolean) {
       setOpen={setOpen}
       handleClose={handleClose}
       selectionHandler={jest.fn()}
-      multiselect={false}
       shouldScroll={{ current: false }}
       open={open}
       selected={[]}
+      searchValue=""
     >
       <ComboboxActivator>{child}</ComboboxActivator>
     </ComboboxContextProvider>,

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -92,7 +92,7 @@ function renderComboboxContent(
       shouldScroll={{ current: false }}
       open={open}
       selected={selected}
-      searchValue=""
+      searchValue={searchValue}
     >
       <ComboboxContent
         selected={selected}
@@ -106,6 +106,7 @@ function renderComboboxContent(
         options={options}
         multiselect={multiSelect}
         hadInitialOptions={hadInitialOptions}
+        handleSearchChange={jest.fn()}
       />
     </ComboboxContextProvider>,
   );

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -81,7 +81,7 @@ function renderComboboxContent(
   selected: ComboboxOption[] = [],
   multiSelect = false,
   open = true,
-  showNoResults = true,
+  hadInitialOptions = true,
   searchValue = "",
 ) {
   return render(
@@ -105,7 +105,7 @@ function renderComboboxContent(
         setOpen={setOpen}
         options={options}
         multiselect={multiSelect}
-        showNoResults={showNoResults}
+        hadInitialOptions={hadInitialOptions}
         handleSearchChange={jest.fn()}
       />
     </ComboboxContextProvider>,

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -39,6 +39,8 @@ describe("ComboboxContent Header", () => {
         [],
         [],
         true,
+        true,
+        false,
       );
 
       expect(queryByText("Select all")).not.toBeInTheDocument();
@@ -61,7 +63,13 @@ describe("ComboboxContent Header", () => {
     });
 
     it("should not render when options do not exist", () => {
-      const { queryByTestId } = renderComboboxContent([], [], false);
+      const { queryByTestId } = renderComboboxContent(
+        [],
+        [],
+        false,
+        true,
+        false,
+      );
 
       expect(queryByTestId("ATL-Combobox-Header")).not.toBeInTheDocument();
     });
@@ -73,6 +81,7 @@ function renderComboboxContent(
   selected: ComboboxOption[] = [],
   multiSelect = false,
   open = true,
+  hadInitialOptions = true,
   searchValue = "",
 ) {
   return render(
@@ -83,6 +92,7 @@ function renderComboboxContent(
       shouldScroll={{ current: false }}
       open={open}
       selected={selected}
+      searchValue=""
     >
       <ComboboxContent
         selected={selected}
@@ -95,6 +105,7 @@ function renderComboboxContent(
         setOpen={setOpen}
         options={options}
         multiselect={multiSelect}
+        hadInitialOptions={hadInitialOptions}
       />
     </ComboboxContextProvider>,
   );

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -81,7 +81,7 @@ function renderComboboxContent(
   selected: ComboboxOption[] = [],
   multiSelect = false,
   open = true,
-  hadInitialOptions = true,
+  showNoResults = true,
   searchValue = "",
 ) {
   return render(
@@ -105,7 +105,7 @@ function renderComboboxContent(
         setOpen={setOpen}
         options={options}
         multiselect={multiSelect}
-        hadInitialOptions={hadInitialOptions}
+        showNoResults={showNoResults}
         handleSearchChange={jest.fn()}
       />
     </ComboboxContextProvider>,

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -40,7 +40,6 @@ describe("ComboboxContent Header", () => {
         [],
         true,
         true,
-        false,
       );
 
       expect(queryByText("Select all")).not.toBeInTheDocument();
@@ -63,13 +62,7 @@ describe("ComboboxContent Header", () => {
     });
 
     it("should not render when options do not exist", () => {
-      const { queryByTestId } = renderComboboxContent(
-        [],
-        [],
-        false,
-        true,
-        false,
-      );
+      const { queryByTestId } = renderComboboxContent([], [], false, true);
 
       expect(queryByTestId("ATL-Combobox-Header")).not.toBeInTheDocument();
     });
@@ -81,7 +74,6 @@ function renderComboboxContent(
   selected: ComboboxOption[] = [],
   multiSelect = false,
   open = true,
-  hadInitialOptions = true,
   searchValue = "",
 ) {
   return render(
@@ -105,7 +97,6 @@ function renderComboboxContent(
         setOpen={setOpen}
         options={options}
         multiselect={multiSelect}
-        hadInitialOptions={hadInitialOptions}
         handleSearchChange={jest.fn()}
       />
     </ComboboxContextProvider>,

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -58,6 +58,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         optionsListRef={optionsListRef}
         searchValue={props.searchValue}
         subjectNoun={props.subjectNoun}
+        loading={props.loading}
       />
       {props.actionElements && (
         <div className={styles.actions} role="group">

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -10,18 +10,11 @@ import { useComboboxAccessibility } from "../../hooks/useComboboxAccessibility";
 import { ComboboxContentProps } from "../../Combobox.types";
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
-  const optionsExist = props.options.length > 0;
-
-  const { filteredOptions, optionsListRef } = useComboboxContent(
-    props.options,
-    props.open,
-    props.selected,
-    props.searchValue,
-  );
+  const { optionsListRef } = useComboboxContent(props.open, props.selected);
 
   const { popperRef, popperStyles, attributes } = useComboboxAccessibility(
     props.handleSelection,
-    filteredOptions,
+    props.options,
     optionsListRef,
     props.open,
     props.wrapperRef,
@@ -44,23 +37,23 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         setSearchValue={props.setSearchValue}
       />
 
-      {props.multiselect && optionsExist && (
+      {props.multiselect && props.hadInitialOptions && (
         <ComboboxContentHeader
-          hasOptionsVisible={filteredOptions.length > 0}
+          hasOptionsVisible={props.options.length > 0}
           subjectNoun={props.subjectNoun}
           selectedCount={props.selected.length}
           onClearAll={() => {
             props.selectedStateSetter([]);
           }}
           onSelectAll={() => {
-            props.selectedStateSetter(filteredOptions);
+            props.selectedStateSetter(props.options);
           }}
         />
       )}
       <ComboboxContentList
         multiselect={props.multiselect}
-        showEmptyState={!optionsExist}
-        options={filteredOptions}
+        showEmptyState={!props.hadInitialOptions}
+        options={props.options}
         selected={props.selected}
         optionsListRef={optionsListRef}
         searchValue={props.searchValue}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -38,7 +38,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         handleSearchChange={props.handleSearchChange}
       />
 
-      {props.multiselect && props.showNoResults && (
+      {props.multiselect && props.hadInitialOptions && (
         <ComboboxContentHeader
           hasOptionsVisible={props.options.length > 0}
           subjectNoun={props.subjectNoun}
@@ -53,7 +53,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       )}
       <ComboboxContentList
         multiselect={props.multiselect}
-        showEmptyState={!props.showNoResults}
+        showEmptyState={!props.hadInitialOptions}
         options={props.options}
         selected={props.selected}
         optionsListRef={optionsListRef}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -35,6 +35,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         placeholder={props.subjectNoun}
         searchValue={props.searchValue}
         setSearchValue={props.setSearchValue}
+        handleSearchChange={props.handleSearchChange}
       />
 
       {props.multiselect && props.hadInitialOptions && (

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -38,7 +38,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         handleSearchChange={props.handleSearchChange}
       />
 
-      {props.multiselect && props.hadInitialOptions && (
+      {props.multiselect && props.showNoResults && (
         <ComboboxContentHeader
           hasOptionsVisible={props.options.length > 0}
           subjectNoun={props.subjectNoun}
@@ -53,7 +53,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       )}
       <ComboboxContentList
         multiselect={props.multiselect}
-        showEmptyState={!props.hadInitialOptions}
+        showEmptyState={!props.showNoResults}
         options={props.options}
         selected={props.selected}
         optionsListRef={optionsListRef}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -10,6 +10,7 @@ import { useComboboxAccessibility } from "../../hooks/useComboboxAccessibility";
 import { ComboboxContentProps } from "../../Combobox.types";
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
+  const optionsExist = props.options.length > 0;
   const { optionsListRef } = useComboboxContent(props.open, props.selected);
 
   const { popperRef, popperStyles, attributes } = useComboboxAccessibility(
@@ -38,9 +39,9 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         handleSearchChange={props.handleSearchChange}
       />
 
-      {props.multiselect && props.hadInitialOptions && (
+      {props.multiselect && optionsExist && (
         <ComboboxContentHeader
-          hasOptionsVisible={props.options.length > 0}
+          hasOptionsVisible={optionsExist}
           subjectNoun={props.subjectNoun}
           selectedCount={props.selected.length}
           onClearAll={() => {
@@ -53,7 +54,6 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       )}
       <ComboboxContentList
         multiselect={props.multiselect}
-        showEmptyState={!props.hadInitialOptions}
         options={props.options}
         selected={props.selected}
         optionsListRef={optionsListRef}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
@@ -57,3 +57,7 @@
 .scrollNone::after {
   opacity: 0;
 }
+
+.loadingContainer {
+  padding: var(--space-small) var(--space-base);
+}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
@@ -59,5 +59,5 @@
 }
 
 .loadingContainer {
-  padding: var(--space-small) var(--space-base);
+  padding: var(--space-base) var(--space-base);
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css.d.ts
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css.d.ts
@@ -6,6 +6,7 @@ declare const styles: {
   readonly "scrollTop": string;
   readonly "scrollNone": string;
   readonly "scrollBottom": string;
+  readonly "loadingContainer": string;
 };
 export = styles;
 

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.test.tsx
@@ -18,43 +18,20 @@ describe("ComboboxContentList", () => {
     expect(queryByText("No Options yet")).not.toBeInTheDocument();
   });
 
-  describe("when showEmptyState is true", () => {
-    it("should render a generic message if no options nor subjectNoun are provided", () => {
-      const { getByText } = renderComboboxContentList([], [], true);
+  describe("when no options are present", () => {
+    it("should render a generic message if no subjectNoun provided", () => {
+      const { getByText } = renderComboboxContentList([], []);
 
       expect(getByText("No options yet")).toBeInTheDocument();
     });
 
-    it("should render a message if no options are provided and a subjectNoun is provided", () => {
-      const { getByText } = renderComboboxContentList(
-        [],
-        [],
-        true,
-        "",
-        "Plumbus",
-      );
+    it("should render a message if a subjectNoun is provided", () => {
+      const { getByText } = renderComboboxContentList([], [], "", "Plumbus");
       expect(getByText("You don't have any Plumbus yet")).toBeInTheDocument();
     });
-    it("should render a message if no options are provided and a search term is entered", () => {
-      const { getByText } = renderComboboxContentList(
-        [],
-        [],
-        true,
-        "Frederick",
-      );
-      expect(getByText("No options yet")).toBeInTheDocument();
-    });
-  });
-
-  describe("when showEmptyState is false", () => {
-    it("should render a message if no options are provided and a search term is entered", () => {
-      const { getByText } = renderComboboxContentList(
-        [],
-        [],
-        false,
-        "Frederick",
-      );
-      expect(getByText("No results for “Frederick”")).toBeInTheDocument();
+    it("should render a message if a search term is entered", () => {
+      const { getByText } = renderComboboxContentList([], [], "Frederick");
+      expect(getByText(/No results for “Frederick”/)).toBeInTheDocument();
     });
   });
 });
@@ -71,7 +48,6 @@ function renderComboboxContentList(
     },
   ],
   selected: ComboboxOption[] = [],
-  showEmptyState = false,
   searchValue = "",
   subjectNoun?: string,
 ) {
@@ -88,7 +64,6 @@ function renderComboboxContentList(
       <ComboboxContentList
         multiselect={false}
         options={options}
-        showEmptyState={showEmptyState}
         selected={selected}
         optionsListRef={{ current: null }}
         searchValue={searchValue}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.test.tsx
@@ -80,10 +80,10 @@ function renderComboboxContentList(
       setOpen={jest.fn()}
       handleClose={jest.fn()}
       selectionHandler={jest.fn()}
-      multiselect={false}
       shouldScroll={{ current: false }}
       open={true}
       selected={[]}
+      searchValue=""
     >
       <ComboboxContentList
         multiselect={false}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
@@ -3,49 +3,19 @@ import classnames from "classnames";
 import { Text } from "@jobber/components/Text";
 import { Glimmer } from "@jobber/components/Glimmer";
 import styles from "./ComboboxContentList.css";
-import { ComboboxListProps } from "../../../Combobox.types";
+import {
+  ComboboxListProps,
+  ComboboxOption as ComboboxOptionType,
+} from "../../../Combobox.types";
 import { ComboboxOption } from "../../ComboboxOption/ComboboxOption";
 
 export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
-  const [listScrollState, setlistScrollState] = useState("");
   const showOptions = !props.showEmptyState && !props.loading;
-
-  useEffect(() => {
-    const handleScroll = () => {
-      if (props.optionsListRef.current) {
-        const { scrollTop, clientHeight, scrollHeight } =
-          props.optionsListRef.current;
-
-        if (scrollHeight === clientHeight) {
-          setlistScrollState("scrollNone");
-        } else if (scrollTop === 0) {
-          setlistScrollState("scrollTop");
-        } else if (scrollTop + clientHeight === scrollHeight) {
-          setlistScrollState("scrollBottom");
-        } else {
-          setlistScrollState("");
-        }
-      }
-    };
-
-    if (!props.showEmptyState && props.options.length === 0) {
-      handleScroll();
-    }
-
-    if (props.optionsListRef.current) {
-      props.optionsListRef.current.addEventListener("scroll", handleScroll);
-      handleScroll();
-    }
-
-    return () => {
-      if (props.optionsListRef.current) {
-        props.optionsListRef.current.removeEventListener(
-          "scroll",
-          handleScroll,
-        );
-      }
-    };
-  }, [props.options]);
+  const { listScrollState } = useScrollState(
+    props.optionsListRef,
+    props.options,
+    props.showEmptyState,
+  );
 
   return (
     <div
@@ -103,4 +73,48 @@ function getZeroIndexStateText(subjectNoun?: string) {
   }
 
   return "No options yet";
+}
+
+function useScrollState(
+  optionsListRef: React.RefObject<HTMLUListElement>,
+  options: ComboboxOptionType[],
+  showEmptyState: boolean,
+) {
+  const [listScrollState, setlistScrollState] = useState("");
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (optionsListRef.current) {
+        const { scrollTop, clientHeight, scrollHeight } =
+          optionsListRef.current;
+
+        if (scrollHeight === clientHeight) {
+          setlistScrollState("scrollNone");
+        } else if (scrollTop === 0) {
+          setlistScrollState("scrollTop");
+        } else if (scrollTop + clientHeight === scrollHeight) {
+          setlistScrollState("scrollBottom");
+        } else {
+          setlistScrollState("");
+        }
+      }
+    };
+
+    if (!showEmptyState && options.length === 0) {
+      handleScroll();
+    }
+
+    if (optionsListRef.current) {
+      optionsListRef.current.addEventListener("scroll", handleScroll);
+      handleScroll();
+    }
+
+    return () => {
+      if (optionsListRef.current) {
+        optionsListRef.current.removeEventListener("scroll", handleScroll);
+      }
+    };
+  }, [options]);
+
+  return { listScrollState };
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
@@ -42,9 +42,13 @@ export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
               );
             })}
           {props.loading && (
-            <div className={styles.loadingContainer}>
-              <Glimmer size="larger" />
-            </div>
+            <>
+              {Array.from({ length: 5 }).map((_, index) => (
+                <div className={styles.loadingContainer} key={index}>
+                  <Glimmer shape="rectangle" size="small" />
+                </div>
+              ))}
+            </>
           )}
         </ul>
       )}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from "react";
 import classnames from "classnames";
 import { Text } from "@jobber/components/Text";
+import { Glimmer } from "@jobber/components/Glimmer";
 import styles from "./ComboboxContentList.css";
 import { ComboboxListProps } from "../../../Combobox.types";
 import { ComboboxOption } from "../../ComboboxOption/ComboboxOption";
 
 export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
   const [listScrollState, setlistScrollState] = useState("");
+  const showOptions = !props.showEmptyState && !props.loading;
 
   useEffect(() => {
     const handleScroll = () => {
@@ -59,7 +61,7 @@ export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
           aria-multiselectable={props.multiselect}
           ref={props.optionsListRef}
         >
-          {!props.showEmptyState &&
+          {showOptions &&
             props.options.map(option => {
               return (
                 <ComboboxOption
@@ -69,6 +71,11 @@ export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
                 />
               );
             })}
+          {props.loading && (
+            <div className={styles.loadingContainer}>
+              <Glimmer size="larger" />
+            </div>
+          )}
         </ul>
       )}
       {!props.showEmptyState && props.options.length === 0 && (

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
@@ -10,11 +10,12 @@ import {
 import { ComboboxOption } from "../../ComboboxOption/ComboboxOption";
 
 export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
-  const showOptions = !props.showEmptyState && !props.loading;
+  const optionsExist = props.options.length > 0;
+  const showOptions = optionsExist && !props.loading;
+  const hasSearchTerm = props.searchValue.length > 0;
   const { listScrollState } = useScrollState(
     props.optionsListRef,
     props.options,
-    props.showEmptyState,
   );
 
   return (
@@ -24,7 +25,7 @@ export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
         styles[listScrollState as keyof typeof styles],
       )}
     >
-      {!props.showEmptyState && props.options.length > 0 && (
+      {optionsExist && (
         <ul
           className={styles.optionsList}
           role="listbox"
@@ -52,7 +53,8 @@ export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
           )}
         </ul>
       )}
-      {!props.showEmptyState && props.options.length === 0 && (
+
+      {hasSearchTerm && !optionsExist && (
         <div className={styles.filterMessage}>
           <Text variation="subdued">
             No results for {`“${props.searchValue}”`}
@@ -60,7 +62,7 @@ export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
         </div>
       )}
 
-      {props.showEmptyState && (
+      {!hasSearchTerm && !optionsExist && (
         <div className={styles.emptyStateMessage}>
           <Text variation="subdued">
             {getZeroIndexStateText(props.subjectNoun)}
@@ -82,7 +84,6 @@ function getZeroIndexStateText(subjectNoun?: string) {
 function useScrollState(
   optionsListRef: React.RefObject<HTMLUListElement>,
   options: ComboboxOptionType[],
-  showEmptyState: boolean,
 ) {
   const [listScrollState, setlistScrollState] = useState("");
 
@@ -104,7 +105,7 @@ function useScrollState(
       }
     };
 
-    if (!showEmptyState && options.length === 0) {
+    if (options.length === 0) {
       handleScroll();
     }
 

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.test.tsx
@@ -9,6 +9,7 @@ describe("ComboboxContentSearch", () => {
         placeholder="Bloop"
         searchValue=""
         open={true}
+        handleSearchChange={jest.fn()}
         setSearchValue={jest.fn()}
       />,
     );
@@ -19,6 +20,7 @@ describe("ComboboxContentSearch", () => {
       <ComboboxContentSearch
         searchValue=""
         open={true}
+        handleSearchChange={jest.fn()}
         setSearchValue={jest.fn()}
       />,
     );
@@ -31,6 +33,7 @@ describe("ComboboxContentSearch", () => {
       <ComboboxContentSearch
         searchValue=""
         open={true}
+        handleSearchChange={jest.fn()}
         setSearchValue={setSearchValue}
       />,
     );
@@ -45,6 +48,7 @@ describe("ComboboxContentSearch", () => {
       <ComboboxContentSearch
         searchValue="Rumplestiltskin"
         open={true}
+        handleSearchChange={jest.fn()}
         setSearchValue={setSearchValue}
       />,
     );
@@ -58,6 +62,7 @@ describe("ComboboxContentSearch", () => {
       <ComboboxContentSearch
         searchValue="Rumplestiltskin"
         open={true}
+        handleSearchChange={jest.fn()}
         setSearchValue={setSearchValue}
       />,
     );
@@ -71,6 +76,7 @@ describe("ComboboxContentSearch", () => {
       <ComboboxContentSearch
         searchValue="Rumplestiltskin"
         open={true}
+        handleSearchChange={jest.fn()}
         setSearchValue={jest.fn()}
       />,
     );
@@ -84,6 +90,7 @@ describe("ComboboxContentSearch", () => {
       <ComboboxContentSearch
         searchValue=""
         open={true}
+        handleSearchChange={jest.fn()}
         setSearchValue={jest.fn()}
       />,
     );

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.tsx
@@ -45,10 +45,12 @@ export function ComboboxContentSearch(props: ComboboxSearchProps): JSX.Element {
 
   function clearSearch() {
     props.setSearchValue("");
+    props.handleSearchChange("");
     searchRef.current?.focus();
   }
 
   function handleSearch(event: React.ChangeEvent<HTMLInputElement>) {
-    props.setSearchValue(event.target.value);
+    props.setSearchValue(event.currentTarget.value);
+    props.handleSearchChange(event.currentTarget.value);
   }
 }

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.test.tsx
@@ -97,6 +97,7 @@ function renderOption(
       open={true}
       shouldScroll={{ current: false }}
       selectionHandler={onSelect}
+      searchValue=""
     >
       <ComboboxOptionComponent label={label} id={id} />
     </ComboboxContextProvider>,

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
@@ -125,6 +125,7 @@ function renderTrigger(
       open={open}
       shouldScroll={{ current: false }}
       selectionHandler={jest.fn()}
+      searchValue=""
     >
       <ComboboxTrigger label={label} selected={selected} />
     </ComboboxContextProvider>,

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -49,16 +49,13 @@ export function useCombobox(
     [],
   );
 
-  const debouncedFilterOptions = useCallback(
-    debounce((value: string) => {
-      const filtered = options.filter(option => {
-        return option.label.toLowerCase().includes(value.toLowerCase());
-      });
+  const debouncedFilterOptions = useCallback((value: string) => {
+    const filtered = options.filter(option => {
+      return option.label.toLowerCase().includes(value.toLowerCase());
+    });
 
-      setInternalFilteredOptions(filtered);
-    }, debounceTime),
-    [],
-  );
+    setInternalFilteredOptions(filtered);
+  }, []);
 
   const { handleClose, handleSelection } = useMakeComboboxHandlers(
     setOpen,

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -1,4 +1,12 @@
-import React, { Dispatch, MutableRefObject, useRef, useState } from "react";
+import React, {
+  Dispatch,
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import debounce from "lodash/debounce";
 import {
   UseMakeComboboxHandlersReturn,
   useMakeComboboxHandlers,
@@ -21,11 +29,27 @@ export function useCombobox(
   onSelect: (selection: ComboboxOption[]) => void,
   onClose?: () => void,
   multiSelect?: boolean,
+  onSearchChange?: (searchValue: string) => void,
+  debounceTime: number = 300,
 ): UseComboboxReturn {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const shouldScroll = useRef<boolean>(false);
   const [open, setOpen] = useState<boolean>(false);
   const [searchValue, setSearchValue] = useState<string>("");
+
+  const searchChangeCallback = useCallback(
+    debounce(
+      (value: string) => onSearchChange && onSearchChange(value),
+      debounceTime,
+    ),
+    [],
+  );
+
+  useEffect(() => {
+    if (onSearchChange) {
+      searchChangeCallback(searchValue);
+    }
+  }, [searchValue]);
 
   const { handleClose, handleSelection } = useMakeComboboxHandlers(
     setOpen,

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -22,11 +22,13 @@ type UseComboboxReturn = {
   selectedOptions: ComboboxOption[];
   selectedStateSetter: (selection: ComboboxOption[]) => void;
   shouldScroll: MutableRefObject<boolean>;
+  filteredOptions: ComboboxOption[];
 } & UseMakeComboboxHandlersReturn;
 
 export function useCombobox(
   selected: ComboboxOption[],
   onSelect: (selection: ComboboxOption[]) => void,
+  options: ComboboxOption[],
   onClose?: () => void,
   multiSelect?: boolean,
   onSearchChange?: (searchValue: string) => void,
@@ -36,6 +38,8 @@ export function useCombobox(
   const shouldScroll = useRef<boolean>(false);
   const [open, setOpen] = useState<boolean>(false);
   const [searchValue, setSearchValue] = useState<string>("");
+  const [filteredOptions, setFilteredOptions] =
+    useState<ComboboxOption[]>(options);
 
   const searchChangeCallback = useCallback(
     debounce(
@@ -45,9 +49,22 @@ export function useCombobox(
     [],
   );
 
+  const debouncedFilterOptions = useCallback(
+    debounce((value: string) => {
+      const filtered = options.filter(option => {
+        return option.label.toLowerCase().includes(value.toLowerCase());
+      });
+
+      setFilteredOptions(filtered);
+    }, debounceTime),
+    [],
+  );
+
   useEffect(() => {
     if (onSearchChange) {
       searchChangeCallback(searchValue);
+    } else {
+      debouncedFilterOptions(searchValue);
     }
   }, [searchValue]);
 
@@ -72,5 +89,6 @@ export function useCombobox(
     shouldScroll,
     handleClose,
     handleSelection,
+    filteredOptions,
   };
 }

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -2,7 +2,6 @@ import React, {
   Dispatch,
   MutableRefObject,
   useCallback,
-  useEffect,
   useRef,
   useState,
 } from "react";
@@ -23,6 +22,7 @@ type UseComboboxReturn = {
   selectedStateSetter: (selection: ComboboxOption[]) => void;
   shouldScroll: MutableRefObject<boolean>;
   filteredOptions: ComboboxOption[];
+  handleSearchChange: (value: string) => void;
 } & UseMakeComboboxHandlersReturn;
 
 export function useCombobox(
@@ -60,14 +60,6 @@ export function useCombobox(
     [],
   );
 
-  useEffect(() => {
-    if (onSearchChange) {
-      searchChangeCallback(searchValue);
-    } else {
-      debouncedFilterOptions(searchValue);
-    }
-  }, [searchValue]);
-
   const { handleClose, handleSelection } = useMakeComboboxHandlers(
     setOpen,
     setSearchValue,
@@ -90,5 +82,8 @@ export function useCombobox(
     handleClose,
     handleSelection,
     filteredOptions,
+    handleSearchChange: onSearchChange
+      ? searchChangeCallback
+      : debouncedFilterOptions,
   };
 }

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -31,7 +31,7 @@ export function useCombobox(
   options: ComboboxOption[],
   onClose?: () => void,
   multiSelect?: boolean,
-  onSearchChange?: (searchValue: string) => void,
+  onSearch?: (searchValue: string) => void,
   debounceTime: number = 300,
 ): UseComboboxReturn {
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -41,11 +41,8 @@ export function useCombobox(
   const [internalFilteredOptions, setInternalFilteredOptions] =
     useState<ComboboxOption[]>(options);
 
-  const searchChangeCallback = useCallback(
-    debounce(
-      (value: string) => onSearchChange && onSearchChange(value),
-      debounceTime,
-    ),
+  const searchCallback = useCallback(
+    debounce((value: string) => onSearch && onSearch(value), debounceTime),
     [],
   );
 
@@ -79,8 +76,6 @@ export function useCombobox(
     handleClose,
     handleSelection,
     internalFilteredOptions,
-    handleSearchChange: onSearchChange
-      ? searchChangeCallback
-      : debouncedFilterOptions,
+    handleSearchChange: onSearch ? searchCallback : debouncedFilterOptions,
   };
 }

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -21,7 +21,7 @@ type UseComboboxReturn = {
   selectedOptions: ComboboxOption[];
   selectedStateSetter: (selection: ComboboxOption[]) => void;
   shouldScroll: MutableRefObject<boolean>;
-  filteredOptions: ComboboxOption[];
+  internalFilteredOptions: ComboboxOption[];
   handleSearchChange: (value: string) => void;
 } & UseMakeComboboxHandlersReturn;
 
@@ -38,7 +38,7 @@ export function useCombobox(
   const shouldScroll = useRef<boolean>(false);
   const [open, setOpen] = useState<boolean>(false);
   const [searchValue, setSearchValue] = useState<string>("");
-  const [filteredOptions, setFilteredOptions] =
+  const [internalFilteredOptions, setInternalFilteredOptions] =
     useState<ComboboxOption[]>(options);
 
   const searchChangeCallback = useCallback(
@@ -55,7 +55,7 @@ export function useCombobox(
         return option.label.toLowerCase().includes(value.toLowerCase());
       });
 
-      setFilteredOptions(filtered);
+      setInternalFilteredOptions(filtered);
     }, debounceTime),
     [],
   );
@@ -81,7 +81,7 @@ export function useCombobox(
     shouldScroll,
     handleClose,
     handleSelection,
-    filteredOptions,
+    internalFilteredOptions,
     handleSearchChange: onSearchChange
       ? searchChangeCallback
       : debouncedFilterOptions,

--- a/packages/components/src/Combobox/hooks/useComboboxContent.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxContent.ts
@@ -3,21 +3,15 @@ import { ComboboxOption } from "../Combobox.types";
 import { ComboboxContext } from "../ComboboxProvider";
 
 interface useComboboxContent {
-  filteredOptions: ComboboxOption[];
   optionsListRef: React.RefObject<HTMLUListElement>;
 }
 
 export function useComboboxContent(
-  options: ComboboxOption[],
   open: boolean,
   selected: ComboboxOption[],
-  searchValue: string,
 ): useComboboxContent {
   const { shouldScroll } = useContext(ComboboxContext);
   const optionsListRef = useRef<HTMLUListElement>(null);
-  const filteredOptions = options.filter(option =>
-    option.label.toLowerCase().includes(searchValue.toLowerCase()),
-  );
 
   useEffect(() => {
     if (open && shouldScroll.current && optionsListRef.current) {
@@ -34,7 +28,6 @@ export function useComboboxContent(
   }, [open, selected]);
 
   return {
-    filteredOptions,
     optionsListRef,
   };
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

we have a known use case where we want to load data as it is searched for rather than having it all in the list up front. it's a tremendous amount of options where you simply wouldn't want to scroll thru them all, nor select them all

with that, we need to expose the ability for a consumer to hook into the search input's value as it changes, to receive that value and go grab whatever data makes sense for that. once they have the data, they can simply iterate over it as the new `Combobox.Option`s

this does present some notable differences from the current experience where we are able to make many more assumptions about the state and behavior of things, so some additional props were needed 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
- onSearch prop, allowing consumer to receive the search term as it changes (debounced)
- a debounce prop to configure the debounce time on said callback, defaults to 300ms
- loading prop to manually display a glimmer while loading, only useful for onSearch flow where we are likely fetching additional data with some sort of API request
- added the corresponding Glimmer and some simple styles to give it some spacing

**Consumer Responsibilites**
when using `onSearch` we stop doing a handful of things for you. you are now responsible for implementing the search, filtering, fetching data, setting/unsetting loading states etc.

the consumer is also responsible handling the clear search, which can be done with the clear button or simply deleting, and the search term is `""` again - at which point it would be up to the consumer to either restore a cached initial list of options, or perhaps simply fire a query again with no search terms to fetch what would hopefully be the original data


### Changed

- moved some scroll code into a hook
- adjusted options logic & var naming, moving it up and simply passing it down to the sub components who don't really care if they are filtered options or the initial options - we can make the same decisions without knowing that detail
- fixed/updated some tests
- if you are searching and have no results, we simply show the `No results for {blah}` no matter what. if you had no options initially or not makes no difference. Search message > Empty message as far as priority now.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

I have an example in the webstory for Combobox now, you can check that out or make your own if you want. it's a bit verbose but simple example of how you might implement this yourself and what would be needed

- existing tests should pass
- debounce should work on the passed in `onSearch` meaning if you do "fsadfadsfs" really fast, you'd only receive one call for that and not however many characters that is
- the non `onSearch` flow should be unchanged

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
