### PR TITLE
docs(components): Improve Combobox Custom Search Example

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { useQuery } from "@apollo/client";
 import { Combobox, ComboboxOption } from "@jobber/components/Combobox";
 import { Button } from "@jobber/components/Button";
 import { Typography } from "@jobber/components/Typography";
 import { Chip } from "@jobber/components/Chip";
 import { Icon } from "@jobber/components/Icon";
-import { LIST_QUERY, ListQueryType, apolloClient } from "./storyUtils";
+import { useFakeQuery } from "./storyUtils";
 
 export default {
   title: "Components/Selections/Combobox/Web",
@@ -293,14 +292,7 @@ const DynamicButton: ComponentStory<typeof Combobox> = args => {
 const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
   const [selected, setSelected] = useState<ComboboxOption[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
-  const { data, loading } = useQuery<ListQueryType>(LIST_QUERY, {
-    variables: {
-      filter: { name: searchTerm },
-    },
-    fetchPolicy: "network-only",
-    nextFetchPolicy: "cache-first",
-    client: apolloClient,
-  });
+  const { data, loading } = useFakeQuery(searchTerm);
 
   return (
     <Combobox
@@ -339,3 +331,17 @@ DynamicAction.args = {};
 
 export const CustomSearch = ComboboxCustomSearch.bind({});
 CustomSearch.args = {};
+
+CustomSearch.parameters = {
+  previewTabs: {
+    code: {
+      hidden: false,
+      extraImports: {
+        "./useFakeQuery": ["useFakeQuery"],
+      },
+      files: {
+        "/useFakeQuery.ts": require("!raw-loader!./storyUtils").default,
+      },
+    },
+  },
+};

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { useQuery } from "@apollo/client";
 import { Combobox, ComboboxOption } from "@jobber/components/Combobox";
 import { Button } from "@jobber/components/Button";
 import { Typography } from "@jobber/components/Typography";
 import { Chip } from "@jobber/components/Chip";
 import { Icon } from "@jobber/components/Icon";
+import { LIST_QUERY, ListQueryType, apolloClient } from "./storyUtils";
 
 export default {
   title: "Components/Selections/Combobox/Web",
@@ -289,33 +291,16 @@ const DynamicButton: ComponentStory<typeof Combobox> = args => {
 };
 
 const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
-  const initialOptions: ComboboxOption[] = [
-    { id: "1", label: "David" },
-    { id: "2", label: "Johnny" },
-    { id: "3", label: "Moira" },
-    { id: "4", label: "Alexis" },
-  ];
   const [selected, setSelected] = useState<ComboboxOption[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [displayOptions, setDisplayOptions] =
-    useState<ComboboxOption[]>(initialOptions);
-
-  const mockQuery = (query: string) => {
-    return new Promise<ComboboxOption[]>(resolve => {
-      setTimeout(() => {
-        if (query === "no") {
-          resolve([]);
-        } else {
-          resolve([
-            { id: "5", label: `Patrick ${query}` },
-            { id: "6", label: `Roland ${query}` },
-            { id: "7", label: `Twyla ${query}` },
-            { id: "8", label: `Stevie ${query}` },
-          ]);
-        }
-      }, 500);
-    });
-  };
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const { data, loading } = useQuery<ListQueryType>(LIST_QUERY, {
+    variables: {
+      filter: { name: searchTerm },
+    },
+    fetchPolicy: "network-only",
+    nextFetchPolicy: "cache-first",
+    client: apolloClient,
+  });
 
   return (
     <Combobox
@@ -324,29 +309,11 @@ const ComboboxCustomSearch: ComponentStory<typeof Combobox> = args => {
       selected={selected}
       label="Teammates"
       multiSelect
-      onSearch={async (term: string) => {
-        setLoading(true);
-
-        if (term == "") {
-          setDisplayOptions(initialOptions);
-        } else {
-          const results = await mockQuery(term);
-
-          setDisplayOptions(results);
-        }
-
-        setLoading(false);
-      }}
+      onSearch={setSearchTerm}
       loading={loading}
     >
-      {displayOptions.map(option => {
-        return (
-          <Combobox.Option
-            key={option.id}
-            id={option.id}
-            label={option.label}
-          />
-        );
+      {data?.characters?.results?.map(({ name }) => {
+        return <Combobox.Option key={name} id={name} label={name} />;
       })}
     </Combobox>
   );

--- a/docs/components/Combobox/storyUtils.ts
+++ b/docs/components/Combobox/storyUtils.ts
@@ -1,14 +1,13 @@
-import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
+import { ApolloClient, InMemoryCache, gql, useQuery } from "@apollo/client";
 
-export interface ListQueryType {
+interface ListQueryType {
   characters: {
     results: {
       name: string;
     }[];
   };
 }
-
-export const LIST_QUERY = gql`
+const LIST_QUERY = gql`
   query ListQuery($filter: FilterCharacter) {
     characters(filter: $filter) {
       results {
@@ -17,8 +16,18 @@ export const LIST_QUERY = gql`
     }
   }
 `;
-
-export const apolloClient = new ApolloClient({
+const apolloClient = new ApolloClient({
   uri: "https://rickandmortyapi.com/graphql",
   cache: new InMemoryCache(),
 });
+
+export function useFakeQuery(searchTerm: string) {
+  return useQuery<ListQueryType>(LIST_QUERY, {
+    variables: {
+      filter: { name: searchTerm },
+    },
+    fetchPolicy: "network-only",
+    nextFetchPolicy: "cache-first",
+    client: apolloClient,
+  });
+}

--- a/docs/components/Combobox/storyUtils.ts
+++ b/docs/components/Combobox/storyUtils.ts
@@ -1,0 +1,24 @@
+import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
+
+export interface ListQueryType {
+  characters: {
+    results: {
+      name: string;
+    }[];
+  };
+}
+
+export const LIST_QUERY = gql`
+  query ListQuery($filter: FilterCharacter) {
+    characters(filter: $filter) {
+      results {
+        name
+      }
+    }
+  }
+`;
+
+export const apolloClient = new ApolloClient({
+  uri: "https://rickandmortyapi.com/graphql",
+  cache: new InMemoryCache(),
+});


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

per some feedback on the initial `onSearch` PR, it would be preferable to have more realistic code as an example for how to implement a custom search with the `onSearch` prop talking to an api to fetch results based on the query

## Changes

swapped out the scuffed code to use Apollo stuff to talk to a Richard and Mortimer character API

make a lil util file with the necessary code because if you have it in the webstory bad things happen, plus it's tidier this way

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

just play around with it! see that you have some options loaded initially

search for some characters not available in the initial set of data, see that it fetches them

undo the search term, get your initial options back!

I will say it's very hard to see the loading state now. I'm not sure this setup is actually ever setting loading to be `true` long enough to be perceptible...

it is definitely toggling the value, but it's difficult to see the loading state at all

![image](https://github.com/GetJobber/atlantis/assets/11843215/2c960156-72ce-4a64-b49a-4d1dbdd94ab1)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
