### PR TITLE
feat(components): Add data-value to sortable options

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -111,19 +111,47 @@ const Template: ComponentStory<typeof DataList> = args => {
           {
             key: "label",
             options: [
-              { label: "First name (A-Z)", order: "asc" },
-              { label: "First name (Z-A)", order: "desc" },
-              { label: "Last name (A-Z)", order: "asc" },
-              { label: "Last name (Z-A)", order: "desc" },
+              {
+                label: "First name (A-Z)",
+                order: "asc",
+                dataValue: "firstName",
+              },
+              {
+                label: "First name (Z-A)",
+                order: "desc",
+                dataValue: "firstName",
+              },
+              { label: "Last name (A-Z)", order: "asc", dataValue: "lastName" },
+              {
+                label: "Last name (Z-A)",
+                order: "desc",
+                dataValue: "lastName",
+              },
             ],
           },
           {
             key: "home",
             options: [
-              { label: "Home world (A-Z)", order: "asc" },
-              { label: "Home world (Z-A)", order: "desc" },
-              { label: "Population (A-Z)", order: "asc" },
-              { label: "Population (Z-A)", order: "desc" },
+              {
+                label: "Home world (A-Z)",
+                order: "asc",
+                dataValue: "homeWorld",
+              },
+              {
+                label: "Home world (Z-A)",
+                order: "desc",
+                dataValue: "homeWorld",
+              },
+              {
+                label: "Population (A-Z)",
+                order: "asc",
+                dataValue: "homePopulation",
+              },
+              {
+                label: "Population (Z-A)",
+                order: "desc",
+                dataValue: "homePopulation",
+              },
             ],
           },
           { key: "lastActivity" },

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -112,20 +112,20 @@ const Template: ComponentStory<typeof DataList> = args => {
             key: "label",
             options: [
               {
+                id: "firstName",
                 label: "First name (A-Z)",
                 order: "asc",
-                dataValue: "firstName",
               },
               {
+                id: "firstName",
                 label: "First name (Z-A)",
                 order: "desc",
-                dataValue: "firstName",
               },
-              { label: "Last name (A-Z)", order: "asc", dataValue: "lastName" },
+              { id: "lastName", label: "Last name (A-Z)", order: "asc" },
               {
+                id: "lastName",
                 label: "Last name (Z-A)",
                 order: "desc",
-                dataValue: "lastName",
               },
             ],
           },
@@ -133,24 +133,24 @@ const Template: ComponentStory<typeof DataList> = args => {
             key: "home",
             options: [
               {
+                id: "homeWorld",
                 label: "Home world (A-Z)",
                 order: "asc",
-                dataValue: "homeWorld",
               },
               {
+                id: "homeWorld",
                 label: "Home world (Z-A)",
                 order: "desc",
-                dataValue: "homeWorld",
               },
               {
+                id: "homePopulation",
                 label: "Population (A-Z)",
                 order: "asc",
-                dataValue: "homePopulation",
               },
               {
+                id: "homePopulation",
                 label: "Population (Z-A)",
                 order: "desc",
-                dataValue: "homePopulation",
               },
             ],
           },

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -51,9 +51,9 @@ export interface DataListSorting extends SortableOptions {
 }
 
 export interface SortableOptions {
+  readonly id: string;
   readonly label: string;
   readonly order: "asc" | "desc";
-  readonly dataValue: string;
 }
 
 export interface DataListProps<T extends DataListObject> {

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -53,6 +53,7 @@ export interface DataListSorting extends SortableOptions {
 export interface SortableOptions {
   readonly label: string;
   readonly order: "asc" | "desc";
+  readonly dataValue: string;
 }
 
 export interface DataListProps<T extends DataListObject> {

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
@@ -18,8 +18,16 @@ const mockContextValue = {
     sortable: sortableKeys.map(key => ({
       key,
       options: [
-        { label: `${headers[key]} (A-Z)`, order: "asc" },
-        { label: `${headers[key]} (Z-A)`, order: "desc" },
+        {
+          label: `${headers[key]} (A-Z)`,
+          order: "asc",
+          dataValue: "dataValueAsc",
+        },
+        {
+          label: `${headers[key]} (Z-A)`,
+          order: "desc",
+          dataValue: "dataValueDesc",
+        },
       ],
     })),
     state: undefined,
@@ -135,6 +143,7 @@ describe("DataListSort", () => {
           key: name,
           label: `${headers[name]} (A-Z)`,
           order: "asc",
+          dataValue: "dataValueAsc",
         });
       },
     );
@@ -152,6 +161,7 @@ describe("DataListSort", () => {
           key: name,
           label: `${headers[name]} (Z-A)`,
           order: "desc",
+          dataValue: "dataValueDesc",
         });
       },
     );
@@ -167,6 +177,7 @@ describe("DataListSort", () => {
         key: name,
         label: `${headers[name]} (A-Z)`,
         order: "asc",
+        dataValue: "dataValueAsc",
       });
     });
 

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
@@ -19,14 +19,14 @@ const mockContextValue = {
       key,
       options: [
         {
+          id: "selectionAsc",
           label: `${headers[key]} (A-Z)`,
           order: "asc",
-          dataValue: "dataValueAsc",
         },
         {
+          id: "selectionDesc",
           label: `${headers[key]} (Z-A)`,
           order: "desc",
-          dataValue: "dataValueDesc",
         },
       ],
     })),
@@ -141,9 +141,9 @@ describe("DataListSort", () => {
 
         expect(handleSort).toHaveBeenCalledWith({
           key: name,
+          id: "selectionAsc",
           label: `${headers[name]} (A-Z)`,
           order: "asc",
-          dataValue: "dataValueAsc",
         });
       },
     );
@@ -161,7 +161,7 @@ describe("DataListSort", () => {
           key: name,
           label: `${headers[name]} (Z-A)`,
           order: "desc",
-          dataValue: "dataValueDesc",
+          id: "selectionDesc",
         });
       },
     );
@@ -177,7 +177,7 @@ describe("DataListSort", () => {
         key: name,
         label: `${headers[name]} (A-Z)`,
         order: "asc",
-        dataValue: "dataValueAsc",
+        id: "selectionAsc",
       });
     });
 

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
@@ -18,7 +18,7 @@ export function DataListSort() {
       onSelect={selection => handleKeyChange(selection[0].id.toString())}
       selected={[
         {
-          id: `${state?.key},${state?.order},${state?.label}`,
+          id: `${state?.key},${state?.order},${state?.label},${state?.dataValue}`,
           label: state?.order || "",
         },
       ]}
@@ -53,20 +53,19 @@ export function DataListSort() {
           customOptions.forEach(option => {
             acc.push({
               label: option.label || "",
-              value: `${sort.key},${option.order},${option.label}`,
+              value: `${sort.key},${option.order},${option.label},${option.dataValue}`,
             });
           });
 
           return acc;
         }
-
         acc.push({
           label: `${label} (A-Z)`,
-          value: `${sort.key},asc,${label}`,
+          value: `${sort.key},asc,${label},${sort.key}`,
         });
         acc.push({
           label: `${label} (Z-A)`,
-          value: `${sort.key},desc,${label}`,
+          value: `${sort.key},desc,${label},${sort.key}`,
         });
 
         return acc;
@@ -83,7 +82,8 @@ export function DataListSort() {
   function getButtonLabel() {
     const selectedOption = sortByOptions.find(
       option =>
-        option.value === `${state?.key},${state?.order},${state?.label}`,
+        option.value ===
+        `${state?.key},${state?.order},${state?.label},${state?.dataValue}`,
     );
 
     return selectedOption?.label || "";
@@ -91,8 +91,8 @@ export function DataListSort() {
 
   function handleKeyChange(value?: string) {
     if (value && value !== "none") {
-      const [key, order, label] = value.split(",");
-      onSort({ key, order: order as "asc" | "desc", label });
+      const [key, order, label, dataValue] = value.split(",");
+      onSort({ key, order: order as "asc" | "desc", label, dataValue });
 
       return;
     }

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
@@ -13,14 +13,12 @@ export function DataListSort() {
 
   const sortByOptions = getSortByOptions();
 
-  const selectedSortID = `${state?.key},${state?.order},${state?.label},${state?.id}`;
-
   return (
     <Combobox
       onSelect={selection => handleKeyChange(selection[0].id.toString())}
       selected={[
         {
-          id: selectedSortID,
+          id: getSelectedSortID(),
           label: state?.order || "",
         },
       ]}
@@ -55,7 +53,12 @@ export function DataListSort() {
           customOptions.forEach(option => {
             acc.push({
               label: option.label || "",
-              value: `${sort.key},${option.order},${option.label},${option.id}`,
+              value: JSON.stringify({
+                key: sort.key,
+                order: option.order,
+                label: option.label,
+                id: option.id,
+              }),
             });
           });
 
@@ -63,11 +66,21 @@ export function DataListSort() {
         }
         acc.push({
           label: `${label} (A-Z)`,
-          value: `${sort.key},asc,${label},${sort.key}`,
+          value: JSON.stringify({
+            key: sort.key,
+            order: "asc",
+            label: label,
+            id: sort.key,
+          }),
         });
         acc.push({
           label: `${label} (Z-A)`,
-          value: `${sort.key},desc,${label},${sort.key}`,
+          value: JSON.stringify({
+            key: sort.key,
+            order: "desc",
+            label: label,
+            id: sort.key,
+          }),
         });
 
         return acc;
@@ -83,7 +96,7 @@ export function DataListSort() {
 
   function getButtonLabel() {
     const selectedOption = sortByOptions.find(
-      option => option.value === selectedSortID,
+      option => option.value === getSelectedSortID(),
     );
 
     return selectedOption?.label || "";
@@ -91,12 +104,23 @@ export function DataListSort() {
 
   function handleKeyChange(value?: string) {
     if (value && value !== "none") {
-      const [key, order, label, id] = value.split(",");
+      const { key, order, label, id } = JSON.parse(value);
       onSort({ key, order: order as "asc" | "desc", label, id });
 
       return;
     }
 
     onSort(undefined);
+  }
+
+  function getSelectedSortID() {
+    const selectedSortID = {
+      key: state?.key,
+      order: state?.order,
+      label: state?.label,
+      id: state?.id,
+    };
+
+    return JSON.stringify(selectedSortID);
   }
 }

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
@@ -13,12 +13,14 @@ export function DataListSort() {
 
   const sortByOptions = getSortByOptions();
 
+  const selectedSortID = `${state?.key},${state?.order},${state?.label},${state?.dataValue}`;
+
   return (
     <Combobox
       onSelect={selection => handleKeyChange(selection[0].id.toString())}
       selected={[
         {
-          id: `${state?.key},${state?.order},${state?.label},${state?.dataValue}`,
+          id: selectedSortID,
           label: state?.order || "",
         },
       ]}
@@ -81,9 +83,7 @@ export function DataListSort() {
 
   function getButtonLabel() {
     const selectedOption = sortByOptions.find(
-      option =>
-        option.value ===
-        `${state?.key},${state?.order},${state?.label},${state?.dataValue}`,
+      option => option.value === selectedSortID,
     );
 
     return selectedOption?.label || "";

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
@@ -13,7 +13,7 @@ export function DataListSort() {
 
   const sortByOptions = getSortByOptions();
 
-  const selectedSortID = `${state?.key},${state?.order},${state?.label},${state?.dataValue}`;
+  const selectedSortID = `${state?.key},${state?.order},${state?.label},${state?.id}`;
 
   return (
     <Combobox
@@ -55,7 +55,7 @@ export function DataListSort() {
           customOptions.forEach(option => {
             acc.push({
               label: option.label || "",
-              value: `${sort.key},${option.order},${option.label},${option.dataValue}`,
+              value: `${sort.key},${option.order},${option.label},${option.id}`,
             });
           });
 
@@ -91,8 +91,8 @@ export function DataListSort() {
 
   function handleKeyChange(value?: string) {
     if (value && value !== "none") {
-      const [key, order, label, dataValue] = value.split(",");
-      onSort({ key, order: order as "asc" | "desc", label, dataValue });
+      const [key, order, label, id] = value.split(",");
+      onSort({ key, order: order as "asc" | "desc", label, id });
 
       return;
     }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -103,7 +103,8 @@ export function DataListHeaderTile<T extends DataListObject>({
       const headerValue = headers[headerKey];
 
       if (headerValue !== undefined) {
-        toggleSorting(headerKey, headerValue);
+        const dataValue = sortableItem?.options?.[0]?.dataValue || headerKey;
+        toggleSorting(headerKey, headerValue, dataValue);
       }
     }
   }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -70,6 +70,7 @@ export function DataListHeaderTile<T extends DataListObject>({
   function toggleSorting(
     sortingKey: string,
     label: string,
+    dataValue: string,
     order?: "asc" | "desc",
   ) {
     const isSameKey =
@@ -88,6 +89,7 @@ export function DataListHeaderTile<T extends DataListObject>({
     sorting?.onSort({
       key: sortingKey,
       label,
+      dataValue,
       order: sortingOrder,
     });
   }
@@ -111,6 +113,7 @@ export function DataListHeaderTile<T extends DataListObject>({
       toggleSorting(
         sortableItem.key,
         selectedOption.label,
+        selectedOption.dataValue,
         selectedOption.order,
       );
     }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -38,9 +38,7 @@ export function DataListHeaderTile<T extends DataListObject>({
 
   const Tag = isSortable ? "button" : "div";
 
-  const selectedOption = sorting?.state
-    ? ({ ...sorting?.state } as SortableOptions)
-    : null;
+  const selectedOption: SortableOptions | null = sorting?.state || null;
 
   return (
     <Tag

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -68,9 +68,9 @@ export function DataListHeaderTile<T extends DataListObject>({
   );
 
   function toggleSorting(
+    id: string,
     sortingKey: string,
     label: string,
-    dataValue: string,
     order?: "asc" | "desc",
   ) {
     const isSameKey =
@@ -87,9 +87,9 @@ export function DataListHeaderTile<T extends DataListObject>({
     const sortingOrder = order || (isSameKey && !isDescending ? "desc" : "asc");
 
     sorting?.onSort({
+      id,
       key: sortingKey,
       label,
-      dataValue,
       order: sortingOrder,
     });
   }
@@ -101,10 +101,10 @@ export function DataListHeaderTile<T extends DataListObject>({
       setIsDropDownOpen(!isDropDownOpen);
     } else {
       const headerValue = headers[headerKey];
+      const id = sortableItem?.options?.[0]?.id || headerKey;
 
       if (headerValue !== undefined) {
-        const dataValue = sortableItem?.options?.[0]?.dataValue || headerKey;
-        toggleSorting(headerKey, headerValue, dataValue);
+        toggleSorting(headerKey, headerValue, id);
       }
     }
   }
@@ -112,9 +112,9 @@ export function DataListHeaderTile<T extends DataListObject>({
   function handleSelectChange(selectedOption: SortableOptions) {
     if (sortableItem) {
       toggleSorting(
+        selectedOption.id,
         sortableItem.key,
         selectedOption.label,
-        selectedOption.dataValue,
         selectedOption.order,
       );
     }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -28,8 +28,6 @@ export function DataListHeaderTile<T extends DataListObject>({
   useRefocusOnActivator(visible);
   const { sorting } = useDataListContext();
   const [isDropDownOpen, setIsDropDownOpen] = React.useState(false);
-  const [selectedSortOption, setSelectedSortOption] =
-    React.useState<SortableOptions | null>(null);
 
   const optionsListRef = useFocusTrap<HTMLUListElement>(isDropDownOpen);
   const dataListHeaderTileRef = React.useRef(null);
@@ -39,6 +37,10 @@ export function DataListHeaderTile<T extends DataListObject>({
   const sortingState = sorting?.state;
 
   const Tag = isSortable ? "button" : "div";
+
+  const selectedOption = sorting?.state
+    ? ({ ...sorting?.state } as SortableOptions)
+    : null;
 
   return (
     <Tag
@@ -52,7 +54,7 @@ export function DataListHeaderTile<T extends DataListObject>({
       {isSortable && sortableItem?.options && isDropDownOpen && (
         <DataListSortingOptions
           options={sortableItem.options}
-          selectedOption={selectedSortOption}
+          selectedOption={selectedOption}
           onSelectChange={handleSelectChange}
           onClose={() => setIsDropDownOpen(false)}
           optionsListRef={optionsListRef}
@@ -104,21 +106,20 @@ export function DataListHeaderTile<T extends DataListObject>({
       const id = sortableItem?.options?.[0]?.id || headerKey;
 
       if (headerValue !== undefined) {
-        toggleSorting(headerKey, headerValue, id);
+        toggleSorting(id, headerKey, headerValue);
       }
     }
   }
 
-  function handleSelectChange(selectedOption: SortableOptions) {
+  function handleSelectChange(newSortOption: SortableOptions) {
     if (sortableItem) {
       toggleSorting(
-        selectedOption.id,
+        newSortOption.id,
         sortableItem.key,
-        selectedOption.label,
-        selectedOption.order,
+        newSortOption.label,
+        newSortOption.order,
       );
     }
-    setSelectedSortOption(selectedOption);
 
     setIsDropDownOpen(true);
   }

--- a/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
@@ -42,7 +42,7 @@ export function DataListSortingOptions({
           onClick={() => onSelectChange(option)}
           onKeyDown={event => handleKeyDown(event, option)}
           tabIndex={0}
-          data-value={option.dataValue}
+          data-value={option.id}
         >
           {option.label}
           {option.label === selectedOption?.label && (

--- a/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
@@ -42,6 +42,7 @@ export function DataListSortingOptions({
           onClick={() => onSelectChange(option)}
           onKeyDown={event => handleKeyDown(event, option)}
           tabIndex={0}
+          data-value={option.dataValue}
         >
           {option.label}
           {option.label === selectedOption?.label && (


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Adding an `id` to the `li` of our sortable options means that mapping sorting logic from the backend to the `DataList` component will:
1. be more straightforward
2. avoid mapping against the label string (ex "Last Name (A-Z)") which is extremely brittle and if that string changes, good luck tracking down why sort is broken 😅 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
`SortableOptions` type now has `id`:

```
export interface SortableOptions {
  readonly id: string;
  readonly label: string;
  readonly order: "asc" | "desc";
}
```

### Added

<!-- new features -->
Everyone gets an `id` 


## Testing desktop screen size:

- [ ] Each custom sort `option` selected will return an `id`

NOTE: <s> Toggling on Last Activity will NOT return an `id` unless you on a small screen. </s> JUST KIDDING I did [this](https://github.com/GetJobber/atlantis/pull/1734/files#diff-9ee4883bf9251e8d0c7ebf791241f261dd3abfe95e9fd3eb337cdd4b7da70c47R106) so now toggling on Last Activity will return the `headerKey` itself. 

![Kapture 2024-01-25 at 20 11 59](https://github.com/GetJobber/atlantis/assets/104797704/8e3a4dec-44cf-4809-8b4f-65c50c930a08)


## Testing mobile screen size:

- [ ] Each `option` selected in the `Combobox` will return a `id`

`id` needed to be pushed into `DataListSort` as well.  Because the `sortable` `options` are now being pushed into a `Combobox`, we needed to add `id` to the `value`  The reason we have an `id` for Last Activity here, even when the Storybook props do not have an `options` array, it because we are mapping `id` to be `sort.key` for now. Again, when each `sortable` header has it's own `options` (in a future ticket this sprint), we won't need to push these `key` only values to the `Combobox`, because `key` only sort values will no longer exist. If that doesn't make sense, let me know I will try to explain better in person.

![Kapture 2024-01-25 at 20 24 37](https://github.com/GetJobber/atlantis/assets/104797704/7f8c9498-ff69-4f85-8b75-726a84abc92f)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
