### PR TITLE
fix(components): Removing uuid in web and replacing with useId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45649,7 +45649,6 @@
         "@types/react-datepicker": "^4.8.0",
         "@types/react-router": "5.1.7",
         "@types/react-router-dom": "^5.3.3",
-        "@types/uuid": "^8.3.3",
         "axios": "^1.6.0",
         "classnames": "^2.3.2",
         "color": "^3.1.2",
@@ -45664,8 +45663,7 @@
         "react-popper": "^2.2.5",
         "react-router-dom": "^5.3.4",
         "time-input-polyfill": "^1.0.7",
-        "ts-xor": "^1.0.8",
-        "uuid": "^8.3.2"
+        "ts-xor": "^1.0.8"
       },
       "devDependencies": {
         "@csstools/postcss-global-data": "^1.0.3",
@@ -45678,7 +45676,6 @@
         "@types/glob": "^7.1.1",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
-        "@types/uuid": "^8.3.3",
         "autoprefixer": "^9.5.1",
         "copyfiles": "^2.4.1",
         "glob": "^7.1.4",
@@ -45691,8 +45688,7 @@
         "rollup-plugin-multi-input": "^1.4.1",
         "rollup-plugin-postcss": "^4.0.2",
         "typed-css-modules": "^0.7.0",
-        "typescript": "^4.9.5",
-        "uuid": "^8.3.2"
+        "typescript": "^4.9.5"
       },
       "peerDependencies": {
         "react": "^18",
@@ -46517,12 +46513,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "packages/components/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
     },
     "packages/design": {
       "name": "@jobber/design",

--- a/packages/components/__mocks__/uuid.ts
+++ b/packages/components/__mocks__/uuid.ts
@@ -1,9 +1,0 @@
-let count = 0;
-const finalSection = 426655440000;
-
-function fakeUUID() {
-  count += 1;
-  return `123e4567-e89b-12d3-a456-${finalSection + count}`;
-}
-
-export const v1 = fakeUUID;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,6 @@
     "@types/react-datepicker": "^4.8.0",
     "@types/react-router": "5.1.7",
     "@types/react-router-dom": "^5.3.3",
-    "@types/uuid": "^8.3.3",
     "axios": "^1.6.0",
     "classnames": "^2.3.2",
     "color": "^3.1.2",
@@ -45,8 +44,7 @@
     "react-popper": "^2.2.5",
     "react-router-dom": "^5.3.4",
     "time-input-polyfill": "^1.0.7",
-    "ts-xor": "^1.0.8",
-    "uuid": "^8.3.2"
+    "ts-xor": "^1.0.8"
   },
   "devDependencies": {
     "@csstools/postcss-global-data": "^1.0.3",
@@ -59,7 +57,6 @@
     "@types/glob": "^7.1.1",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "@types/uuid": "^8.3.3",
     "autoprefixer": "^9.5.1",
     "copyfiles": "^2.4.1",
     "glob": "^7.1.4",
@@ -72,8 +69,7 @@
     "rollup-plugin-multi-input": "^1.4.1",
     "rollup-plugin-postcss": "^4.0.2",
     "typed-css-modules": "^0.7.0",
-    "typescript": "^4.9.5",
-    "uuid": "^8.3.2"
+    "typescript": "^4.9.5"
   },
   "peerDependencies": {
     "react": "^18",

--- a/packages/components/rollup.config.js
+++ b/packages/components/rollup.config.js
@@ -117,7 +117,6 @@ export default {
     "color",
     "framer-motion",
     "classnames",
-    "uuid",
     new RegExp("lodash/.*"),
     "@std-proposal/temporal",
     "@jobber/design",

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`it should display headers when headers are passed in 1`] = `
         >
           <label
             class="label"
-            for="123e4567-e89b-12d3-a456-426655440033"
+            for=":r6:"
           >
             placeholder_name
           </label>
@@ -27,7 +27,7 @@ exports[`it should display headers when headers are passed in 1`] = `
             <input
               autocomplete="off"
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440033"
+              id=":r6:"
               type="text"
               value=""
             />
@@ -56,7 +56,7 @@ exports[`renders an Autocomplete 1`] = `
         >
           <label
             class="label"
-            for="123e4567-e89b-12d3-a456-426655440001"
+            for=":r0:"
           >
             placeholder_name
           </label>
@@ -66,7 +66,7 @@ exports[`renders an Autocomplete 1`] = `
             <input
               autocomplete="off"
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440001"
+              id=":r0:"
               type="text"
               value=""
             />

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -1,5 +1,10 @@
-import React, { ChangeEvent, ReactElement, useEffect, useState } from "react";
-import { v1 as uuidv1 } from "uuid";
+import React, {
+  ChangeEvent,
+  ReactElement,
+  useEffect,
+  useId,
+  useState,
+} from "react";
 import classnames from "classnames";
 import { XOR } from "ts-xor";
 import { Controller, useForm, useFormContext } from "react-hook-form";
@@ -87,7 +92,7 @@ export function Checkbox({
       : // If there isn't a Form Context being provided, get a form for this field.
         useForm({ mode: "onTouched" });
 
-  const [identifier] = useState(uuidv1());
+  const [identifier] = useState(useId());
 
   /**
    * Generate a name if one is not supplied, this is the name

--- a/packages/components/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 1`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440005"
+              id=":r2:"
               type="checkbox"
               value=""
             />
@@ -65,7 +65,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 1`]
             aria-label="Foo"
             checked=""
             class="input indeterminate"
-            id="123e4567-e89b-12d3-a456-426655440005"
+            id=":r2:"
             type="checkbox"
             value=""
           />
@@ -169,7 +169,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 2`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440005"
+              id=":r2:"
               type="checkbox"
               value=""
             />
@@ -214,7 +214,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 2`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440006"
+              id=":r3:"
               type="checkbox"
               value=""
             />
@@ -260,7 +260,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 2`]
           <input
             aria-label="Foo"
             class="input indeterminate"
-            id="123e4567-e89b-12d3-a456-426655440006"
+            id=":r3:"
             type="checkbox"
             value=""
           />
@@ -364,7 +364,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 3`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440005"
+              id=":r2:"
               type="checkbox"
               value=""
             />
@@ -409,7 +409,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 3`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440006"
+              id=":r3:"
               type="checkbox"
               value=""
             />
@@ -455,7 +455,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 3`]
               aria-label="Foo"
               checked=""
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440007"
+              id=":r4:"
               type="checkbox"
               value=""
             />
@@ -502,7 +502,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 3`]
             aria-label="Foo"
             checked=""
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440007"
+            id=":r4:"
             type="checkbox"
             value=""
           />
@@ -606,7 +606,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440005"
+              id=":r2:"
               type="checkbox"
               value=""
             />
@@ -651,7 +651,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440006"
+              id=":r3:"
               type="checkbox"
               value=""
             />
@@ -697,7 +697,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
               aria-label="Foo"
               checked=""
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440007"
+              id=":r4:"
               type="checkbox"
               value=""
             />
@@ -742,7 +742,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
             <input
               aria-label="Foo"
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440008"
+              id=":r5:"
               type="checkbox"
               value=""
             />
@@ -788,7 +788,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
           <input
             aria-label="Foo"
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440008"
+            id=":r5:"
             type="checkbox"
             value=""
           />
@@ -892,7 +892,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440005"
+              id=":r2:"
               type="checkbox"
               value=""
             />
@@ -937,7 +937,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440006"
+              id=":r3:"
               type="checkbox"
               value=""
             />
@@ -983,7 +983,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
               aria-label="Foo"
               checked=""
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440007"
+              id=":r4:"
               type="checkbox"
               value=""
             />
@@ -1028,7 +1028,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
             <input
               aria-label="Foo"
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440008"
+              id=":r5:"
               type="checkbox"
               value=""
             />
@@ -1074,7 +1074,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440009"
+              id=":r6:"
               type="checkbox"
               value="true"
             />
@@ -1121,7 +1121,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
             aria-label="Foo"
             checked=""
             class="input indeterminate"
-            id="123e4567-e89b-12d3-a456-426655440009"
+            id=":r6:"
             type="checkbox"
             value="true"
           />
@@ -1225,7 +1225,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440005"
+              id=":r2:"
               type="checkbox"
               value=""
             />
@@ -1270,7 +1270,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440006"
+              id=":r3:"
               type="checkbox"
               value=""
             />
@@ -1316,7 +1316,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
               aria-label="Foo"
               checked=""
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440007"
+              id=":r4:"
               type="checkbox"
               value=""
             />
@@ -1361,7 +1361,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             <input
               aria-label="Foo"
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440008"
+              id=":r5:"
               type="checkbox"
               value=""
             />
@@ -1407,7 +1407,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440009"
+              id=":r6:"
               type="checkbox"
               value="true"
             />
@@ -1452,7 +1452,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440010"
+              id=":r7:"
               type="checkbox"
               value="false"
             />
@@ -1498,7 +1498,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
           <input
             aria-label="Foo"
             class="input indeterminate"
-            id="123e4567-e89b-12d3-a456-426655440010"
+            id=":r7:"
             type="checkbox"
             value="false"
           />
@@ -1602,7 +1602,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440005"
+              id=":r2:"
               type="checkbox"
               value=""
             />
@@ -1647,7 +1647,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440006"
+              id=":r3:"
               type="checkbox"
               value=""
             />
@@ -1693,7 +1693,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
               aria-label="Foo"
               checked=""
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440007"
+              id=":r4:"
               type="checkbox"
               value=""
             />
@@ -1738,7 +1738,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             <input
               aria-label="Foo"
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440008"
+              id=":r5:"
               type="checkbox"
               value=""
             />
@@ -1784,7 +1784,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440009"
+              id=":r6:"
               type="checkbox"
               value="true"
             />
@@ -1829,7 +1829,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440010"
+              id=":r7:"
               type="checkbox"
               value="false"
             />
@@ -1875,7 +1875,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
               aria-label="Foo"
               checked=""
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440011"
+              id=":r8:"
               type="checkbox"
               value="true"
             />
@@ -1922,7 +1922,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             aria-label="Foo"
             checked=""
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440011"
+            id=":r8:"
             type="checkbox"
             value="true"
           />
@@ -2026,7 +2026,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440005"
+              id=":r2:"
               type="checkbox"
               value=""
             />
@@ -2071,7 +2071,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440006"
+              id=":r3:"
               type="checkbox"
               value=""
             />
@@ -2117,7 +2117,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
               aria-label="Foo"
               checked=""
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440007"
+              id=":r4:"
               type="checkbox"
               value=""
             />
@@ -2162,7 +2162,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             <input
               aria-label="Foo"
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440008"
+              id=":r5:"
               type="checkbox"
               value=""
             />
@@ -2208,7 +2208,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
               aria-label="Foo"
               checked=""
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440009"
+              id=":r6:"
               type="checkbox"
               value="true"
             />
@@ -2253,7 +2253,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             <input
               aria-label="Foo"
               class="input indeterminate"
-              id="123e4567-e89b-12d3-a456-426655440010"
+              id=":r7:"
               type="checkbox"
               value="false"
             />
@@ -2299,7 +2299,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
               aria-label="Foo"
               checked=""
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440011"
+              id=":r8:"
               type="checkbox"
               value="true"
             />
@@ -2344,7 +2344,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             <input
               aria-label="Foo"
               class="input"
-              id="123e4567-e89b-12d3-a456-426655440012"
+              id=":r9:"
               type="checkbox"
               value="false"
             />
@@ -2390,7 +2390,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
           <input
             aria-label="Foo"
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440012"
+            id=":r9:"
             type="checkbox"
             value="false"
           />

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -2,10 +2,10 @@ import React, {
   ChangeEvent,
   KeyboardEvent,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
-import { v1 as uuidV1 } from "uuid";
 import debounce from "lodash/debounce";
 import { useLiveAnnounce } from "@jobber/hooks/useLiveAnnounce";
 import {
@@ -15,8 +15,6 @@ import {
 import { Icon } from "../../../Icon";
 import { ChipProps } from "../../Chip";
 
-const menuId = uuidV1();
-
 // eslint-disable-next-line max-statements
 export function useInternalChipDismissibleInput({
   options,
@@ -25,6 +23,7 @@ export function useInternalChipDismissibleInput({
   onOptionSelect,
   onSearch,
 }: ChipDismissibleInputProps) {
+  const menuId = useId();
   const [allOptions, setAllOptions] = useState<
     ChipDismissibleInputOptionProps[]
   >([]);
@@ -89,6 +88,7 @@ export function useInternalChipDismissibleInput({
     handleSelectOption: (selected: typeof computed.activeOption) => {
       if (allOptions.length === 0) return;
       const setValue = selected.custom ? onCustomOptionSelect : onOptionSelect;
+
       if (setValue) {
         setValue(selected.value);
         liveAnnounce(`${selected.label} Added`);
@@ -120,6 +120,7 @@ export function useInternalChipDismissibleInput({
           // If there's no text left to delete,
           // and delete is pressed again, focus on a chip instead.
           const target = computed.inputRef.current?.previousElementSibling;
+
           if (target instanceof HTMLElement) {
             target.focus();
           }

--- a/packages/components/src/Chips/InternalChipSingleSelect.tsx
+++ b/packages/components/src/Chips/InternalChipSingleSelect.tsx
@@ -1,5 +1,4 @@
-import React, { KeyboardEvent, MouseEvent } from "react";
-import { v1 as uuidv1 } from "uuid";
+import React, { KeyboardEvent, MouseEvent, useId } from "react";
 import styles from "./InternalChip.css";
 import { InternalChip } from "./InternalChip";
 import { ChipSingleSelectProps } from "./ChipsTypes";
@@ -12,7 +11,7 @@ type InternalChipChoiceProps = Pick<
 export function InternalChipSingleSelect({
   children,
   selected,
-  name = uuidv1(),
+  name = useId(),
   onChange,
   onClick,
 }: InternalChipChoiceProps) {
@@ -20,6 +19,7 @@ export function InternalChipSingleSelect({
     <div className={styles.wrapper} data-testid="singleselect-chips">
       {React.Children.map(children, child => {
         const isSelected = child.props.value === selected;
+
         return (
           <label>
             <input

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -4,10 +4,10 @@ import React, {
   KeyboardEvent,
   MutableRefObject,
   useEffect,
+  useId,
   useImperativeHandle,
   useState,
 } from "react";
-import { v1 as uuidv1 } from "uuid";
 import { Controller, useForm, useFormContext } from "react-hook-form";
 import { FormFieldProps } from "./FormFieldTypes";
 import styles from "./FormField.css";
@@ -56,8 +56,8 @@ export function FormField(props: FormFieldProps) {
     : // If there isn't a Form Context being provided, get a form for this field.
       useForm({ mode: "onTouched" });
 
-  const [identifier] = useState(uuidv1());
-  const [descriptionIdentifier] = useState(`descriptionUUID--${uuidv1()}`);
+  const [identifier] = useState(useId());
+  const [descriptionIdentifier] = useState(`descriptionUUID--${useId()}`);
   /**
    * Generate a name if one is not supplied, this is the name
    * that will be used for react-hook-form and not neccessarily

--- a/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
+++ b/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`FormField when small renders 1`] = `
         >
           <input
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440009"
+            id=":r8:"
             type="text"
             value=""
           />
@@ -45,7 +45,7 @@ exports[`FormField with no props renders 1`] = `
         >
           <input
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440001"
+            id=":r0:"
             type="text"
             value=""
           />

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useId } from "react";
 import classnames from "classnames";
 import { DropzoneOptions, FileError, useDropzone } from "react-dropzone";
 import axios, { AxiosRequestConfig } from "axios";
-import { v1 as uuidv1 } from "uuid";
 import styles from "./InputFile.css";
 import { InputValidation } from "../InputValidation";
 import { Button } from "../Button";
@@ -56,7 +55,7 @@ export interface UploadParams {
 
   /**
    * Key to identify file.
-   * If unspecified a `uuid` will be used.
+   * If unspecified a `useId` will be used.
    */
   readonly key?: string;
 
@@ -271,7 +270,7 @@ export function InputFile({
       return;
     }
 
-    const { url, key = uuidv1(), fields = {}, httpMethod = "POST" } = params;
+    const { url, key = useId(), fields = {}, httpMethod = "POST" } = params;
 
     const fileUpload = getFileUpload(file, key, url);
     onUploadStart && onUploadStart({ ...fileUpload });

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useId } from "react";
+import React, { useCallback } from "react";
 import classnames from "classnames";
 import { DropzoneOptions, FileError, useDropzone } from "react-dropzone";
 import axios, { AxiosRequestConfig } from "axios";
@@ -55,7 +55,7 @@ export interface UploadParams {
 
   /**
    * Key to identify file.
-   * If unspecified a `useId` will be used.
+   * If unspecified a generated Id will be used.
    */
   readonly key?: string;
 
@@ -270,7 +270,12 @@ export function InputFile({
       return;
     }
 
-    const { url, key = useId(), fields = {}, httpMethod = "POST" } = params;
+    const {
+      url,
+      key = generateId(),
+      fields = {},
+      httpMethod = "POST",
+    } = params;
 
     const fileUpload = getFileUpload(file, key, url);
     onUploadStart && onUploadStart({ ...fileUpload });
@@ -415,4 +420,8 @@ export function updateFiles(updatedFile: FileUpload, files: FileUpload[]) {
   }
 
   return newFiles;
+}
+
+function generateId() {
+  return Math.floor(Math.random() * Date.now()).toString(16);
 }

--- a/packages/components/src/InputNumber/InputNumber.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.test.tsx
@@ -21,8 +21,8 @@ it("renders an input type number", () => {
             >
               <input
                 class="input"
-                id="123e4567-e89b-12d3-a456-426655440001"
-                name="generatedName--123e4567-e89b-12d3-a456-426655440001"
+                id=":r0:"
+                name="generatedName--:r0:"
                 type="number"
                 value="123"
               />

--- a/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
+++ b/packages/components/src/InputPassword/__snapshots__/InputPassword.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<InputPassword /> renders an input type password 1`] = `
         >
           <input
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440001"
+            id=":r0:"
             type="password"
             value="123"
           />

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -19,7 +19,7 @@ it("renders a regular input for text and numbers", () => {
           >
             <label
               class="label"
-              for="123e4567-e89b-12d3-a456-426655440001"
+              for=":r0:"
             >
               Favourite colour
             </label>
@@ -28,7 +28,7 @@ it("renders a regular input for text and numbers", () => {
             >
               <input
                 class="input"
-                id="123e4567-e89b-12d3-a456-426655440001"
+                id=":r0:"
                 type="text"
                 value=""
               />
@@ -58,7 +58,7 @@ it("renders a textarea", () => {
           >
             <label
               class="label"
-              for="123e4567-e89b-12d3-a456-426655440003"
+              for=":r2:"
             >
               Describe your favourite colour?
             </label>
@@ -67,7 +67,7 @@ it("renders a textarea", () => {
             >
               <textarea
                 class="input"
-                id="123e4567-e89b-12d3-a456-426655440003"
+                id=":r2:"
                 rows="3"
               />
             </div>
@@ -100,7 +100,7 @@ it("renders a textarea with 4 rows", () => {
           >
             <label
               class="label"
-              for="123e4567-e89b-12d3-a456-426655440005"
+              for=":r4:"
             >
               Describe your favourite colour?
             </label>
@@ -109,7 +109,7 @@ it("renders a textarea with 4 rows", () => {
             >
               <textarea
                 class="input"
-                id="123e4567-e89b-12d3-a456-426655440005"
+                id=":r4:"
                 rows="4"
               />
             </div>

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -3,8 +3,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Menu } from ".";
 import { Button } from "../Button";
 
-jest.mock("uuid");
-
 describe("Menu", () => {
   it("renders", () => {
     const { container } = render(

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -4,10 +4,10 @@ import React, {
   RefObject,
   createRef,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
-import { v1 as uuidv1 } from "uuid";
 import classnames from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
 import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
@@ -69,8 +69,8 @@ export function Menu({ activator, items }: MenuProps) {
     horizontal: "right",
   });
   const wrapperRef = createRef<HTMLDivElement>();
-  const buttonID = uuidv1();
-  const menuID = uuidv1();
+  const buttonID = useId();
+  const menuID = useId();
 
   useOnKeyDown(handleKeyboardShortcut, ["Escape"]);
   useSafeLayoutEffect(() => {

--- a/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
@@ -40,11 +40,11 @@ exports[`Menu with custom activator renders 1`] = `
     class="wrapper"
   >
     <button
-      aria-controls=":r9:"
+      aria-controls=":rc:"
       aria-expanded="false"
       aria-haspopup="true"
       class="button base work primary"
-      id=":r8:"
+      id=":rb:"
       type="button"
     >
       <span

--- a/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`Menu renders 1`] = `
     class="wrapper"
   >
     <button
-      aria-controls="123e4567-e89b-12d3-a456-426655440004"
+      aria-controls=":r1:"
       aria-expanded="false"
       aria-haspopup="true"
       class="button base hasIconAndLabel work secondary fullWidth"
-      id="123e4567-e89b-12d3-a456-426655440003"
+      id=":r0:"
       type="button"
     >
       <svg
@@ -40,11 +40,11 @@ exports[`Menu with custom activator renders 1`] = `
     class="wrapper"
   >
     <button
-      aria-controls="123e4567-e89b-12d3-a456-426655440040"
+      aria-controls=":r9:"
       aria-expanded="false"
       aria-haspopup="true"
       class="button base work primary"
-      id="123e4567-e89b-12d3-a456-426655440039"
+      id=":r8:"
       type="button"
     >
       <span

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -59,11 +59,11 @@ exports[`When actions are provided renders a Page with action buttons and a menu
                 class="wrapper"
               >
                 <button
-                  aria-controls="123e4567-e89b-12d3-a456-426655440004"
+                  aria-controls=":r1:"
                   aria-expanded="false"
                   aria-haspopup="true"
                   class="button base hasIconAndLabel work secondary fullWidth"
-                  id="123e4567-e89b-12d3-a456-426655440003"
+                  id=":r0:"
                   type="button"
                 >
                   <svg

--- a/packages/components/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.test.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { fireEvent, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { RadioGroup, RadioOption } from ".";
 
 test("renders a RadioGroup", () => {
@@ -40,18 +41,13 @@ test("it should be able to disable options", () => {
   expect(container.querySelector(`[value="bear"]`)).toBeDisabled();
 });
 
-test("it should have unique ids on all radio options", () => {
-  const { container, getAllByLabelText } = render(<MockRadioGroup />);
-  const labels = getAllByLabelText("Two");
-  const radio1 = container.querySelector(
-    `input#${labels[0].id}`,
-  ) as HTMLInputElement;
-  const radio2 = container.querySelector(
-    `input#${labels[1].id}`,
-  ) as HTMLInputElement;
-  expect(radio1.checked).toBeFalsy();
+test("it should have unique ids on all radio options", async () => {
+  const { getAllByRole } = render(<MockRadioGroup />);
+  const radio1 = getAllByRole("radio")[0] as HTMLInputElement;
+  const radio2 = getAllByRole("radio")[1] as HTMLInputElement;
+  expect(radio1.checked).toBeTruthy();
   expect(radio2.checked).toBeFalsy();
-  fireEvent.click(labels[1]);
+  await userEvent.click(radio2);
   expect(radio1.checked).toBeFalsy();
   expect(radio2.checked).toBeTruthy();
 });

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -26,7 +26,7 @@ interface RadioGroupProps {
    * The name of the radio group, that links the radio options back up
    * to the group.
    *
-   * @default uuid
+   * @default useId()
    */
   readonly name?: string;
 }

--- a/packages/components/src/RadioGroup/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup/RadioGroup.tsx
@@ -1,5 +1,4 @@
-import React, { ReactElement } from "react";
-import { v1 as uuidv1 } from "uuid";
+import React, { ReactElement, useId } from "react";
 import { InternalRadioOption } from "./RadioOption";
 import styles from "./RadioGroup.css";
 
@@ -37,7 +36,7 @@ export function RadioGroup({
   value,
   ariaLabel,
   onChange,
-  name = uuidv1(),
+  name = useId(),
 }: RadioGroupProps) {
   return (
     <div role="radiogroup" aria-label={ariaLabel} className={styles.radioGroup}>

--- a/packages/components/src/RadioGroup/RadioOption.tsx
+++ b/packages/components/src/RadioGroup/RadioOption.tsx
@@ -1,6 +1,5 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useId } from "react";
 import { XOR } from "ts-xor";
-import { v1 as uuidv1 } from "uuid";
 import styles from "./RadioGroup.css";
 import { Text } from "../Text";
 
@@ -69,8 +68,9 @@ export function InternalRadioOption({
   children,
   onChange,
 }: InternalRadioOptionProps) {
-  const inputId = `${value.toString()}_${uuidv1()}`;
+  const inputId = `${value.toString()}_${useId()}`;
   const shouldRenderIndependentChildren = label && children;
+
   return (
     <div>
       <input

--- a/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/components/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -11,14 +11,14 @@ exports[`renders a RadioGroup 1`] = `
       <input
         checked=""
         class="input"
-        id="one_123e4567-e89b-12d3-a456-426655440002"
-        name="123e4567-e89b-12d3-a456-426655440001"
+        id="one_:r1:"
+        name=":r0:"
         type="radio"
         value="one"
       />
       <label
         class="label"
-        for="one_123e4567-e89b-12d3-a456-426655440002"
+        for="one_:r1:"
       >
         One
       </label>
@@ -26,14 +26,14 @@ exports[`renders a RadioGroup 1`] = `
     <div>
       <input
         class="input"
-        id="two_123e4567-e89b-12d3-a456-426655440003"
-        name="123e4567-e89b-12d3-a456-426655440001"
+        id="two_:r2:"
+        name=":r0:"
         type="radio"
         value="two"
       />
       <label
         class="label"
-        for="two_123e4567-e89b-12d3-a456-426655440003"
+        for="two_:r2:"
       >
         Two
       </label>
@@ -48,14 +48,14 @@ exports[`renders a RadioGroup 1`] = `
       <input
         checked=""
         class="input"
-        id="one_123e4567-e89b-12d3-a456-426655440005"
-        name="123e4567-e89b-12d3-a456-426655440004"
+        id="one_:r4:"
+        name=":r3:"
         type="radio"
         value="one"
       />
       <label
         class="label"
-        for="one_123e4567-e89b-12d3-a456-426655440005"
+        for="one_:r4:"
       >
         One
       </label>
@@ -63,14 +63,14 @@ exports[`renders a RadioGroup 1`] = `
     <div>
       <input
         class="input"
-        id="two_123e4567-e89b-12d3-a456-426655440006"
-        name="123e4567-e89b-12d3-a456-426655440004"
+        id="two_:r5:"
+        name=":r3:"
         type="radio"
         value="two"
       />
       <label
         class="label"
-        for="two_123e4567-e89b-12d3-a456-426655440006"
+        for="two_:r5:"
       >
         Two
       </label>

--- a/packages/components/src/RecurringSelect/components/DayOfMonthSelect.tsx
+++ b/packages/components/src/RecurringSelect/components/DayOfMonthSelect.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-import { v1 as uuidv1 } from "uuid";
+import React, { useId } from "react";
 import styles from "./DayOfMonthSelect.css";
 import checkboxStyles from "../DateCellCheckbox.css";
 import { DayOfMonth } from "../types";
 
 interface DayOfMonthSelectProps {
-  selectedDays: Set<DayOfMonth>;
-  disabled: boolean;
+  readonly selectedDays: Set<DayOfMonth>;
+  readonly disabled: boolean;
   onChange(selectedDays: Set<DayOfMonth>): void;
 }
 
@@ -21,7 +20,7 @@ export function DayOfMonthSelect({
     <div className={styles.container}>
       {daysInMonth.map(day => {
         const isSelected = selectedDays.has(day as DayOfMonth);
-        const inputId = uuidv1();
+        const inputId = useId();
 
         return (
           <div key={`${day}`} className={checkboxStyles.checkboxWrapper}>

--- a/packages/components/src/RecurringSelect/components/WeeklySelect.tsx
+++ b/packages/components/src/RecurringSelect/components/WeeklySelect.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-import { v1 as uuidv1 } from "uuid";
+import React, { useId } from "react";
 import styles from "./WeeklySelect.css";
 import checkboxStyles from "../DateCellCheckbox.css";
 import { WeekDay } from "../types";
 
 interface WeeklySelectProps {
-  disabled: boolean;
-  selectedDays: Set<WeekDay>;
+  readonly disabled: boolean;
+  readonly selectedDays: Set<WeekDay>;
   onChange(selectedDays: Set<WeekDay>): void;
 }
 const weekDays = [0, 1, 2, 3, 4, 5, 6];
@@ -32,7 +31,7 @@ export function WeeklySelect({
     <div className={styles.container}>
       {weekDays.map(weekDay => {
         const isSelected = selectedDays.has(weekDay);
-        const inputId = uuidv1();
+        const inputId = useId();
 
         return (
           <div key={`${weekDay}`} className={checkboxStyles.checkboxWrapper}>

--- a/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`renders a Select with many options 1`] = `
         >
           <select
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440005"
+            id=":r4:"
           >
             <option>
               Foo
@@ -71,7 +71,7 @@ exports[`renders a Select with no options 1`] = `
         >
           <select
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440001"
+            id=":r0:"
           />
           <span
             class="postfix"
@@ -112,7 +112,7 @@ exports[`renders a Select with one option 1`] = `
         >
           <select
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440003"
+            id=":r2:"
           >
             <option>
               Foo
@@ -157,7 +157,7 @@ exports[`renders correctly as large 1`] = `
         >
           <select
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440009"
+            id=":r8:"
           >
             <option>
               Foo
@@ -202,7 +202,7 @@ exports[`renders correctly as small 1`] = `
         >
           <select
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440007"
+            id=":r6:"
           >
             <option>
               Foo
@@ -248,7 +248,7 @@ exports[`renders correctly when disabled 1`] = `
           <select
             class="input"
             disabled=""
-            id="123e4567-e89b-12d3-a456-426655440011"
+            id=":ra:"
           >
             <option>
               Foo
@@ -293,7 +293,7 @@ exports[`renders correctly when invalid 1`] = `
         >
           <select
             class="input"
-            id="123e4567-e89b-12d3-a456-426655440013"
+            id=":rc:"
           >
             <option>
               Foo


### PR DESCRIPTION
## Motivations

We have an upcoming need to support SSR, and our usage of uuid does not play well with that kind of rendering. We need the ids to match from server to client.

## Changes

- Removed uuid usage in internal components. Should not affect external functionality.

## Testing

- All form elements or anything previously using uuid, should render and operate as normal.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
