### PR TITLE
fix(components): Prevent ComboBox popover width from expanding [JOB-80990]

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.css
@@ -1,7 +1,6 @@
 .content {
   z-index: var(--elevation-tooltip);
-  max-width: var(--popover--width);
-  min-width: calc(var(--space-extravagant) * 3.75);
+  width: calc(var(--space-extravagant) * 3.75);
   box-shadow: var(--shadow-base);
   margin-top: var(--space-small);
   border: var(--border-base) solid var(--color-border);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When typing in the ComboBox search input, after text reaches a certain length it was expanding the width of the popover and we want to prevent that.

## Changes

### Added

- <!-- new features -->

### Changed

- <!-- new features -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Updated the ComboBox CSS to remove min/max-width in favour of a static width.

### Security

- <!-- in case of vulnerabilities -->

## Testing

### Desktop - Before

https://github.com/GetJobber/atlantis/assets/82835373/7194cf11-1e60-44cb-bbb3-60f94bd4d711



### Desktop - After

https://github.com/GetJobber/atlantis/assets/82835373/707b325d-1179-4f3a-86e6-82d9ef08cd60


### Mobile - Before

Below you can see the text overflows and expands the width of the popover.

<img src="https://github.com/GetJobber/atlantis/assets/82835373/1e2ec124-1536-4cbc-a8b6-4c405b55ef8b" width=300 />

### Mobile - After

<img src="https://github.com/GetJobber/atlantis/assets/82835373/d2697ff1-9af2-4afe-ae2c-aa56614f9556" width=300 />

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
