### PR TITLE
fix(components): Add SortableOptions Partial to DataListSorting

### DIFF
--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -51,9 +51,9 @@ export interface DataListSorting extends SortableOptions {
 }
 
 export interface SortableOptions {
-  readonly id: string | undefined;
-  readonly label: string | undefined;
-  readonly order: "asc" | "desc";
+  readonly id?: string;
+  readonly label?: string;
+  readonly order?: "asc" | "desc";
 }
 
 export interface DataListProps<T extends DataListObject> {

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -46,14 +46,14 @@ export type DataListHeader<T extends DataListObject> = {
   readonly [K in keyof T]?: string;
 };
 
-export interface DataListSorting extends SortableOptions {
+export interface DataListSorting extends Partial<SortableOptions> {
   readonly key: string;
 }
 
 export interface SortableOptions {
-  readonly id?: string;
-  readonly label?: string;
-  readonly order?: "asc" | "desc";
+  readonly id: string;
+  readonly label: string;
+  readonly order: "asc" | "desc";
 }
 
 export interface DataListProps<T extends DataListObject> {

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -51,8 +51,8 @@ export interface DataListSorting extends SortableOptions {
 }
 
 export interface SortableOptions {
-  readonly id: string;
-  readonly label: string;
+  readonly id: string | undefined;
+  readonly label: string | undefined;
   readonly order: "asc" | "desc";
 }
 

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -38,8 +38,6 @@ export function DataListHeaderTile<T extends DataListObject>({
 
   const Tag = isSortable ? "button" : "div";
 
-  const selectedOption: SortableOptions | null = sorting?.state || null;
-
   return (
     <Tag
       className={classnames(styles.headerLabel, {
@@ -52,7 +50,7 @@ export function DataListHeaderTile<T extends DataListObject>({
       {isSortable && sortableItem?.options && isDropDownOpen && (
         <DataListSortingOptions
           options={sortableItem.options}
-          selectedOption={selectedOption}
+          selectedOption={sorting?.state || null}
           onSelectChange={handleSelectChange}
           onClose={() => setIsDropDownOpen(false)}
           optionsListRef={optionsListRef}

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -68,9 +68,9 @@ export function DataListHeaderTile<T extends DataListObject>({
   );
 
   function toggleSorting(
-    id: string,
     sortingKey: string,
-    label: string,
+    id?: string,
+    label?: string,
     order?: "asc" | "desc",
   ) {
     const isSameKey =
@@ -87,8 +87,8 @@ export function DataListHeaderTile<T extends DataListObject>({
     const sortingOrder = order || (isSameKey && !isDescending ? "desc" : "asc");
 
     sorting?.onSort({
-      id,
       key: sortingKey,
+      id,
       label,
       order: sortingOrder,
     });
@@ -112,8 +112,8 @@ export function DataListHeaderTile<T extends DataListObject>({
   function handleSelectChange(newSortOption: SortableOptions) {
     if (sortableItem) {
       toggleSorting(
-        newSortOption.id,
         sortableItem.key,
+        newSortOption.id,
         newSortOption.label,
         newSortOption.order,
       );

--- a/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
@@ -3,11 +3,11 @@ import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
 import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
 import { Icon } from "@jobber/components/Icon";
 import styles from "./DataListSortingOptions.css";
-import { SortableOptions } from "../../../DataList.types";
+import { DataListSorting, SortableOptions } from "../../../DataList.types";
 
 interface DataListSortingOptionsProps {
   readonly options: SortableOptions[];
-  readonly selectedOption: SortableOptions | null;
+  readonly selectedOption: DataListSorting | null;
   readonly onSelectChange: (selectedOption: SortableOptions) => void;
   readonly onClose: () => void;
   readonly optionsListRef: React.RefObject<HTMLUListElement>;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->


### Changed

<!-- changes in existing functionality -->

`DataListSorting` type needs to have a Partial extend for `SortableOptions` in order to continue allowing for sorting with or without options (`id`, `label` & `order`)


## Testing

<!-- How to test your changes. -->
Darryl and I have been working on implementing changes needed [here](https://github.com/GetJobber/Jobber/pull/42605)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
