### PR TITLE
fix(components): Update handling of sorting state

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -66,29 +66,37 @@ export function DataListHeaderTile<T extends DataListObject>({
   );
 
   function toggleSorting(
-    sortingKey: string,
-    id?: string,
-    label?: string,
-    order?: "asc" | "desc",
+    newSortingKey: string,
+    newId?: string,
+    newLabel?: string,
+    newOrder?: "asc" | "desc",
   ) {
-    const isSameKey =
-      sortingState?.label === label && sortingKey === sortingState?.key;
+    const isSameKey = newSortingKey === sortingState?.key;
     const isDescending = sortingState?.order === "desc";
 
-    if (isSameKey && isDescending && order !== "asc") {
-      if (order === "desc") return;
+    if (isSameKey && isDescending && newOrder === undefined) {
       sorting?.onSort(undefined);
 
       return;
     }
 
-    const sortingOrder = order || (isSameKey && !isDescending ? "desc" : "asc");
+    const sortingOrder =
+      newOrder || (isSameKey && !isDescending ? "desc" : "asc");
 
+    setSorting(newSortingKey, newId, newLabel, sortingOrder);
+  }
+
+  function setSorting(
+    newSortingKey: string,
+    newId?: string,
+    newLabel?: string,
+    newOrder?: "asc" | "desc",
+  ) {
     sorting?.onSort({
-      key: sortingKey,
-      id,
-      label,
-      order: sortingOrder,
+      key: newSortingKey,
+      id: newId,
+      label: newLabel,
+      order: newOrder,
     });
   }
 
@@ -109,7 +117,7 @@ export function DataListHeaderTile<T extends DataListObject>({
 
   function handleSelectChange(newSortOption: SortableOptions) {
     if (sortableItem) {
-      toggleSorting(
+      setSorting(
         sortableItem.key,
         newSortOption.id,
         newSortOption.label,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Last Activity header was not sorting in the correct order

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
 <!-- new features -->
- added `setSorting` function to better handle sorting state updates; and share that function between `toggleSorting` as well as `handleSelectChange` (sorting on key only vs. sorting with options)

### Changed

<!-- changes in existing functionality -->
- updated the check for order being `undefined` in `toggleSorting`
- update variable names 


## Testing

<!-- How to test your changes. -->
Update sorting state in the web stories to make sure that on load, Last activity header has desc sort indicated. Another click on the header returns no sorting state. Clicking a third time means the sorting state is asc.

```
  const [sortingState, setSortingState] = useState<DataListSorting>({
    key: "lastActivity",
    order: "desc",
  });
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
