### PR TITLE
fix(components): Ensure Combobox Updates on New Options

### DIFF
--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { render, screen } from "@testing-library/react";
 import { UserEvent, userEvent } from "@testing-library/user-event";
 import { Combobox } from "./Combobox";
@@ -510,6 +510,16 @@ describe("Combobox Custom onSearch", () => {
   });
 });
 
+describe("Combobox option reactiveness", () => {
+  it("should render the correct options when they instantly change", async () => {
+    render(<ImmediatelyAlteredOptionCombobox />);
+    expect(screen.getByText("Bilbo Baggins")).toBeInTheDocument();
+    expect(screen.getByText("Frodo Baggins")).toBeInTheDocument();
+    expect(screen.getByText("Pippin Took")).toBeInTheDocument();
+    expect(screen.getByText("Meriadoc Brandybuck")).toBeInTheDocument();
+  });
+});
+
 function renderCustomOnSearchCombobox(
   loading: boolean,
   renderWithoutOptions = false,
@@ -560,4 +570,45 @@ function renderMultiSelectCombobox() {
   mockMultiSelectValue.mockReturnValueOnce(true);
 
   return renderCombobox();
+}
+
+function ImmediatelyAlteredOptionCombobox() {
+  const firstOptions = [
+    {
+      id: "1",
+      label: "Bilbo Baggins",
+    },
+    {
+      id: "2",
+      label: "Frodo Baggins",
+    },
+  ];
+  const secondOptions = [
+    {
+      id: "3",
+      label: "Pippin Took",
+    },
+    {
+      id: "4",
+      label: "Meriadoc Brandybuck",
+    },
+  ];
+  const [options, setOptions] = useState(firstOptions);
+
+  useEffect(() => {
+    setOptions([...firstOptions, ...secondOptions]);
+  }, []);
+
+  return (
+    <Combobox
+      label={activatorLabel}
+      multiSelect={true}
+      selected={mockSelectedValue()}
+      onSelect={handleSelect}
+    >
+      {options.map(option => (
+        <Combobox.Option id={option.id} label={option.label} key={option.id} />
+      ))}
+    </Combobox>
+  );
 }

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -42,8 +42,8 @@ export function useCombobox(
     useState<ComboboxOption[]>(options);
 
   const searchCallback = useCallback(
-    debounce((value: string) => onSearch && onSearch(value), debounceTime),
-    [],
+    debounce((value: string) => onSearch?.(value), debounceTime),
+    [onSearch, debounceTime],
   );
 
   const debouncedFilterOptions = useCallback((value: string) => {

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from "react";
 import debounce from "lodash/debounce";
+import noop from "lodash/noop";
 import {
   UseMakeComboboxHandlersReturn,
   useMakeComboboxHandlers,
@@ -38,21 +39,11 @@ export function useCombobox(
   const shouldScroll = useRef<boolean>(false);
   const [open, setOpen] = useState<boolean>(false);
   const [searchValue, setSearchValue] = useState<string>("");
-  const [internalFilteredOptions, setInternalFilteredOptions] =
-    useState<ComboboxOption[]>(options);
 
   const searchCallback = useCallback(
     debounce((value: string) => onSearch?.(value), debounceTime),
     [onSearch, debounceTime],
   );
-
-  const debouncedFilterOptions = useCallback((value: string) => {
-    const filtered = options.filter(option => {
-      return option.label.toLowerCase().includes(value.toLowerCase());
-    });
-
-    setInternalFilteredOptions(filtered);
-  }, []);
 
   const { handleClose, handleSelection } = useMakeComboboxHandlers(
     setOpen,
@@ -62,6 +53,10 @@ export function useCombobox(
     onSelect,
     multiSelect,
     onClose,
+  );
+
+  const internalFilteredOptions = options.filter(option =>
+    option.label.toLowerCase().includes(searchValue.toLowerCase()),
   );
 
   return {
@@ -76,6 +71,6 @@ export function useCombobox(
     handleClose,
     handleSelection,
     internalFilteredOptions,
-    handleSearchChange: onSearch ? searchCallback : debouncedFilterOptions,
+    handleSearchChange: onSearch ? searchCallback : noop,
   };
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

there's an issue with new options being passed in not being recognized

## Changes

added some dependencies to the `useCallback` array

made the filtered options re-calculate whenever the search term changes

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

options will now correctly update if you change them in some way other than with `onSearch`

### Security

- <!-- in case of vulnerabilities -->

## Testing

give the combobox new options but in a way that is not thru the `onSearch` prop and it will not have a splendid time

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
