### PR TITLE
fix(components): Extract and Export Sortable Type 

### DIFF
--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -56,6 +56,11 @@ export interface SortableOptions {
   readonly order: "asc" | "desc";
 }
 
+export interface DataListSortable {
+  readonly key: string;
+  readonly options?: SortableOptions[];
+}
+
 export interface DataListProps<T extends DataListObject> {
   /**
    * The data to render in the DataList.
@@ -116,10 +121,7 @@ export interface DataListProps<T extends DataListObject> {
    * `onSort`: The callback function when the user sorting a column.
    */
   readonly sorting?: {
-    readonly sortable: {
-      key: string;
-      options?: SortableOptions[];
-    }[];
+    readonly sortable: DataListSortable[];
     readonly state: DataListSorting | undefined;
     readonly onSort: (sorting?: DataListSorting) => void;
   };

--- a/packages/components/src/DataList/index.ts
+++ b/packages/components/src/DataList/index.ts
@@ -2,6 +2,7 @@ export * from "./DataList";
 export {
   DataListItemType,
   DataListSorting,
+  DataListSortable,
   DataListSelectedType,
   DataListSelectedAllType,
 } from "./DataList.types";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

when implementing the new multi sorted header, I ran into the following

when I'm making my array of sorting objects, I don't have a nice type to refer to. I have to manually build out an object with  a `key` and optional `options` of type `SortableOptions`

![image](https://github.com/GetJobber/atlantis/assets/11843215/2292ea78-69c3-4d7f-b66e-7861b7ccea79)


and our linter yells at you for trying import from here to boot
![image](https://github.com/GetJobber/atlantis/assets/11843215/1eec38b9-49b9-40d8-bf8e-5670113fbdf1)

so I'd like to make a type that encapsulates the expected type for the `sortable` that we can easily use on the implementation side!

## Changes



### Added

- added a type
- exported the type from the index so it can be accessed without linting violations

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
