### PR TITLE
docs: Fix broken links in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,17 +72,17 @@ This following list has installation links for each package:
 
 These are the core packages you'll need to build with Atlantis:
 
-- [Components](/packages/components)
-- [Design](/packages/design)
-- [Hooks](/packages/hooks)
+- [Components](../?path=/docs/packages-components--page)
+- [Design](../?path=/docs/packages-design--page)
+- [Hooks](../?path=/docs/packages-hooks--page)
 
 ### Tooling and configuration
 
 If you're looking to build documentation and tooling using Atlantis' development
 standards, these packages will be useful:
 
-- [EsLint configuration](/packages/eslint-config)
-- [StyleLint configuration](/packages/stylelint-config)
+- [EsLint configuration](../?path=/docs/packages-eslint-config--page)
+- [StyleLint configuration](../?path=/docs/packages-stylelint-config--page)
 
 ## Generating a component
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

During the testing of the Storybook 7 upgrade we saw that links in the main README were broken. This PR fixes that

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fixed links in the README that were broken

### Security

- <!-- in case of vulnerabilities -->

## Testing

 Verify that these links take you to the correct page instead of giving a 404 / an error page

<img width="958" alt="image" src="https://github.com/GetJobber/atlantis/assets/17303106/a01f4cb7-1c01-4b8b-a007-ff070bda22ab">


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
