### PR TITLE
feat(components-native): JOB-88274 Prep inputs for retheme

### DIFF
--- a/packages/components-native/src/InputDate/InputDate.tsx
+++ b/packages/components-native/src/InputDate/InputDate.tsx
@@ -174,6 +174,7 @@ function InternalInputDate({
   return (
     <>
       <InputPressable
+        focused={showPicker}
         clearable={canClearDate}
         disabled={disabled}
         invalid={invalid}

--- a/packages/components-native/src/InputFieldWrapper/CommonInputStyles.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/CommonInputStyles.style.ts
@@ -34,5 +34,6 @@ export const commonInputStyles = StyleSheet.create({
     borderColor: tokens["color-border"],
     borderStyle: "solid",
     borderWidth: tokens["border-base"],
+    borderRadius: tokens["radius-base"],
   },
 });

--- a/packages/components-native/src/InputFieldWrapper/CommonInputStyles.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/CommonInputStyles.style.ts
@@ -30,8 +30,9 @@ export const commonInputStyles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     width: "100%",
-    borderColor: tokens["color-grey"],
+    borderColor: tokens["color-border"],
     borderStyle: "solid",
-    borderBottomWidth: tokens["border-base"],
+    borderWidth: tokens["border-base"],
+    paddingLeft: tokens["space-base"],
   },
 });

--- a/packages/components-native/src/InputFieldWrapper/CommonInputStyles.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/CommonInputStyles.style.ts
@@ -11,7 +11,7 @@ export const commonInputStyles = StyleSheet.create({
     fontFamily: typographyStyles.baseRegularRegular.fontFamily,
     fontSize: typographyStyles.defaultSize.fontSize,
     letterSpacing: typographyStyles.baseLetterSpacing.letterSpacing,
-    minHeight: tokens["space-largest"],
+    minHeight: tokens["space-largest"] + tokens["space-small"],
     padding: 0,
   },
 
@@ -24,15 +24,15 @@ export const commonInputStyles = StyleSheet.create({
   },
 
   container: {
+    paddingLeft: tokens["space-base"],
     marginVertical: tokens["space-smaller"],
     backgroundColor: tokens["color-surface"],
-    minHeight: tokens["space-largest"],
+    minHeight: tokens["space-largest"] + tokens["space-small"],
     flexDirection: "row",
     justifyContent: "space-between",
     width: "100%",
     borderColor: tokens["color-border"],
     borderStyle: "solid",
     borderWidth: tokens["border-base"],
-    paddingLeft: tokens["space-base"],
   },
 });

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
@@ -46,8 +46,6 @@ export const styles = StyleSheet.create({
 
   disabled: {
     backgroundColor: tokens["color-disabled--secondary"],
-    borderTopLeftRadius: tokens["radius-large"],
-    borderTopRightRadius: tokens["radius-large"],
   },
 
   fieldAffix: {

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
@@ -80,7 +80,7 @@ export const styles = StyleSheet.create({
   suffixLabel: {
     justifyContent: "center",
     paddingTop: tokens["space-minuscule"],
-    paddingRight: tokens["space-base"],
+    paddingRight: tokens["space-small"],
   },
   suffixIconMargin: {
     marginLeft: tokens["space-small"] + tokens["space-smaller"],

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
@@ -74,11 +74,13 @@ export const styles = StyleSheet.create({
 
   suffixIcon: {
     justifyContent: "center",
+    paddingRight: tokens["space-small"],
   },
 
   suffixLabel: {
     justifyContent: "center",
     paddingTop: tokens["space-minuscule"],
+    paddingRight: tokens["space-base"],
   },
   suffixIconMargin: {
     marginLeft: tokens["space-small"] + tokens["space-smaller"],

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
@@ -36,7 +36,7 @@ export const styles = StyleSheet.create({
     paddingTop: tokens["space-small"] - tokens["space-smallest"],
     backgroundColor: tokens["color-surface"],
     maxHeight:
-      (typographyStyles.smallSize.lineHeight || 0) + tokens["space-smaller"],
+      (typographyStyles.defaultSize.lineHeight || 0) + tokens["space-smaller"],
     zIndex: 1,
   },
   // Prevents the miniLabel from cutting off the ClearAction button
@@ -55,7 +55,7 @@ export const styles = StyleSheet.create({
   },
 
   fieldAffixMiniLabel: {
-    paddingTop: 0,
+    paddingTop: tokens["space-small"] - tokens["space-smallest"],
     // @ts-expect-error tsc-ci
     top: typographyStyles.smallSize.fontSize / 2,
     right: 0,

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
@@ -23,7 +23,9 @@ export const styles = StyleSheet.create({
   label: {
     // for placeholder
     position: "absolute",
-    top: typographyStyles.smallSize.fontSize,
+    display: "flex",
+    justifyContent: "center",
+    top: 0,
     right: 0,
     bottom: 0,
     left: 0,
@@ -31,7 +33,7 @@ export const styles = StyleSheet.create({
 
   miniLabel: {
     top: 0,
-    paddingTop: tokens["space-smallest"],
+    paddingTop: tokens["space-small"] - tokens["space-smallest"],
     backgroundColor: tokens["color-surface"],
     maxHeight:
       (typographyStyles.smallSize.lineHeight || 0) + tokens["space-smaller"],

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.test.tsx
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.test.tsx
@@ -192,9 +192,7 @@ describe("InputFieldWrapper", () => {
         includeHiddenElements: true,
       });
 
-      expect(placeholder.props.style).toContainEqual(
-        typographyStyles.interactive,
-      );
+      expect(placeholder.props.style).toContainEqual(typographyStyles.subdued);
       expect(placeholder.props.style).toContainEqual(
         typographyStyles.defaultSize,
       );

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.test.tsx
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.test.tsx
@@ -65,8 +65,6 @@ describe("InputFieldWrapper", () => {
 
     expect(getByTestId("ATL-InputFieldWrapper").props.style).toContainEqual({
       backgroundColor: "rgb(225, 225, 225)",
-      borderTopLeftRadius: 4,
-      borderTopRightRadius: 4,
     });
   });
 

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.tsx
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.tsx
@@ -146,12 +146,7 @@ export function InputFieldWrapper({
           >
             <Placeholder
               placeholder={placeholder}
-              labelVariation={getLabelVariation(
-                error,
-                invalid,
-                focused,
-                disabled,
-              )}
+              labelVariation={getLabelVariation(error, invalid, disabled)}
               hasMiniLabel={hasMiniLabel}
               styleOverride={styleOverride?.placeholderText}
             />
@@ -218,15 +213,12 @@ export function InputFieldWrapper({
 function getLabelVariation(
   error?: FieldError,
   invalid?: boolean | string,
-  focused?: boolean,
   disabled?: boolean,
 ): TextVariation {
   if (invalid || error) {
     return "error";
   } else if (disabled) {
     return "disabled";
-  } else if (focused) {
-    return "interactive";
   }
 
   return "subdued";

--- a/packages/components-native/src/InputPressable/InputPressable.style.ts
+++ b/packages/components-native/src/InputPressable/InputPressable.style.ts
@@ -2,16 +2,16 @@ import { tokens } from "@jobber/design/foundation";
 import { StyleSheet } from "react-native";
 import { typographyStyles } from "../Typography/Typography.style";
 
-const miniLabelFontSize = typographyStyles.smallSize.fontSize || 0;
-const miniLabelPadding = tokens["space-small"];
-
 export const styles = StyleSheet.create({
   pressable: {
     flex: 1,
   },
 
   inputPressableStyles: {
-    paddingTop: miniLabelPadding + miniLabelFontSize,
+    paddingTop:
+      (typographyStyles.defaultSize.fontSize || 0) +
+      tokens["space-small"] +
+      tokens["space-smaller"],
     lineHeight: typographyStyles.defaultSize.lineHeight,
   },
 

--- a/packages/components-native/src/InputPressable/InputPressable.tsx
+++ b/packages/components-native/src/InputPressable/InputPressable.tsx
@@ -23,6 +23,11 @@ export interface InputPressableProps {
   readonly disabled?: boolean;
 
   /**
+   * Indicates if the input is focused
+   */
+  readonly focused?: boolean;
+
+  /**
    * Indicates if there is an validation error
    */
   readonly error?: FieldError;
@@ -95,6 +100,7 @@ export function InputPressableInternal(
     suffix,
     clearable = "never",
     onClear,
+    focused,
   }: InputPressableProps,
   ref: Ref<InputPressableRef>,
 ): JSX.Element {
@@ -119,7 +125,7 @@ export function InputPressableInternal(
       suffix={suffix}
       hasValue={hasValue}
       hasMiniLabel={hasMiniLabel}
-      focused={false}
+      focused={focused}
       error={error}
       invalid={invalid}
       placeholder={placeholder}

--- a/packages/components-native/src/InputSearch/InputSearch.style.ts
+++ b/packages/components-native/src/InputSearch/InputSearch.style.ts
@@ -1,9 +1,7 @@
 import { StyleSheet } from "react-native";
-import { tokens } from "../utils/design";
 
 export const styles = StyleSheet.create({
   container: {
     width: "100%",
-    paddingHorizontal: tokens["space-base"],
   },
 });

--- a/packages/components-native/src/InputText/InputText.style.ts
+++ b/packages/components-native/src/InputText/InputText.style.ts
@@ -13,6 +13,7 @@ export const styles = StyleSheet.create({
   multiLineInput: {
     paddingTop: 0,
     lineHeight: typographyStyles.defaultSize.lineHeight,
+    paddingRight: tokens["space-base"] - tokens["space-smallest"],
   },
 
   multiLineInputWithMini: {

--- a/packages/components-native/src/InputText/InputText.style.ts
+++ b/packages/components-native/src/InputText/InputText.style.ts
@@ -17,7 +17,7 @@ export const styles = StyleSheet.create({
 
   multiLineInputWithMini: {
     paddingTop: tokens["space-large"] + tokens["space-smallest"],
-    paddingBottom: tokens["space-smaller"] - tokens["space-smallest"],
+    paddingBottom: tokens["space-small"] - tokens["space-smallest"],
   },
 
   multilineInputiOS: {

--- a/packages/components-native/src/InputText/InputText.style.ts
+++ b/packages/components-native/src/InputText/InputText.style.ts
@@ -4,22 +4,25 @@ import { typographyStyles } from "../Typography";
 
 export const styles = StyleSheet.create({
   inputPaddingTop: {
-    paddingTop: typographyStyles.smallSize.fontSize,
+    paddingTop:
+      (typographyStyles.smallSize.fontSize || 0) +
+      tokens["space-smaller"] +
+      tokens["space-smallest"],
   },
 
   multiLineInput: {
-    paddingTop: tokens["space-base"] - tokens["space-smallest"],
-    paddingBottom: tokens["space-smaller"],
+    paddingTop: 0,
     lineHeight: typographyStyles.defaultSize.lineHeight,
   },
 
   multiLineInputWithMini: {
-    paddingTop: tokens["space-large"],
+    paddingTop: tokens["space-large"] + tokens["space-smallest"],
+    paddingBottom: tokens["space-smaller"] + tokens["space-smallest"],
   },
 
   multilineInputiOS: {
     // for placeholder
     paddingTop:
-      (typographyStyles.smallSize.fontSize || 0) + tokens["space-smallest"],
+      (typographyStyles.defaultSize.fontSize || 0) + tokens["space-smallest"],
   },
 });

--- a/packages/components-native/src/InputText/InputText.style.ts
+++ b/packages/components-native/src/InputText/InputText.style.ts
@@ -17,7 +17,7 @@ export const styles = StyleSheet.create({
 
   multiLineInputWithMini: {
     paddingTop: tokens["space-large"] + tokens["space-smallest"],
-    paddingBottom: tokens["space-smaller"] + tokens["space-smallest"],
+    paddingBottom: tokens["space-smaller"] - tokens["space-smallest"],
   },
 
   multilineInputiOS: {

--- a/packages/components-native/src/InputText/InputText.tsx
+++ b/packages/components-native/src/InputText/InputText.tsx
@@ -377,8 +377,8 @@ function InputTextInternal(
           styles.inputPaddingTop,
           !hasMiniLabel && commonInputStyles.inputEmpty,
           disabled && commonInputStyles.inputDisabled,
-          multiline && Platform.OS === "ios" && styles.multilineInputiOS,
           multiline && styles.multiLineInput,
+          multiline && Platform.OS === "ios" && styles.multilineInputiOS,
           multiline && hasMiniLabel && styles.multiLineInputWithMini,
           styleOverride?.inputText,
         ]}

--- a/packages/components-native/src/InputTime/InputTime.tsx
+++ b/packages/components-native/src/InputTime/InputTime.tsx
@@ -159,6 +159,7 @@ function InternalInputTime({
         clearable={canClearTime}
         disabled={disabled}
         invalid={invalid}
+        focused={showPicker}
         placeholder={placeholder ?? t("time")}
         prefix={showIcon ? { icon: "timer" } : undefined}
         value={formattedTime}

--- a/packages/components-native/src/Select/Select.style.ts
+++ b/packages/components-native/src/Select/Select.style.ts
@@ -9,6 +9,8 @@ export const styles = StyleSheet.create({
       flexDirection: "column",
       justifyContent: "flex-end",
       minHeight: tokens["space-largest"] + tokens["border-base"],
+      marginVertical: 0,
+      borderWidth: 0,
     },
   ]),
 
@@ -20,6 +22,7 @@ export const styles = StyleSheet.create({
       paddingBottom: tokens["space-smaller"],
       minHeight: 0,
       minWidth: "100%",
+      paddingRight: tokens["space-small"],
     },
   ]),
 

--- a/packages/components-native/src/Select/Select.style.ts
+++ b/packages/components-native/src/Select/Select.style.ts
@@ -7,8 +7,8 @@ export const styles = StyleSheet.create({
     commonInputStyles.container,
     {
       flexDirection: "column",
-      justifyContent: "flex-end",
-      minHeight: tokens["space-largest"] + tokens["border-base"],
+      justifyContent: "center",
+      minHeight: tokens["space-largest"] + tokens["space-small"],
       marginVertical: 0,
       borderWidth: 0,
     },
@@ -19,7 +19,7 @@ export const styles = StyleSheet.create({
     {
       flexDirection: "row",
       flexGrow: 0,
-      paddingBottom: tokens["space-smaller"],
+      paddingTop: tokens["space-smaller"],
       minHeight: 0,
       minWidth: "100%",
       paddingRight: tokens["space-small"],
@@ -32,6 +32,9 @@ export const styles = StyleSheet.create({
   },
 
   icon: {
+    position: "absolute",
+    bottom: "50%",
+    right: tokens["space-small"],
     flexGrow: 0,
     flexShrink: 0,
   },

--- a/packages/components-native/src/Select/Select.tsx
+++ b/packages/components-native/src/Select/Select.tsx
@@ -151,15 +151,13 @@ export function Select({
           <View
             style={[styles.container, (invalid || !!error) && styles.invalid]}
           >
-            {label && (
-              <Text
-                level="textSupporting"
-                variation={textVariation}
-                hideFromScreenReader={true}
-              >
-                {label}
-              </Text>
-            )}
+            <Text
+              level="textSupporting"
+              variation={textVariation}
+              hideFromScreenReader={true}
+            >
+              {label}
+            </Text>
 
             <View style={styles.input}>
               <View style={styles.value}>

--- a/packages/components-native/src/Select/Select.tsx
+++ b/packages/components-native/src/Select/Select.tsx
@@ -131,7 +131,7 @@ export function Select({
       invalid={invalid || !!error}
       hasValue={hasValue}
       styleOverride={{
-        container: { borderBottomWidth: undefined },
+        container: { paddingLeft: undefined },
       }}
     >
       <View


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Updating the base styling of `components-native`'s Input to match our new designs

## Changes

### Added

- Added focused state to InputPressable

### Changed

- Changed theming of Inputs to prepare for the retheme
   - Added full borders around our Inputs
   - Updated the size of the Inputs to match the new designs.
   - Added padding to Inputs to match the new designs

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing
 - Use the Jobber Mobile builds [here](https://github.com/GetJobber/jobber-mobile/pull/8688) and verify the styling of Inputs matches the designs

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
