### PR TITLE
fix: ensure loading spinner shows up on combobox when actions are there

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
@@ -66,11 +66,11 @@
 .loadingContainer.hasOptions {
   display: flex;
   justify-content: center;
-
-  position: fixed;
+  position: sticky;
   bottom: 0;
-
-  width: 100%;
-
   padding: var(--space-base) 0;
+}
+
+.loadingContainer.hasOptions:empty {
+  display: none;
 }

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.tsx
@@ -3,6 +3,7 @@ import classnames from "classnames";
 import { Text } from "@jobber/components/Text";
 import { Glimmer } from "@jobber/components/Glimmer";
 import { Spinner } from "@jobber/components/Spinner";
+import { AnimatedPresence } from "@jobber/components/AnimatedPresence";
 import styles from "./ComboboxContentList.css";
 import {
   ComboboxListProps,
@@ -43,16 +44,15 @@ export function ComboboxContentList(props: ComboboxListProps): JSX.Element {
             );
           })}
 
-          {props.loading && optionsExist && (
-            <div
-              className={classnames([
-                styles.loadingContainer,
-                styles.hasOptions,
-              ])}
-            >
-              <Spinner size="small" />
-            </div>
-          )}
+          <div
+            className={classnames([styles.loadingContainer, styles.hasOptions])}
+          >
+            <AnimatedPresence transition="fromBottom">
+              {Boolean(props.loading && optionsExist) && (
+                <Spinner size="small" />
+              )}
+            </AnimatedPresence>
+          </div>
 
           {props.onLoadMore && (
             <ComboboxLoadMore onLoadMore={props.onLoadMore} />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Noticed that when you set the loading to true, the spinner doesn't show up when an action is available. It's because it's being rendered under behind the actions 
![image](https://github.com/GetJobber/atlantis/assets/15986172/9fdc1195-4d1f-43ae-a027-86e9c40f4cf5)

This fixes it

![image](https://github.com/GetJobber/atlantis/assets/15986172/bfd19e3d-09ed-4f1d-8421-02f9fa089fa7)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- from fixed to sticky so it stays the the bottom but keeps itself visible when scrolled

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
