### PR TITLE
feat(components): Conditionally render DataListStickyHeader based on presence of children

### DIFF
--- a/packages/components/src/DataList/DataList.const.ts
+++ b/packages/components/src/DataList/DataList.const.ts
@@ -32,6 +32,7 @@ export const DATA_LIST_FILTERING_SPINNER_TEST_ID =
 export const DATA_LIST_LOADING_MORE_SPINNER_TEST_ID =
   "ATL-DataList-loadingMoreSpinner";
 export const DATA_LOAD_MORE_TEST_ID = "ATL-DataList-LoadMore-trigger";
+export const DATA_LIST_STICKY_HEADER_TEST_ID = "ATL-DataList-stickyHeader";
 
 export const TRANSITION_DURATION_IN_SECONDS = tokens["timing-base"] / 1000;
 export const TRANSITION_DELAY_IN_SECONDS = tokens["timing-quick"] / 1000;

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -166,10 +166,12 @@ describe("DataList", () => {
   describe("Layout", () => {
     const layoutWrapper = "layout-wrapper";
     const layoutItem = "layout-item";
+    const mockOnSearch = jest.fn();
 
     beforeEach(() => {
       render(
         <DataList data={mockData} headers={mockHeaders}>
+          <DataList.Search onSearch={mockOnSearch} />
           <DataList.Layout>
             {(item: DataListItemType<typeof mockData>) => (
               <div data-testid={layoutWrapper}>
@@ -313,6 +315,7 @@ describe("DataList", () => {
       }) => {
         const layout1Wrapper = "layout1-wrapper";
         const layout2Wrapper = "layout2-wrapper";
+        const mockOnSearch = jest.fn();
         setUpMediaQueries(mockedQueries);
         render(
           <DataList
@@ -320,6 +323,7 @@ describe("DataList", () => {
             headers={mockHeaders}
             headerVisibility={headerVisibility}
           >
+            <DataList.Search onSearch={mockOnSearch} />
             <DataList.Layout size={layoutSize1}>
               {(item: DataListItemType<typeof mockData>) => (
                 <div data-testid={layout1Wrapper}>
@@ -346,6 +350,8 @@ describe("DataList", () => {
   });
 
   describe("Header", () => {
+    const mockOnSearch = jest.fn();
+
     function renderLayout(
       headerVisibility?: DataListProps<
         (typeof mockData)[0]
@@ -359,6 +365,7 @@ describe("DataList", () => {
           headerVisibility={headerVisibility}
           sorting={sorting}
         >
+          <DataList.Search onSearch={mockOnSearch} />
           <DataList.Layout>
             {(item: DataListItemType<typeof mockData>) => (
               <div>{item.name}</div>
@@ -389,6 +396,8 @@ describe("DataList", () => {
   });
 
   describe("Sorting", () => {
+    const mockOnSearch = jest.fn();
+
     function MockSortingLayout({
       sorting,
     }: {
@@ -396,6 +405,7 @@ describe("DataList", () => {
     }) {
       return (
         <DataList data={mockData} headers={mockHeaders} sorting={sorting}>
+          <DataList.Search onSearch={mockOnSearch} />
           <DataList.Layout>
             {(item: DataListItemType<typeof mockData>) => (
               <div>{item.name}</div>
@@ -566,6 +576,7 @@ describe("DataList", () => {
     it("should show the StatusBar when it's provided", () => {
       const bannerText =
         "Something went wrong. Refresh or check your internet connection.";
+      const mockOnSearch = jest.fn();
       render(
         <DataList
           data={Array.from({ length: MAX_DATA_COUNT + 1 }, (_, id) => ({
@@ -573,6 +584,7 @@ describe("DataList", () => {
           }))}
           headers={{ id: "ID" }}
         >
+          <DataList.Search onSearch={mockOnSearch} />
           <DataList.StatusBar>
             <Banner type="error" icon="alert">
               {bannerText}

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -397,36 +397,24 @@ describe("DataList", () => {
   });
 
   describe("DataListStickyHeader", () => {
-    const layoutWrapper = "layout-wrapper";
-    const layoutItem = "layout-item";
     const mockOnSearch = jest.fn();
 
     const renderDataListWithLayout = (children: ReactElement) => {
       render(
         <DataList data={mockData} headers={{}}>
           {children}
-          <DataList.Layout>
-            {(item: DataListItemType<typeof mockData>) => (
-              <div data-testid={layoutWrapper}>
-                <div data-testid={layoutItem}>{item.name}</div>
-                <div data-testid={layoutItem}>{item.email}</div>
-              </div>
-            )}
-          </DataList.Layout>
         </DataList>,
       );
     };
 
-    it("should render the default layout and Sticky Header if DataList.Search is provided", () => {
+    it("should render the Sticky Header if DataList.Search is provided", () => {
       renderDataListWithLayout(<DataList.Search onSearch={mockOnSearch} />);
       expect(
         screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
       ).toBeInTheDocument();
-      expect(screen.getAllByTestId(layoutWrapper)).toHaveLength(2);
-      expect(screen.getAllByTestId(layoutItem)).toHaveLength(4);
     });
 
-    it("should render the default layout and Sticky Header if DataList.Filters is provided", () => {
+    it("should render the Sticky Header if DataList.Filters is provided", () => {
       renderDataListWithLayout(
         <DataList.Filters>
           <div>Filters</div>
@@ -435,17 +423,13 @@ describe("DataList", () => {
       expect(
         screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
       ).toBeInTheDocument();
-      expect(screen.getAllByTestId(layoutWrapper)).toHaveLength(2);
-      expect(screen.getAllByTestId(layoutItem)).toHaveLength(4);
     });
 
-    it("should render the default layout without Sticky Header if DataList.Search and DataList.Filters are not provided", () => {
+    it("should not render Sticky Header when DataList.Search and DataList.Filters are not provided", () => {
       renderDataListWithLayout(<></>);
       expect(
         screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
       ).not.toBeInTheDocument();
-      expect(screen.getAllByTestId(layoutWrapper)).toHaveLength(2);
-      expect(screen.getAllByTestId(layoutItem)).toHaveLength(4);
     });
   });
 

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-statements */
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
-import React from "react";
+import React, { ReactElement } from "react";
 import { configMocks, mockIntersectionObserver } from "jsdom-testing-mocks";
 import userEvent from "@testing-library/user-event";
 import { Banner } from "@jobber/components/Banner";
@@ -10,6 +10,7 @@ import {
   Breakpoints,
   DATA_LIST_FILTERING_SPINNER_TEST_ID,
   DATA_LIST_LOADING_MORE_SPINNER_TEST_ID,
+  DATA_LIST_STICKY_HEADER_TEST_ID,
   DATA_LOAD_MORE_TEST_ID,
   EMPTY_FILTER_RESULTS_MESSAGE,
 } from "./DataList.const";
@@ -392,6 +393,59 @@ describe("DataList", () => {
       renderLayout({ xs: false });
       expect(screen.queryByText(mockHeaders.name)).not.toBeInTheDocument();
       expect(screen.queryByText(mockHeaders.email)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("DataListStickyHeader", () => {
+    const layoutWrapper = "layout-wrapper";
+    const layoutItem = "layout-item";
+    const mockOnSearch = jest.fn();
+
+    const renderDataListWithLayout = (children: ReactElement) => {
+      render(
+        <DataList data={mockData} headers={{}}>
+          {children}
+          <DataList.Layout>
+            {(item: DataListItemType<typeof mockData>) => (
+              <div data-testid={layoutWrapper}>
+                <div data-testid={layoutItem}>{item.name}</div>
+                <div data-testid={layoutItem}>{item.email}</div>
+              </div>
+            )}
+          </DataList.Layout>
+        </DataList>,
+      );
+    };
+
+    it("should render the default layout and Sticky Header if DataList.Search is provided", () => {
+      renderDataListWithLayout(<DataList.Search onSearch={mockOnSearch} />);
+      expect(
+        screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
+      ).toBeInTheDocument();
+      expect(screen.getAllByTestId(layoutWrapper)).toHaveLength(2);
+      expect(screen.getAllByTestId(layoutItem)).toHaveLength(4);
+    });
+
+    it("should render the default layout and Sticky Header if DataList.Filters is provided", () => {
+      renderDataListWithLayout(
+        <DataList.Filters>
+          <div>Filters</div>
+        </DataList.Filters>,
+      );
+      expect(
+        screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
+      ).toBeInTheDocument();
+      expect(screen.getAllByTestId(layoutWrapper)).toHaveLength(2);
+      expect(screen.getAllByTestId(layoutItem)).toHaveLength(4);
+    });
+
+    it("should render the default layout without Sticky Header if DataList.Search and DataList.Filters are not provided", () => {
+      renderDataListWithLayout(<></>);
+      expect(
+        screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByTestId(layoutWrapper)).toHaveLength(2);
+      expect(screen.getAllByTestId(layoutItem)).toHaveLength(4);
     });
   });
 

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -83,8 +83,6 @@ export function DataList<T extends DataListObject>({
     props.children,
     DataListBulkActions,
   );
-
-  // are filterComponent or searchComponent truthy?
   const shouldRenderStickyHeader = !!filterComponent || !!searchComponent;
 
   return (

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -84,6 +84,9 @@ export function DataList<T extends DataListObject>({
     DataListBulkActions,
   );
 
+  // are filterComponent or searchComponent truthy?
+  const shouldRenderStickyHeader = !!filterComponent || !!searchComponent;
+
   return (
     <DataListContext.Provider
       value={{
@@ -103,7 +106,7 @@ export function DataList<T extends DataListObject>({
         sorting: sorting as DataListProps<DataListObject>["sorting"],
       }}
     >
-      <InternalDataList />
+      <InternalDataList shouldRenderStickyHeader={shouldRenderStickyHeader} />
     </DataListContext.Provider>
   );
 
@@ -122,7 +125,11 @@ export function DataList<T extends DataListObject>({
   }
 }
 
-function InternalDataList() {
+function InternalDataList({
+  shouldRenderStickyHeader,
+}: {
+  readonly shouldRenderStickyHeader: boolean;
+}) {
   const {
     data,
     title,
@@ -149,16 +156,18 @@ function InternalDataList() {
       heading as per the design requirements */}
       <div ref={backToTopRef} />
 
-      <DataListStickyHeader>
-        <div className={styles.headerFilters}>
-          <InternalDataListFilters />
-          <InternalDataListSearch />
-        </div>
+      {shouldRenderStickyHeader && (
+        <DataListStickyHeader>
+          <div className={styles.headerFilters}>
+            <InternalDataListFilters />
+            <InternalDataListSearch />
+          </div>
 
-        <InternalDataListStatusBar />
+          <InternalDataListStatusBar />
 
-        <DataListHeader />
-      </DataListStickyHeader>
+          <DataListHeader />
+        </DataListStickyHeader>
+      )}
 
       {initialLoading && <DataListLoadingState />}
 

--- a/packages/components/src/DataList/__POM__/DataList.selectable.pom.tsx
+++ b/packages/components/src/DataList/__POM__/DataList.selectable.pom.tsx
@@ -4,6 +4,7 @@ import { userEvent } from "@testing-library/user-event";
 import { DataList } from "../DataList";
 import { DataListSelectedType } from "../DataList.types";
 
+const mockOnSearch = jest.fn();
 const mockData = [
   { id: 1, label: "Jake Peralta" },
   { id: 2, label: "Amy Santiago" },
@@ -26,6 +27,7 @@ function ControlledDataList() {
       onSelect={setSelected}
       onSelectAll={setSelected}
     >
+      <DataList.Search onSearch={mockOnSearch} />
       <DataList.Layout>{item => <div>{item.label}</div>}</DataList.Layout>
     </DataList>
   );

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.tsx
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from "react";
 import styles from "./DataListStickyHeader.css";
+import { DATA_LIST_STICKY_HEADER_TEST_ID } from "../../DataList.const";
 
 export function DataListStickyHeader({ children }: PropsWithChildren<object>) {
   const [isStuck, setIsStuck] = useState(false);
@@ -29,6 +30,7 @@ export function DataListStickyHeader({ children }: PropsWithChildren<object>) {
 
   return (
     <div
+      data-testid={DATA_LIST_STICKY_HEADER_TEST_ID}
       ref={ref}
       className={classNames(styles.header, { [styles.stuck]: isStuck })}
     >


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
To better support a single column `DataList` and remove unnecessary empty `<divs />` , we are conditionally rendering the presence of children within the `DataListStickyHeader`.

Example:
| Before | After |
| :----: | :----: |
|  <img width="597" alt="Screenshot 2024-02-12 at 4 48 19 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/d4ccad28-50f3-4431-a09b-55447b1cb30d"> | <img width="605" alt="Screenshot 2024-02-12 at 4 45 49 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/ea344d6f-81b9-4102-8512-683f3add3b43"> |

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
| Children              | Web | Web Mobile |
| :---------------- | :------: | :----: |
| Default                         |   <img width="731" alt="Screenshot 2024-02-12 at 4 19 49 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/363b184e-78a4-40c2-ad18-5518c2038c20"> | <img width="295" alt="Screenshot 2024-02-12 at 4 18 37 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/629af00f-2efb-4a81-ba8a-ca031d14ae97"> |
| Filters Only                  |   <img width="732" alt="Screenshot 2024-02-12 at 4 20 27 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/0904b2a4-cef1-40ab-a3cb-260c49d2f33c">  | <img width="335" alt="Screenshot 2024-02-12 at 4 20 55 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/f03e41c5-9717-47c2-83dc-fb60e2eb6b2d"> |
| Search Only                 |  <img width="724" alt="Screenshot 2024-02-12 at 4 29 05 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/bbf3bdaf-6c3d-4987-849e-f425df6658e5"> |  * note below <img width="338" alt="Screenshot 2024-02-12 at 4 22 26 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/2cb8de28-b9b0-4457-b961-de28faacede9">  |
| No Filters, No Search, No Headers |  <img width="725" alt="Screenshot 2024-02-12 at 4 30 02 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/fbd6ceea-d144-47b8-b2d9-8f086171ae61"> | <img width="308" alt="Screenshot 2024-02-12 at 4 30 48 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/bb01700b-0803-4fbb-b20f-7935dbe9f1fe"> |
| Using `Heading` instead of `title` prop |  <img width="698" alt="Screenshot 2024-02-12 at 4 40 17 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/a0398197-285d-4a70-b957-d8ba725ef57b"> | <img width="324" alt="Screenshot 2024-02-12 at 4 39 46 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/c202d1e1-50fe-4b7b-bce7-96e24dea8d66"> | 

(*) This is pre-existing.  The example is without `headers` and search only; ticket [here](https://jobber.atlassian.net/jira/software/c/projects/JOB/boards/284/backlog?selectedIssue=JOB-88875) to fix this rendering should a single column `DataList` ever have search only

### Added

<!-- new features -->
- `DataListStickyHeader` gets a `data-testid`: `DATA_LIST_STICKY_HEADER_TEST_ID`
- Tests to check that `DataListStickyHeader` renders when given children & does **not** render when children are not passed in
 
### Changed

 <!-- changes in existing functionality -->
- Conditionally rendering the `DataListStickyHeader` by checking `shouldRenderStickyHeader`

## Testing

<!-- How to test your changes. -->
In Storybook, test on web and web mobile screens that the `DataListStickyHeader` will not show up as an empty div if there are no children.

When there are filters and/or a search, those are children of the sticky header and therefore, it will be present

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
