### PR TITLE
feat(components): Render DataListStickyHeader when headers are present

### DIFF
--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -32,6 +32,10 @@
   grid-template-columns: auto fit-content(calc(var(--base-unit) * 14));
 }
 
+.headerFilters:empty {
+  display: none;
+}
+
 .headerTitles {
   display: flex;
   flex-direction: column;

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -399,7 +399,7 @@ describe("DataList", () => {
   describe("DataListStickyHeader", () => {
     const mockOnSearch = jest.fn();
 
-    const renderDataListWithLayout = (children: ReactElement) => {
+    const renderDataList = (children: ReactElement) => {
       render(
         <DataList data={mockData} headers={{}}>
           {children}
@@ -407,15 +407,23 @@ describe("DataList", () => {
       );
     };
 
+    const renderDataListWithHeaders = (children: ReactElement) => {
+      render(
+        <DataList data={mockData} headers={mockHeaders}>
+          {children}
+        </DataList>,
+      );
+    };
+
     it("should render the Sticky Header if DataList.Search is provided", () => {
-      renderDataListWithLayout(<DataList.Search onSearch={mockOnSearch} />);
+      renderDataList(<DataList.Search onSearch={mockOnSearch} />);
       expect(
         screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
       ).toBeInTheDocument();
     });
 
     it("should render the Sticky Header if DataList.Filters is provided", () => {
-      renderDataListWithLayout(
+      renderDataList(
         <DataList.Filters>
           <div>Filters</div>
         </DataList.Filters>,
@@ -425,8 +433,15 @@ describe("DataList", () => {
       ).toBeInTheDocument();
     });
 
-    it("should not render Sticky Header when DataList.Search and DataList.Filters are not provided", () => {
-      renderDataListWithLayout(<></>);
+    it("should render the Sticky Header when Headers are provided", () => {
+      renderDataListWithHeaders(<></>);
+      expect(
+        screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
+      ).toBeInTheDocument();
+    });
+
+    it("should not render Sticky Header when DataList.Search, DataList.Filters or no Headers are not provided", () => {
+      renderDataList(<></>);
       expect(
         screen.queryByTestId(DATA_LIST_STICKY_HEADER_TEST_ID),
       ).not.toBeInTheDocument();

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -162,10 +162,10 @@ function InternalDataList({
           </div>
 
           <InternalDataListStatusBar />
-
-          <DataListHeader />
         </DataListStickyHeader>
       )}
+
+      <DataListHeader />
 
       {initialLoading && <DataListLoadingState />}
 

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -87,7 +87,7 @@ export function DataList<T extends DataListObject>({
   const headerCount = Object.keys(props.headers).length;
 
   const shouldRenderStickyHeader =
-    !!filterComponent || !!searchComponent || !!(headerCount > 0);
+    !!filterComponent || !!searchComponent || headerCount > 0;
 
   return (
     <DataListContext.Provider

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -165,8 +165,8 @@ function InternalDataList({
             <InternalDataListSearch />
           </div>
 
-          <DataListHeader />
           <InternalDataListStatusBar />
+          <DataListHeader />
         </DataListStickyHeader>
       )}
 

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 import React, { useRef, useState } from "react";
 import styles from "./DataList.css";
 import { DataListTotalCount } from "./components/DataListTotalCount";
@@ -83,7 +84,10 @@ export function DataList<T extends DataListObject>({
     props.children,
     DataListBulkActions,
   );
-  const shouldRenderStickyHeader = !!filterComponent || !!searchComponent;
+  const headerCount = Object.keys(props.headers).length;
+
+  const shouldRenderStickyHeader =
+    !!filterComponent || !!searchComponent || !!(headerCount > 0);
 
   return (
     <DataListContext.Provider
@@ -161,11 +165,10 @@ function InternalDataList({
             <InternalDataListSearch />
           </div>
 
+          <DataListHeader />
           <InternalDataListStatusBar />
         </DataListStickyHeader>
       )}
-
-      <DataListHeader />
 
       {initialLoading && <DataListLoadingState />}
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
My initial implementation of conditionally rendering the `DataListStickyHeader` ([here](https://github.com/GetJobber/atlantis/pull/1755)) was not accounting for the sticky header having `headers` present.  

When a `DataList` has `headers` but not `Search` or `Filters`, we should still see the Sticky Header (containing `headers`)

However when I put that original PR into JO, certain `DataList` implementations were failing because they **have** headers but **not** Search or Filters.  And because the entire Sticky Header was being conditionally rendered, their `headers` disappeared, causing tests to fail.

With this change, if `headers`  || `Search` || `Filters` exist, then the `DataListStickyHeader` will render.  

If none of those components exist, the `DataListStickyHeader` will not render and therefore, the big empty gap will also not render.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
- included a header count check in `shouldRenderStickyHeader`

### Added

<!-- new features -->
- test to document that when headers are present, the Sticky Header will render
- test to document that when there are no `headers`, `Filter` or `Search` then the Sticky Header will not render (no empty space in the UI)


## Testing

Change the Storybook implementation. If:

1. if `headers` || `Filter` || `Search` are present, they appear in the Sticky header and are sticky on scroll
2. if there are no `headers` && `Filter` && `Search` present, the Sticky Header should not render and therefore there is no large gap between the title of the `DataList` and the first line item
3. small screens should behave the same ^
<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
