### PR TITLE
fix(components-native): remove action label letter spacing

### DIFF
--- a/packages/components-native/src/ActionLabel/ActionLabel.test.tsx
+++ b/packages/components-native/src/ActionLabel/ActionLabel.test.tsx
@@ -10,7 +10,7 @@ const defaultStyles = {
   textAlign: "center",
   fontSize: tokens["typography--fontSize-base"],
   lineHeight: tokens["typography--lineHeight-tight"],
-  letterSpacing: tokens["typography--letterSpacing-loose"],
+  letterSpacing: tokens["typography--letterSpacing-base"],
 };
 
 describe("ActionLabel", () => {

--- a/packages/components-native/src/ActionLabel/ActionLabel.tsx
+++ b/packages/components-native/src/ActionLabel/ActionLabel.tsx
@@ -51,7 +51,6 @@ export function ActionLabel({
       fontWeight={getFontWeight(type)}
       align={align}
       lineHeight="tight"
-      letterSpacing={getLetterSpacing(type)}
       maxFontScaleSize={tokens["typography--fontSize-large"]}
       selectable={false}
     >
@@ -78,12 +77,4 @@ function getFontWeight(type: ActionLabelType) {
   }
 
   return "semiBold";
-}
-
-function getLetterSpacing(type: ActionLabelType) {
-  if (type === "cardTitle") {
-    return "base";
-  }
-
-  return "loose";
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

WIth the retheme happening, don't need this anymore

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- Letter spacing on action label

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
