### PR TITLE
fix(components-native): hard code status label radius

### DIFF
--- a/packages/components-native/src/StatusLabel/StatusLabel.style.ts
+++ b/packages/components-native/src/StatusLabel/StatusLabel.style.ts
@@ -5,6 +5,9 @@ const statusLabelIconDiameter = tokens["space-base"] - tokens["space-smaller"]; 
 
 const indicatorOffset = tokens["space-smallest"] + tokens["space-minuscule"];
 
+// Needs to be hardcoded to 3 as this shouldn't change with the tokens
+const statusLabelRadius = 3;
+
 export const styles = StyleSheet.create({
   statusLabelRow: {
     flexDirection: "row",
@@ -15,7 +18,7 @@ export const styles = StyleSheet.create({
     flexShrink: 1,
   },
   statusLabelIcon: {
-    borderRadius: tokens["radius-base"],
+    borderRadius: statusLabelRadius,
     backgroundColor: tokens["color-success"],
     width: statusLabelIconDiameter,
     height: statusLabelIconDiameter,

--- a/packages/components-native/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/components-native/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`StatusLabel alignment when alignment prop set to "end" should match sna
       [
         {
           "backgroundColor": "rgb(125, 176, 14)",
-          "borderRadius": 2,
+          "borderRadius": 3,
           "height": 12,
           "marginTop": 3,
           "width": 12,
@@ -143,7 +143,7 @@ exports[`StatusLabel alignment when alignment prop set to default ("start") shou
       [
         {
           "backgroundColor": "rgb(125, 176, 14)",
-          "borderRadius": 2,
+          "borderRadius": 3,
           "height": 12,
           "marginTop": 3,
           "width": 12,
@@ -222,7 +222,7 @@ exports[`StatusLabel status when status prop set to "critical" should match snap
       [
         {
           "backgroundColor": "rgb(125, 176, 14)",
-          "borderRadius": 2,
+          "borderRadius": 3,
           "height": 12,
           "marginTop": 3,
           "width": 12,
@@ -301,7 +301,7 @@ exports[`StatusLabel status when status prop set to "inactive" should match snap
       [
         {
           "backgroundColor": "rgb(125, 176, 14)",
-          "borderRadius": 2,
+          "borderRadius": 3,
           "height": 12,
           "marginTop": 3,
           "width": 12,
@@ -380,7 +380,7 @@ exports[`StatusLabel status when status prop set to "informative" should match s
       [
         {
           "backgroundColor": "rgb(125, 176, 14)",
-          "borderRadius": 2,
+          "borderRadius": 3,
           "height": 12,
           "marginTop": 3,
           "width": 12,
@@ -459,7 +459,7 @@ exports[`StatusLabel status when status prop set to "warning" should match snaps
       [
         {
           "backgroundColor": "rgb(125, 176, 14)",
-          "borderRadius": 2,
+          "borderRadius": 3,
           "height": 12,
           "marginTop": 3,
           "width": 12,
@@ -538,7 +538,7 @@ exports[`StatusLabel status when status prop set to default ("success") should m
       [
         {
           "backgroundColor": "rgb(125, 176, 14)",
-          "borderRadius": 2,
+          "borderRadius": 3,
           "height": 12,
           "marginTop": 3,
           "width": 12,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Avoid status label radius from being affected by tokens as it has to always be this shape regardless of tokens.

It's also set to 3 to follow what the web is doing https://github.com/GetJobber/atlantis/blob/5e1ab691f54f32589367e99fc60cd05b749f5df6/packages/components/src/StatusLabel/StatusLabel.css#L17

When retheme happens, the radius base token would be set to 8 and it would change the status label indicator to a circle which we don't want.

## Before

![image](https://github.com/GetJobber/atlantis/assets/15986172/5d6b8c56-2d78-47ef-b2b3-f3380c9a7098)

## After

![image](https://github.com/GetJobber/atlantis/assets/15986172/2718a823-46a9-4195-b06c-57a9ae96ba36)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- status label indicator from radius-base to hardcoded 3

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
