### PR TITLE
fix(components-native): Apply input transform in InputText before trim [OPS-20241]

### DIFF
--- a/packages/components-native/src/InputText/InputText.test.tsx
+++ b/packages/components-native/src/InputText/InputText.test.tsx
@@ -582,8 +582,6 @@ describe("Transform", () => {
       const form = useForm();
       useEffect(() => {
         return form.watch((value, { name, type }) => {
-          console.log(value, name, type);
-          console.log("value", value);
           onFormValueUpdate(value);
         }).unsubscribe;
       }, [form]);

--- a/packages/components-native/src/InputText/InputText.test.tsx
+++ b/packages/components-native/src/InputText/InputText.test.tsx
@@ -581,7 +581,7 @@ describe("Transform", () => {
     function FormWrapper({ children }: { readonly children: React.ReactNode }) {
       const form = useForm();
       useEffect(() => {
-        return form.watch((value, { name, type }) => {
+        return form.watch(value => {
           onFormValueUpdate(value);
         }).unsubscribe;
       }, [form]);

--- a/packages/components-native/src/InputText/InputText.tsx
+++ b/packages/components-native/src/InputText/InputText.tsx
@@ -18,11 +18,7 @@ import {
   TextInputProps,
   TextStyle,
 } from "react-native";
-import {
-  ControllerRenderProps,
-  FieldValues,
-  RegisterOptions,
-} from "react-hook-form";
+import { RegisterOptions } from "react-hook-form";
 import { IconNames } from "@jobber/design";
 import identity from "lodash/identity";
 import { Clearable, useShowClear } from "@jobber/hooks";
@@ -427,7 +423,6 @@ function InputTextInternal(
      * https://github.com/facebook/react-native/issues/36521#issuecomment-1555421134
      */
     const removedIOSCharValue = isIOS ? value.replace(/\uFFFC/g, "") : value;
-    const newValue = outputTransform(removedIOSCharValue);
     updateFormAndState(removedIOSCharValue);
   }
 
@@ -452,6 +447,7 @@ function InputTextInternal(
     const newValue = outputTransform(rawValue);
     onChangeText?.(newValue);
     field.onChange(newValue);
+  }
 }
 
 function trimWhitespace(
@@ -493,7 +489,6 @@ function useTextInputRef({ ref, onClear }: UseTextInputRefProps) {
 
 function useMiniLabel(internalValue: string): {
   hasMiniLabel: boolean;
-  setHasMiniLabel: React.Dispatch<React.SetStateAction<boolean>>;
 } {
   const [hasMiniLabel, setHasMiniLabel] = useState(Boolean(internalValue));
   useEffect(() => {


### PR DESCRIPTION
## Motivations

InputNumber was providing string values when text ended with a space.

## Changes

InputText applies the transform before treating the form field value as a string.

## Testing

Use InputNumber finish the number with a space like "13 " and see that InputNumber returns the number 13 instead of the string "13" **after blur**

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
