### PR TITLE
feat(components-native): Update Heading styles

### DIFF
--- a/packages/components-native/src/Heading/Heading.tsx
+++ b/packages/components-native/src/Heading/Heading.tsx
@@ -100,21 +100,21 @@ function getHeadingStyle(
   const headingLevelToStyle: Record<HeadingLevel, HeadingStyle> = {
     title: {
       fontFamily: "display",
-      fontWeight: "black",
+      fontWeight: "extraBold",
       size: "jumbo",
       lineHeight: "jumbo",
       color: variation,
     },
     subtitle: {
-      fontFamily: "display",
-      fontWeight: "extraBold",
+      fontFamily: "base",
+      fontWeight: "bold",
       size: "largest",
       lineHeight: "largest",
       color: variation,
     },
     heading: {
-      fontFamily: "display",
-      fontWeight: "extraBold",
+      fontFamily: "base",
+      fontWeight: "bold",
       size: "larger",
       lineHeight: "large",
       color: variation,

--- a/packages/components-native/src/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/packages/components-native/src/Heading/__snapshots__/Heading.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`when Heading called with Subtitle variation should match snapshot 1`] =
   style={
     [
       {
-        "fontFamily": "jobberpro-xbd",
+        "fontFamily": "inter-bold",
       },
       {
         "color": "rgb(1, 41, 57)",
@@ -45,7 +45,7 @@ exports[`when Heading called with an alignment should match snapshot 1`] = `
   style={
     [
       {
-        "fontFamily": "jobberpro-xbd",
+        "fontFamily": "inter-bold",
       },
       {
         "color": "rgb(1, 41, 57)",
@@ -79,7 +79,7 @@ exports[`when Heading called with maxLines should match snapshot 1`] = `
   style={
     [
       {
-        "fontFamily": "jobberpro-xbd",
+        "fontFamily": "inter-bold",
       },
       {
         "color": "rgb(1, 41, 57)",
@@ -112,7 +112,7 @@ exports[`when Heading called with reverseTheme should match snapshot 1`] = `
   style={
     [
       {
-        "fontFamily": "jobberpro-xbd",
+        "fontFamily": "inter-bold",
       },
       {
         "color": "rgba(255, 255, 255, 1)",
@@ -213,7 +213,7 @@ exports[`when Heading called with text as the only prop should match snapshot 1`
   style={
     [
       {
-        "fontFamily": "jobberpro-xbd",
+        "fontFamily": "inter-bold",
       },
       {
         "color": "rgb(1, 41, 57)",
@@ -247,7 +247,7 @@ exports[`when Heading called with title variation should match snapshot 1`] = `
   style={
     [
       {
-        "fontFamily": "jobberpro-blk",
+        "fontFamily": "jobberpro-xbd",
       },
       {
         "color": "rgb(1, 41, 57)",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
To prep for retheme, `components-native` `Heading` needs to have updated styling

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed
 <!-- changes in existing functionality -->
See [Figma](https://www.figma.com/file/ZJYCUJFHPxxzNDAKeZ9hhh/Mobile-Re-theme-Implementation?type=whiteboard&node-id=84%3A22552&t=Gp2MVGxLredCYkDr-1) showing before/after

`fontWeight` changes:
- `title` now has 800/`extraBold` 
- `subtitle` & `heading` now have 700/`base`

`fontFamily` changes:
- `subtitle` & `heading` now have `Inter`

Snapshot tests were also updated to reflect new values.

## Testing

<!-- How to test your changes. -->
You can look at the Heading mobile story and inspect the new computed values

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
