### PR TITLE
fix(components): Always show clear when there are selected options in ComboBox

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -39,7 +39,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         handleSearchChange={props.handleSearchChange}
       />
 
-      {((props.multiselect && optionsExist) || props.selected.length > 0) && (
+      {props.multiselect && (optionsExist || props.selected.length > 0) && (
         <ComboboxContentHeader
           hasOptionsVisible={optionsExist}
           subjectNoun={props.subjectNoun}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -39,7 +39,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         handleSearchChange={props.handleSearchChange}
       />
 
-      {((props.multiselect && optionsExist) || props.selected.length) && (
+      {((props.multiselect && optionsExist) || props.selected.length > 0) && (
         <ComboboxContentHeader
           hasOptionsVisible={optionsExist}
           subjectNoun={props.subjectNoun}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -39,7 +39,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
         handleSearchChange={props.handleSearchChange}
       />
 
-      {props.multiselect && optionsExist && (
+      {((props.multiselect && optionsExist) || props.selected.length) && (
         <ComboboxContentHeader
           hasOptionsVisible={optionsExist}
           subjectNoun={props.subjectNoun}


### PR DESCRIPTION
## Motivations

A [bug ticket](https://jobber.atlassian.net/browse/OPS-20251) was reported whereby the client list is blank due to a tag filter, and the filter cannot be cleared because there are currently no client tags in your account, which prevents the clear button from appearing. 

We worked around this issue in https://github.com/GetJobber/Jobber/pull/43181 by clearing selections if there are no tags in the account. However, it seems that having the "clear" button always visible when there are "selections" provided would be valuable. This change ensures the header is alway shown in cases where there is an active selection, regardless of options being supplied. 

## Changes

### Changed

- ComboBoxHeader always appears when there are selections provided, to ensure the clear operation can always be accessed. 

![Screenshot 2024-02-16 at 12 20 26 PM](https://github.com/GetJobber/atlantis/assets/59584307/c0974397-5b56-431f-9107-2e323fdd7876)


## Testing

This can be seen in the client list using a few edge case scenarios:

- Switching between franchise accounts after applying a tag filter, and the second franchise does not have any tags
- Having a single tag on some clients, filtering on that tag, and then deleting all those clients

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
