### PR TITLE
feat(components): Adds a role of status to the Glimmer component 

### DIFF
--- a/packages/components/src/Glimmer/Glimmer.tsx
+++ b/packages/components/src/Glimmer/Glimmer.tsx
@@ -76,6 +76,7 @@ export function Glimmer({
   return (
     <div
       aria-busy="true"
+      role="status"
       className={className}
       data-testid={GLIMMER_TEST_ID}
       style={{ width }}
@@ -103,6 +104,7 @@ Glimmer.Header = function GlimmerHeader({
     4: "base",
     5: "small",
   };
+
   return (
     <div className={styles.header} data-testid={GLIMMER_HEADER_TEST_ID}>
       <Glimmer size={headerSize[level]} {...props} />
@@ -153,6 +155,7 @@ Glimmer.Button = function GlimmerButton({
   const buttonClassNames = classnames(styles.button, {
     [styles.buttonFill]: fullWidth,
   });
+
   return (
     <div className={buttonClassNames} data-testid={GLIMMER_BUTTON_TEST_ID}>
       <Glimmer {...props} size="auto" />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This will hopefully improve accessibility but honestly the reason for this change is to make it easier to grab glimmers during testing. Rather than relying on glimmer test IDs.  We can use [getByRole](https://testing-library.com/docs/queries/byrole/#busy) to find the glimmers on the page. 

`getAllByRole('status', { busy: true })` will return a non empty array if there are glimmers on the page. Without this change the same line would work however it would be `getAllByRole('generic', { busy: true})` which doesn't feel as correct. 

https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html

>4. After a user activates a process, an icon symbolizing 'busy' appears on the screen. The screen reader announces "application busy".

<!-- Why did you do what you did? -->

## Changes

Simply adding the status role to the glimmer component. 

---


[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
