### PR TITLE
fix(components): keep ComboboxContentHeader label and action aligned across themes

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentHeader/ComboboxContentHeader.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentHeader/ComboboxContentHeader.css
@@ -2,5 +2,6 @@
   display: flex;
   padding: var(--space-base) var(--space-small) 0 var(--space-base);
   justify-content: space-between;
+  align-items: baseline;
   gap: var(--space-smaller);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Small buttons are larger in the new theme, causing misalignment between the header and button label in ComboboxContentHeader.

![image](https://github.com/GetJobber/atlantis/assets/39704901/78c8e484-2af1-4ccf-a71a-1ea348bc5b9e)

**Before**
![image](https://github.com/GetJobber/atlantis/assets/39704901/4798a813-22fe-4caa-b7d6-fc3e3a381f16)
![image](https://github.com/GetJobber/atlantis/assets/39704901/de9f7dc6-5122-4cbe-82aa-832f9a0bd802)

**After**
![image](https://github.com/GetJobber/atlantis/assets/39704901/7d597c00-f543-408e-ab3a-2237da9150f9)
![image](https://github.com/GetJobber/atlantis/assets/39704901/137a8f6d-33c5-4abd-9b38-165183112ec3)

## Changes

### Fixed

- Text remains aligned in both old and new themes

## Testing

Toggle the `.jobber-retheme` class on the Storybook iframe body.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
