### PR TITLE
feat(components): Bring back card accent in retheme

### DIFF
--- a/packages/components/src/Card/Card.css
+++ b/packages/components/src/Card/Card.css
@@ -38,20 +38,12 @@
   border-top-width: 0;
 }
 
-:global(.jobber-retheme) .accent {
-  border-top-width: 1px;
-}
-
 .accent::before {
   content: " ";
   display: block;
   margin: 0 calc(-1 * var(--border-base));
-  border-top: 0.5rem solid var(--card--accent-color);
+  border-top: 0.375rem solid var(--card--accent-color);
   border-radius: var(--radius-base) var(--radius-base) 0 0;
-}
-
-:global(.jobber-retheme) .accent::before {
-  display: none;
 }
 
 .clickable {


### PR DESCRIPTION
## Motivations

Object colours are coming back

## Changes

Removes the override for the retheme that got rid of the accents. Makes them 6px instead of 8.

### Before
Accents were removed
![image](https://github.com/GetJobber/atlantis/assets/10064579/f1559583-3356-483c-a6ba-d6509f0d1bf7)

### After
Accents are back and slightly smaller
![image](https://github.com/GetJobber/atlantis/assets/10064579/614e4365-8834-4ba7-8383-a1119006e3bd)

## Testing

Apply `.jobber-retheme` to the body of the component in Storybook preview
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
