### PR TITLE
feat(components-native): Bump peerDependency for react-native-reanimated to also accept v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
         "react-native-modal-datetime-picker": "^15.0.1",
         "react-native-modalize": "^2.0.13",
         "react-native-portalize": "^1.0.7",
-        "react-native-reanimated": "^2.17.0",
+        "react-native-reanimated": "^3.7.1",
         "react-native-safe-area-context": "^4.5.2",
         "react-native-web": "^0.18.12",
         "react-router-dom": "^5.3.4",
@@ -31048,7 +31048,8 @@
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -38348,22 +38349,30 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.17.0.tgz",
-      "integrity": "sha512-bVy+FUEaHXq4i+aPPqzGeor1rG4scgVNBbBz21ohvC7iMpB9IIgvGsmy1FAoodZhZ5sa3EPF67Rcec76F1PXlQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.7.1.tgz",
+      "integrity": "sha512-bapCxhnS58+GZynQmA/f5U8vRlmhXlI/WhYg0dqnNAGXHNIc+38ahRWcG8iK8e0R2v9M8Ky2ZWObEC6bmweofg==",
       "dependencies": {
         "@babel/plugin-transform-object-assign": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
-        "invariant": "^2.2.4",
-        "lodash.isequal": "^4.5.0",
-        "setimmediate": "^1.0.5",
-        "string-hash-64": "^1.0.3"
+        "convert-source-map": "^2.0.0",
+        "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-proposal-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-reanimated/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/react-native-safe-area-context": {
       "version": "4.5.2",
@@ -40375,7 +40384,8 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -41067,11 +41077,6 @@
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
       "dev": true
-    },
-    "node_modules/string-hash-64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
-      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45745,7 +45745,7 @@
         "react-native-modal-datetime-picker": " >=13.0.0",
         "react-native-modalize": "^2.0.13",
         "react-native-portalize": "^1.0.7",
-        "react-native-reanimated": "^2.17.0",
+        "react-native-reanimated": "^2.0.0 || ^3.0.0",
         "react-native-safe-area-context": "^4.5.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "react-native-modal-datetime-picker": "^15.0.1",
     "react-native-modalize": "^2.0.13",
     "react-native-portalize": "^1.0.7",
-    "react-native-reanimated": "^2.17.0",
+    "react-native-reanimated": "^3.7.1",
     "react-native-safe-area-context": "^4.5.2",
     "react-native-web": "^0.18.12",
     "react-router-dom": "^5.3.4",

--- a/packages/components-native/package.json
+++ b/packages/components-native/package.json
@@ -81,7 +81,7 @@
     "react-native-modal-datetime-picker": " >=13.0.0",
     "react-native-modalize": "^2.0.13",
     "react-native-portalize": "^1.0.7",
-    "react-native-reanimated": "^2.17.0",
+    "react-native-reanimated": "^2.0.0 || ^3.0.0",
     "react-native-safe-area-context": "^4.5.2"
   }
 }

--- a/packages/components-native/src/Button/components/InternalButtonLoading/InternalButtonLoading.tsx
+++ b/packages/components-native/src/Button/components/InternalButtonLoading/InternalButtonLoading.tsx
@@ -21,6 +21,9 @@ const imageWidth = 96;
 const offset = PixelRatio.roundToNearestPixel(imageWidth / PixelRatio.get());
 const leftOffset = -1 * offset;
 
+// looks like deprecation for FlatList in reanimated is cascading down to other exports
+// This is not createAnimatedComponent(FlatList), we are fine
+// eslint-disable-next-line import/no-deprecated
 const AnimatedImage = Animated.createAnimatedComponent(ImageBackground);
 
 function InternalButtonLoadingInternal({
@@ -71,6 +74,7 @@ function getLoadingPattern({
 }: InternalButtonLoadingProps): string {
   if (variation === "cancel") return darkPattern;
   if (type === "primary") return lightPattern;
+
   return darkPattern;
 }
 

--- a/packages/components-native/src/Disclosure/Disclosure.tsx
+++ b/packages/components-native/src/Disclosure/Disclosure.tsx
@@ -1,10 +1,5 @@
 import React, { useState } from "react";
-import {
-  LayoutChangeEvent,
-  ScrollView,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import { LayoutChangeEvent, TouchableOpacity, View } from "react-native";
 import Reanimated, {
   Easing,
   useAnimatedStyle,
@@ -16,8 +11,8 @@ import { styles } from "./Disclosure.style";
 import { tokens } from "../utils/design";
 import { Icon } from "../Icon";
 
-const ReanimatedView = Reanimated.createAnimatedComponent(View);
-const ReanimatedScrollView = Reanimated.createAnimatedComponent(ScrollView);
+const ReanimatedView = Reanimated.View;
+const ReanimatedScrollView = Reanimated.ScrollView;
 
 interface DisclosureProps {
   /**

--- a/packages/components-native/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
+++ b/packages/components-native/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
@@ -117,18 +117,16 @@ exports[`renders a Disclosure with a header and a content when open is true 1`] 
     </View>
   </View>
   <RCTScrollView
+    collapsable={false}
     scrollEnabled={false}
+    scrollEventThrottle={0.0001}
     showsHorizontalScrollIndicator={false}
     showsVerticalScrollIndicator={false}
     style={
-      [
-        {
-          "paddingTop": 8,
-        },
-        {
-          "height": 100,
-        },
-      ]
+      {
+        "height": 100,
+        "paddingTop": 8,
+      }
     }
   >
     <View>
@@ -290,18 +288,16 @@ exports[`renders a Disclosure with a header and with a content of size 0 when cl
     </View>
   </View>
   <RCTScrollView
+    collapsable={false}
     scrollEnabled={false}
+    scrollEventThrottle={0.0001}
     showsHorizontalScrollIndicator={false}
     showsVerticalScrollIndicator={false}
     style={
-      [
-        {
-          "paddingTop": 8,
-        },
-        {
-          "height": 0,
-        },
-      ]
+      {
+        "height": 0,
+        "paddingTop": 8,
+      }
     }
   >
     <View>
@@ -431,18 +427,16 @@ exports[`should not render the caret when the Disclosure is empty 1`] = `
     </View>
   </View>
   <RCTScrollView
+    collapsable={false}
     scrollEnabled={false}
+    scrollEventThrottle={0.0001}
     showsHorizontalScrollIndicator={false}
     showsVerticalScrollIndicator={false}
     style={
-      [
-        {
-          "paddingTop": 8,
-        },
-        {
-          "height": 0,
-        },
-      ]
+      {
+        "height": 0,
+        "paddingTop": 8,
+      }
     }
   >
     <View>


### PR DESCRIPTION
## Motivations

We want components-native to support reanimated@3

React Native Reanimated docs [Migrating from Reanimated 2.x to 3.x](https://docs.swmansion.com/react-native-reanimated/docs/guides/migration-from-2.x) have this to say
> Reanimated 3.x doesn't introduce any breaking changes between 2.x and 3.x in terms of the API. All the code you've written in Reanimated v2 API works in 3.x without any changes. However, Reanimated 3.x drops the Reanimated v1 API entirely.

I do not see us using Reanimated v1 API

Had to fix ts errors around deprecation of `createAnimatedComponent(FlatList)`

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- reanimated peerDependancy bumped to include version 3

## Testing

Could use some help here, is there still a way to launch storybook for native components?

components that use reanimated
- FormActionBar
- Button (loading state)
- ProgressBar
- Disclosure

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
