### PR TITLE
fix(components): Fix button label and icon alignment when inside a modal

### DIFF
--- a/packages/components/src/Modal/Modal.css
+++ b/packages/components/src/Modal/Modal.css
@@ -131,10 +131,10 @@
   margin-left: var(--space-small);
 }
 
-.rightAction *:first-child {
+.rightAction > *:first-child {
   order: 2; /* 1 */
 }
 
-.rightAction *:nth-child(2) {
+.rightAction > *:nth-child(2) {
   order: 1; /* 1 */
 }


### PR DESCRIPTION
## Motivations
When using actions on a modal we allow the passing of icons into the buttons. Turns out our CSS for ordering of the actions also affects the children within the action (labels and icons). This causes whenever you add an icon to a button the right section of a modal the icon will also swap places with the label.

## Changes
Made the global selector more specific so it doesn't touch every element within the left/right sides, just the first element (the buttons themselves)

### Before
![image](https://github.com/GetJobber/atlantis/assets/10064579/173eff2f-508d-48eb-a00d-d77839734878)

### After
![image](https://github.com/GetJobber/atlantis/assets/10064579/c460bd54-48cc-461d-939a-e34d255b50bf)

## Testing

Add an icon to a modal action and see what happens

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
