### PR TITLE
fix(components): Fix an improper console mock in a test

### DIFF
--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -431,9 +431,9 @@ describe("Combobox Compound Component Validation", () => {
 
   it("throws an error when there are multiple Combobox Activators present", () => {
     // This keeps the testing console clean
-    jest.spyOn(console, "error").mockImplementation(() => {
-      return;
-    });
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => ({}));
     expect(() =>
       render(
         <Combobox label={activatorLabel} selected={[]} onSelect={jest.fn()}>
@@ -446,7 +446,7 @@ describe("Combobox Compound Component Validation", () => {
         </Combobox>,
       ),
     ).toThrow(COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
-    jest.spyOn(console, "error").mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 });
 

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -416,6 +416,17 @@ describe("Combobox Compound Component Validation", () => {
   it("renders without error if the correct count and composition of elements are present", () => {
     expect(renderCombobox).not.toThrow();
   });
+  it("renders without error when there is a ComboboxActivator", () => {
+    expect(() =>
+      render(
+        <Combobox label={activatorLabel} selected={[]} onSelect={jest.fn()}>
+          <Combobox.Activator>
+            <Button label="Click me" />
+          </Combobox.Activator>
+        </Combobox>,
+      ),
+    ).not.toThrow();
+  });
   it("throws an error when there are multiple Combobox Activators present", () => {
     // This keeps the testing console clean
     jest.spyOn(console, "error").mockImplementation(() => {
@@ -434,17 +445,6 @@ describe("Combobox Compound Component Validation", () => {
       ),
     ).toThrow(COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
     jest.spyOn(console, "error").mockRestore();
-  });
-  it("renders without error when there is a ComboboxActivator", () => {
-    expect(() =>
-      render(
-        <Combobox label={activatorLabel} selected={[]} onSelect={jest.fn()}>
-          <Combobox.Activator>
-            <Button label="Click me" />
-          </Combobox.Activator>
-        </Combobox>,
-      ),
-    ).not.toThrow();
   });
 });
 

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -416,6 +416,7 @@ describe("Combobox Compound Component Validation", () => {
   it("renders without error if the correct count and composition of elements are present", () => {
     expect(renderCombobox).not.toThrow();
   });
+
   it("renders without error when there is a ComboboxActivator", () => {
     expect(() =>
       render(
@@ -427,6 +428,7 @@ describe("Combobox Compound Component Validation", () => {
       ),
     ).not.toThrow();
   });
+
   it("throws an error when there are multiple Combobox Activators present", () => {
     // This keeps the testing console clean
     jest.spyOn(console, "error").mockImplementation(() => {

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -416,22 +416,11 @@ describe("Combobox Compound Component Validation", () => {
   it("renders without error if the correct count and composition of elements are present", () => {
     expect(renderCombobox).not.toThrow();
   });
-
-  it("renders without error when there is a ComboboxActivator", () => {
-    expect(() =>
-      render(
-        <Combobox label={activatorLabel} selected={[]} onSelect={jest.fn()}>
-          <Combobox.Activator>
-            <Button label="Click me" />
-          </Combobox.Activator>
-        </Combobox>,
-      ),
-    ).not.toThrow();
-  });
-
   it("throws an error when there are multiple Combobox Activators present", () => {
     // This keeps the testing console clean
-    console.error = jest.fn();
+    jest.spyOn(console, "error").mockImplementation(() => {
+      return;
+    });
     expect(() =>
       render(
         <Combobox label={activatorLabel} selected={[]} onSelect={jest.fn()}>
@@ -444,6 +433,18 @@ describe("Combobox Compound Component Validation", () => {
         </Combobox>,
       ),
     ).toThrow(COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);
+    jest.spyOn(console, "error").mockRestore();
+  });
+  it("renders without error when there is a ComboboxActivator", () => {
+    expect(() =>
+      render(
+        <Combobox label={activatorLabel} selected={[]} onSelect={jest.fn()}>
+          <Combobox.Activator>
+            <Button label="Click me" />
+          </Combobox.Activator>
+        </Combobox>,
+      ),
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
I mocked out console error in one test but forgot that the scope would leak since it was on global scope 🤦‍♂️ 

I've fixed it with a [method from Kent C Dodds](https://github.com/jestjs/jest/pull/5267#issuecomment-356605468). This is to keep the console clean in tests with expected errors. 

<!-- How to test your changes. -->
## Testing
Just drop a console error in a test following this one and make sure you see it. 
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
