### PR TITLE
fix(components): Add unique keys to DataList sort option items

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
@@ -38,7 +38,7 @@ export function DataListSortingOptions({
       {options.map(option => (
         <li
           className={styles.option}
-          key={option.id}
+          key={option.id + option.order}
           onClick={() => onSelectChange(option)}
           onKeyDown={event => handleKeyDown(event, option)}
           tabIndex={0}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
We're getting react warnings anytime options mount for clients names because the `option.id` is not a unique id. These children need unique keys. Adding in the `order` helps differentiate the items. Examples instead of `firstName` and `firstName` it's now `firstNameasc` and `firstNamedesc`. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
Included `option.order` in the option `li` key for DataList sort options to make the react node key more unique. 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
