### PR TITLE
feat(components-native): Update Button learning variation style

### DIFF
--- a/packages/components-native/src/Button/Button.style.ts
+++ b/packages/components-native/src/Button/Button.style.ts
@@ -79,8 +79,8 @@ export const styles = StyleSheet.create({
   },
 
   learning: {
-    backgroundColor: tokens["color-informative"],
-    borderColor: tokens["color-informative"],
+    backgroundColor: tokens["color-interactive--subtle"],
+    borderColor: tokens["color-interactive--subtle"],
   },
 
   destructive: {

--- a/packages/components-native/src/Button/Button.test.tsx
+++ b/packages/components-native/src/Button/Button.test.tsx
@@ -78,7 +78,7 @@ describe("Button", () => {
       },
     ],
     ["destructive", { bgColor: tokens["color-destructive"] }],
-    ["learning", { bgColor: tokens["color-informative"] }],
+    ["learning", { bgColor: tokens["color-interactive--subtle"] }],
   ])("renders a %s Button", (variation, { bgColor, borderColor }) => {
     const { buttonStyle } = renderButton(
       <Button label={variation} variation={variation} onPress={jest.fn()} />,
@@ -218,7 +218,7 @@ describe("Button", () => {
         variation: "learning",
         type: "secondary",
       });
-      expect(iconColor).toBe(tokens["color-informative"]);
+      expect(iconColor).toBe(tokens["color-interactive--subtle"]);
       expect(textColor).toBe(iconColor);
     });
 

--- a/packages/components-native/src/Button/Button.tsx
+++ b/packages/components-native/src/Button/Button.tsx
@@ -179,7 +179,7 @@ function getActionLabelVariation(
 
   switch (variation) {
     case "learning":
-      return "learning";
+      return "subtle";
     case "destructive":
       return "destructive";
     case "cancel":
@@ -204,7 +204,7 @@ function getIconColorVariation(
 
   switch (variation) {
     case "learning":
-      return "informative";
+      return "interactiveSubtle";
     case "destructive":
       return "destructive";
     case "cancel":


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Updating our mobile Button `learning` variation color tokens for the retheme.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->


### Changed

- Updated mobile Button color tokens from `information` to `interactive` for the `learning` variation
- Updated tests

## Testing

Check out the mobile Button in Storybook and apply the `learning` variation type. All types should now use the interactive color.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
