### PR TITLE
refactor(components): Deprecate to prop for Button

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -53,7 +53,9 @@ interface ButtonAnchorProps extends ButtonFoundationProps {
 
 interface ButtonLinkProps<S = unknown> extends ButtonFoundationProps {
   /**
-   * Used for client side routing. Only use when inside a routed component.
+   * **Deprecated**: to will be removed in the next major version
+   * Use shared ButtonLink component from Jobber instead
+   * @deprecated
    */
   readonly to?: LinkProps<S>["to"];
 }

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -54,7 +54,6 @@ interface ButtonAnchorProps extends ButtonFoundationProps {
 interface ButtonLinkProps<S = unknown> extends ButtonFoundationProps {
   /**
    * **Deprecated**: to will be removed in the next major version
-   * Use shared ButtonLink component from Jobber instead
    * @deprecated
    */
   readonly to?: LinkProps<S>["to"];


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
We need to decouple the atlantis button from react router in order to support the Remix work and support SSR.
In order to do this we need to remove the to prop from our Atlantis button component.


### Deprecated
Add deprecation warning to the Button `to` prop.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
