### PR TITLE
feat(components): Restyle web statusLabel

### DIFF
--- a/packages/components/src/StatusIndicator/StatusIndicator.css
+++ b/packages/components/src/StatusIndicator/StatusIndicator.css
@@ -1,8 +1,12 @@
+:root {
+  --statusLabel-icon-diameter: 8px;
+}
+
 .statusIndicator {
   display: inline-block;
   width: var(--statusLabel-icon-diameter);
   height: var(--statusLabel-icon-diameter);
-  border-radius: 3px;
+  border-radius: 50%;
   background-color: var(--color-success);
   flex-shrink: 0;
 }

--- a/packages/components/src/StatusLabel/StatusLabel.css
+++ b/packages/components/src/StatusLabel/StatusLabel.css
@@ -1,20 +1,58 @@
-:root {
-  --statusLabel-icon-diameter: 10px;
-}
-
 .statusLabelRow {
   display: flex;
+  width: fit-content;
+  padding: 6px 10px 6px 8px;
+  border-radius: 12px;
   flex-direction: row;
   flex-wrap: nowrap;
-  gap: var(--space-small);
-  width: fit-content;
+  gap: 6px;
+}
+
+/* Reset the <Text> line height so we can reliably get 24px tall */
+.statusLabelRow p {
+  line-height: 1;
 }
 
 .labelTextEndAligned {
   flex-direction: row-reverse;
 }
 
-.statusIndicator {
-  display: inline-flex;
-  padding-top: var(--space-minuscule);
+.statusIndicatorWrapper {
+  display: flex;
+  padding-top: 2px;
+}
+
+.success {
+  background-color: var(--color-success--surface);
+  p {
+    color: var(--color-success--onSurface);
+  }
+}
+
+.warning {
+  background-color: var(--color-warning--surface);
+  p {
+    color: var(--color-warning--onSurface);
+  }
+}
+
+.critical {
+  background-color: var(--color-critical--surface);
+  p {
+    color: var(--color-critical--onSurface);
+  }
+}
+
+.inactive {
+  background-color: var(--color-inactive--surface);
+  p {
+    color: var(--color-inactive--onSurface);
+  }
+}
+
+.informative {
+  background-color: var(--color-informative--surface);
+  p {
+    color: var(--color-informative--onSurface);
+  }
 }

--- a/packages/components/src/StatusLabel/StatusLabel.css
+++ b/packages/components/src/StatusLabel/StatusLabel.css
@@ -25,11 +25,11 @@
 .statusLabelRow {
   display: flex;
   width: fit-content;
-  padding: 6px 10px 6px 8px;
-  border-radius: 12px;
+  padding: 0.375rem 0.625rem 0.375rem 0.5rem;
+  border-radius: 0.75rem;
   flex-direction: row;
   flex-wrap: nowrap;
-  gap: 6px;
+  gap: 0.375rem;
   background-color: var(--labelBackgroundColor);
 }
 
@@ -44,5 +44,5 @@
 
 .statusIndicatorWrapper {
   display: flex;
-  padding-top: 2px;
+  padding-top: 0.125rem;
 }

--- a/packages/components/src/StatusLabel/StatusLabel.css
+++ b/packages/components/src/StatusLabel/StatusLabel.css
@@ -1,3 +1,27 @@
+:root {
+  --labelBackgroundColor: var(--color-success--surface);
+}
+
+.success {
+  --labelBackgroundColor: var(--color-success--surface);
+}
+
+.warning {
+  --labelBackgroundColor: var(--color-warning--surface);
+}
+
+.critical {
+  --labelBackgroundColor: var(--color-critical--surface);
+}
+
+.inactive {
+  --labelBackgroundColor: var(--color-inactive--surface);
+}
+
+.informative {
+  --labelBackgroundColor: var(--color-informative--surface);
+}
+
 .statusLabelRow {
   display: flex;
   width: fit-content;
@@ -6,6 +30,7 @@
   flex-direction: row;
   flex-wrap: nowrap;
   gap: 6px;
+  background-color: var(--labelBackgroundColor);
 }
 
 /* Reset the <Text> line height so we can reliably get 24px tall */
@@ -20,24 +45,4 @@
 .statusIndicatorWrapper {
   display: flex;
   padding-top: 2px;
-}
-
-.success {
-  background-color: var(--color-success--surface);
-}
-
-.warning {
-  background-color: var(--color-warning--surface);
-}
-
-.critical {
-  background-color: var(--color-critical--surface);
-}
-
-.inactive {
-  background-color: var(--color-inactive--surface);
-}
-
-.informative {
-  background-color: var(--color-informative--surface);
 }

--- a/packages/components/src/StatusLabel/StatusLabel.css
+++ b/packages/components/src/StatusLabel/StatusLabel.css
@@ -24,35 +24,20 @@
 
 .success {
   background-color: var(--color-success--surface);
-  p {
-    color: var(--color-success--onSurface);
-  }
 }
 
 .warning {
   background-color: var(--color-warning--surface);
-  p {
-    color: var(--color-warning--onSurface);
-  }
 }
 
 .critical {
   background-color: var(--color-critical--surface);
-  p {
-    color: var(--color-critical--onSurface);
-  }
 }
 
 .inactive {
   background-color: var(--color-inactive--surface);
-  p {
-    color: var(--color-inactive--onSurface);
-  }
 }
 
 .informative {
   background-color: var(--color-informative--surface);
-  p {
-    color: var(--color-informative--onSurface);
-  }
 }

--- a/packages/components/src/StatusLabel/StatusLabel.css.d.ts
+++ b/packages/components/src/StatusLabel/StatusLabel.css.d.ts
@@ -1,7 +1,12 @@
 declare const styles: {
   readonly "statusLabelRow": string;
   readonly "labelTextEndAligned": string;
-  readonly "statusIndicator": string;
+  readonly "statusIndicatorWrapper": string;
+  readonly "success": string;
+  readonly "warning": string;
+  readonly "critical": string;
+  readonly "inactive": string;
+  readonly "informative": string;
 };
 export = styles;
 

--- a/packages/components/src/StatusLabel/StatusLabel.css.d.ts
+++ b/packages/components/src/StatusLabel/StatusLabel.css.d.ts
@@ -1,12 +1,12 @@
 declare const styles: {
-  readonly "statusLabelRow": string;
-  readonly "labelTextEndAligned": string;
-  readonly "statusIndicatorWrapper": string;
   readonly "success": string;
   readonly "warning": string;
   readonly "critical": string;
   readonly "inactive": string;
   readonly "informative": string;
+  readonly "statusLabelRow": string;
+  readonly "labelTextEndAligned": string;
+  readonly "statusIndicatorWrapper": string;
 };
 export = styles;
 

--- a/packages/components/src/StatusLabel/StatusLabel.tsx
+++ b/packages/components/src/StatusLabel/StatusLabel.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import classnames from "classnames";
 import styles from "./StatusLabel.css";
 import { StatusIndicatorType } from "../StatusIndicator/StatusIndicator.type";
-import { Text } from "../Text";
+import { Typography } from "../Typography";
 import { StatusIndicator } from "../StatusIndicator/StatusIndicator";
 
 export interface StatusLabelType {
@@ -48,9 +48,9 @@ export function StatusLabel({
         <StatusIndicator status={status} />
       </div>
 
-      <Text size="small" align={alignment}>
+      <Typography size="small" textColor={status} align={alignment}>
         {label}
-      </Text>
+      </Typography>
     </div>
   );
 }

--- a/packages/components/src/StatusLabel/StatusLabel.tsx
+++ b/packages/components/src/StatusLabel/StatusLabel.tsx
@@ -38,12 +38,13 @@ export function StatusLabel({
 }: StatusLabelProps): JSX.Element {
   const containerClassNames = classnames(
     styles.statusLabelRow,
+    styles[status],
     alignment === "end" && styles.labelTextEndAligned,
   );
 
   return (
     <div role="status" className={containerClassNames}>
-      <div className={styles.statusIndicator}>
+      <div className={styles.statusIndicatorWrapper}>
         <StatusIndicator status={status} />
       </div>
 

--- a/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`renders a critical StatusLabel 1`] = `
 <div>
   <div
-    class="statusLabelRow"
+    class="statusLabelRow critical"
     role="status"
   >
     <div
-      class="statusIndicator"
+      class="statusIndicatorWrapper"
     >
       <span
         class="statusIndicator"
@@ -26,11 +26,11 @@ exports[`renders a critical StatusLabel 1`] = `
 exports[`renders a successful StatusLabel 1`] = `
 <div>
   <div
-    class="statusLabelRow"
+    class="statusLabelRow success"
     role="status"
   >
     <div
-      class="statusIndicator"
+      class="statusIndicatorWrapper"
     >
       <span
         class="statusIndicator"
@@ -49,11 +49,11 @@ exports[`renders a successful StatusLabel 1`] = `
 exports[`renders a warning StatusLabel 1`] = `
 <div>
   <div
-    class="statusLabelRow"
+    class="statusLabelRow warning"
     role="status"
   >
     <div
-      class="statusIndicator"
+      class="statusIndicatorWrapper"
     >
       <span
         class="statusIndicator"
@@ -72,11 +72,11 @@ exports[`renders a warning StatusLabel 1`] = `
 exports[`renders an end-aligned StatusLabel 1`] = `
 <div>
   <div
-    class="statusLabelRow labelTextEndAligned"
+    class="statusLabelRow informative labelTextEndAligned"
     role="status"
   >
     <div
-      class="statusIndicator"
+      class="statusIndicatorWrapper"
     >
       <span
         class="statusIndicator"
@@ -95,11 +95,11 @@ exports[`renders an end-aligned StatusLabel 1`] = `
 exports[`renders an inactive StatusLabel 1`] = `
 <div>
   <div
-    class="statusLabelRow"
+    class="statusLabelRow inactive"
     role="status"
   >
     <div
-      class="statusIndicator"
+      class="statusIndicatorWrapper"
     >
       <span
         class="statusIndicator"
@@ -118,11 +118,11 @@ exports[`renders an inactive StatusLabel 1`] = `
 exports[`renders an informative StatusLabel 1`] = `
 <div>
   <div
-    class="statusLabelRow"
+    class="statusLabelRow informative"
     role="status"
   >
     <div
-      class="statusIndicator"
+      class="statusIndicatorWrapper"
     >
       <span
         class="statusIndicator"

--- a/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`renders a critical StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small text"
+      class="base regular small critical"
     >
       Foo
     </p>
@@ -38,7 +38,7 @@ exports[`renders a successful StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small text"
+      class="base regular small success"
     >
       Foo
     </p>
@@ -61,7 +61,7 @@ exports[`renders a warning StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small text"
+      class="base regular small warning"
     >
       Foo
     </p>
@@ -84,7 +84,7 @@ exports[`renders an end-aligned StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small text end"
+      class="base regular small informative end"
     >
       Foo
     </p>
@@ -107,7 +107,7 @@ exports[`renders an inactive StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small text"
+      class="base regular small inactive"
     >
       Foo
     </p>
@@ -130,7 +130,7 @@ exports[`renders an informative StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small text"
+      class="base regular small informative"
     >
       Foo
     </p>

--- a/packages/components/src/Typography/css/TextColors.css
+++ b/packages/components/src/Typography/css/TextColors.css
@@ -50,8 +50,12 @@
   color: var(--color-text--secondary);
 }
 
+.inactive {
+  color: var(--color-inactive--onSurface);
+}
+
 .critical {
-  color: var(--color-critical);
+  color: var(--color-critical--onSurface);
 }
 
 .warning {

--- a/packages/components/src/Typography/css/TextColors.css.d.ts
+++ b/packages/components/src/Typography/css/TextColors.css.d.ts
@@ -12,6 +12,7 @@ declare const styles: {
   readonly "heading": string;
   readonly "text": string;
   readonly "textSecondary": string;
+  readonly "inactive": string;
   readonly "critical": string;
   readonly "warning": string;
   readonly "informative": string;


### PR DESCRIPTION
## Motivations

<!-- Why did you do what you did? -->

## Changes
- StatusLabels look different, they have a background and rounded corners with matching coloured text
- StatusIndicator becomes a circle instead of a rounded square
- InputValidation (and any place use we use `Typography textColor="critical"`) gets a darker shade of red
- Moved a root variable to statusIndicator from statusLabel as it is no longer used in statusIndicator

### Changed

### Before
![image](https://github.com/GetJobber/atlantis/assets/10064579/7108ec9b-be55-4d8e-b533-5c1bf6bf9d49)

<img width="318" alt="image" src="https://github.com/GetJobber/atlantis/assets/10064579/da41b000-0597-4f17-bb6d-2ab4813623d0">

### After
<img width="173" alt="image" src="https://github.com/GetJobber/atlantis/assets/10064579/16a95177-de2d-499a-9524-e01bb2f92083">

Input validation text changes to using a darker red as Typography critical variant was updated
<img width="314" alt="image" src="https://github.com/GetJobber/atlantis/assets/10064579/e4dcf207-ae5a-4eeb-b5fb-3cb8f201016e">

## Comments
StatusLabel and inlineLabel (which was deprecated but not really because people still use it) now look pretty similar. We could continue that way, or potentially combine the two components and make the indicator a boolean. Will leave that decision to later.

## Testing
Atlantis import can be tested in this Rails branch `restyle-status-labels`. Note the colours will be slightly different as I've updated the tokens that we'll change to after the re-theme. 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
