### PR TITLE
fix(components): Removing Broken CI Badge

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,5 @@
 # 🔱 Atlantis
 
-[![CircleCI](https://circleci.com/gh/GetJobber/atlantis/tree/master.svg?style=svg)](https://circleci.com/gh/GetJobber/atlantis/tree/master)
-
 ## What is Atlantis?
 
 > Design systems enable teams to build better products faster by making design
@@ -152,9 +150,9 @@ npm run lint:css
 npm run lint:ts
 ```
 
-If you want to troubleshoot linting errors in CircleCI, try running locally
-first to find the error. If that doesn't work you can open the artifacts for the
-linting step. To find the errors causing the failure, search for `Error - `.
+If you want to troubleshoot linting errors in CI, try running locally first to
+find the error. If that doesn't work you can open the artifacts for the linting
+step. To find the errors causing the failure, search for `Error - `.
 
 ## Repo structure
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,9 +19,6 @@
     "dist/*"
   ],
   "dependencies": {
-    "@jobber/design": "^0.55.1",
-    "@jobber/formatters": "*",
-    "@jobber/hooks": "^2.9.1",
     "@popperjs/core": "^2.0.6",
     "@std-proposal/temporal": "0.0.1",
     "@tanstack/react-table": "8.5.13",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,6 +19,9 @@
     "dist/*"
   ],
   "dependencies": {
+    "@jobber/design": "^0.55.1",
+    "@jobber/formatters": "*",
+    "@jobber/hooks": "^2.9.1",
     "@popperjs/core": "^2.0.6",
     "@std-proposal/temporal": "0.0.1",
     "@tanstack/react-table": "8.5.13",


### PR DESCRIPTION
## Motivations

We updated a CI configuration option which removed our public availability of our build success badge.

This PR removes that badge from our README, now that it doesn't work anymore.

### Before
![image](https://github.com/GetJobber/atlantis/assets/145565743/a0d90f35-1058-4d82-b747-3f3c47bedac9)

### After
![image](https://github.com/GetJobber/atlantis/assets/145565743/6e60d9b3-91dd-4d70-8eab-476e78b96de6)


## Changes

- Removed CI Badge in README.md
- Removed reference to CircleCI in README, opting for generic `CI` instead.

### Removed

- CI Badge in README.md
- CircleCI reference in README.md

### Security

- Badge is no longer present

## Testing

- The Badge should no longer be present when running Storybook and viewing the landing page.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
