### PR TITLE
fix(components): Use unique item key in DataListSortingOptions

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
@@ -38,7 +38,7 @@ export function DataListSortingOptions({
       {options.map(option => (
         <li
           className={styles.option}
-          key={option.id}
+          key={`${option.id}${option.order}`}
           onClick={() => onSelectChange(option)}
           onKeyDown={event => handleKeyDown(event, option)}
           tabIndex={0}


### PR DESCRIPTION
## Motivations

The clients index in Jobber supports directional sorting on names. Because we have two sorting options with the same id, but different direction, we see the following error in the browser console:

```
Warning: Encountered two children with the same key, `firstName`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

This error also floods the console when unit testing.

## Changes

### Changed

Construct element `key` based on both the option `id` and `order`


[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
