### PR TITLE
fix(components): Make useMediaQuery SSR Friendly

### DIFF
--- a/packages/components/src/DataList/hooks/useMediaQuery.ts
+++ b/packages/components/src/DataList/hooks/useMediaQuery.ts
@@ -1,6 +1,22 @@
-import { useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
-export function useMediaQuery(CSSMediaQuery: string) {
+type MediaQuery = `(${string}:${string})`;
+
+export const mediaQueryStore = {
+  subscribe(onChange: () => void, query: MediaQuery) {
+    const matchMedia = window.matchMedia(query);
+    matchMedia.addEventListener("change", onChange);
+
+    return () => {
+      matchMedia.removeEventListener("change", onChange);
+    };
+  },
+  getSnapshot(query: MediaQuery) {
+    return () => window.matchMedia(query).matches;
+  },
+};
+
+export function useMediaQuery(query: MediaQuery) {
   /**
    * matchMedia have had full support for browsers since 2012 but jest, being a
    * lite version of a DOM, doesn't support it.
@@ -14,22 +30,16 @@ export function useMediaQuery(CSSMediaQuery: string) {
    */
   if (window.matchMedia === undefined) return true;
 
-  const [matches, setMatches] = useState(
-    window.matchMedia(CSSMediaQuery).matches,
+  const subscribeMediaQuery = useCallback(
+    (onChange: () => void) => mediaQueryStore.subscribe(onChange, query),
+    [query],
   );
 
-  useEffect(() => {
-    const media = window.matchMedia(CSSMediaQuery);
-
-    if (media.matches !== matches) {
-      setMatches(media.matches);
-    }
-
-    const listener = () => setMatches(media.matches);
-    media.addEventListener("change", listener);
-
-    return () => media.removeEventListener("change", listener);
-  }, [CSSMediaQuery]);
+  const matches = useSyncExternalStore(
+    subscribeMediaQuery,
+    mediaQueryStore.getSnapshot(query),
+    () => true,
+  );
 
   return matches;
 }

--- a/packages/components/src/DataList/hooks/useMediaQuery.ts
+++ b/packages/components/src/DataList/hooks/useMediaQuery.ts
@@ -28,7 +28,12 @@ export function useMediaQuery(query: MediaQuery) {
    * screen sizes, they can use the `mockViewportWidth` function from
    * `@jobber/components/useBreakpoints`.
    */
-  if (window.matchMedia === undefined) return true;
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia === "undefined"
+  ) {
+    return true;
+  }
 
   const subscribeMediaQuery = useCallback(
     (onChange: () => void) => mediaQueryStore.subscribe(onChange, query),


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

Note that we originally merged this but reverted because we thought there might have been a last minute breaking change but we have assured that everything works as expected.

## Motivations
Our useMediaQuery implementation currently isn't SSR friendly because it makes use of DOM specific objects.

In order to prepare atlantis for the remix work we need to ensure that our library is compatible with server side rendering. With SSR the application will be rendered on the server and the server doesn't recognize the window and therefore our currently implementation won't work.

## Changes
Update useMediaQuery to make use of useSyncExternalStore from the react library that enables this hook to be rendered on the server instead of just on the client via a guard.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
