### PR TITLE
feat: Add stylelint-config to pre-release options

### DIFF
--- a/.github/workflows/trigger-qa-build.yml
+++ b/.github/workflows/trigger-qa-build.yml
@@ -16,6 +16,7 @@ on:
         - Force Publish Hooks
         - Force Publish All
         - Force Publish Components-native
+        - Force Publish Stylelint-config
 
 jobs:
   trigger_pre_release_build:
@@ -60,6 +61,8 @@ jobs:
             FORCE_PUBLISH_SETTINGS="--force-publish @jobber/components,@jobber/design"
             elif [ "$PUBLISH_SETTING" == "Force Publish Hooks" ]; then
             FORCE_PUBLISH_SETTINGS="--force-publish @jobber/hooks"
+            elif [ "$PUBLISH_SETTING" == "Force Publish Stylelint-config" ]; then
+            FORCE_PUBLISH_SETTINGS="--force-publish @jobber/stylelint-config"
             else
             FORCE_PUBLISH_SETTINGS="--force-publish"
             fi


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Our pre-release builds don't include the `stylelint-config` package.  In upgrading `stylelint` in [this PR](https://github.com/GetJobber/atlantis/pull/1819), it became apparent that we'd need this pre-release option.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

<!-- new features -->
`Force Publish Stylelint-config` added to the Trigger Pre-release Build workflow


## Testing

<!-- How to test your changes. -->
1. Branch off of `TAYLOR/add-stylelint-config-to-prereleases` (this PR's branch)
2. Create a draft PR with a change to the `stylelint-config` `package.json`.  [Here](https://github.com/GetJobber/atlantis/pull/1822) is a branch where I upgraded 2 packages in the `package.json` to trigger the github-actions comment
3. Via github-actions, copy your draft PR branch & trigger a pre-release build with the `Force Publish Stylelint-config` desired workflow option
4. Check that a pre-release is commented on your draft PR

I also installed that back into [another repo](https://github.com/GetJobber/Jobber/pull/44569/files) to make sure the correct package is being updated

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
