### PR TITLE
feat(components): Make inlineLabel sizing match statusLabel

### DIFF
--- a/packages/components/src/InlineLabel/InlineLabel.css
+++ b/packages/components/src/InlineLabel/InlineLabel.css
@@ -1,18 +1,32 @@
 .inlineLabel {
   display: inline-flex;
-  border-radius: var(--radius-large);
 }
 
 .base {
   padding: calc(var(--space-smaller) * 1.5) calc(var(--space-small) * 1.25);
+  border-radius: var(--radius-large);
+
+  span {
+    line-height: 0.75rem;
+  }
 }
 
 .large {
-  padding: calc(var(--space-smaller) * 1.5) calc(var(--space-small) * 1.25);
+  padding: calc(var(--space-small) * 1.25) calc(var(--space-small) * 1.5);
+  border-radius: var(--radius-larger);
+
+  span {
+    line-height: 1rem;
+  }
 }
 
 .larger {
-  padding: calc(var(--space-small) * 1.25) calc(var(--space-smaller) * 3.5);
+  padding: calc(var(--space-small) * 1.5) calc(var(--space-base));
+  border-radius: var(--radius-larger);
+
+  span {
+    line-height: 1rem;
+  }
 }
 
 .greyBlue {

--- a/packages/components/src/InlineLabel/InlineLabel.css
+++ b/packages/components/src/InlineLabel/InlineLabel.css
@@ -5,28 +5,28 @@
 .base {
   padding: calc(var(--space-smaller) * 1.5) calc(var(--space-small) * 1.25);
   border-radius: var(--radius-large);
+}
 
-  span {
-    line-height: 0.75rem;
-  }
+.base span {
+  line-height: 0.75rem;
 }
 
 .large {
   padding: calc(var(--space-small) * 1.25) calc(var(--space-small) * 1.5);
   border-radius: var(--radius-larger);
+}
 
-  span {
-    line-height: 1rem;
-  }
+.large span {
+  line-height: 1rem;
 }
 
 .larger {
   padding: calc(var(--space-small) * 1.5) calc(var(--space-base));
   border-radius: var(--radius-larger);
+}
 
-  span {
-    line-height: 1rem;
-  }
+.larger span {
+  line-height: 1rem;
 }
 
 .greyBlue {


### PR DESCRIPTION
## Motivations
As part of the re-theme the statusLabel was updated in styling. This PR makes the inlineLabel the same height and styling as the statusLabel so they don't feel out of place when used on the same screen together.

## Changes
- Adjusted the height by setting a consistent line height
- Cleaned up spacing on larger variants, less square, more rectangle, and a little rounder

### Changed

Before
![image](https://github.com/GetJobber/atlantis/assets/10064579/be5dead1-dd0c-4f96-8836-0c9734ee8757)
![image](https://github.com/GetJobber/atlantis/assets/10064579/a7e23436-dfb9-40bf-a9fe-f6964d70e9ba)

After
![image](https://github.com/GetJobber/atlantis/assets/10064579/45a48b7f-7a0a-44d0-a0d2-45373a07cc20)
![image](https://github.com/GetJobber/atlantis/assets/10064579/58ae6f14-6638-4942-9381-05ae52884e32)

## Testing

Stare at your screen for a long time and ponder "is this really just a 1.7px change?", the answer is yes.

Note, these all get rounder in the re-theme

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
