### PR TITLE
fix(components): stop InputPhoneNumber crashing page when it's translated with a Google Translate browser extension  — Patch Release

### DIFF
--- a/packages/components/src/InputPhoneNumber/InputMask.tsx
+++ b/packages/components/src/InputPhoneNumber/InputMask.tsx
@@ -57,7 +57,7 @@ export function InputMask({
   const inputMask = (
     <div className={styles.mask} aria-hidden="true">
       <span className={styles.hiddenValue}>{stringifiedValue}</span>
-      {placeholderValue}
+      <span>{placeholderValue}</span>
     </div>
   );
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The bug occurs when a user translates the page with a browser extension and inputs a phone number.

### Fixed

fixed page crashing on phone number input, when the page is translated with a browser extension

## Testing

BEFORE:

- use Chrome browser (I wasn't able to make Google Translate extension work in Firefox, but Firefox native translation feature doesn't crash the page)
- install [Google Translate browser extension](https://chromewebstore.google.com/detail/google-translate/aapbdbdomjkkjkaonfhkkikfgjllcleb), go to Extension Options and set your primary language to Spanish
- navigate to the InputPhoneNumber component on storybook
- click TRANSLATE THIS PAGE
- start typing your phone number
- when you type the last digit - the page should crash

AFTER:

the page doesn't crash

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
