### PR TITLE
feat(components-native): implement toolbar visibility

### DIFF
--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.test.tsx
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.test.tsx
@@ -259,5 +259,14 @@ describe("InputFieldWrapper", () => {
 
       expect(queryByText("I am a tool")).toBeNull();
     });
+
+    it("renders a toolbar when toolbarVisibility is always", () => {
+      const { getByText } = renderInputFieldWrapper({
+        focused: false,
+        toolbar: <Text>I am a tool</Text>,
+        toolbarVisibility: "always",
+      });
+      expect(getByText("I am a tool")).toBeDefined();
+    });
   });
 });

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.tsx
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.tsx
@@ -93,6 +93,11 @@ export interface InputFieldWrapperProps {
    * Add a toolbar below the input field for actions like rewriting the text.
    */
   readonly toolbar?: React.ReactNode;
+
+  /**
+   * Change the behaviour of when the toolbar becomes visible.
+   */
+  readonly toolbarVisibility?: "always" | "while-editing";
 }
 
 export function InputFieldWrapper({
@@ -111,11 +116,14 @@ export function InputFieldWrapper({
   showClearAction = false,
   styleOverride,
   toolbar,
+  toolbarVisibility = "while-editing",
 }: InputFieldWrapperProps): JSX.Element {
   fieldAffixRequiredPropsCheck([prefix, suffix]);
   const handleClear = onClear ?? noopClear;
   warnIfClearActionWithNoOnClear(onClear, showClearAction);
   const inputInvalid = Boolean(invalid) || Boolean(error);
+  const isToolbarVisible =
+    toolbar && (toolbarVisibility === "always" || focused);
 
   return (
     <ErrorMessageWrapper message={getMessage({ invalid, error })}>
@@ -202,7 +210,7 @@ export function InputFieldWrapper({
           )}
         </View>
 
-        {toolbar && focused && <View style={styles.toolbar}>{toolbar}</View>}
+        {isToolbarVisible && <View style={styles.toolbar}>{toolbar}</View>}
       </View>
       {assistiveText && !error && !invalid && (
         <Text

--- a/packages/components-native/src/InputText/InputText.tsx
+++ b/packages/components-native/src/InputText/InputText.tsx
@@ -33,7 +33,7 @@ import { InputFieldWrapper } from "../InputFieldWrapper";
 import { commonInputStyles } from "../InputFieldWrapper/CommonInputStyles.style";
 
 export interface InputTextProps
-  extends Pick<InputFieldWrapperProps, "toolbar"> {
+  extends Pick<InputFieldWrapperProps, "toolbar" | "toolbarVisibility"> {
   /**
    * Highlights the field red and shows message below (if string) to indicate an error
    */
@@ -265,6 +265,7 @@ function InputTextInternal(
     secureTextEntry,
     styleOverride,
     toolbar,
+    toolbarVisibility,
   }: InputTextProps,
   ref: Ref<InputTextRef>,
 ) {
@@ -367,6 +368,7 @@ function InputTextInternal(
       showClearAction={showClear}
       styleOverride={styleOverride}
       toolbar={toolbar}
+      toolbarVisibility={toolbarVisibility}
     >
       <TextInput
         inputAccessoryViewID={inputAccessoryID || undefined}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Found out that there are scenarios where we need to keep the toobar shown even if you've focused out of the field. For example, an action that opens a bottom sheet could take away the focus from the input, which hides the toolbar and then closes the bottom sheet.

adding a prop to control wether the toolbar is always shown or only on focus (while-editing) fixes that problem.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `toolbarVisibility` prop on components-native InputText that accepts the value of "always" or "while-editing"
  - Those values are consistent with the clear prop language

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
