### PR TITLE
feat(components): Heading can accept an element prop to override the numbered heading element

### DIFF
--- a/packages/components/src/Heading/Heading.test.tsx
+++ b/packages/components/src/Heading/Heading.test.tsx
@@ -66,3 +66,20 @@ it("renders a Heading 5", () => {
     </div>
   `);
 });
+
+it("renders a non heading inline element", () => {
+  const { container } = render(
+    <Heading level={5} element="span">
+      Dis be a span
+    </Heading>,
+  );
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <span
+        class="base bold base heading"
+      >
+        Dis be a span
+      </span>
+    </div>
+  `);
+});

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -11,7 +11,7 @@ interface HeadingProps {
   readonly level: HeadingLevel;
   readonly children: ReactNode;
   /**
-   * @default "p"
+   * Allows overriding of the element rendered. Defaults to the heading specified with level.
    */
   readonly element?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
 }

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -10,11 +10,15 @@ interface HeadingProps {
    */
   readonly level: HeadingLevel;
   readonly children: ReactNode;
+  /**
+   * @default "p"
+   */
+  readonly element?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
 }
 
 export type LevelMap = Record<HeadingLevel, TypographyOptions>;
 
-export function Heading({ level = 5, children }: HeadingProps) {
+export function Heading({ level = 5, children, element }: HeadingProps) {
   const { JOBBER_RETHEME: inRetheme } = useAtlantisConfig();
 
   const levelMap: LevelMap = {
@@ -57,5 +61,12 @@ export function Heading({ level = 5, children }: HeadingProps) {
     },
   };
 
-  return <Typography {...levelMap[level]}>{children}</Typography>;
+  return (
+    <Typography
+      {...levelMap[level]}
+      element={element || levelMap[level].element}
+    >
+      {children}
+    </Typography>
+  );
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Our designers often use headings in their designs for the styles without intending for them to be that semantic heading. However, there's no way for devs to do this without custom CSS. So our codebase is filled with invalid HTML where we have heading structures like h1 > h4 > h4 > h2 > h4. This is an HTML violation and an accessibility violation. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
You can now cast a heading as an element different than the level you provided. So you can have a span styled like an `<h2>` or an `<h4>` that looks like an `<h1>`. This separates the intended styles from the semantic meaning of the element and allows devs to accomplish designs without disrupting document structure.

## Testing

<!-- How to test your changes. -->
Try it out!
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
## This is a great gif of Atlantis
![amazing gif of atlantis](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDA4OHI3NHpuNnV2MmprNGZ6dmx6MWZoNDN5a2pyZHIxc2gxYWMxaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l3vR7CSdOjnplhkbu/giphy.gif)
