### PR TITLE
fix(components-native): ensure prefix is beside the input

### DIFF
--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
@@ -11,6 +11,11 @@ export const styles = StyleSheet.create({
     },
   ]),
 
+  field: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+
   inputContainer: {
     flexDirection: "row",
     flex: 1,

--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.tsx
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.tsx
@@ -137,77 +137,79 @@ export function InputFieldWrapper({
           styleOverride?.container,
         ]}
       >
-        {prefix?.icon && (
-          <PrefixIcon
-            disabled={disabled}
-            focused={focused}
-            hasMiniLabel={hasMiniLabel}
-            inputInvalid={inputInvalid}
-            icon={prefix.icon}
-          />
-        )}
-        <View style={[styles.inputContainer]}>
-          <View
-            style={[
-              !!placeholder && styles.label,
-              hasMiniLabel && styles.miniLabel,
-              disabled && styles.disabled,
-              hasMiniLabel &&
-                showClearAction &&
-                styles.miniLabelShowClearAction,
-            ]}
-            pointerEvents="none"
-          >
-            <Placeholder
-              placeholder={placeholder}
-              labelVariation={getLabelVariation(error, invalid, disabled)}
-              hasMiniLabel={hasMiniLabel}
-              styleOverride={styleOverride?.placeholderText}
-            />
-          </View>
-          {prefix?.label && hasValue && (
-            <PrefixLabel
+        <View style={styles.field}>
+          {prefix?.icon && (
+            <PrefixIcon
               disabled={disabled}
               focused={focused}
               hasMiniLabel={hasMiniLabel}
               inputInvalid={inputInvalid}
-              label={prefix.label}
-              styleOverride={styleOverride?.prefixLabel}
+              icon={prefix.icon}
             />
           )}
-          {children}
-          {(showClearAction || suffix?.label || suffix?.icon) && (
-            <View style={styles.inputEndContainer}>
-              {showClearAction && (
-                <ClearAction
-                  hasMarginRight={!!suffix?.icon || !!suffix?.label}
-                  onPress={handleClear}
-                />
-              )}
-              {suffix?.label && hasValue && (
-                <SuffixLabel
-                  disabled={disabled}
-                  focused={focused}
-                  hasMiniLabel={hasMiniLabel}
-                  inputInvalid={inputInvalid}
-                  label={suffix.label}
-                  hasLeftMargin={!showClearAction}
-                  styleOverride={styleOverride?.suffixLabel}
-                />
-              )}
-              {suffix?.icon && (
-                <SuffixIcon
-                  disabled={disabled}
-                  focused={focused}
-                  hasMiniLabel={hasMiniLabel}
-                  hasLeftMargin={!!(!showClearAction || suffix?.label)}
-                  inputInvalid={inputInvalid}
-                  icon={suffix.icon}
-                  onPress={suffix.onPress}
-                />
-              )}
+          <View style={[styles.inputContainer]}>
+            <View
+              style={[
+                !!placeholder && styles.label,
+                hasMiniLabel && styles.miniLabel,
+                disabled && styles.disabled,
+                hasMiniLabel &&
+                  showClearAction &&
+                  styles.miniLabelShowClearAction,
+              ]}
+              pointerEvents="none"
+            >
+              <Placeholder
+                placeholder={placeholder}
+                labelVariation={getLabelVariation(error, invalid, disabled)}
+                hasMiniLabel={hasMiniLabel}
+                styleOverride={styleOverride?.placeholderText}
+              />
             </View>
-          )}
+            {prefix?.label && hasValue && (
+              <PrefixLabel
+                disabled={disabled}
+                focused={focused}
+                hasMiniLabel={hasMiniLabel}
+                inputInvalid={inputInvalid}
+                label={prefix.label}
+                styleOverride={styleOverride?.prefixLabel}
+              />
+            )}
+            {children}
+            {(showClearAction || suffix?.label || suffix?.icon) && (
+              <View style={styles.inputEndContainer}>
+                {showClearAction && (
+                  <ClearAction
+                    hasMarginRight={!!suffix?.icon || !!suffix?.label}
+                    onPress={handleClear}
+                  />
+                )}
+                {suffix?.label && hasValue && (
+                  <SuffixLabel
+                    disabled={disabled}
+                    focused={focused}
+                    hasMiniLabel={hasMiniLabel}
+                    inputInvalid={inputInvalid}
+                    label={suffix.label}
+                    hasLeftMargin={!showClearAction}
+                    styleOverride={styleOverride?.suffixLabel}
+                  />
+                )}
+                {suffix?.icon && (
+                  <SuffixIcon
+                    disabled={disabled}
+                    focused={focused}
+                    hasMiniLabel={hasMiniLabel}
+                    hasLeftMargin={!!(!showClearAction || suffix?.label)}
+                    inputInvalid={inputInvalid}
+                    icon={suffix.icon}
+                    onPress={suffix.onPress}
+                  />
+                )}
+              </View>
+            )}
+          </View>
         </View>
 
         {isToolbarVisible && <View style={styles.toolbar}>{toolbar}</View>}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There was this issue after we added the toolbar

![image](https://github.com/GetJobber/atlantis/assets/15986172/df4d2890-0cdc-481f-aa69-d739acd7aada)

![image](https://github.com/GetJobber/atlantis/assets/15986172/5f007696-f890-4712-9172-b240fa65d51e)


and now it's fixed

![image](https://github.com/GetJobber/atlantis/assets/15986172/afce4db2-dbc5-4314-bb7c-3ad9eada3dbd)

![image](https://github.com/GetJobber/atlantis/assets/15986172/9da5f02e-8436-4fae-a0f9-e679aff52baf)


Hide whitespace to see what really changed

![image](https://github.com/GetJobber/atlantis/assets/15986172/5a4fc17a-773c-4126-a4de-9991a5e9e3db)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- prefix icon not being beside the input

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
