### PR TITLE
feat(design): Create longArrowRight and rename backArrow

### DIFF
--- a/docs/components/AnimatedSwitcher/Web.stories.tsx
+++ b/docs/components/AnimatedSwitcher/Web.stories.tsx
@@ -61,7 +61,7 @@ const IconTemplate: ComponentStory<typeof AnimatedSwitcher> = args => {
         <AnimatedSwitcher.Icon
           switched={switched}
           initialIcon="menu"
-          switchToIcon="backArrow"
+          switchToIcon="longArrowLeft"
         />
         <AnimatedSwitcher.Icon
           switched={switched}

--- a/docs/components/Icon/Icon.stories.mdx
+++ b/docs/components/Icon/Icon.stories.mdx
@@ -77,15 +77,16 @@ use the default icon color.
 
 ### Arrows
 
-| Icon                          | `Name`          |
-| :---------------------------- | :-------------- |
-| <Icon name="arrowDown" />     | `arrowDown`     |
-| <Icon name="arrowLeft" />     | `arrowLeft`     |
-| <Icon name="arrowRight" />    | `arrowRight`    |
-| <Icon name="arrowUp" />       | `arrowUp`       |
-| <Icon name="backArrow" />     | `backArrow`     |
-| <Icon name="longArrowDown" /> | `longArrowDown` |
-| <Icon name="longArrowUp" />   | `longArrowUp`   |
+| Icon                           | `Name`           |
+| :----------------------------- | :--------------- |
+| <Icon name="arrowDown" />      | `arrowDown`      |
+| <Icon name="arrowLeft" />      | `arrowLeft`      |
+| <Icon name="arrowRight" />     | `arrowRight`     |
+| <Icon name="arrowUp" />        | `arrowUp`        |
+| <Icon name="longArrowDown" />  | `longArrowDown`  |
+| <Icon name="longArrowLeft" />  | `longArrowLeft`  |
+| <Icon name="longArrowRight" /> | `longArrowRight` |
+| <Icon name="longArrowUp" />    | `longArrowUp`    |
 
 ### Calendar & scheduling
 

--- a/packages/components-native/src/ActionItem/ActionItem.test.tsx
+++ b/packages/components-native/src/ActionItem/ActionItem.test.tsx
@@ -6,7 +6,7 @@ import { Text } from "../Text";
 
 describe("ActionItem", () => {
   const pressHandler = jest.fn();
-  const defaultActionIcon = "arrowRight";
+  const defaultActionIcon = "longArrowRight";
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -63,7 +63,7 @@ describe("ActionItem", () => {
       expect(queryByTestId(defaultActionIcon)).toBeFalsy();
     });
 
-    it("should display arrowRight icon when edit name is used", () => {
+    it("should display longArrowRight icon when edit name is used", () => {
       const iconName = "edit";
       const { getByTestId } = render(
         <ActionItem onPress={pressHandler} actionIcon={iconName} />,

--- a/packages/components-native/src/ActionItem/ActionItem.tsx
+++ b/packages/components-native/src/ActionItem/ActionItem.tsx
@@ -124,7 +124,7 @@ type ActionIconNames = IconNames | "editpencil";
 
 function getActionIcon(icon: ActionIconNames): IconNames {
   if (icon === "edit") {
-    return "arrowRight";
+    return "longArrowRight";
   } else if (icon === "editpencil") {
     return "edit";
   }

--- a/packages/design/src/icons/Icon.css
+++ b/packages/design/src/icons/Icon.css
@@ -12,6 +12,14 @@
   transform: rotate(-90deg);
 }
 
+.longArrowRight {
+  transform: rotate(180deg);
+}
+
+.longArrowLeft {
+  transform: rotate(0deg);
+}
+
 .thumbsDown {
   transform: scaleY(-1);
 }

--- a/packages/design/src/icons/Icon.css.d.ts
+++ b/packages/design/src/icons/Icon.css.d.ts
@@ -2,6 +2,8 @@ declare const styles: {
   readonly "icon": string;
   readonly "longArrowUp": string;
   readonly "longArrowDown": string;
+  readonly "longArrowRight": string;
+  readonly "longArrowLeft": string;
   readonly "thumbsDown": string;
   readonly "person": string;
   readonly "clients": string;

--- a/packages/design/src/icons/getIcon.ts
+++ b/packages/design/src/icons/getIcon.ts
@@ -22,6 +22,8 @@ export type IconNames =
   | keyof typeof iconMap.icons
   | "longArrowUp"
   | "longArrowDown"
+  | "longArrowRight"
+  | "longArrowLeft"
   | "remove"
   | "thumbsDown"
   | "truck";
@@ -49,6 +51,8 @@ export function getIcon({ name, color, size = "base" }: IconProps) {
   const svgClassNames = classnames(styles.icon, sizes[size], {
     [styles.longArrowUp]: name === "longArrowUp",
     [styles.longArrowDown]: name === "longArrowDown",
+    [styles.longArrowRight]: name === "longArrowRight",
+    [styles.longArrowLeft]: name === "longArrowLeft",
     [styles.thumbsDown]: name === "thumbsDown",
     [styles.runningTimer]: name === "runningTimer",
   });
@@ -76,6 +80,10 @@ function mapToCorrectIcon(name: IconNames) {
     case "longArrowUp":
       return "backArrow";
     case "longArrowDown":
+      return "backArrow";
+    case "longArrowRight":
+      return "backArrow";
+    case "longArrowLeft":
       return "backArrow";
     case "remove":
       return "cross";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->


## Motivations

<!-- Why did you do what you did? -->
This work stems from updating `ActionItem` to align with retheme.  

As a side effect, Arrow icons are now more streamlined:

<img width="1350" alt="Screenshot 2024-04-01 at 8 22 00 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/3d3a868c-a63c-4a48-970e-c0bae908f250">


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

<!-- new features -->
- Created `longArrowRight`:

<img width="502" alt="Screenshot 2024-03-26 at 8 17 43 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/ed2814ca-9ce4-4847-875e-4c1861b6c10b">

For this, we are still using `backArrow.svg` and just simply rotating the icon via css.  I did this same thing to the `longArrowLeft`.


### Changed

<!-- changes in existing functionality -->
- The major change to `ActionItem`, is updating the `actionIcon` to be a 'long tail' arrow pointing right (where previously it was just `arrowRight`).  Any `ActionItem` without a set `actionIcon` prop will give you `longArrowRight` as a default
- Any existing implementation of `<Icon name="backArrow" />` (which is now called `longArrowLeft`) will not break, and will continue to display the long tailed arrow pointing left.

## Testing

<!-- How to test your changes. -->

#### - [here](https://github.com/GetJobber/jobber-mobile/pull/9071) is a PR showing examples of this change in mobile with builds for testing

- using the pre-release you can find examples of `ActionItem` and `ActionItemGroup` that are imported from `@jobber/components-native` that now look just like the [retheme mock up](https://www.figma.com/file/ZJYCUJFHPxxzNDAKeZ9hhh/Mobile-Re-theme-Implementation?type=whiteboard&node-id=1%3A9651&t=2folQXbKcbgaJ3sj-1)
- use `longArrowLeft`, `longArrowRight` and even `backArrow` to make sure that nothing breaks in web/mobile for any existing/new icon implementations
- otherwise, you can look at Storybook examples:

<img width="507" alt="Screenshot 2024-03-26 at 8 38 09 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/c7cd4a10-d556-4d09-b5ff-5e0a887a6d05">

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
