### PR TITLE
fix(components): Fix when InputDate's emptyValueLabel is updated

### DIFF
--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -82,6 +82,7 @@ export function InputDate(inputProps: InputDateProps) {
         useEffect(() => {
           value && formFieldActionsRef.current?.setValue(value);
         }, [value]);
+        const showEmptyValueLabel = !value && !isFocused;
 
         return (
           // We prevent the picker from opening on focus for keyboard navigation, so to maintain a good UX for mouse users we want to open the picker on click
@@ -90,7 +91,7 @@ export function InputDate(inputProps: InputDateProps) {
               {...newActivatorProps}
               {...inputProps}
               value={
-                !value && !isFocused ? inputProps.emptyValueLabel || "" : value
+                showEmptyValueLabel ? inputProps.emptyValueLabel || "" : value
               }
               placeholder={inputProps.placeholder}
               onChange={(_, event) => {

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -67,9 +67,7 @@ export function InputDate(inputProps: InputDateProps) {
       activator={activatorProps => {
         const { onChange, onClick, value } = activatorProps;
         const newActivatorProps = omit(activatorProps, ["activator"]);
-        const [showEmptyPlaceholder, setShowEmptyPlaceholder] = useState(
-          !value,
-        );
+        const [isFocused, setIsFocused] = useState(false);
         const suffix =
           inputProps.showIcon !== false
             ? ({
@@ -91,20 +89,22 @@ export function InputDate(inputProps: InputDateProps) {
             <FormField
               {...newActivatorProps}
               {...inputProps}
-              value={showEmptyPlaceholder ? inputProps.emptyValueLabel : value}
+              value={
+                !value && !isFocused ? inputProps.emptyValueLabel || "" : value
+              }
               placeholder={inputProps.placeholder}
               onChange={(_, event) => {
                 onChange && onChange(event);
-                setShowEmptyPlaceholder(false);
               }}
               onBlur={() => {
                 inputProps.onBlur && inputProps.onBlur();
                 activatorProps.onBlur && activatorProps.onBlur();
-                setShowEmptyPlaceholder(!value);
+                setIsFocused(false);
               }}
               onFocus={() => {
                 inputProps.onFocus && inputProps.onFocus();
                 activatorProps.onFocus && activatorProps.onFocus();
+                setIsFocused(true);
               }}
               onKeyUp={event => {
                 if (


### PR DESCRIPTION


<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

InputDate component was updated in [this PR](https://github.com/GetJobber/atlantis/pull/1817) to allow a value other than a date as the initial/empty value. I found scenarios in the schedule page where the empty value label wasn't rendered. This PR is a fix to cover those scenarios. 

https://github.com/GetJobber/atlantis/assets/35830155/89133d3b-a3a5-4471-bd95-7684420af8ed

## Changes

Replaced the `showEmptyPlaceholder` state with a `isFocused` state which is set to `false` at the beginning and set to true when user focuses on the field. This creates a bette experience for the user as they don't need to delete the placeholder value. 


https://github.com/GetJobber/atlantis/assets/35830155/0eb534c7-5e28-4c44-8a1b-4a70daca801c

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
