### PR TITLE
feat(components): adds ability to provide "preferredPlacement" for Tooltip

### DIFF
--- a/docs/components/Tooltip/Web.stories.tsx
+++ b/docs/components/Tooltip/Web.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Tooltip } from "@jobber/components/Tooltip";
 import { Button } from "@jobber/components/Button";
+import { Flex } from "@jobber/components/Flex";
 
 export default {
   title: "Components/Overlays/Tooltip/Web",
@@ -14,14 +15,14 @@ export default {
 
 const BasicTemplate: ComponentStory<typeof Tooltip> = args => {
   return (
-    <>
+    <Flex gap="large" template={["shrink", "shrink"]}>
       <Tooltip {...args}>
         <Button label="Hover on Me" />
       </Tooltip>
       <Tooltip {...args}>
         <Button label="Hover on Me Too" />
       </Tooltip>
-    </>
+    </Flex>
   );
 };
 

--- a/packages/components/src/Popover/Popover.css
+++ b/packages/components/src/Popover/Popover.css
@@ -57,25 +57,25 @@
 }
 
 .popover[data-popper-placement^="top"] > .arrow {
-  bottom: -5px;
+  padding-bottom: -5px;
 }
 .popover[data-popper-placement^="top"] > .arrow::before {
   transform: rotate(-135deg);
 }
 
 .popover[data-popper-placement^="bottom"] > .arrow {
-  top: -7px;
+  padding-top: -7px;
 }
 
 .popover[data-popper-placement^="left"] > .arrow {
-  right: -5px;
+  padding-right: -5px;
 }
 .popover[data-popper-placement^="left"] > .arrow::before {
   transform: rotate(135deg);
 }
 
 .popover[data-popper-placement^="right"] > .arrow {
-  left: -7px;
+  padding-left: -7px;
 }
 .popover[data-popper-placement^="right"] > .arrow::before {
   transform: rotate(-45deg);

--- a/packages/components/src/Tooltip/Tooltip.css
+++ b/packages/components/src/Tooltip/Tooltip.css
@@ -43,38 +43,52 @@
   transform: rotate(45deg);
 }
 
-.above {
+.top {
   padding-bottom: var(--space-small);
 }
 
-.above .tooltip {
+.top .tooltip {
   transform-origin: bottom center;
 }
 
-.above .tooltip .arrow {
+.top .tooltip .arrow {
   bottom: var(--tooltip--offset);
 }
 
-.above .tooltip .arrow::after {
-  border-top-width: 0;
-  border-left-width: 0;
-}
-
-.below {
+.bottom {
   padding-top: var(--space-small);
 }
 
-.below .tooltip {
+.bottom .tooltip {
   transform-origin: top center;
 }
 
-.below .tooltip .arrow {
+.bottom .tooltip .arrow {
   top: var(--tooltip--offset);
 }
 
-.below .tooltip .arrow::after {
-  border-bottom-width: 0;
-  border-right-width: 0;
+.left {
+  padding-right: var(--space-small);
+}
+
+.left .tooltip {
+  transform-origin: right center;
+}
+
+.left .tooltip .arrow {
+  right: var(--tooltip--offset);
+}
+
+.right {
+  padding-left: var(--space-small);
+}
+
+.right .tooltip {
+  transform-origin: left center;
+}
+
+.right .tooltip .arrow {
+  left: var(--tooltip--offset);
 }
 
 .tooltipMessage {

--- a/packages/components/src/Tooltip/Tooltip.css.d.ts
+++ b/packages/components/src/Tooltip/Tooltip.css.d.ts
@@ -3,8 +3,10 @@ declare const styles: {
   readonly "tooltipWrapper": string;
   readonly "tooltip": string;
   readonly "arrow": string;
-  readonly "above": string;
-  readonly "below": string;
+  readonly "top": string;
+  readonly "bottom": string;
+  readonly "left": string;
+  readonly "right": string;
   readonly "tooltipMessage": string;
 };
 export = styles;

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Tooltip } from ".";
 
@@ -118,4 +118,29 @@ describe("with a message of an empty string", () => {
     const visibleTooltip = document.querySelector("div[role='tooltip']");
     expect(visibleTooltip).toBeNull();
   });
+});
+
+describe("with a preferred placement", () => {
+  it.each(["top", "bottom", "left", "right"] as const)(
+    "should show the tooltip on the %s",
+    async placement => {
+      const message = "Tipping the tool on the right";
+      const content = "Hover on me";
+      const contentID = "hover-on-me";
+
+      render(
+        <Tooltip message={message} preferredPlacement={placement}>
+          <div data-testid={contentID}>{content}</div>
+        </Tooltip>,
+      );
+
+      const tooltipContent = screen.getByTestId(contentID);
+      await userEvent.hover(tooltipContent);
+
+      const tooltip = screen.getByRole("tooltip");
+
+      expect(tooltip).toHaveAttribute("data-popper-placement", placement);
+      expect(tooltip).toHaveClass(placement);
+    },
+  );
 });

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -6,6 +6,7 @@ import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
 import { useIsMounted } from "@jobber/hooks/useIsMounted";
 import styles from "./Tooltip.css";
 import { useTooltipPositioning } from "./useTooltipPositioning";
+import { Placement } from "./Tooltip.types";
 
 const variation = {
   startOrStop: { scale: 0.6, opacity: 0 },
@@ -18,11 +19,19 @@ interface TooltipProps {
    * Tooltip text
    */
   readonly message: string;
+  /**
+   * Describes the preferred placement of the Popover.
+   * @default 'top'
+   */
+  readonly preferredPlacement?: Placement;
 }
 
-export function Tooltip({ message, children }: TooltipProps) {
+export function Tooltip({
+  message,
+  children,
+  preferredPlacement = "top",
+}: TooltipProps) {
   const [show, setShow] = useState(false);
-  const mounted = useIsMounted();
 
   const {
     attributes,
@@ -31,52 +40,52 @@ export function Tooltip({ message, children }: TooltipProps) {
     styles: popperStyles,
     setArrowRef,
     setTooltipRef,
-  } = useTooltipPositioning();
+  } = useTooltipPositioning({ preferredPlacement: preferredPlacement });
 
   initializeListeners();
 
   const toolTipClassNames = classnames(
     styles.tooltipWrapper,
-    placement === "bottom" && styles.below,
-    placement === "top" && styles.above,
+    placement === "bottom" && styles.bottom,
+    placement === "top" && styles.top,
+    placement === "left" && styles.left,
+    placement === "right" && styles.right,
   );
 
   return (
     <>
       <span className={styles.shadowActivator} ref={shadowRef} />
       {children}
-      {mounted.current ? (
-        <TooltipPortal>
-          {show && Boolean(message) && (
-            <div
-              className={toolTipClassNames}
-              style={popperStyles.popper}
-              ref={setTooltipRef}
-              role="tooltip"
-              {...attributes.popper}
+      <TooltipPortal>
+        {show && Boolean(message) && (
+          <div
+            className={toolTipClassNames}
+            style={popperStyles.popper}
+            ref={setTooltipRef}
+            role="tooltip"
+            {...attributes.popper}
+          >
+            <motion.div
+              className={styles.tooltip}
+              variants={variation}
+              initial="startOrStop"
+              animate="done"
+              exit="startOrStop"
+              transition={{
+                damping: 50,
+                stiffness: 500,
+              }}
             >
-              <motion.div
-                className={styles.tooltip}
-                variants={variation}
-                initial="startOrStop"
-                animate="done"
-                exit="startOrStop"
-                transition={{
-                  damping: 50,
-                  stiffness: 500,
-                }}
-              >
-                <p className={styles.tooltipMessage}>{message}</p>
-                <div
-                  ref={setArrowRef}
-                  style={popperStyles.arrow}
-                  className={styles.arrow}
-                />
-              </motion.div>
-            </div>
-          )}
-        </TooltipPortal>
-      ) : null}
+              <p className={styles.tooltipMessage}>{message}</p>
+              <div
+                ref={setArrowRef}
+                style={popperStyles.arrow}
+                className={styles.arrow}
+              />
+            </motion.div>
+          </div>
+        )}
+      </TooltipPortal>
     </>
   );
 
@@ -133,9 +142,15 @@ export function Tooltip({ message, children }: TooltipProps) {
 }
 
 interface TooltipPortalProps {
-  children: ReactNode;
+  readonly children: ReactNode;
 }
 
 function TooltipPortal({ children }: TooltipPortalProps) {
+  const mounted = useIsMounted();
+
+  if (!mounted) {
+    return null;
+  }
+
   return ReactDOM.createPortal(children, document.body);
 }

--- a/packages/components/src/Tooltip/Tooltip.types.ts
+++ b/packages/components/src/Tooltip/Tooltip.types.ts
@@ -1,0 +1,1 @@
+export type Placement = "top" | "bottom" | "left" | "right";

--- a/packages/components/src/Tooltip/useTooltipPositioning.ts
+++ b/packages/components/src/Tooltip/useTooltipPositioning.ts
@@ -1,7 +1,16 @@
 import { useRef, useState } from "react";
 import { usePopper } from "react-popper";
+import { Placement } from "./Tooltip.types";
 
-export function useTooltipPositioning() {
+const DEFAULT_PLACEMENT: Placement = "top";
+
+interface ToolTipPositionOptions {
+  readonly preferredPlacement?: Placement;
+}
+
+export function useTooltipPositioning({
+  preferredPlacement,
+}: ToolTipPositionOptions) {
   const shadowRef = useRef<HTMLSpanElement>(null);
   const [positionElement, setTooltipRef] = useState<HTMLDivElement | null>();
   const [arrowElement, setArrowRef] = useState<HTMLDivElement | null>();
@@ -10,7 +19,7 @@ export function useTooltipPositioning() {
     shadowRef.current?.nextElementSibling,
     positionElement,
     {
-      placement: "top",
+      placement: preferredPlacement,
       modifiers: [
         { name: "flip", options: { fallbackPlacements: ["bottom"] } },
         {
@@ -23,7 +32,7 @@ export function useTooltipPositioning() {
 
   return {
     ...popper,
-    placement: popper.state?.placement,
+    placement: popper.state?.placement || DEFAULT_PLACEMENT,
     shadowRef,
     setArrowRef,
     setTooltipRef,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
There are instances where being able to influence the placement of a tooltip is desired such as on a navigation elements within the shell of a UI. By adding a `preferredPlacement` consumers are able to influence the placement depending on their contextual needs. By default it will use `top` like it always has.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
- Adds ability to provide `preferredPlacement` to Tooltip component.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
