### PR TITLE
docs(components-native): Mark mobile Menu component as alpha

### DIFF
--- a/.storybook/components/SidebarLabel/SidebarLabel.tsx
+++ b/.storybook/components/SidebarLabel/SidebarLabel.tsx
@@ -1,10 +1,10 @@
 import React, { MouseEvent, useEffect, useRef } from "react";
 import { useStorybookApi } from "@storybook/api";
-import { alphaComponents } from "./alphaComponents";
+import { alphaComponents, alphaMobileComponents } from "./alphaComponents";
 
 export function SidebarLabel(label: Record<string, any>) {
   const ref = useRef<HTMLSpanElement>(null);
-  const { selectStory, getCurrentStoryData } = useStorybookApi();
+  const { selectStory, getCurrentStoryData, getData } = useStorybookApi();
   const currentStory = getCurrentStoryData();
 
   useEffect(() => {
@@ -21,10 +21,20 @@ export function SidebarLabel(label: Record<string, any>) {
     }
   }, []);
 
+
+  let markAsAlpha = alphaComponents.includes(label.name);
+
+  if (label.name === "Mobile") {
+    const parent = getData(label.parent);
+    if (alphaMobileComponents.includes(parent.name)) {
+      markAsAlpha = true;
+    }
+  }
+
   return (
     <span ref={ref} onClick={handleClick}>
       {label.name}
-      {alphaComponents.includes(label.name) && (
+      {markAsAlpha && (
         <span
           style={{
             marginLeft: "var(--space-small)",

--- a/.storybook/components/SidebarLabel/alphaComponents.ts
+++ b/.storybook/components/SidebarLabel/alphaComponents.ts
@@ -1,1 +1,2 @@
 export const alphaComponents = ["DataList", "Combobox"];
+export const alphaMobileComponents = ["Menu"]


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We have determined that the mobile Menu component is not ready for prime time and needs work to handle various overflow cases. We've decided to mark it as _alpha_ until we can invest more time in it.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Mark the mobile Menu component as alpha


## Testing

Open storybook and you should see this little alpha tag:

<img width="208" alt="Screenshot 2024-04-04 at 1 41 11 PM" src="https://github.com/GetJobber/atlantis/assets/82835373/256027e1-2cda-4b3d-aaa7-59762331208d">


