### PR TITLE
build: removing manual release for now.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,16 +170,16 @@ workflows:
             - install_dependencies
       - lint_javascript:
           requires:
-            - check_for_manual_release
+            - install_dependencies
       - lint_css:
           requires:
-            - check_for_manual_release
+            - install_dependencies
       - test:
           requires:
-            - check_for_manual_release
+            - install_dependencies
       - build_docs:
           requires:
-            - check_for_manual_release
+            - install_dependencies
       - release:
           filters:
             branches:


### PR DESCRIPTION
## Motivations

We need to force a major version bump, and our manual check is preventing that.

## Changes

Removed manual release check.



### Removed

- Manual Release check


[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
