### PR TITLE
build: Moving Manual Release Check back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,16 +170,16 @@ workflows:
             - install_dependencies
       - lint_javascript:
           requires:
-            - check_for_manual_release
+            - install_dependencies
       - lint_css:
           requires:
-            - check_for_manual_release
+            - install_dependencies
       - test:
           requires:
-            - check_for_manual_release
+            - install_dependencies
       - build_docs:
           requires:
-            - check_for_manual_release
+            - install_dependencies
       - release:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,16 +170,16 @@ workflows:
             - install_dependencies
       - lint_javascript:
           requires:
-            - install_dependencies
+            - check_for_manual_release
       - lint_css:
           requires:
-            - install_dependencies
+            - check_for_manual_release
       - test:
           requires:
-            - install_dependencies
+            - check_for_manual_release
       - build_docs:
           requires:
-            - install_dependencies
+            - check_for_manual_release
       - release:
           filters:
             branches:

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/components",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Motivations

- Darryl and I had to force a manual release of Atlantis to 5.0
- The manual release check was preventing that manual force push.
- We removed the manual release check in a previous PR, but now we're putting it back.

## Changes

- Manual Release Check back in the CI chain.

## Testing

This PR should not clear CI until the manual release check is complete.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
