### PR TITLE
build(formatters): Fixing a build issue with formatters in a Cloudflare environment

### DIFF
--- a/packages/formatters/src/global.ts
+++ b/packages/formatters/src/global.ts
@@ -1,4 +1,4 @@
-declare const global: Record<string, unknown>;
+const global: Record<string, unknown> = {};
 
 function getGlobal() {
   if (typeof window !== "undefined") {


### PR DESCRIPTION
## Motivations

Sometimes Atlantis is built in a Cloudflare environment. Our usage of the 'global' variable in formatters breaks there. We've fixed that in this PR.

## Changes

Move 'global' to a proper variable (not a declaration) and provides a default value so it doesn't crash if attempting to access in a cloudflare environment.

### Changed

- Formatters

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
