### PR TITLE
fix(components): SSR Fixes

### DIFF
--- a/packages/components/src/Toast/showToast.tsx
+++ b/packages/components/src/Toast/showToast.tsx
@@ -15,23 +15,29 @@ import { Toast, ToastProps, ToastRef } from "./Toast";
 import styles from "./Toast.css";
 
 const targetId = "atlantis-toast-element";
-let target = document.querySelector(`#${targetId}`);
+let target =
+  typeof document !== "undefined" && document.querySelector(`#${targetId}`);
 
-if (!target) {
+if (typeof document !== "undefined" && !target) {
   target = document.createElement("div");
   target.id = targetId;
   target.classList.add(styles.wrapper);
   document.body.appendChild(target);
 }
 
-const root = createRoot(target);
+const root = target && createRoot(target);
 
 export function showToast(props: ToastProps) {
   // Ensure target and body is still there when rendering the toast. This is due
   // to an issue with ReactDOM createRoot assuming document is always there and
   // Jest taking the document down.
-  if (document.body.contains(target)) {
-    root.render(<ToasterOven {...props} />);
+  if (
+    target &&
+    typeof document !== "undefined" &&
+    document.body.contains(target) &&
+    root
+  ) {
+    root?.render(<ToasterOven {...props} />);
   }
 }
 

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -148,7 +148,7 @@ interface TooltipPortalProps {
 function TooltipPortal({ children }: TooltipPortalProps) {
   const mounted = useIsMounted();
 
-  if (!mounted) {
+  if (!mounted?.current) {
     return null;
   }
 


### PR DESCRIPTION
## Motivations

We have some SSR related failures in SSR environments. These changes should fix the issues.

## Changes

- Guarding 'document' within Toast properly.
- Modifying a recent change to Tooltip to account for the Ref in useIsMounted.

### Changed

- Toast
- Tooltip

### Fixed

- SSR Issues (document not available in Cloudflare, Tooltip causing hydration issues)

## Testing

- Should clear CI with no changes.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
