### PR TITLE
fix(components): SSR Fixes

### DIFF
--- a/packages/components/src/Toast/showToast.tsx
+++ b/packages/components/src/Toast/showToast.tsx
@@ -15,23 +15,29 @@ import { Toast, ToastProps, ToastRef } from "./Toast";
 import styles from "./Toast.css";
 
 const targetId = "atlantis-toast-element";
-let target = document.querySelector(`#${targetId}`);
+let target =
+  typeof document !== "undefined" && document.querySelector(`#${targetId}`);
 
-if (!target) {
+if (typeof document !== "undefined" && !target) {
   target = document.createElement("div");
   target.id = targetId;
   target.classList.add(styles.wrapper);
   document.body.appendChild(target);
 }
 
-const root = createRoot(target);
+const root = target && createRoot(target);
 
 export function showToast(props: ToastProps) {
   // Ensure target and body is still there when rendering the toast. This is due
   // to an issue with ReactDOM createRoot assuming document is always there and
   // Jest taking the document down.
-  if (document.body.contains(target)) {
-    root.render(<ToasterOven {...props} />);
+  if (
+    target &&
+    typeof document !== "undefined" &&
+    document.body.contains(target) &&
+    root
+  ) {
+    root?.render(<ToasterOven {...props} />);
   }
 }
 

--- a/packages/components/src/Toast/showToast.tsx
+++ b/packages/components/src/Toast/showToast.tsx
@@ -15,29 +15,23 @@ import { Toast, ToastProps, ToastRef } from "./Toast";
 import styles from "./Toast.css";
 
 const targetId = "atlantis-toast-element";
-let target =
-  typeof document !== "undefined" && document.querySelector(`#${targetId}`);
+let target = document.querySelector(`#${targetId}`);
 
-if (typeof document !== "undefined" && !target) {
+if (!target) {
   target = document.createElement("div");
   target.id = targetId;
   target.classList.add(styles.wrapper);
   document.body.appendChild(target);
 }
 
-const root = target && createRoot(target);
+const root = createRoot(target);
 
 export function showToast(props: ToastProps) {
   // Ensure target and body is still there when rendering the toast. This is due
   // to an issue with ReactDOM createRoot assuming document is always there and
   // Jest taking the document down.
-  if (
-    target &&
-    typeof document !== "undefined" &&
-    document.body.contains(target) &&
-    root
-  ) {
-    root?.render(<ToasterOven {...props} />);
+  if (document.body.contains(target)) {
+    root.render(<ToasterOven {...props} />);
   }
 }
 

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -148,7 +148,7 @@ interface TooltipPortalProps {
 function TooltipPortal({ children }: TooltipPortalProps) {
   const mounted = useIsMounted();
 
-  if (!mounted) {
+  if (!mounted?.current) {
     return null;
   }
 

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -69,6 +69,5 @@ export * from "./Switch";
 export * from "./Table";
 export * from "./Tabs";
 export * from "./Text";
-export * from "./Toast";
 export * from "./Tooltip";
 export * from "./Typography";


### PR DESCRIPTION
## Motivations

We have some SSR related issues.

A recent update to Tooltip treated a Ref as a Boolean, so instead of flipping between true/false it was permanently true (which breaks in SSR environments)

In addition, it was noted that the Toast component when loaded via the ESM barrel file broke client-side functionality in certain framework environments. This is because the Toast component currently creates a React Root when the `showToast` function is imported, for compatibility in environments that aren't full SPAs. That createRoot call was conflicting with framework `hydrateRoot` calls and preventing all client-side interaction.

Some effort was taken to see if we could update the Toast component in a way that would support both island based loading and full SPA loading. Working solutions ran into issues with local (and remote) tests, and the timebox expired to get the tests in a passing state. A follow-up issue has been created to find a solution that fits into both worlds and keeps our tests happy as well.

So the solution for now is to remove the Toast from the ESM barrel file, and only import it directly (via a dynamic import in certain framework environments). This solves the immediate issue while leaving more room for a holistic, toasty solution in the future.


## Changes

- Removing Toast from the ESM Barrel File (follow-up issue created to refactor Toast)
- Modifying a recent change to Tooltip to account for the Ref in useIsMounted.

### Changed

- Toast
- Tooltip

### Fixed

- SSR Issues (document not available in non-browser environments, Tooltip causing hydration issues)

## Testing

- Should clear CI with no issues.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
