### PR TITLE
fix(components): Select improvements

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -134,9 +134,11 @@
   width: auto;
 }
 
-.inline .select select {
+/* .select select,
+.right select,
+.select .label {
   padding-right: calc(var(--field--padding-right) + var(--base-unit) * 2);
-}
+} */
 
 .center {
   --field--textAlign: center;
@@ -234,6 +236,12 @@
   pointer-events: none;
   transform: translateY(var(--field--placeholder-transform));
   transition: all var(--timing-quick);
+}
+
+.select select,
+.right select,
+.select .label {
+  padding-right: calc(var(--field--padding-right) + var(--base-unit) * 2);
 }
 
 .textarea .label {

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -134,12 +134,6 @@
   width: auto;
 }
 
-/* .select select,
-.right select,
-.select .label {
-  padding-right: calc(var(--field--padding-right) + var(--base-unit) * 2);
-} */
-
 .center {
   --field--textAlign: center;
 }

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -9,13 +9,13 @@ declare const styles: {
   readonly "disabled": string;
   readonly "small": string;
   readonly "inline": string;
-  readonly "select": string;
   readonly "center": string;
   readonly "right": string;
   readonly "maxLength": string;
   readonly "inputWrapper": string;
   readonly "childrenWrapper": string;
   readonly "input": string;
+  readonly "select": string;
   readonly "label": string;
   readonly "postfix": string;
   readonly "affixIcon": string;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
After shipping [this PR](https://github.com/GetJobber/atlantis/pull/1783), a few existing behaviours were made even more obvious. This PR is to fix those visual inconsistencies.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

`padding-right` has been applied to all instances of `Select` (not just inline usages):

#### Basic Story (not inline)
Before |  After
:---:|:---:
<img width="123" alt="Screenshot 2024-04-17 at 8 06 54 AM" src="https://github.com/GetJobber/atlantis/assets/104797704/eb088193-ee3a-49d3-8d0e-8ebed3858552"> | <img width="113" alt="Screenshot 2024-04-17 at 8 07 38 AM" src="https://github.com/GetJobber/atlantis/assets/104797704/3cb0df81-e624-42c5-bcb7-4865d3140e99">

#### Right align
Before |  After
:---:|:---:
<img width="495" alt="Screenshot 2024-04-17 at 8 09 26 AM" src="https://github.com/GetJobber/atlantis/assets/104797704/2c0e7290-a52d-460e-bf3c-a191638400f0"> | <img width="497" alt="Screenshot 2024-04-17 at 8 09 49 AM" src="https://github.com/GetJobber/atlantis/assets/104797704/e7ffd448-db5b-43ef-8d5b-710a9702b2c0">

#### Small maxLength
Before |  After
:---:|:---:
<img width="651" alt="Screenshot 2024-04-17 at 8 12 38 AM" src="https://github.com/GetJobber/atlantis/assets/104797704/27768160-151c-415b-9a3d-64fd402bd8e2"> | <img width="664" alt="Screenshot 2024-04-17 at 8 13 03 AM" src="https://github.com/GetJobber/atlantis/assets/104797704/9abd62b8-65b3-4d76-ac56-34a9a4f5beaa">


## Testing

<!-- How to test your changes. -->
- test all possible
-  configurations of `Select` within Storybook
- test using the pre-release build [here](https://github.com/GetJobber/Jobber/pull/45446)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
