### PR TITLE
fix(components): remove Chip prefix background [JOB-92493]

### DIFF
--- a/docs/components/Chip/Web.stories.tsx
+++ b/docs/components/Chip/Web.stories.tsx
@@ -45,7 +45,7 @@ const PrefixTemplate: ComponentStory<typeof Chip> = props => {
     <Content>
       <Chip {...props} onClick={() => alert("you clicked me!")}>
         <Chip.Prefix>
-          <Icon name="cross" size="small" />
+          <Icon name="home" size="small" />
         </Chip.Prefix>
       </Chip>
     </Content>

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -39,6 +39,7 @@
 .chip .suffix {
   margin-left: var(--space-small);
   margin-right: calc(-1 * var(--space-small));
+  background-color: var(--color-surface);
 }
 
 .chip .prefix,
@@ -48,7 +49,6 @@
   height: var(--space-large);
   flex-shrink: 0;
   border-radius: var(--radius-circle);
-  background-color: var(--color-surface);
   align-items: center;
   justify-content: center;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In initial development of Chip, we missed that only suffix should have the `surface` background. This leads to unexpected results when using in-product.

![image](https://github.com/GetJobber/atlantis/assets/39704901/49469b3a-02b8-45e5-8809-44fd6d6f0c26)

## Changes

### Fixed

-  white (surface) background color from prefix, now only applied to suffix

## Testing

See the Prefix story

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
