### PR TITLE
feat(components): Add autofocus support for InputText (JOB-94181)

### DIFF
--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -44,7 +44,7 @@ export function FormField(props: FormFieldProps) {
     onValidation,
     onKeyUp,
     clearable = "never",
-    autoFocus,
+    autofocus,
   } = props;
 
   const {
@@ -109,13 +109,14 @@ export function FormField(props: FormFieldProps) {
           onChange: handleChange,
           onBlur: handleBlur,
           onFocus: handleFocus,
+          autoFocus: autofocus,
           ...(description &&
             !inline && { "aria-describedby": descriptionIdentifier }),
         };
 
         const textFieldProps = {
           ...fieldProps,
-          autoFocus,
+          autoFocus: autofocus,
           onKeyDown: handleKeyDown,
         };
 

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -44,6 +44,7 @@ export function FormField(props: FormFieldProps) {
     onValidation,
     onKeyUp,
     clearable = "never",
+    autoFocus,
   } = props;
 
   const {
@@ -114,6 +115,7 @@ export function FormField(props: FormFieldProps) {
 
         const textFieldProps = {
           ...fieldProps,
+          autoFocus,
           onKeyDown: handleKeyDown,
         };
 

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -130,7 +130,7 @@ export interface FormFieldProps extends CommonFormFieldProps {
   /**
    * Determines if the input should be auto-focused, using the HTML attribute
    */
-  readonly autoFocus?: boolean;
+  readonly autofocus?: boolean;
 
   /**
    * Determines if browser form autocomplete is enabled.

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -128,6 +128,11 @@ export interface FormFieldProps extends CommonFormFieldProps {
   actionsRef?: RefObject<FieldActionsRef>;
 
   /**
+   * Determines if the input should be auto-focused, using the HTML attribute
+   */
+  readonly autoFocus?: boolean;
+
+  /**
    * Determines if browser form autocomplete is enabled.
    * Note that "one-time-code" is experimental and should not be used without
    * consultation. "address-line1" and "address-line2" are

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -182,7 +182,7 @@ describe("focusing", () => {
     const placeholder = "Got milk?";
 
     const { getByLabelText } = render(
-      <InputText placeholder={placeholder} autoFocus />,
+      <InputText placeholder={placeholder} autofocus />,
     );
 
     expect(getByLabelText(placeholder)).toHaveFocus();

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -164,17 +164,29 @@ test("it should handle inserting text", () => {
   expect(changeHandler).toHaveBeenCalledWith(secondResult);
 });
 
-test("it should focus input text", () => {
-  const placeholder = "Got milk?";
+describe("focusing", () => {
+  test("it should focus input text", () => {
+    const placeholder = "Got milk?";
 
-  const textRef = React.createRef<InputTextRef>();
+    const textRef = React.createRef<InputTextRef>();
 
-  const { getByLabelText } = render(
-    <InputText placeholder={placeholder} ref={textRef} />,
-  );
+    const { getByLabelText } = render(
+      <InputText placeholder={placeholder} ref={textRef} />,
+    );
 
-  textRef.current?.focus();
-  expect(getByLabelText(placeholder)).toHaveFocus();
+    textRef.current?.focus();
+    expect(getByLabelText(placeholder)).toHaveFocus();
+  });
+
+  test("it supports the autofocus attribute", async () => {
+    const placeholder = "Got milk?";
+
+    const { getByLabelText } = render(
+      <InputText placeholder={placeholder} autoFocus />,
+    );
+
+    expect(getByLabelText(placeholder)).toHaveFocus();
+  });
 });
 
 test("it should scroll into view input text", () => {

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -32,6 +32,7 @@ interface BaseProps
       | "suffix"
     > {
   multiline?: boolean;
+  autoFocus?: boolean;
 }
 
 export interface InputTextRef {

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -17,6 +17,7 @@ interface BaseProps
   extends CommonFormFieldProps,
     Pick<
       FormFieldProps,
+      | "autofocus"
       | "maxLength"
       | "readonly"
       | "autocomplete"
@@ -32,7 +33,6 @@ interface BaseProps
       | "suffix"
     > {
   multiline?: boolean;
-  autoFocus?: boolean;
 }
 
 export interface InputTextRef {


### PR DESCRIPTION
## Motivations
We want our input text to have autofocus as part of design requirements, for the chat drawer. The Native component supports the autofocus prop, but the HTML web version does not. This PR adds support for this prop for the web component.

### Added
- Added `autoFocus` to `InputText`

## Testing
Added tests for `InputText` to assert that focus is given when the new prop is used.

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)