### PR TITLE
fix(components): update small button sizing

### DIFF
--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -180,8 +180,8 @@ a.button.disabled:hover {
 /* Sizes */
 
 .small {
-  --button--size: 24px;
-  padding: var(--space-small) calc(var(--space-base) - var(--space-smaller));
+  --button--size: 32px;
+  padding: var(--space-smaller) calc(var(--space-base) - var(--space-smaller));
 }
 
 .base {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The Atlantis button updates in the retheme looked OK for small buttons _with a label_, but were TOO SMALL when just an icon:
![image](https://github.com/GetJobber/atlantis/assets/39704901/e58c9779-2a75-4804-a726-0b07c113591c)

This is considerably smaller than the [Figma spec](https://www.figma.com/file/rIIhulZvcp9M82lNOCGv16/Product%2FOnline?type=design&node-id=14531%3A17&mode=design&t=ij64MZJIw7uMAvcE-1) calls for.

## Changes

### Fixed

- Small buttons are now 32 by 32px when they only have an Icon, and are 32px high when they have a label

## Testing

Set up a small button with an icon and no label in Storybook

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![image](https://github.com/GetJobber/atlantis/assets/39704901/a9db8061-ba6c-47e7-a89c-e34f419d1d79)

