### PR TITLE
refactor(design): update value of taupe--light

### DIFF
--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -83,7 +83,7 @@
   --color-blue--dark: rgb(1, 25, 35);
 
   --color-taupe: rgb(241, 239, 233);
-  --color-taupe--light: rgb(247, 246, 243);
+  --color-taupe--light: rgb(252, 250, 244);
   --color-taupe--dark: rgb(231, 229, 217);
 
   --color-green: rgb(50, 130, 28);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The value for `taupe--light` did not match [Figma design specs](https://www.figma.com/file/HXWXusJPZLmaJNGlKEpiyhXW/branch/LKuwUrH3xAgzre1TKBsZ9x/Product%2FBase?type=design&node-id=18688%3A357&mode=design&t=KBZfoLVvsEX9cJad-1)

## Changes

### Changed

- rgb value of `taupe--light`

## Testing

View color docs in the Cloudflare build

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
