### PR TITLE
fix(components): Allow InputText Default Value to be Clearable

### DIFF
--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -173,7 +173,7 @@ export function FormField(props: FormFieldProps) {
 
         function handleClear() {
           handleBlur();
-          setValue(controlledName, undefined, { shouldValidate: true });
+          setValue(controlledName, "", { shouldValidate: true });
           onChange && onChange("");
           inputRef?.current?.focus();
         }

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -1,6 +1,7 @@
 import { ChangeEvent, ReactNode, RefObject } from "react";
 import { RegisterOptions } from "react-hook-form";
 import { XOR } from "ts-xor";
+import { Clearable } from "@jobber/hooks/src/useShowClear";
 import { IconNames } from "../Icon";
 
 export type FormFieldTypes =
@@ -121,7 +122,7 @@ export interface CommonFormFieldProps {
    * clearable. if the input value isn't editable (i.e. `InputTime`) you can
    * set it to `always`.
    */
-  readonly clearable?: "never" | "always";
+  readonly clearable?: Clearable;
 }
 
 export interface FormFieldProps extends CommonFormFieldProps {

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import classnames from "classnames";
-import { useShowClear } from "@jobber/hooks/useShowClear";
+import { Clearable, useShowClear } from "@jobber/hooks/useShowClear";
 import { AnimatePresence, motion } from "framer-motion";
 import { tokens } from "@jobber/design";
 import { FormFieldProps } from "./FormFieldTypes";
@@ -22,7 +22,7 @@ interface FormFieldWrapperProps extends FormFieldProps {
   readonly error: string;
   readonly identifier: string;
   readonly descriptionIdentifier: string;
-  readonly clearable: "never" | "always";
+  readonly clearable: Clearable;
   readonly onClear: () => void;
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

currently, if you provide a `defaultValue` to an `InputText` and make that clearable, you cannot actually clear that value. it will always remain.

this was exposed via DataList's search, if you give that an `initialValue` it is passed into an `InputText` as a `defaultValue` which is where the real problem is

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

if you provide a `defaultValue` to an `InputText` along with `clearable` and it will work as intended

(sorta) fixed a type issue where we were only accepting "always" and "never" as values for `clearable` when there is code to deal with `while-editing` but there was no way to hit that code, at least if you listened to the types

### Security

- <!-- in case of vulnerabilities -->

## Testing

**DataList**
give the `DataList.Search` an `initialValue`, see that you can clear the value when pressing the X

**InputText**
give an `InputText` a `defaultValue` and make it `clearable`, see that you can clear the value when pressing the X

**While-editing clear type**

give an `InputText` a `while-editing` `clearable` prop, see that once you type in the input and maintain focus, it is clearable. if you keep the value and lose focus on the input, the X to clear is no longer present*

*other Input types are not handling focus properly and so this ain't working for them

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
