### PR TITLE
fix(components): Input Text Safari Resize Handle

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -70,9 +70,12 @@
 
 .horizontalWrapper {
   display: flex;
-  width: 100%;
   height: var(--field--height);
   flex: 1;
+}
+
+.textarea .horizontalWrapper {
+  margin-right: var(--field--padding-right);
 }
 
 .timeInputLabel:not(:focus-within) input {
@@ -216,6 +219,7 @@
   flex: 1;
   resize: none;
   scroll-padding-bottom: var(--space-base);
+  padding-right: 0;
 }
 
 .select .input {

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -2,11 +2,11 @@ declare const styles: {
   readonly "container": string;
   readonly "wrapper": string;
   readonly "horizontalWrapper": string;
+  readonly "textarea": string;
   readonly "timeInputLabel": string;
   readonly "miniLabel": string;
   readonly "large": string;
   readonly "text": string;
-  readonly "textarea": string;
   readonly "invalid": string;
   readonly "disabled": string;
   readonly "small": string;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

On Safari, you can't resize a text area 😱

it only happens on multiline `InputText`s that **don't** have a toolbar prop.

this is because the toolbar will use margins to make sure its content doesn't cover the handle. however the non toolbar version will fill the entire area, and I guess Safari treats this different from other browsers 🤷 
<img width="495" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/04ad076e-da95-40a4-b298-185a24324fa0">

<img width="480" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/123fe486-1d63-4497-9857-59fa51ef566e">



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

made it so that the resize handle that is only present on multiline InputTexts is not obstructed and can be used on all browsers, especially Safari which was not having a great time

we put some padding around the entire textarea anyway, so I've just implemented that same amount of spacing but with margin on the container that would otherwise obstruct the resize handle. making sure to only do this for the multiline/textarea case because 

A) I don't want to interfere with the spacing of all the other input types. there are so many variations that have right aligned elements
B) many of the right aligned props are broken or not supported with multiline anyway :^)

`clearable` isn't supported, `loading` is lost, `suffix` icon & label are lost etc.

### Security

- <!-- in case of vulnerabilities -->

## Testing

**on Chrome, Safari and Firefox**
head to the storybook for InputText and make it `multiline`. you should be able to drag the resize handle to extend/shorten it.

also try some other props such as `size` and `rows`. with a `small` `size` it should still have enough margin to allow you to grab and use the resize handle

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
