### PR TITLE
fix(components): Reduce Scope of Safari Scrollbar Issue

### DIFF
--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -106,7 +106,7 @@
 
 .wrapper.textarea.safari {
   overflow: unset;
-  overflow-x: scroll;
+  overflow-y: scroll;
 }
 
 .invalid,

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -74,10 +74,6 @@
   flex: 1;
 }
 
-.textarea .horizontalWrapper {
-  margin-right: var(--field--padding-right);
-}
-
 .timeInputLabel:not(:focus-within) input {
   color: var(--field--background-color);
   -webkit-text-fill-color: var(--field--background-color);
@@ -106,6 +102,11 @@
 .wrapper.textarea {
   resize: vertical;
   overflow: auto;
+}
+
+.wrapper.textarea.safari {
+  overflow: unset;
+  overflow-x: scroll;
 }
 
 .invalid,
@@ -219,7 +220,6 @@
   flex: 1;
   resize: none;
   scroll-padding-bottom: var(--space-base);
-  padding-right: 0;
 }
 
 .select .input {

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -74,6 +74,10 @@
   flex: 1;
 }
 
+.textarea.safari .horizontalWrapper {
+  margin-right: var(--field--padding-right);
+}
+
 .timeInputLabel:not(:focus-within) input {
   color: var(--field--background-color);
   -webkit-text-fill-color: var(--field--background-color);
@@ -102,11 +106,6 @@
 .wrapper.textarea {
   resize: vertical;
   overflow: auto;
-}
-
-.wrapper.textarea.safari {
-  overflow: unset;
-  overflow-y: scroll;
 }
 
 .invalid,
@@ -231,6 +230,10 @@
 .input:-webkit-autofill:focus,
 .input:-webkit-autofill:active {
   -webkit-box-shadow: 0 0 0 30px var(--color-surface) inset !important;
+}
+
+.textarea.safari .input {
+  padding-right: 0;
 }
 
 /**

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -2,12 +2,12 @@ declare const styles: {
   readonly "container": string;
   readonly "wrapper": string;
   readonly "horizontalWrapper": string;
+  readonly "textarea": string;
+  readonly "safari": string;
   readonly "timeInputLabel": string;
   readonly "miniLabel": string;
   readonly "large": string;
   readonly "text": string;
-  readonly "textarea": string;
-  readonly "safari": string;
   readonly "invalid": string;
   readonly "disabled": string;
   readonly "small": string;

--- a/packages/components/src/FormField/FormField.css.d.ts
+++ b/packages/components/src/FormField/FormField.css.d.ts
@@ -2,11 +2,12 @@ declare const styles: {
   readonly "container": string;
   readonly "wrapper": string;
   readonly "horizontalWrapper": string;
-  readonly "textarea": string;
   readonly "timeInputLabel": string;
   readonly "miniLabel": string;
   readonly "large": string;
   readonly "text": string;
+  readonly "textarea": string;
+  readonly "safari": string;
   readonly "invalid": string;
   readonly "disabled": string;
   readonly "small": string;

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -70,7 +70,7 @@ export function FormFieldWrapper({
         (placeholder && type === "tel"),
       [styles.text]: type === "textarea" || type === "text",
       [styles.textarea]: type === "textarea",
-      [styles.safari]: isSafari && type === "textarea" && !toolbar,
+      [styles.safari]: isSafari && type === "textarea",
       [styles.select]: type === "select",
       [styles.invalid]: invalid ?? error,
       [styles.disabled]: disabled,

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -16,6 +16,7 @@ import { FormFieldDescription } from "./FormFieldDescription";
 import { ClearAction } from "./components/ClearAction";
 import { useToolbar } from "./hooks/useToolbar";
 import { useFormFieldFocus } from "./hooks/useFormFieldFocus";
+import { useIsSafari } from "./hooks/useIsSafari";
 import { InputValidation } from "../InputValidation";
 
 interface FormFieldWrapperProps extends FormFieldProps {
@@ -31,6 +32,7 @@ interface LabelPadding {
   paddingRight: number | string | undefined;
 }
 
+// eslint-disable-next-line max-statements
 export function FormFieldWrapper({
   align,
   description,
@@ -55,6 +57,7 @@ export function FormFieldWrapper({
   toolbarVisibility = "while-editing",
   wrapperRef,
 }: PropsWithChildren<FormFieldWrapperProps>) {
+  const isSafari = useIsSafari();
   const wrapperClasses = classnames(
     styles.wrapper,
     size && styles[size],
@@ -67,6 +70,7 @@ export function FormFieldWrapper({
         (placeholder && type === "tel"),
       [styles.text]: type === "textarea" || type === "text",
       [styles.textarea]: type === "textarea",
+      [styles.safari]: isSafari && type === "textarea",
       [styles.select]: type === "select",
       [styles.invalid]: invalid ?? error,
       [styles.disabled]: disabled,

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -70,7 +70,7 @@ export function FormFieldWrapper({
         (placeholder && type === "tel"),
       [styles.text]: type === "textarea" || type === "text",
       [styles.textarea]: type === "textarea",
-      [styles.safari]: isSafari && type === "textarea",
+      [styles.safari]: isSafari && type === "textarea" && !toolbar,
       [styles.select]: type === "select",
       [styles.invalid]: invalid ?? error,
       [styles.disabled]: disabled,

--- a/packages/components/src/FormField/hooks/useIsSafari.ts
+++ b/packages/components/src/FormField/hooks/useIsSafari.ts
@@ -1,0 +1,5 @@
+export function useIsSafari(): boolean {
+  return globalThis?.navigator
+    ? /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+    : false;
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

the quick fix for the not being able to grab the resize handle has broader effects than I'd like. namely when you have content that is greater than the area, your scrollbar is not right aligned. the margin pushes it off a bit
**Before (Chrome)**
<img width="577" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/cffe71fc-0f48-414f-9009-fb0bfd876fd5">

**Before (Firefox)**
<img width="696" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/e85f9487-7f9d-43a5-ab35-5e0bb4db007e">


I really tried to do this in a more elegant way, and got like 90% of the way there but more issues keep on popping up and I need to move on with my life, so here we are.

**After (Chrome, then Firefox)**
<img width="728" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/e110bb7e-9c6a-4d93-9843-2fd770f89262">

<img width="699" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/5e6bd99d-b0b6-41fb-bfc9-4ba365eea2f5">



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

only going to apply the margin replacing padding approach on Safari where it is problematic. the others, firefox & chrome, have no need for the margins and it can make them look bad with certain scrollbar settings.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

**on Firefox, Chrome and Safari**

with a multiline InputText, try using the resize handle

try typing enough content that it wants to scroll, should still be able to use the resize handle. on Safari it will look a bit off :/

toolbar should all be fine. that was never the problematic case even with Safari since it has something in place to avoid overlapping with the resize handle

also, try this out with different macOS scrollbar settings. Taylor caught the last issue because we had different optiosn selected.

![Appearance](https://github.com/GetJobber/atlantis/assets/11843215/10e53816-542f-41e6-9c4f-bda5a352ffb4)


[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
