### PR TITLE
fix(components): use semantic values in combobox

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.css
@@ -35,17 +35,17 @@
   bottom: var(--space-small);
   background: linear-gradient(
     180deg,
-    rgba(255, 255, 255, 0) 0%,
-    rgb(255, 255, 255) 100%
+    transparent 0%,
+    var(--color-surface) 100%
   );
 }
 
 .container::before {
   top: var(--space-small);
   background: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0)
+    180deg,
+    var(--color-surface) 0%,
+    transparent 100%
   );
 }
 

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentSearch/ComboboxContentSearch.css
@@ -8,8 +8,10 @@
   padding-right: calc(var(--space-large) * 2.25);
   border: none;
   border-bottom: var(--border-base) solid var(--color-border);
+  color: var(--field-value-color);
   font-family: var(--typography--fontFamily-normal);
   font-size: var(--typography--fontSize-base);
+  background-color: var(--color-surface);
 }
 
 .searchInput::-webkit-search-decoration,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Combobox was either not specifying a value and being over-ridden, or specifying a hard-coded color value in a few places.

This means that in a new theme or mode, we weren't seeing the expected outputs. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- color and background-color declarations to ComboboxContentSearch

### Changed

- overflow gradient value definitions

### Fixed

- Combobox search and overflow now respond to changes in theme 

## Testing

- Modify the value of `--color-surface` and observe that Combobox responds appropriately

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
