### PR TITLE
chore: fix DataListSort label issue

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -110,6 +110,7 @@ const Template: ComponentStory<typeof DataList> = args => {
         sortable: [
           {
             key: "label",
+            sortType: "dropdown",
             options: [
               {
                 id: "firstName",
@@ -131,6 +132,7 @@ const Template: ComponentStory<typeof DataList> = args => {
           },
           {
             key: "home",
+            sortType: "dropdown",
             options: [
               {
                 id: "homeWorld",
@@ -154,7 +156,22 @@ const Template: ComponentStory<typeof DataList> = args => {
               },
             ],
           },
-          { key: "lastActivity" },
+          {
+            key: "lastActivity",
+            sortType: "toggle",
+            options: [
+              {
+                id: "lastActivity",
+                label: "Last activity (Newest first)",
+                order: "desc",
+              },
+              {
+                id: "lastActivity",
+                label: "Last activity (Oldest first)",
+                order: "asc",
+              },
+            ],
+          },
         ],
       }}
     >

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -430,6 +430,7 @@ describe("DataList", () => {
         sortable: [
           {
             key: "name",
+            sortType: "dropdown",
             options: [
               { id: "name", label: "Ascending", order: "asc" },
               { id: "name", label: "Descending", order: "desc" },

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -58,6 +58,7 @@ export interface SortableOptions {
 
 export interface DataListSortable {
   readonly key: string;
+  readonly sortType: "toggle" | "dropdown";
   readonly options?: SortableOptions[];
 }
 

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.tsx
@@ -64,24 +64,24 @@ export function DataListSort() {
 
           return acc;
         }
-        acc.push({
-          label: `${label} (A-Z)`,
-          value: JSON.stringify({
-            key: sort.key,
-            order: "asc",
-            label: label,
-            id: sort.key,
-          }),
-        });
-        acc.push({
-          label: `${label} (Z-A)`,
-          value: JSON.stringify({
-            key: sort.key,
-            order: "desc",
-            label: label,
-            id: sort.key,
-          }),
-        });
+        // acc.push({
+        //   label: `${label} (A-Z)`,
+        //   value: JSON.stringify({
+        //     key: sort.key,
+        //     order: "asc",
+        //     label: label,
+        //     id: sort.key,
+        //   }),
+        // });
+        // acc.push({
+        //   label: `${label} (Z-A)`,
+        //   value: JSON.stringify({
+        //     key: sort.key,
+        //     order: "desc",
+        //     label: label,
+        //     id: sort.key,
+        //   }),
+        // });
 
         return acc;
       },

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -100,7 +100,7 @@ export function DataListHeaderTile<T extends DataListObject>({
   function handleOnClick() {
     if (!isSortable) return;
 
-    if (sortableItem?.options) {
+    if (sortableItem?.sortType === "dropdown") {
       setIsDropDownOpen(!isDropDownOpen);
     } else {
       const id = sortableItem?.options?.[0]?.id || headerKey;

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -102,7 +102,7 @@ export function DataListHeaderTile<T extends DataListObject>({
 
     if (sortableItem?.sortType === "dropdown") {
       setIsDropDownOpen(!isDropDownOpen);
-    } else if (sortableItem?.sortType === "toggle") {
+    } else {
       const id = sortableItem?.options?.[0]?.id || headerKey;
       toggleSorting(id, headerKey, headers[headerKey]);
     }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -102,7 +102,7 @@ export function DataListHeaderTile<T extends DataListObject>({
 
     if (sortableItem?.sortType === "dropdown") {
       setIsDropDownOpen(!isDropDownOpen);
-    } else {
+    } else if (sortableItem?.sortType === "toggle") {
       const id = sortableItem?.options?.[0]?.id || headerKey;
       toggleSorting(id, headerKey, headers[headerKey]);
     }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -80,7 +80,12 @@ export function DataListHeaderTile<T extends DataListObject>({
     }
 
     const sortingOrder = isSameKey ? "desc" : "asc";
-    setSorting(newSortingKey, newId, newLabel, sortingOrder);
+    const label =
+      sortableItem?.options?.find(option => {
+        return option.order === sortingOrder;
+      })?.label || newLabel;
+
+    setSorting(newSortingKey, newId, label, sortingOrder);
   }
 
   function setSorting(


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Investigation PR

Issue:
When a DataList header has toggle sort > When the sorting labels go into the Combobox on small screens > the label for each sorting option is hardcoded (ex. Last Activity (A-Z))

### What we want to see:

Sort option labels **are not** hardcoded via the component. 
Sort option labels **are** determined via the `sortable` prop

#### On widescreens:

1. Last Activity column has a toggle sort (no dropdown menu with sort options)
2. While toggling, the arrow indicators are changing and matching the order direction
3. Name & Home World columns maintain the ability to choose a sort option via dropdown menu
4. When choosing custom sort options, the arrow indicators are changing and matching the order direction

#### On smallscreens:

1. A `Combobox` Sort appears in the `DataListStickyHeader`
2. All sort options are listed in the `Combobox` - including custom labels for the Last Activity header

<img width="539" alt="Screenshot 2024-05-06 at 10 52 46 PM" src="https://github.com/GetJobber/atlantis/assets/104797704/c9352429-c835-4326-999b-bde8b862064f">

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
