### PR TITLE
feat(components): add textCase=none to Typography

### DIFF
--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -224,6 +224,7 @@ function SectionHeader({ text }: SectionHeaderProps) {
         size="base"
         textColor="textSecondary"
         fontWeight="regular"
+        textCase="none"
       >
         {text}
       </Typography>

--- a/packages/components/src/Typography/Typography.test.tsx
+++ b/packages/components/src/Typography/Typography.test.tsx
@@ -196,6 +196,21 @@ it("renders a capitalized text", () => {
   `);
 });
 
+it("renders text with no text-transform applied", () => {
+  const { container } = render(
+    <Typography textCase="none">wElL tHiS iS hArD tO tYpE</Typography>,
+  );
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <p
+        class="base regular none"
+      >
+        wElL tHiS iS hArD tO tYpE
+      </p>
+    </div>
+  `);
+});
+
 it("should add textTruncate class when numberOfLines property is passed", () => {
   const { container } = render(
     <Typography numberOfLines={3}>Pretend this is a multiline text</Typography>,

--- a/packages/components/src/Typography/css/TextCases.css
+++ b/packages/components/src/Typography/css/TextCases.css
@@ -9,3 +9,7 @@
 .capitalize {
   text-transform: capitalize;
 }
+
+.none {
+  text-transform: none;
+}

--- a/packages/components/src/Typography/css/TextCases.css.d.ts
+++ b/packages/components/src/Typography/css/TextCases.css.d.ts
@@ -2,6 +2,7 @@ declare const styles: {
   readonly "uppercase": string;
   readonly "lowercase": string;
   readonly "capitalize": string;
+  readonly "none": string;
 };
 export = styles;
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Because menu's subheading uses an `element={h6}` semantically, it was picking up styling from in-app CSS classes in Jobber that target `h6` making it uppercase. We still want it to be a semantic h6, so I added a `none` to `textCase` from `Typography` to give us the locked-down specificity we need for that to not happen.

## Changes

### Added

- New textcase of `none` to Typography

## Testing

Set a style of `h6 { text-transform: uppercase; }` (and other adjustments like font-weight, if you like) in the inspector stylesheet and observe that the casing of the Menu's subheader is preserved

![image](https://github.com/GetJobber/atlantis/assets/39704901/23a6a6fc-f00b-4586-af57-787c2908dc1e)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
