### PR TITLE
feat(components): Allow for passing ref to Button component

### DIFF
--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -241,3 +241,23 @@ describe("Button role", () => {
     expect(getByRole("combobox")).toBeInstanceOf(HTMLButtonElement);
   });
 });
+
+describe("Button ref", () => {
+  it("uses ref forwarding to provide a ref to the button or anchor element", () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+
+    render(<Button label="hello" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+
+    render(<Button ariaLabel="hello" icon="add" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+
+    render(<Button label="hello" url="/world" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+
+    render(<Button label="hello" to="/world" ref={ref} />, {
+      wrapper: Router,
+    });
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+  });
+});

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Ref, forwardRef } from "react";
 import classnames from "classnames";
 import { XOR } from "ts-xor";
 import { Link, LinkProps } from "react-router-dom";
@@ -100,7 +100,10 @@ export type ButtonProps = XOR<
   > &
   XOR<ButtonIconProps, ButtonLabelProps>;
 
-export function Button(props: ButtonProps) {
+export const Button = forwardRef(function Button(
+  props: ButtonProps,
+  ref: Ref<HTMLAnchorElement | HTMLButtonElement>,
+) {
   const {
     ariaControls,
     ariaHaspopup,
@@ -158,7 +161,7 @@ export function Button(props: ButtonProps) {
 
   if (to) {
     return (
-      <Link {...tagProps} to={to}>
+      <Link {...tagProps} to={to} ref={ref as Ref<HTMLAnchorElement>}>
         {buttonInternals}
       </Link>
     );
@@ -166,8 +169,12 @@ export function Button(props: ButtonProps) {
 
   const Tag = url ? "a" : "button";
 
-  return <Tag {...tagProps}>{buttonInternals}</Tag>;
-}
+  return (
+    <Tag {...tagProps} ref={ref as unknown as string}>
+      {buttonInternals}
+    </Tag>
+  );
+});
 
 function ButtonInternals({ label, icon, size = "base" }: ButtonProps) {
   return (


### PR DESCRIPTION
## Motivations
Provides a way to reference the button and give it focus. In the video, after using the keyboard to open and close the _Line Item_ pop up and menu, the button receives focus again.

This is currently achieved by wrapping in the button in a extra _div_ and using `ref.current.querySelector("button")`. Being able to reference the button directly would be nicer.

https://github.com/GetJobber/atlantis/assets/14314519/057ae7fb-812a-4f97-b49d-feb959d77cf3


## Added

Implemented the _Button_ component using. _forwardRef_. I tried really hard to make it typesafer where depending on used props such as _url_ and _to_ the _ref_ would be typed accordingly but the heavy use of _XOR_ would require a complete refactor of the prop types to achieve this.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![image](https://github.com/GetJobber/atlantis/assets/14314519/94382b3d-8dcf-40a7-9699-ba21d7c2d53a)
