### PR TITLE
feat(components): Add support for link click listener for Markdown component (JOB-96041)

### DIFF
--- a/packages/components/src/FeatureSwitch/__snapshots__/FeatureSwitch.test.tsx.snap
+++ b/packages/components/src/FeatureSwitch/__snapshots__/FeatureSwitch.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`renders a full FeatureSwitch 1`] = `
             Send a 
             <a
               href="www.fakeurl.com"
+              rel="noreferrer"
               target="_blank"
             >
               notification

--- a/packages/components/src/Markdown/Markdown.test.tsx
+++ b/packages/components/src/Markdown/Markdown.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { Markdown } from ".";
 
@@ -68,36 +68,30 @@ it("renders a without headings, paragraph, and wrapping content", () => {
   expect(container).toMatchSnapshot();
 });
 
-describe("custom components", () => {
-  it("uses the provided components for the generated HTML", () => {
-    const { queryByTestId } = render(
+describe("links", () => {
+  it("calls the callback when onLinkClick is provided", () => {
+    const onLinkClick = jest.fn();
+    const link = "http://to.somewhere/";
+    const { queryByText } = render(
       <Markdown
-        content="This is a [link](http://to.somewhere)"
-        components={{
-          a: ({ href, children }) => (
-            <a href={href} data-testid="foo-bar">
-              {children}
-            </a>
-          ),
-        }}
+        content={`This is a [link](${link})`}
+        onLinkClick={onLinkClick}
       />,
     );
 
-    expect(queryByTestId("foo-bar")).not.toBeNull();
+    fireEvent.click(queryByText("link") as HTMLElement);
+
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+    expect((onLinkClick.mock.calls[0][0] as HTMLAnchorElement).href).toBe(link);
   });
 
-  it("overrides the default components", () => {
-    const { queryByTestId } = render(
-      <Markdown
-        content="# A heading"
-        components={{
-          // Make all h1's be h2's
-          h1: ({ children }) => <h2 data-testid="foo-bar">{children}</h2>,
-        }}
-      />,
+  it("opens links in a new tab when externalLink is true", () => {
+    const link = "http://to.somewhere/";
+    const { queryByText } = render(
+      <Markdown content={`This [link](${link})`} externalLink />,
     );
 
-    expect(queryByTestId("foo-bar")).not.toBeNull();
-    expect(queryByTestId("foo-bar")?.nodeName).toEqual("H2");
+    expect((queryByText("link") as HTMLAnchorElement).target).toBe("_blank");
+    expect((queryByText("link") as HTMLAnchorElement).href).toBe(link);
   });
 });

--- a/packages/components/src/Markdown/Markdown.test.tsx
+++ b/packages/components/src/Markdown/Markdown.test.tsx
@@ -67,3 +67,37 @@ it("renders a without headings, paragraph, and wrapping content", () => {
   );
   expect(container).toMatchSnapshot();
 });
+
+describe("custom components", () => {
+  it("uses the provided components for the generated HTML", () => {
+    const { queryByTestId } = render(
+      <Markdown
+        content="This is a [link](http://to.somewhere)"
+        components={{
+          a: ({ href, children }) => (
+            <a href={href} data-testid="foo-bar">
+              {children}
+            </a>
+          ),
+        }}
+      />,
+    );
+
+    expect(queryByTestId("foo-bar")).not.toBeNull();
+  });
+
+  it("overrides the default components", () => {
+    const { queryByTestId } = render(
+      <Markdown
+        content="# A heading"
+        components={{
+          // Make all h1's be h2's
+          h1: ({ children }) => <h2 data-testid="foo-bar">{children}</h2>,
+        }}
+      />,
+    );
+
+    expect(queryByTestId("foo-bar")).not.toBeNull();
+    expect(queryByTestId("foo-bar")?.nodeName).toEqual("H2");
+  });
+});

--- a/packages/components/src/Markdown/Markdown.tsx
+++ b/packages/components/src/Markdown/Markdown.tsx
@@ -1,5 +1,7 @@
 import React, { DetailedHTMLProps, HTMLAttributes } from "react";
 import ReactMarkdown from "react-markdown";
+import { NormalComponents } from "react-markdown/lib/complex-types";
+import { SpecialComponents } from "react-markdown/lib/ast-to-react";
 import { Text } from "../Text";
 import { Emphasis } from "../Emphasis";
 import { Heading } from "../Heading";
@@ -21,9 +23,18 @@ interface MarkdownProps {
    * `[link name](url)`
    */
   readonly basicUsage?: boolean;
+
+  readonly components?: Partial<
+    Omit<NormalComponents, keyof SpecialComponents> & SpecialComponents
+  >;
 }
 
-export function Markdown({ content, externalLink, basicUsage }: MarkdownProps) {
+export function Markdown({
+  content,
+  externalLink,
+  basicUsage,
+  components,
+}: MarkdownProps) {
   const props = {
     ...(basicUsage && {
       disallowedElements: [
@@ -60,6 +71,7 @@ export function Markdown({ content, externalLink, basicUsage }: MarkdownProps) {
           h3: renderHeading(3),
           h4: renderHeading(4),
           h5: renderHeading(5),
+          ...components,
         }}
       >
         {content}

--- a/packages/components/src/Markdown/Markdown.tsx
+++ b/packages/components/src/Markdown/Markdown.tsx
@@ -1,7 +1,5 @@
 import React, { DetailedHTMLProps, HTMLAttributes } from "react";
 import ReactMarkdown from "react-markdown";
-import { NormalComponents } from "react-markdown/lib/complex-types";
-import { SpecialComponents } from "react-markdown/lib/ast-to-react";
 import { Text } from "../Text";
 import { Emphasis } from "../Emphasis";
 import { Heading } from "../Heading";
@@ -24,16 +22,19 @@ interface MarkdownProps {
    */
   readonly basicUsage?: boolean;
 
-  readonly components?: Partial<
-    Omit<NormalComponents, keyof SpecialComponents> & SpecialComponents
-  >;
+  /**
+   *
+   * Callback that gets called when a link in the text is clicked.
+   * @param target the target element that was clicked
+   */
+  readonly onLinkClick?: (target: HTMLAnchorElement) => void;
 }
 
 export function Markdown({
   content,
   externalLink,
   basicUsage,
-  components,
+  onLinkClick,
 }: MarkdownProps) {
   const props = {
     ...(basicUsage && {
@@ -71,7 +72,7 @@ export function Markdown({
           h3: renderHeading(3),
           h4: renderHeading(4),
           h5: renderHeading(5),
-          ...components,
+          a: renderLink(onLinkClick, !!externalLink),
         }}
       >
         {content}
@@ -100,4 +101,29 @@ function renderHeading(level: 1 | 2 | 3 | 4 | 5) {
   }
 
   return buildHeading;
+}
+
+function renderLink(
+  onLinkClick: ((target: HTMLAnchorElement) => void) | undefined,
+  externalLink: boolean,
+) {
+  // eslint-disable-next-line react/display-name
+  return ({
+    children,
+    href,
+  }: React.DetailedHTMLProps<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    HTMLAnchorElement
+  >) => (
+    <a
+      href={href}
+      onClick={event => {
+        return onLinkClick?.(event.target as HTMLAnchorElement);
+      }}
+      target={externalLink ? "_blank" : undefined}
+      rel="noreferrer"
+    >
+      {children}
+    </a>
+  );
 }

--- a/packages/components/src/Markdown/__snapshots__/Markdown.test.tsx.snap
+++ b/packages/components/src/Markdown/__snapshots__/Markdown.test.tsx.snap
@@ -193,6 +193,7 @@ exports[`renders a without headings, paragraph, and wrapping content 1`] = `
 and of course a 
   <a
     href="http://to.somewhere"
+    rel="noreferrer"
   >
     link
   </a>

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -134,6 +134,7 @@ exports[`renders a Page 1`] = `
           Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our 
           <a
             href="https://help.getjobber.com/hc/en-us/articles/115009737128"
+            rel="noreferrer"
           >
             Help Center
           </a>


### PR DESCRIPTION
## Motivations
The markdown component works well for handling markdown text, but our team has run into a use case where we need to know when a link was clicked. This PR extends the Markdown component to expose the underlying React Markdown's `component` prop. This way, we can use a custom component and attach whatever events we want.

### Added
Added an optional `components` prop to the Markdown component. This object is spread to the React Markdown component, ensuring that existing values can be overridden if desired.

Also added tests for this functionality.

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)