### PR TITLE
feat(components): Box Component

### DIFF
--- a/.storybook/components/SidebarLabel/alphaComponents.ts
+++ b/.storybook/components/SidebarLabel/alphaComponents.ts
@@ -1,2 +1,2 @@
-export const alphaComponents = ["DataList", "Combobox"];
+export const alphaComponents = ["DataList", "Combobox", "Box"];
 export const alphaMobileComponents = ["Menu"]

--- a/docs/components/Box/Box.stories.mdx
+++ b/docs/components/Box/Box.stories.mdx
@@ -2,4 +2,117 @@ import { Box } from "@jobber/components/Box";
 
 <Meta title="Components/Layouts and Structure/Box/Docs" component={Box} />
 
-Box Documentation
+# Box
+
+A box is a generic way to add structure to your page. Stop reaching for CSS
+Modules to perform basic page layout, and instead use the Box component.
+
+## Design & Usage guidelines
+
+A box is useful for wrapping content with a specific HTML5 element, and with
+common Atlantis specific CSS styles. Box supports standard alignment, border,
+borderColor, borderRadius, direction, gap, height, justification, margin,
+overflow, padding, position, width and whitespace options.
+
+A box should be used if your wrapping CSS styles can be achieved with a prop
+configuration of the Box component. Some basic examples are below, all
+configuration options are provided in the Basic Web example via the left-hand
+navigation.
+
+### No Props
+
+<Canvas>
+  <Box>
+    This is Box without props. It marks your content as display: flex and
+    flex-direction: column
+  </Box>
+</Canvas>
+
+### Border Base and Padding Base
+
+<Canvas>
+  <Box border="base" padding="base">
+    By default you get no padding or borders, but with two 'base' props you can
+    have both.
+  </Box>
+</Canvas>
+
+### Border Thick and Padding Large
+
+<Canvas>
+  <Box border="thick" padding="large">
+    Standard paddings and margins are available, and different borders. This is
+    using the 'thick' border along with padding 'large'
+  </Box>
+</Canvas>
+
+### Border Thickest and Margin Largest and Padding Extravagant
+
+<Canvas>
+  <Box margin="largest" border="thickest" padding="extravagant">
+    Want a big margin and huge padding? Box has those too.
+  </Box>
+</Canvas>
+
+## What about actual layout usages?
+
+If you don't really want borders around everything but just want to lay out some
+content on the page? You can do that too.
+
+<Canvas>
+  <Box direction="row">
+    <Box padding="base" width="grow">
+      Left
+    </Box>
+    <Box padding="base" width="grow">
+      Right
+    </Box>
+  </Box>
+</Canvas>
+
+### Maybe some custom heights or widths?
+
+Box has those as well.
+
+<Canvas>
+  <Box direction="row" alignItems="center">
+    <Box padding="base" width={350} border="base">
+      Left, 350px wide
+    </Box>
+    <Box padding="base" height={75} border="base">
+      Right, 75px high
+    </Box>
+  </Box>
+</Canvas>
+
+### What about a gap between elements?
+
+Standard sizes are supported.
+
+<Canvas>
+  <Box direction="row" alignItems="center" gap="large">
+    <Box padding="base" width={50} border="base">
+      Left, 50px wide
+    </Box>
+    <Box padding="base" height={25} border="base">
+      Right, 25px high
+    </Box>
+  </Box>
+</Canvas>
+
+### I have specific border-left and margin-bottom requirements.
+
+Box supports objects for some of its props, including padding and margin
+"bottom, horizontal, left, right, top, vertical"
+
+<Canvas>
+  <Box padding={{ top: "large" }} border="thick">
+    Top Padding?
+  </Box>
+</Canvas>
+
+<Canvas>
+  <Box margin={{ left: "large" }} border="base" padding="base">
+    Left Margin?
+  </Box>
+</Canvas>

--- a/docs/components/Box/Box.stories.mdx
+++ b/docs/components/Box/Box.stories.mdx
@@ -1,11 +1,22 @@
 import { Box } from "@jobber/components/Box";
 
-<Meta title="Components/Layouts and Structure/Box/Docs" component={Box} />
+<Meta
+  title="Components/Layouts and Structure/Box/Docs"
+  component={Box}
+  parameters={{ alpha: true }}
+/>
 
 # Box
 
 A box is a generic way to add structure to your page. Stop reaching for CSS
 Modules to perform basic page layout, and instead use the Box component.
+
+## Alpha State - Use Semantic Colours Please.
+
+The Box component is currently in Alpha status. In particular, we intend to
+fast-follow and restrict any non-semantic color usage. It was faster to roll
+this component with the full colour set for now. We will remove the Alpha status
+when we remove non-semantic colours, and we will warn developers when we do so.
 
 ## Design & Usage guidelines
 

--- a/docs/components/Box/Box.stories.mdx
+++ b/docs/components/Box/Box.stories.mdx
@@ -1,0 +1,5 @@
+import { Box } from "@jobber/components/Box";
+
+<Meta title="Components/Layouts and Structure/Box/Docs" component={Box} />
+
+Box Documentation

--- a/docs/components/Box/Web.stories.tsx
+++ b/docs/components/Box/Web.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta } from "@storybook/react";
+import { Box } from "@jobber/components/Box";
+
+export default {
+  title: "Components/Layout and Structure/Box/Web",
+  component: Box,
+  parameters: {
+    viewMode: "story",
+    previewTabs: { code: { hidden: false } },
+  },
+} as ComponentMeta<typeof Box>;

--- a/docs/components/Box/Web.stories.tsx
+++ b/docs/components/Box/Web.stories.tsx
@@ -1,11 +1,19 @@
-import { ComponentMeta } from "@storybook/react";
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Box } from "@jobber/components/Box";
 
 export default {
-  title: "Components/Layout and Structure/Box/Web",
+  title: "Components/Layouts and Structure/Box/Web",
   component: Box,
   parameters: {
     viewMode: "story",
     previewTabs: { code: { hidden: false } },
   },
 } as ComponentMeta<typeof Box>;
+
+const BasicTemplate: ComponentStory<typeof Box> = args => (
+  <Box {...args}>Box Content</Box>
+);
+
+export const Basic = BasicTemplate.bind({});
+Basic.args = {};

--- a/docs/components/Flex/Web.stories.tsx
+++ b/docs/components/Flex/Web.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 const BasicTemplate: ComponentStory<typeof Flex> = args => (
   <Flex {...args}>
-    <Flex alignItems="start" template={["shrink", "grow"]}>
+    <Flex align="start" template={["shrink", "grow"]}>
       <Icon name="quote" />
       <Content spacing="small">
         <Flex template={["grow", "shrink"]}>
@@ -35,15 +35,4 @@ const BasicTemplate: ComponentStory<typeof Flex> = args => (
 export const Basic = BasicTemplate.bind({});
 Basic.args = {
   template: ["grow", "shrink"],
-};
-
-export const JustifyContent: ComponentStory<typeof Flex> = args => (
-  <Flex {...args}>
-    <div style={{ height: 20 }}>Left</div>
-    <div style={{ height: 30 }}>Center</div>
-    <div style={{ height: 40 }}>Right</div>
-  </Flex>
-);
-JustifyContent.args = {
-  template: [],
 };

--- a/docs/components/Flex/Web.stories.tsx
+++ b/docs/components/Flex/Web.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 const BasicTemplate: ComponentStory<typeof Flex> = args => (
   <Flex {...args}>
-    <Flex align="start" template={["shrink", "grow"]}>
+    <Flex alignItems="start" template={["shrink", "grow"]}>
       <Icon name="quote" />
       <Content spacing="small">
         <Flex template={["grow", "shrink"]}>
@@ -35,4 +35,15 @@ const BasicTemplate: ComponentStory<typeof Flex> = args => (
 export const Basic = BasicTemplate.bind({});
 Basic.args = {
   template: ["grow", "shrink"],
+};
+
+export const JustifyContent: ComponentStory<typeof Flex> = args => (
+  <Flex {...args}>
+    <div style={{ height: 20 }}>Left</div>
+    <div style={{ height: 30 }}>Center</div>
+    <div style={{ height: 40 }}>Right</div>
+  </Flex>
+);
+JustifyContent.args = {
+  template: [],
 };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,6 +44,11 @@
       "import": "./dist/Banner/index.mjs",
       "require": "./dist/Banner/index.cjs"
     },
+    "./Box": {
+      "types": "./dist/Box/index.d.ts",
+      "import": "./dist/Box/index.mjs",
+      "require": "./dist/Box/index.cjs"
+    },
     "./Button": {
       "types": "./dist/Button/index.d.ts",
       "import": "./dist/Button/index.mjs",

--- a/packages/components/src/Box/Box.tsx
+++ b/packages/components/src/Box/Box.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import classnames from "classnames";
+import { getBorderClassNames, getBorderVars } from "./utils/getBoxConfig";
+import {
+  getHeightClassName,
+  getHeightVars,
+  getWidthClassName,
+  getWidthVars,
+} from "./utils/getBoxDimension";
+import {
+  getMarginClassNames,
+  getMarginVars,
+  getPaddingClassNames,
+  getPaddingVars,
+} from "./utils/getBoxSpaces";
+import type { BoxProps } from "./Box.types";
+import styles from "./styles/Box.css";
+import gapStyles from "./styles/BoxGap.css";
+import radiusStyles from "./styles/BoxRadius.css";
+
+export function Box({
+  alignItems,
+  alignSelf,
+  as: Tag = "div",
+  background,
+  border,
+  borderColor,
+  children,
+  direction,
+  gap,
+  height = "auto",
+  justifyContent,
+  margin,
+  overflow,
+  padding,
+  position = "relative",
+  preserveWhiteSpace,
+  radius,
+  width = "auto",
+  ...props
+}: BoxProps) {
+  return (
+    <Tag
+      {...props}
+      className={classnames(
+        styles.box,
+        preserveWhiteSpace && styles["preserve-white-space"],
+        getPaddingClassNames(padding),
+        getMarginClassNames(margin),
+        getHeightClassName(height),
+        getWidthClassName(width),
+        getBorderClassNames(border),
+        radius && radiusStyles[`radius-${radius}`],
+        gap && gapStyles[`gap-${gap}`],
+      )}
+      style={{
+        ...getPaddingVars(padding),
+        ...getMarginVars(margin),
+        ...getHeightVars(height),
+        ...getWidthVars(width),
+        ...getBorderVars(border),
+        ...(background && { backgroundColor: `var(--color-${background})` }),
+        ...(borderColor && { borderColor: `var(--color-${borderColor})` }),
+        alignItems,
+        alignSelf,
+        flexDirection: direction,
+        justifyContent,
+        overflow,
+        position,
+      }}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/packages/components/src/Box/Box.types.ts
+++ b/packages/components/src/Box/Box.types.ts
@@ -1,0 +1,53 @@
+import type { CSSProperties, PropsWithChildren } from "react";
+import type { tokens } from "@jobber/design";
+
+export interface BoxProps
+  extends PropsWithChildren,
+    Pick<
+      CSSProperties,
+      "position" | "justifyContent" | "alignItems" | "alignSelf" | "overflow"
+    >,
+    Partial<Pick<HTMLElement, "tabIndex">> {
+  readonly as?: "div" | "span" | "section" | "article" | "aside" | "main";
+  readonly background?: Colors;
+  readonly border?: BorderWidth | BoxBorderWidth;
+  readonly borderColor?: Colors;
+  readonly direction?: CSSProperties["flexDirection"];
+  readonly gap?: Sizes;
+  readonly height?: BoxDimension;
+  readonly margin?: Sizes | BoxSpace;
+  readonly padding?: Sizes | BoxSpace;
+  readonly preserveWhiteSpace?: boolean;
+  readonly radius?: Radii;
+  readonly width?: BoxDimension;
+}
+
+type TokensType = keyof typeof tokens;
+
+type Prefixes = TokensType extends `${infer Prefix}-${string}` ? Prefix : never;
+type ExtractTokens<T extends string> = Extract<TokensType, `${T}-${string}`>;
+type Tokenize<T extends Prefixes> =
+  ExtractTokens<T> extends `${T}-${infer Value}` ? Value : never;
+
+export type Sizes = Tokenize<"space">;
+export type Radii = Tokenize<"radius">;
+export type Colors = Tokenize<"color">;
+export type BorderWidth = Tokenize<"border">;
+
+interface BoxSpace {
+  readonly bottom?: Sizes;
+  readonly horizontal?: Sizes;
+  readonly left?: Sizes;
+  readonly right?: Sizes;
+  readonly top?: Sizes;
+  readonly vertical?: Sizes;
+}
+
+export type BoxDimension = number | `${string}%` | "auto" | "shrink" | "grow";
+
+interface BoxBorderWidth {
+  readonly bottom?: BorderWidth;
+  readonly left?: BorderWidth;
+  readonly right?: BorderWidth;
+  readonly top?: BorderWidth;
+}

--- a/packages/components/src/Box/index.ts
+++ b/packages/components/src/Box/index.ts
@@ -1,0 +1,1 @@
+export * from "./Box";

--- a/packages/components/src/Box/styles/Box.css
+++ b/packages/components/src/Box/styles/Box.css
@@ -1,0 +1,9 @@
+.box {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.preserve-white-space {
+  white-space: pre-wrap;
+}

--- a/packages/components/src/Box/styles/Box.css.d.ts
+++ b/packages/components/src/Box/styles/Box.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "box": string;
+  readonly "preserve-white-space": string;
+};
+export = styles;
+

--- a/packages/components/src/Box/styles/BoxBorder.css
+++ b/packages/components/src/Box/styles/BoxBorder.css
@@ -1,0 +1,24 @@
+.border {
+  border-color: var(--color-border);
+  border-style: solid;
+}
+
+.border-base {
+  border-width: var(--box-border);
+}
+
+.border-top {
+  border-top-width: var(--box-border-top);
+}
+
+.border-right {
+  border-right-width: var(--box-border-right);
+}
+
+.border-bottom {
+  border-bottom-width: var(--box-border-bottom);
+}
+
+.border-left {
+  border-left-width: var(--box-border-left);
+}

--- a/packages/components/src/Box/styles/BoxBorder.css.d.ts
+++ b/packages/components/src/Box/styles/BoxBorder.css.d.ts
@@ -1,0 +1,10 @@
+declare const styles: {
+  readonly "border": string;
+  readonly "border-base": string;
+  readonly "border-top": string;
+  readonly "border-right": string;
+  readonly "border-bottom": string;
+  readonly "border-left": string;
+};
+export = styles;
+

--- a/packages/components/src/Box/styles/BoxDimension.css
+++ b/packages/components/src/Box/styles/BoxDimension.css
@@ -1,0 +1,21 @@
+.height-auto {
+  height: auto;
+}
+
+.width-auto {
+  width: auto;
+}
+
+.height-shrink,
+.width-shrink {
+  min-width: 0;
+  min-height: 0;
+  flex: 0 0 auto;
+}
+
+.height-grow,
+.width-grow {
+  min-width: 0;
+  min-height: 0;
+  flex: 1 1 auto;
+}

--- a/packages/components/src/Box/styles/BoxDimension.css.d.ts
+++ b/packages/components/src/Box/styles/BoxDimension.css.d.ts
@@ -1,0 +1,10 @@
+declare const styles: {
+  readonly "height-auto": string;
+  readonly "width-auto": string;
+  readonly "height-shrink": string;
+  readonly "width-shrink": string;
+  readonly "height-grow": string;
+  readonly "width-grow": string;
+};
+export = styles;
+

--- a/packages/components/src/Box/styles/BoxGap.css
+++ b/packages/components/src/Box/styles/BoxGap.css
@@ -1,0 +1,35 @@
+.gap-minuscule {
+  gap: var(--space-minuscule);
+}
+
+.gap-smallest {
+  gap: var(--space-smallest);
+}
+
+.gap-smaller {
+  gap: var(--space-smaller);
+}
+
+.gap-small {
+  gap: var(--space-small);
+}
+
+.gap-base {
+  gap: var(--space-base);
+}
+
+.gap-large {
+  gap: var(--space-large);
+}
+
+.gap-larger {
+  gap: var(--space-larger);
+}
+
+.gap-largest {
+  gap: var(--space-largest);
+}
+
+.gap-extravagant {
+  gap: var(--space-extravagant);
+}

--- a/packages/components/src/Box/styles/BoxGap.css.d.ts
+++ b/packages/components/src/Box/styles/BoxGap.css.d.ts
@@ -1,0 +1,13 @@
+declare const styles: {
+  readonly "gap-minuscule": string;
+  readonly "gap-smallest": string;
+  readonly "gap-smaller": string;
+  readonly "gap-small": string;
+  readonly "gap-base": string;
+  readonly "gap-large": string;
+  readonly "gap-larger": string;
+  readonly "gap-largest": string;
+  readonly "gap-extravagant": string;
+};
+export = styles;
+

--- a/packages/components/src/Box/styles/BoxMargin.css
+++ b/packages/components/src/Box/styles/BoxMargin.css
@@ -1,0 +1,29 @@
+.base {
+  margin: var(--box-margin, 0);
+}
+
+.horizontal {
+  margin-left: var(--box-margin-horizontal);
+  margin-right: var(--box-margin-horizontal);
+}
+
+.vertical {
+  margin-top: var(--box-margin-vertical);
+  margin-bottom: var(--box-margin-vertical);
+}
+
+.top {
+  margin-top: var(--box-margin-top);
+}
+
+.right {
+  margin-right: var(--box-margin-right);
+}
+
+.bottom {
+  margin-bottom: var(--box-margin-bottom);
+}
+
+.left {
+  margin-left: var(--box-margin-left);
+}

--- a/packages/components/src/Box/styles/BoxMargin.css.d.ts
+++ b/packages/components/src/Box/styles/BoxMargin.css.d.ts
@@ -1,0 +1,11 @@
+declare const styles: {
+  readonly "base": string;
+  readonly "horizontal": string;
+  readonly "vertical": string;
+  readonly "top": string;
+  readonly "right": string;
+  readonly "bottom": string;
+  readonly "left": string;
+};
+export = styles;
+

--- a/packages/components/src/Box/styles/BoxPadding.css
+++ b/packages/components/src/Box/styles/BoxPadding.css
@@ -1,0 +1,29 @@
+.base {
+  padding: var(--box-padding, 0);
+}
+
+.horizontal {
+  padding-left: var(--box-padding-horizontal);
+  padding-right: var(--box-padding-horizontal);
+}
+
+.vertical {
+  padding-top: var(--box-padding-vertical);
+  padding-bottom: var(--box-padding-vertical);
+}
+
+.top {
+  padding-top: var(--box-padding-top);
+}
+
+.right {
+  padding-right: var(--box-padding-right);
+}
+
+.bottom {
+  padding-bottom: var(--box-padding-bottom);
+}
+
+.left {
+  padding-left: var(--box-padding-left);
+}

--- a/packages/components/src/Box/styles/BoxPadding.css.d.ts
+++ b/packages/components/src/Box/styles/BoxPadding.css.d.ts
@@ -1,0 +1,11 @@
+declare const styles: {
+  readonly "base": string;
+  readonly "horizontal": string;
+  readonly "vertical": string;
+  readonly "top": string;
+  readonly "right": string;
+  readonly "bottom": string;
+  readonly "left": string;
+};
+export = styles;
+

--- a/packages/components/src/Box/styles/BoxRadius.css
+++ b/packages/components/src/Box/styles/BoxRadius.css
@@ -1,0 +1,19 @@
+.radius-small {
+  border-radius: var(--radius-small);
+}
+
+.radius-base {
+  border-radius: var(--radius-base);
+}
+
+.radius-large {
+  border-radius: var(--radius-large);
+}
+
+.radius-larger {
+  border-radius: var(--radius-larger);
+}
+
+.radius-circle {
+  border-radius: var(--radius-circle);
+}

--- a/packages/components/src/Box/styles/BoxRadius.css.d.ts
+++ b/packages/components/src/Box/styles/BoxRadius.css.d.ts
@@ -1,0 +1,9 @@
+declare const styles: {
+  readonly "radius-small": string;
+  readonly "radius-base": string;
+  readonly "radius-large": string;
+  readonly "radius-larger": string;
+  readonly "radius-circle": string;
+};
+export = styles;
+

--- a/packages/components/src/Box/utils/getBoxConfig.ts
+++ b/packages/components/src/Box/utils/getBoxConfig.ts
@@ -1,0 +1,70 @@
+import classnames from "classnames";
+import borderStyles from "../styles/BoxBorder.css";
+
+// Borders
+export const getBorderClassNames = <T>(size: T) =>
+  getClassNames<T>({
+    defaultClass: "border",
+    prefix: "border",
+    size,
+    styles: borderStyles,
+  });
+export const getBorderVars = <T>(size: T) =>
+  getVars<T>({ size, tokenPrefix: "border", varPrefix: "border" });
+
+interface GetClassNamesParams<T> {
+  readonly defaultClass?: string;
+  readonly prefix: string;
+  readonly size: T;
+  readonly styles: Record<string, string>;
+}
+
+export function getClassNames<T>({
+  defaultClass,
+  prefix,
+  size,
+  styles,
+}: GetClassNamesParams<T>) {
+  if (!size) return;
+  const className: (string | undefined)[] = [
+    defaultClass && styles[defaultClass],
+  ];
+
+  if (typeof size === "string") {
+    className.push(styles[`${prefix}-base`]);
+
+    // Return early since we don't need to process the object
+    return classnames(className);
+  }
+
+  Object.keys(size).forEach(key => className.push(styles[`${prefix}-${key}`]));
+
+  return classnames(className);
+}
+
+interface GetVarsParams<T> {
+  readonly size: T;
+  readonly tokenPrefix: string;
+  readonly varPrefix: string;
+}
+
+export function getVars<T>({ size, tokenPrefix, varPrefix }: GetVarsParams<T>) {
+  if (!size) return;
+
+  const fullPrefix = `--box-${varPrefix}`;
+  const customProperties: Record<string, string> = {};
+
+  if (typeof size === "string") {
+    customProperties[fullPrefix] = `var(--${tokenPrefix}-${size})`;
+
+    // Return early since we don't need to process the object
+    return customProperties;
+  }
+
+  const entries: [string, T][] = Object.entries(size);
+  entries.forEach(([key, value]) => {
+    customProperties[`${fullPrefix}-${key}`] = `var(--${tokenPrefix}-${value})`;
+  });
+
+  return customProperties;
+}

--- a/packages/components/src/Box/utils/getBoxDimension.ts
+++ b/packages/components/src/Box/utils/getBoxDimension.ts
@@ -1,0 +1,32 @@
+import type { BoxDimension } from "../Box.types";
+import styles from "../styles/BoxDimension.css";
+
+export const getHeightClassName = (value: BoxDimension) =>
+  getClassName(value, "height");
+export const getHeightVars = (value: BoxDimension) => getVars(value, "height");
+
+export const getWidthClassName = (value: BoxDimension) =>
+  getClassName(value, "width");
+export const getWidthVars = (value: BoxDimension) => getVars(value, "width");
+
+function getClassName(value: BoxDimension, prefix: string): string | undefined {
+  if (typeof value === "string" && !value.endsWith("%")) {
+    return (styles as Record<string, string | undefined>)[`${prefix}-${value}`];
+  }
+
+  return (styles as Record<string, string | undefined>)[`${prefix}-auto`];
+}
+
+function getVars(value: BoxDimension, prefix: string) {
+  let size: string | undefined;
+
+  if (typeof value === "string" && value.endsWith("%")) {
+    size = value;
+  } else if (typeof value === "number") {
+    size = `${value}px`;
+  }
+
+  if (size) {
+    return { [prefix]: size };
+  }
+}

--- a/packages/components/src/Box/utils/getBoxSpaces.ts
+++ b/packages/components/src/Box/utils/getBoxSpaces.ts
@@ -1,0 +1,60 @@
+import classNames from "classnames";
+import type { BoxProps, Sizes } from "../Box.types";
+import marginStyles from "../styles/BoxMargin.css";
+import paddingStyles from "../styles/BoxPadding.css";
+
+type Size = BoxProps["padding"] | BoxProps["margin"];
+
+// Padding
+export const getPaddingClassNames = getClassNames;
+export const getPaddingVars = getVars;
+
+// Margin
+export const getMarginClassNames = (size: Size) => getClassNames(size, true);
+export const getMarginVars = (size: Size) => getVars(size, "--box-margin");
+
+/**
+ * Converts BoxSpace object values into class names.
+ */
+function getClassNames(size: Size, isMargin = false) {
+  if (!size) return;
+
+  const styles = isMargin ? marginStyles : paddingStyles;
+  const className: string[] = [];
+
+  if (typeof size === "string") {
+    className.push(styles.base);
+
+    // Return early since we don't need to process the object
+    return classNames(className);
+  }
+
+  Object.keys(size).forEach(key =>
+    className.push(` ${(styles as Record<string, string | undefined>)[key]}`),
+  );
+
+  return classNames(className);
+}
+
+/**
+ * Converts BoxSpace object values into custom properties.
+ */
+function getVars(size: Size, basePrefix = "--box-padding") {
+  if (!size) return;
+
+  const customProperties: Record<string, string> = {};
+
+  if (typeof size === "string") {
+    customProperties[basePrefix] = `var(--space-${size})`;
+
+    // Return early since we don't need to process the object
+    return customProperties;
+  }
+
+  const paddingEntries: [string, Sizes][] = Object.entries(size);
+  paddingEntries.forEach(([key, value]) => {
+    customProperties[`${basePrefix}-${key}`] = `var(--space-${value})`;
+  });
+
+  return customProperties;
+}

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -4,6 +4,7 @@ export * from "./AtlantisContext";
 export { Autocomplete } from "./Autocomplete";
 export * from "./Avatar";
 export * from "./Banner";
+export * from "./Box";
 export * from "./Button";
 export * from "./ButtonDismiss";
 export * from "./Card";


### PR DESCRIPTION
## Motivations

We've had a need for a generic layout component for a while. This component was rolled elsewhere, and we're moving it into Atlantis so everyone can benefit from its greatness.

The Box component is for all your wrapping component needs. You can put borders around your box, or padding, or margins, or border radiuses. You can set flex direction, gap size, all sorts of fun things.

There is basic documentation, but could be expanded with additional examples.

## Changes

* Added the Box component

### Added

- The Box Component

## Testing

The box component should render well in the provided storybook stories.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
