### PR TITLE
fix(components): Allow Button variation prop combined with submit prop

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -70,7 +70,7 @@ interface DestructiveActionProps extends ButtonFoundationProps {
 }
 
 interface SubmitActionProps
-  extends Omit<ButtonFoundationProps, "external" | "onClick"> {
+  extends Omit<BaseActionProps, "external" | "onClick"> {
   readonly name?: string;
   readonly submit: boolean;
   readonly type?: "primary" | "secondary" | "tertiary";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When a Button had `submit`, TS disallowed `variation` because we were extending ButtonFoundationProps instead of BaseActionProps. Confirmed with Chris, allowing `variation` combined with `submit` makes sense.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Updated Button prop types to allow variation + submit


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
