### PR TITLE
fix(components): Portalled Menu Take 2

### DIFF
--- a/packages/components/src/FormField/hooks/useActiveElement.ts
+++ b/packages/components/src/FormField/hooks/useActiveElement.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export function useActiveElement() {
+  const [active, setActive] = useState(document?.activeElement);
+
+  const handleFocusIn = () => {
+    setActive(document?.activeElement);
+  };
+
+  useEffect(() => {
+    document?.addEventListener("focusin", handleFocusIn);
+
+    return () => {
+      document?.removeEventListener("focusin", handleFocusIn);
+    };
+  }, []);
+
+  return active;
+}

--- a/packages/components/src/FormField/hooks/useFormFieldFocus.ts
+++ b/packages/components/src/FormField/hooks/useFormFieldFocus.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useActiveElement } from "./useActiveElement";
 
 interface UseFormFieldFocus {
   focused: boolean;
@@ -8,27 +9,43 @@ interface UseFormFieldFocusProps {
   wrapperRef?: React.RefObject<HTMLDivElement>;
 }
 
+const PORTAL_FOCUS_ATTRIBUTE_NAME = "data-atl-maintain-portal-focus";
+
+export const formFieldFocusAttribute = {
+  [PORTAL_FOCUS_ATTRIBUTE_NAME]: "true",
+};
+
 export function useFormFieldFocus(
   props: UseFormFieldFocusProps,
 ): UseFormFieldFocus {
   const [focused, setFocused] = useState(false);
+  const activeElement = useActiveElement();
+  const activeElementRef = useRef(activeElement);
 
   useEffect(() => {
-    function handleFocusIn() {
-      setFocused(true);
-    }
+    activeElementRef.current = activeElement;
+  }, [activeElement]);
 
-    function handleFocusOut() {
-      setTimeout(() => {
-        const focusedElementWithinWrapper = props.wrapperRef?.current?.contains(
-          document.activeElement,
-        );
+  function handleFocusIn() {
+    setFocused(true);
+  }
 
-        if (!focusedElementWithinWrapper) {
-          setFocused(false);
-        }
-      }, 1);
-    }
+  function handleFocusOut() {
+    setTimeout(() => {
+      const focusedElementWithinWrapper = props.wrapperRef?.current?.contains(
+        document.activeElement,
+      );
+      const focusException = activeElementRef.current?.closest(
+        `[${PORTAL_FOCUS_ATTRIBUTE_NAME}='true']`,
+      );
+
+      if (!focusedElementWithinWrapper && !focusException) {
+        setFocused(false);
+      }
+    }, 1);
+  }
+
+  useEffect(() => {
     props.wrapperRef?.current?.addEventListener("focusin", handleFocusIn);
     props.wrapperRef?.current?.addEventListener("focusout", handleFocusOut);
 

--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -3,18 +3,21 @@
 }
 
 .wrapper {
-  --menu-space: var(--space-small);
-  --menu-offset: var(--space-smallest);
-  display: inline-block;
   position: relative;
 }
 
-.menu {
-  position: fixed;
-  bottom: 0;
-  left: 0;
+.popperContainer {
   z-index: var(--elevation-menu);
-  width: 100%;
+}
+
+.shadowRef {
+  display: none;
+}
+
+.menu {
+  --menu-space: var(--space-small);
+  --menu-offset: var(--space-smallest);
+  z-index: var(--elevation-menu);
   max-height: 72vh;
   box-shadow: var(--shadow-base);
   padding: var(--menu-space);
@@ -24,43 +27,19 @@
   overflow-y: scroll;
   background-color: var(--color-surface);
 
+  @media (--small-screens-and-below) {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+
   @media (--small-screens-and-up) {
-    position: absolute;
-    left: auto;
     width: calc(var(--base-unit) * 12.5);
     padding: var(--menu-space);
     border: var(--border-base) solid var(--color-border);
     border-radius: var(--radius-base);
     overflow: auto;
-  }
-}
-
-.above {
-  @media (--small-screens-and-up) {
-    bottom: 100%;
-    margin-bottom: var(--menu-offset);
-  }
-}
-
-.below {
-  @media (--small-screens-and-up) {
-    top: 100%;
-    bottom: auto;
-    margin-top: var(--menu-offset);
-  }
-}
-
-.left {
-  @media (--small-screens-and-up) {
-    right: 0;
-    left: auto;
-  }
-}
-
-.right {
-  @media (--small-screens-and-up) {
-    right: auto;
-    left: 0;
   }
 }
 
@@ -97,11 +76,13 @@
 }
 
 .action:hover,
-.action:focus-visible {
+.action:focus {
   background-color: var(--color-surface--hover);
-  outline-color: var(--color-focus);
 }
 
+.action:focus-visible {
+  outline-color: var(--color-focus);
+}
 .action span {
   /* match appearance of Button labels */
   -webkit-font-smoothing: antialiased;

--- a/packages/components/src/Menu/Menu.css.d.ts
+++ b/packages/components/src/Menu/Menu.css.d.ts
@@ -1,10 +1,8 @@
 declare const styles: {
   readonly "wrapper": string;
+  readonly "popperContainer": string;
+  readonly "shadowRef": string;
   readonly "menu": string;
-  readonly "above": string;
-  readonly "below": string;
-  readonly "left": string;
-  readonly "right": string;
   readonly "section": string;
   readonly "sectionHeader": string;
   readonly "action": string;

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -169,8 +169,5 @@ it("should focus first action item from the menu when activated", async () => {
 
   fireEvent.click(getByRole("button"));
   const firstMenuItem = screen.getAllByRole("menuitem")[0];
-  expect(firstMenuItem).not.toHaveFocus();
-  jest.runAllTimers();
   expect(firstMenuItem).toHaveFocus();
-  jest.useRealTimers();
 });

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -90,6 +90,7 @@ export function Menu({ activator, items }: MenuProps) {
     state,
   } = usePopper(shadowRef.current?.nextElementSibling, popperElement, {
     placement: "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "flip",

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -22,7 +22,7 @@ import { Typography } from "../Typography";
 import { Icon } from "../Icon";
 import { formFieldFocusAttribute } from "../FormField/hooks/useFormFieldFocus";
 
-const SMALL_SCREEN_BREAKPOINT = 489;
+const SMALL_SCREEN_BREAKPOINT = 490;
 const MENU_OFFSET = 6;
 
 const variation = {
@@ -31,7 +31,7 @@ const variation = {
     let y = 10;
 
     if (placement?.includes("bottom")) y *= -1;
-    if (window.innerWidth < 640) y = 150;
+    if (window.innerWidth < SMALL_SCREEN_BREAKPOINT) y = 150;
 
     return { opacity: 0, y };
   },
@@ -107,7 +107,7 @@ export function Menu({ activator, items }: MenuProps) {
     ],
   });
   const positionAttributes =
-    width > SMALL_SCREEN_BREAKPOINT
+    width >= SMALL_SCREEN_BREAKPOINT
       ? {
           ...attributes.popper,
           style: popperStyles.popper,

--- a/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
@@ -5,6 +5,9 @@ exports[`Menu renders 1`] = `
   <div
     class="wrapper"
   >
+    <span
+      class="shadowRef"
+    />
     <button
       aria-controls=":r1:"
       aria-expanded="false"
@@ -39,6 +42,9 @@ exports[`Menu with custom activator renders 1`] = `
   <div
     class="wrapper"
   >
+    <span
+      class="shadowRef"
+    />
     <button
       aria-controls=":rc:"
       aria-expanded="false"

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -58,6 +58,9 @@ exports[`When actions are provided renders a Page with action buttons and a menu
               <div
                 class="wrapper"
               >
+                <span
+                  class="shadowRef"
+                />
                 <button
                   aria-controls=":r1:"
                   aria-expanded="false"

--- a/packages/hooks/README.mdx
+++ b/packages/hooks/README.mdx
@@ -14,6 +14,7 @@ Shared hooks for components in Atlantis.
 - [usePasswordStrength](../?path=/docs/hooks-usepasswordstrength--use-password-strength)
 - [useRefocusOnActivator](../?path=/docs/hooks-userefocusonactivator--use-refocus-on-activator)
 - [useResizeObserver](../?path=/docs/packages-hooks--page)
+- [useWindowDimensions](../?path=/docs/hooks-usewindowdimensions--page)
 
 ## Installing
 

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -13,3 +13,4 @@ export * from "./useRefocusOnActivator";
 export * from "./useResizeObserver";
 export * from "./useSafeLayoutEffect";
 export * from "./useShowClear";
+export * from "./useWindowDimensions";

--- a/packages/hooks/src/useWindowDimensions/index.ts
+++ b/packages/hooks/src/useWindowDimensions/index.ts
@@ -1,0 +1,1 @@
+export { useWindowDimensions } from "./useWindowDimensions";

--- a/packages/hooks/src/useWindowDimensions/useWIndowDimensions.test.tsx
+++ b/packages/hooks/src/useWindowDimensions/useWIndowDimensions.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { fireEvent } from "@testing-library/react";
+import { useWindowDimensions } from "./useWindowDimensions";
+
+describe("useWindowDimensions", () => {
+  it("should return window dimensions", () => {
+    window.innerHeight = 100;
+    window.innerWidth = 1000;
+
+    const { result } = renderHook(() => useWindowDimensions());
+
+    expect(result.current).toEqual({ width: 1000, height: 100 });
+  });
+
+  describe("resize event", () => {
+    it("should return window dimensions after resize", () => {
+      window.innerHeight = 100;
+      window.innerWidth = 1000;
+
+      const { result } = renderHook(() => useWindowDimensions());
+
+      window.innerWidth = 500;
+
+      fireEvent(window, new Event("resize"));
+
+      expect(result.current).toEqual({ width: 500, height: 100 });
+    });
+  });
+});

--- a/packages/hooks/src/useWindowDimensions/useWindowDimensions.stories.mdx
+++ b/packages/hooks/src/useWindowDimensions/useWindowDimensions.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import * as hooks from "./useWindowDimensions";
+
+<Meta title="Hooks/useWindowDimensions" />
+
+# useWindowDimensions
+
+`useWindowDimensions` is a hook that allows you to get the dimensions of the
+window. Very much like the React Native hook by the same name.
+
+```tsx
+import { useWindowDimensions } from "@jobber/hooks/useWindowDimensions";
+```
+
+<Canvas withToolbar>
+  <Story name="useWindowDimensions">
+    {() => {
+      const { width } = hooks.useWindowDimensions();
+      return <h1>Width is {`${width}`}</h1>;
+    }}
+  </Story>
+</Canvas>

--- a/packages/hooks/src/useWindowDimensions/useWindowDimensions.ts
+++ b/packages/hooks/src/useWindowDimensions/useWindowDimensions.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+function getWindowDimensions() {
+  if (!globalThis?.document) {
+    return {
+      width: 0,
+      height: 0,
+    };
+  }
+
+  const { innerWidth: width, innerHeight: height } = window;
+
+  return {
+    width,
+    height,
+  };
+}
+
+export function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions(),
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window?.addEventListener("resize", handleResize);
+
+    return () => window?.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowDimensions;
+}


### PR DESCRIPTION

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This reverts commit ad35140afe6ac6756cf5167e29d9f94ef4b68286.

I want to bring back those changes, but with a couple extra little fixes

## Changes

- using `fixed` placement strategy to avoid absolute sometimes pushing content when incorrectly transformed/translated
- only apply extra y offset for small screen

for the y offset thing, the small UI achieved thru CSS used to also look at 640px as the breakpoint but it was updated in the CSS at some point however the JS part was not and that's how we got here. I think this might have been related to the issue I was seeing with the transform being incorrect after opening in the small screen state

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

pushing content

menu displacement way too much on medium screens. that code should only apply for the little bottom sheet like UX that we do thru CSS on small screens (sub 490px)

### Security

- <!-- in case of vulnerabilities -->

## Testing

refer to the previous PR please and thank you. all those steps are still valid

the only additional thing to look out for is on screens > 490 and < 640 the menu animation should be the same as screens > 640

it shouldn't move an additional amount in that range like it was previously. only the small screen (< 490) should get that but it'll look very different since we display a totally distinct UI in that case


<!-- How to test your changes. -->

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
