### PR TITLE
fix(components): fixes a bug where we call setState inside of the react render cycle

### DIFF
--- a/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
@@ -57,16 +57,12 @@ function confirmationModalReducer(
       };
 
     case "confirm":
-      state.onConfirm && state.onConfirm();
-
       return {
         ...state,
         open: false,
       };
 
     case "cancel":
-      state.onCancel && state.onCancel();
-
       return {
         ...state,
         open: false,
@@ -261,6 +257,12 @@ export const ConfirmationModal = forwardRef(function ConfirmationModalInternal(
 
   function handleAction(type: "confirm" | "cancel") {
     return () => {
+      if (type === "confirm") {
+        state.onConfirm && state.onConfirm();
+      } else if (type === "cancel") {
+        state.onCancel && state.onCancel();
+      }
+
       dispatch({ type });
       onRequestClose && onRequestClose();
     };

--- a/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/components/src/ConfirmationModal/ConfirmationModal.tsx
@@ -258,9 +258,9 @@ export const ConfirmationModal = forwardRef(function ConfirmationModalInternal(
   function handleAction(type: "confirm" | "cancel") {
     return () => {
       if (type === "confirm") {
-        state.onConfirm && state.onConfirm();
+        state.onConfirm?.();
       } else if (type === "cancel") {
-        state.onCancel && state.onCancel();
+        state.onCancel?.();
       }
 
       dispatch({ type });

--- a/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx
+++ b/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx
@@ -54,7 +54,7 @@ test("simple ConfirmationModal should cancel", () => {
   expect(requestCloseHandler).toHaveBeenCalled();
 });
 
-test("confirm action should not happen during a render cycle", () => {
+test("confirm action should not happen during a render cycle and cause a React warning", () => {
   jest.spyOn(console, "error");
 
   function StatefulWrapper() {

--- a/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx
+++ b/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx
@@ -54,6 +54,35 @@ test("simple ConfirmationModal should cancel", () => {
   expect(requestCloseHandler).toHaveBeenCalled();
 });
 
+test("confirm action should not happen during a render cycle", () => {
+  jest.spyOn(console, "error");
+
+  function StatefulWrapper() {
+    const [foo, setFoo] = React.useState(true);
+
+    return (
+      <>
+        {foo ? "FOO TRUE" : "FOO FALSE"}
+        <ConfirmationModal
+          title="Should we?"
+          message="Do something…"
+          open={true}
+          confirmLabel="We Shall"
+          onConfirm={() => setFoo(false)}
+          onCancel={() => null}
+          onRequestClose={() => null}
+        />
+      </>
+    );
+  }
+
+  const { getByText } = render(<StatefulWrapper />);
+
+  fireEvent.click(getByText("We Shall"));
+  expect(getByText("FOO FALSE")).toBeInTheDocument();
+  expect(console.error).not.toHaveBeenCalled();
+});
+
 describe("using keyboard shortcuts", () => {
   describe("while focused on actions", () => {
     it("should perform the shortcut if ctrl or meta key is also pressed", () => {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->
## Motivations

- discovered a bug where we were calling `setState` _inside_ the react render cycle (in this case inside the reducer function)
- this bug manifested with an ugly console error in both the browser and in tests
```
console.error
    Warning: Cannot update a component (`QuotesIndex`) while rendering a different component (`ForwardRef(ConfirmationModalInternal)`). To locate the bad setState() call inside `ForwardRef(ConfirmationModalInternal)`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
```

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- moved calling of ConfirmationModal callbacks out of the reducer
- this removed a react error from the console

## Testing

- this was a pure refactor to fix the bug
- added a regression test that would fail without this change
- here is what the error would look like in the test:
```
"Warning: Cannot update a component (`%s`) while rendering a different component (`%s`). To locate the bad setState() call inside `%s`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render%s", "StatefulWrapper", "ForwardRef(ConfirmationModalInternal)", "ForwardRef(ConfirmationModalInternal)", "
        at title (/Users/cameron/workspace/atlantis/packages/components/src/ConfirmationModal/ConfirmationModal.tsx:173:5)
        at useState (/Users/cameron/workspace/atlantis/packages/components/src/ConfirmationModal/tests/interaction-ConfirmationModal.test.tsx:61:33)"
```

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
