### PR TITLE
fix(components-native): Dismiss keyboard on Date and Time Picker being opened

### DIFF
--- a/docs/components/InputPressable/InputPressable.stories.mdx
+++ b/docs/components/InputPressable/InputPressable.stories.mdx
@@ -17,6 +17,9 @@ InputPressable can only be used as a controlled component. Given the nature of
 this input component which requires a wrapper to set the value, it doesn't make
 sense for this component to be uncontrolled.
 
+To prevent a previously focused input from being focused again when the
+`InputPressable` is closed you can `Keyboard.dismiss()` in the `onPress`
+
 ### States
 
 A

--- a/packages/components-native/src/InputDate/InputDate.test.tsx
+++ b/packages/components-native/src/InputDate/InputDate.test.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import { Host } from "react-native-portalize";
 import { FormProvider, useForm } from "react-hook-form";
+import { Keyboard } from "react-native";
 import { InputDate } from "./InputDate";
 import { Button } from "../Button";
 import * as atlantisContext from "../AtlantisContext/AtlantisContext";
+
+const keyboardDismissSpy = jest.spyOn(Keyboard, "dismiss");
 
 describe("InputDate", () => {
   describe("Visuals", () => {
@@ -133,6 +136,11 @@ describe("InputDate", () => {
 
       fireEvent.press(screen.getByLabelText("Confirm"));
       expect(handleChange).toHaveBeenCalledWith(expect.any(Date));
+    });
+
+    it("should dismiss the keyboard when the date picker is opened", () => {
+      renderDatePicker();
+      expect(keyboardDismissSpy).toHaveBeenCalled();
     });
   });
   const mockOnSubmit = jest.fn();

--- a/packages/components-native/src/InputDate/InputDate.tsx
+++ b/packages/components-native/src/InputDate/InputDate.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import DateTimePicker from "react-native-modal-datetime-picker";
-import { Platform } from "react-native";
+import { Keyboard, Platform } from "react-native";
 import { FieldError, UseControllerProps } from "react-hook-form";
 import { XOR } from "ts-xor";
 import { Clearable } from "@jobber/hooks";
@@ -204,6 +204,7 @@ function InternalInputDate({
   );
 
   function showDatePicker() {
+    Keyboard.dismiss();
     setShowPicker(true);
   }
 

--- a/packages/components-native/src/InputTime/InputTime.test.tsx
+++ b/packages/components-native/src/InputTime/InputTime.test.tsx
@@ -2,10 +2,12 @@ import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import { Host } from "react-native-portalize";
 import { FormProvider, useForm } from "react-hook-form";
+import { Keyboard } from "react-native";
 import { InputTime } from "./InputTime";
 import * as atlantisContext from "../AtlantisContext/AtlantisContext";
 import { Button } from "../Button";
 
+const keyboardDismissSpy = jest.spyOn(Keyboard, "dismiss");
 afterEach(() => {
   jest.spyOn(atlantisContext, "useAtlantisContext").mockRestore();
 });
@@ -102,6 +104,7 @@ describe("With emptyValueLabel", () => {
   });
 });
 
+// eslint-disable-next-line max-statements
 describe("Time picker", () => {
   const placeholder = "Tap me";
   const handleChange = jest.fn();
@@ -141,6 +144,11 @@ describe("Time picker", () => {
 
     fireEvent.press(screen.getByLabelText("Confirm"));
     expect(handleChange).toHaveBeenCalledWith(expect.any(Date));
+  });
+
+  it("should dismiss the keyboard when the time picker is opened", () => {
+    renderTimePicker();
+    expect(keyboardDismissSpy).toHaveBeenCalled();
   });
 
   it("should be a time picker", () => {

--- a/packages/components-native/src/InputTime/InputTime.tsx
+++ b/packages/components-native/src/InputTime/InputTime.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from "react";
 import { FieldError, UseControllerProps } from "react-hook-form";
 import { XOR } from "ts-xor";
 import DateTimePicker from "react-native-modal-datetime-picker";
-import { View } from "react-native";
+import { Keyboard, View } from "react-native";
 import { Clearable } from "@jobber/hooks";
 import { styles } from "./InputTime.style";
 import { getTimeZoneOffsetInMinutes, roundUpToNearestMinutes } from "./utils";
@@ -182,6 +182,7 @@ function InternalInputTime({
   );
 
   function showDatePicker() {
+    Keyboard.dismiss();
     setShowPicker(true);
   }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When an `InputDate` or `InputTime` was closed when an `InputText` was previously focused the `Form` would scroll to the `InputText` this created a jarring experience for users. This PR dismisses the keyboard when an `InputDate` or `InputTime` is focused

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fixed: Other inputs remaining focused when an `InputDate` or `InputTime` were opened

### Security

- <!-- in case of vulnerabilities -->

## Testing
QA can be done in https://github.com/GetJobber/jobber-mobile/pull/9307

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
