### PR TITLE
fix(components): Animated switcher

### DIFF
--- a/docs/components/AnimatedSwitcher/Web.stories.tsx
+++ b/docs/components/AnimatedSwitcher/Web.stories.tsx
@@ -22,26 +22,15 @@ const BasicTemplate: ComponentStory<typeof AnimatedSwitcher> = args => {
       {...args}
       switched={switched}
       initialChild={
-        <>
-          <Button label="Mark complete" onClick={() => setSwitched(true)} />
-          <Button label="Mark complete" onClick={() => setSwitched(true)} />
-        </>
+        <Button label="Mark complete" onClick={() => setSwitched(true)} />
       }
       switchTo={
-        <>
-          <Button
-            icon="checkmark"
-            label="Complete"
-            type="secondary"
-            onClick={() => setSwitched(false)}
-          />
-          <Button
-            icon="checkmark"
-            label="Complete"
-            type="secondary"
-            onClick={() => setSwitched(false)}
-          />
-        </>
+        <Button
+          icon="checkmark"
+          label="Complete"
+          type="secondary"
+          onClick={() => setSwitched(false)}
+        />
       }
     />
   );

--- a/docs/components/AnimatedSwitcher/Web.stories.tsx
+++ b/docs/components/AnimatedSwitcher/Web.stories.tsx
@@ -22,15 +22,26 @@ const BasicTemplate: ComponentStory<typeof AnimatedSwitcher> = args => {
       {...args}
       switched={switched}
       initialChild={
-        <Button label="Mark complete" onClick={() => setSwitched(true)} />
+        <>
+          <Button label="Mark complete" onClick={() => setSwitched(true)} />
+          <Button label="Mark complete" onClick={() => setSwitched(true)} />
+        </>
       }
       switchTo={
-        <Button
-          icon="checkmark"
-          label="Complete"
-          type="secondary"
-          onClick={() => setSwitched(false)}
-        />
+        <>
+          <Button
+            icon="checkmark"
+            label="Complete"
+            type="secondary"
+            onClick={() => setSwitched(false)}
+          />
+          <Button
+            icon="checkmark"
+            label="Complete"
+            type="secondary"
+            onClick={() => setSwitched(false)}
+          />
+        </>
       }
     />
   );

--- a/packages/components/src/AnimatedSwitcher/AnimatedSwitcher.tsx
+++ b/packages/components/src/AnimatedSwitcher/AnimatedSwitcher.tsx
@@ -72,10 +72,13 @@ export function AnimatedSwitcher({
   }
 
   function getChildData() {
-    let data = { key: `${initialChild.type}_1`, child: initialChild };
+    let data = {
+      key: `${initialChild.type.toString()}_1`,
+      child: initialChild,
+    };
 
     if (switched) {
-      data = { key: `${switchTo.type}_2`, child: switchTo };
+      data = { key: `${switchTo.type.toString()}_2`, child: switchTo };
     }
 
     return {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When using `AnimatedSwitcher` if `initialChild` or `switchedTo` where wrapped in a fragment it would cause an error. This can be seen in [this](https://codesandbox.io/p/sandbox/laughing-wind-dmdlq3?file=%2FExample.tsx&utm_medium=sandpack) CodeSandbox example when switching the component.

The main way this would pop up was in `DataList` if a layout was wrapped in a fragment (see JO QA PR)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- fixed `AnimatedSwitcher` breaking when components wrapped in a fragment

### Security

- <!-- in case of vulnerabilities -->

## Testing

Run `git revert 5da59ced7c93080717f78ba0e1d7452721d7eb41` and verify the Animated Switcher doesn't break when the `initialChild` or `switchedTo` is wrapped by a fragment.
Verify that AnimatedSwitcher works when `initialChild` or `switchedTo` is not wrapped in a fragment

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
