### PR TITLE
fix(components): Increase zIndex for Menu

### DIFF
--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -7,7 +7,7 @@
 }
 
 .popperContainer {
-  z-index: var(--elevation-menu);
+  z-index: var(--elevation-modal);
 }
 
 .shadowRef {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

If you have a Menu inside a Modal, previously it would inherit that zIndex and show up fine

however now that we're portalling it out to the body, the zindex of the menu is lesser than the Modal and it gets hidden 😱 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

no more of this Menu being hidden by Modal

![image](https://github.com/GetJobber/atlantis/assets/11843215/6ddc2384-d347-4889-8a20-2b37885aa4da)


vs now

![image](https://github.com/GetJobber/atlantis/assets/11843215/ccf1e737-295c-403f-b041-318106dc33c6)


### Security

- <!-- in case of vulnerabilities -->

## Testing

use a `Menu` inside of a `Modal`

see that when the Menu is opened, you can see and interact with those elements. they are not hidden/obstructed by the Modal.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
