### PR TITLE
fix(components): Menu Small Screen zIndex Layering 

### DIFF
--- a/packages/components/src/Menu/Menu.css
+++ b/packages/components/src/Menu/Menu.css
@@ -17,7 +17,7 @@
 .menu {
   --menu-space: var(--space-small);
   --menu-offset: var(--space-smallest);
-  z-index: var(--elevation-menu);
+  z-index: var(--elevation-modal);
   max-height: 72vh;
   box-shadow: var(--shadow-base);
   padding: var(--menu-space);
@@ -94,7 +94,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: var(--elevation-menu);
+  z-index: var(--elevation-modal);
   background-color: var(--color-overlay);
 
   @media (--small-screens-and-up) {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When fixing the zindex for Menus within Modals, I forgot to account for the small screen UI using different classes, and so the `menu` elevation was still being used placing it behind the Modal

![image](https://github.com/GetJobber/atlantis/assets/11843215/787d8066-1e90-4be2-93aa-24ee9f578629)


also, the overlay from the Menu wasn't layered correctly on big screens. that was the Modal overlay being shown. we want the Menu overlay to be present to close just the Menu

![image](https://github.com/GetJobber/atlantis/assets/11843215/63b8b06e-50e0-4248-b699-dbf05911c7c1)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- overlay when Menu used within a Modal
- menu on small screens when Menu used within a Modal

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
