### PR TITLE
docs(components): Added more description about how Form onSubmit works with throwing errors. 

### DIFF
--- a/docs/components/Form/Form.stories.mdx
+++ b/docs/components/Form/Form.stories.mdx
@@ -77,7 +77,7 @@ appropriate fallback.
 
 Note: When a server-side error happens, inside the `onSubmit` function, an error
 must be thrown. Throwing an error inside the `onSubmit` function will ensure
-that your `onSubmitError` function is called instead of your "onSubmitSuccess".
+that your `onSubmitError` function is called instead of your `onSubmitSuccess`.
 
 #### Client-side errors
 

--- a/docs/components/Form/Form.stories.mdx
+++ b/docs/components/Form/Form.stories.mdx
@@ -75,6 +75,10 @@ If the user can address the errors, inform them how to do so in the banner.
 Otherwise, a generic message informing the user that something went wrong is an
 appropriate fallback.
 
+Note: When a server-side error happens, inside the `onSubmit` function, an error
+must be thrown. Throwing an error inside the `onSubmit` function will ensure
+that your `onSubmitError` function is called instead of your "onSubmitSuccess".
+
 #### Client-side errors
 
 Client-side errors are issues that we can catch and inform the user of before

--- a/packages/components-native/src/Form/types.ts
+++ b/packages/components-native/src/Form/types.ts
@@ -73,7 +73,10 @@ export interface FormProps<T extends FieldValues, SubmitResponseType> {
   onBeforeSubmit?: (data: FormValues<T>) => Promise<boolean>;
 
   /**
-   * A callback function that handles the submission of form data
+   * A callback function that handles the submission of form data.
+   * If errors happen during submission, the error must not be caught and handled without throwing it again.
+   * If no error is thrown, the onSubmitSuccess callback will be called.
+   * If an error is thrown, the onSubmitError callback will be called.
    */
   onSubmit: (data: FormValues<T>) => Promise<SubmitResponseType>;
 

--- a/packages/components-native/src/Form/types.ts
+++ b/packages/components-native/src/Form/types.ts
@@ -74,9 +74,9 @@ export interface FormProps<T extends FieldValues, SubmitResponseType> {
 
   /**
    * A callback function that handles the submission of form data.
-   * If errors happen during submission, the error must not be caught and handled without throwing it again.
-   * If no error is thrown, the onSubmitSuccess callback will be called.
-   * If an error is thrown, the onSubmitError callback will be called.
+   * If an error occurs during submission, it should not be caught and handled silently; the error must be thrown again.
+   * If the submission is successful and no error is thrown, the `onSubmitSuccess` callback will be called.
+   * If an error is thrown, the `onSubmitError` callback will be called.
    */
   onSubmit: (data: FormValues<T>) => Promise<SubmitResponseType>;
 


### PR DESCRIPTION
## Motivations

We had a bug during development about 2 months ago. It resulted when an error was handled during the `onSubmit` function of the form, preventing it from bubbling up. This didn't allow the form library to catch the error and trigger the `onSubmitError` function.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

Added some description to the inline comment for form's `onSubmit` function and added some sentences to the form's story document page. 

## Testing

n/a

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
