### PR TITLE
fix(components): Fix DataList Sticky Header Extra Width [JOB-96126]

### DIFF
--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
@@ -17,9 +17,9 @@
   background-color: var(--color-surface);
   opacity: 0;
   transform: translateY(-50%);
-  transition: 
+  transition:
     opacity var(--transition-properties),
-    width var(--transition-properties), 
+    width var(--transition-properties),
     visibility var(--transition-properties);
 
   @media (--medium-screens-and-up) {

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
@@ -17,8 +17,10 @@
   background-color: var(--color-surface);
   opacity: 0;
   transform: translateY(-50%);
-  transition: opacity var(--transition-properties),
-    width var(--transition-properties), visibility var(--transition-properties);
+  transition: 
+    opacity var(--transition-properties),
+    width var(--transition-properties), 
+    visibility var(--transition-properties);
 
   @media (--medium-screens-and-up) {
     display: block;

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
@@ -6,8 +6,8 @@
 .searchInput {
   --transition-properties: var(--timing-base) ease-in-out;
   --button-offset: calc(var(--space-largest) - var(--space-smaller));
-  display: none;
 
+  display: none;
   position: absolute;
   top: 50%;
   right: var(--button-offset);

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.css
@@ -6,6 +6,7 @@
 .searchInput {
   --transition-properties: var(--timing-base) ease-in-out;
   --button-offset: calc(var(--space-largest) - var(--space-smaller));
+  display: none;
 
   position: absolute;
   top: 50%;
@@ -16,16 +17,22 @@
   background-color: var(--color-surface);
   opacity: 0;
   transform: translateY(-50%);
-  transition:
-    opacity var(--transition-properties),
-    width var(--transition-properties),
-    visibility var(--transition-properties);
+  transition: opacity var(--transition-properties),
+    width var(--transition-properties), visibility var(--transition-properties);
+
+  @media (--medium-screens-and-up) {
+    display: block;
+  }
 }
 
 .searchInputVisible {
   visibility: visible;
   width: calc(100% - var(--button-offset));
   opacity: 1;
+}
+
+.searchInputVisible.searchInput {
+  display: block;
 }
 
 .searchInput,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Right now there's an issue on medium and below screens where you can scroll horizontally because of some extra unintended width

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

Even though we're setting a `width: 0` on this parent element

<img width="1594" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/2502c19c-65db-40a5-bad3-d22594362cda">
the nested FormField elements still have a width
<img width="1593" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/33fef17e-09f0-48b7-b390-00a551cf9ba8">
<img width="1598" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/af1a5f36-a445-4a46-976d-6e596338d1d0">

these are causing the layout to have horizontal scrolling
![Kapture 2024-06-05 at 14 11 41](https://github.com/GetJobber/atlantis/assets/11843215/2f047fc8-0757-4e8e-960e-47b8e5241d40)

with that `width: 0` we're clearly trying to make them take up no space, and have them be functionally invisible. so, instead of doing it with a `width` I'm doing it with `display: none`

I tried doing some conditionals in the JSX via `visible && (....` however `visible` is `false` on big screens which isn't right. in that case it is definitely visible, we're just not accounting for that fact
### Security

- <!-- in case of vulnerabilities -->

## Testing
this can all be done in Storybook

head on over to the DataList basic example. swap to a mobile view, see that you can pull it back and forth horizontally on master

see that you can no longer do that on this PR

additionally
- on large screens, the search should always be there - no button needed to toggle visibility
- on medium and below screen, the search button should be there and when you press it the search input shows AND it is auto focused then when you press the X to hide the search input, it goes away again
- small/mobile screens same thing as medium and below
<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
