### PR TITLE
fix(components): use semantic value for Datepicker background

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.css
+++ b/packages/components/src/DatePicker/DatePicker.css
@@ -15,6 +15,7 @@
   border-color: var(--color-border);
   border-radius: var(--radius-base);
   font-family: var(--typography--fontFamily-normal);
+  background-color: var(--color-surface);
 }
 
 .datePicker.inline {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The wrapper for the `react-datepicker` used in Datepicker is hard-coded to #fff, meaning when you define a new `surface` color, the component doesn't respond and you get "show-through" between the cells

![image](https://github.com/GetJobber/atlantis/assets/39704901/8d07befb-f068-461e-bae7-6175a2185bd3)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Datepicker respondes to semantic updates

## Testing

Override `--color-surface` token in inspector stylesheet

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
