### PR TITLE
feat(components): modify the Page component's title prop to accept a ReactNode 

### DIFF
--- a/docs/components/Page/Web.stories.tsx
+++ b/docs/components/Page/Web.stories.tsx
@@ -3,6 +3,9 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Page } from "@jobber/components/Page";
 import { Content } from "@jobber/components/Content";
 import { Text } from "@jobber/components/Text";
+import { StatusLabel } from "@jobber/components/StatusLabel";
+import { Heading } from "@jobber/components/Heading";
+import { Flex } from "@jobber/components/Flex";
 
 export default {
   title: "Components/Layouts and Structure/Page/Web",
@@ -19,6 +22,17 @@ const BasicTemplate: ComponentStory<typeof Page> = args => (
       <Text>Page content here</Text>
     </Content>
   </Page>
+);
+
+const htmlElement = (
+  <Flex template={["shrink", "shrink"]}>
+    <Heading level={1}>Notifications</Heading>
+    <StatusLabel
+      label={"Success"}
+      alignment={"start"}
+      status={"success"}
+    ></StatusLabel>
+  </Flex>
 );
 
 export const Basic = BasicTemplate.bind({});
@@ -72,6 +86,13 @@ export const WithSubtitle = BasicTemplate.bind({});
 WithSubtitle.args = {
   title: "Notifications",
   subtitle: "Notify me of all the work",
+  intro:
+    "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
+};
+
+export const WithCustomTitle = BasicTemplate.bind({});
+WithCustomTitle.args = {
+  title: htmlElement,
   intro:
     "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
 };

--- a/docs/components/Page/Web.stories.tsx
+++ b/docs/components/Page/Web.stories.tsx
@@ -3,9 +3,6 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Page } from "@jobber/components/Page";
 import { Content } from "@jobber/components/Content";
 import { Text } from "@jobber/components/Text";
-import { StatusLabel } from "@jobber/components/StatusLabel";
-import { Heading } from "@jobber/components/Heading";
-import { Flex } from "@jobber/components/Flex";
 
 export default {
   title: "Components/Layouts and Structure/Page/Web",
@@ -22,17 +19,6 @@ const BasicTemplate: ComponentStory<typeof Page> = args => (
       <Text>Page content here</Text>
     </Content>
   </Page>
-);
-
-const htmlElement = (
-  <Flex template={["shrink", "shrink"]}>
-    <Heading level={1}>Notifications</Heading>
-    <StatusLabel
-      label={"Success"}
-      alignment={"start"}
-      status={"success"}
-    ></StatusLabel>
-  </Flex>
 );
 
 export const Basic = BasicTemplate.bind({});
@@ -86,13 +72,6 @@ export const WithSubtitle = BasicTemplate.bind({});
 WithSubtitle.args = {
   title: "Notifications",
   subtitle: "Notify me of all the work",
-  intro:
-    "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
-};
-
-export const WithCustomTitle = BasicTemplate.bind({});
-WithCustomTitle.args = {
-  title: htmlElement,
   intro:
     "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
 };

--- a/docs/components/Page/Web.stories.tsx
+++ b/docs/components/Page/Web.stories.tsx
@@ -3,6 +3,9 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Page } from "@jobber/components/Page";
 import { Content } from "@jobber/components/Content";
 import { Text } from "@jobber/components/Text";
+import { StatusLabel } from "@jobber/components/StatusLabel";
+import { Heading } from "@jobber/components/Heading";
+import { Flex } from "@jobber/components/Flex";
 
 export default {
   title: "Components/Layouts and Structure/Page/Web",
@@ -19,6 +22,17 @@ const BasicTemplate: ComponentStory<typeof Page> = args => (
       <Text>Page content here</Text>
     </Content>
   </Page>
+);
+
+const metaDataElement = (
+  <Flex template={["shrink", "shrink"]}>
+    <Heading level={1}>Notifications</Heading>
+    <StatusLabel
+      label={"Success"}
+      alignment={"start"}
+      status={"success"}
+    ></StatusLabel>
+  </Flex>
 );
 
 export const Basic = BasicTemplate.bind({});
@@ -72,6 +86,14 @@ export const WithSubtitle = BasicTemplate.bind({});
 WithSubtitle.args = {
   title: "Notifications",
   subtitle: "Notify me of all the work",
+  intro:
+    "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
+};
+
+export const WithTitleMetaData = BasicTemplate.bind({});
+WithTitleMetaData.args = {
+  title: "Notifications",
+  titleMetaData: metaDataElement,
   intro:
     "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
 };

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -34,24 +34,6 @@ it("renders a Page", () => {
   expect(container).toMatchSnapshot();
 });
 
-describe("when title is a component", () => {
-  it("renders a Page with a component title", () => {
-    const { container } = render(
-      <Page
-        title={
-          <h3>
-            <strong>Notifications as a custom component</strong>
-          </h3>
-        }
-      >
-        Sup
-      </Page>,
-    );
-
-    expect(container).toMatchSnapshot();
-  });
-});
-
 describe("When actions are provided", () => {
   it("renders a Page with action buttons and a menu", () => {
     const sampleActionMenu: SectionProps[] = [

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -186,4 +186,20 @@ describe("When intro is provided with links", () => {
     expect(renderedLink.textContent).toBe("click me, I dare you");
     expect(renderedLink.getAttribute("target")).toBe("_blank");
   });
+
+  describe("When titleMetaData is provided", () => {
+    it("renders the title with metadata", () => {
+      const { container } = render(
+        <Page
+          title="The Eye"
+          titleMetaData={<>Extra component by the title</>}
+          intro="Huh, guess so."
+        >
+          Sup
+        </Page>,
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -34,6 +34,24 @@ it("renders a Page", () => {
   expect(container).toMatchSnapshot();
 });
 
+describe("when title is a component", () => {
+  it("renders a Page with a component title", () => {
+    const { container } = render(
+      <Page
+        title={
+          <h3>
+            <strong>Notifications as a custom component</strong>
+          </h3>
+        }
+      >
+        Sup
+      </Page>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});
+
 describe("When actions are provided", () => {
   it("renders a Page with action buttons and a menu", () => {
     const sampleActionMenu: SectionProps[] = [

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -18,9 +18,9 @@ interface PageFoundationProps {
   readonly children: ReactNode | ReactNode[];
 
   /**
-   * Title of the page.
+   * Title of the page. This will be formatted as a heading if it is a string.
    */
-  readonly title: string;
+  readonly title: ReactNode;
 
   /**
    * Subtitle of the page.
@@ -126,7 +126,11 @@ export function Page({
         <Content>
           <div className={titleBarClasses} ref={titleBarRef}>
             <div>
-              <Heading level={1}>{title}</Heading>
+              {typeof title === "string" ? (
+                <Heading level={1}>{title}</Heading>
+              ) : (
+                title
+              )}
               {subtitle && (
                 <div className={styles.subtitle}>
                   <Text size="large" variation="subdued">

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -23,6 +23,11 @@ interface PageFoundationProps {
   readonly title: string;
 
   /**
+   * Title metadata component to be displayed next to the title.
+   */
+  readonly titleMetaData?: ReactNode;
+
+  /**
    * Subtitle of the page.
    */
   readonly subtitle?: string;
@@ -80,6 +85,7 @@ export type PageProps = XOR<PageFoundationProps, PageWithIntroProps>;
 // eslint-disable-next-line max-statements
 export function Page({
   title,
+  titleMetaData,
   intro,
   externalIntroLinks,
   subtitle,
@@ -127,6 +133,7 @@ export function Page({
           <div className={titleBarClasses} ref={titleBarRef}>
             <div>
               <Heading level={1}>{title}</Heading>
+              {titleMetaData}
               {subtitle && (
                 <div className={styles.subtitle}>
                   <Text size="large" variation="subdued">

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -18,9 +18,9 @@ interface PageFoundationProps {
   readonly children: ReactNode | ReactNode[];
 
   /**
-   * Title of the page. This will be formatted as a heading if it is a string.
+   * Title of the page.
    */
-  readonly title: ReactNode;
+  readonly title: string;
 
   /**
    * Subtitle of the page.
@@ -126,11 +126,7 @@ export function Page({
         <Content>
           <div className={titleBarClasses} ref={titleBarRef}>
             <div>
-              {typeof title === "string" ? (
-                <Heading level={1}>{title}</Heading>
-              ) : (
-                title
-              )}
+              <Heading level={1}>{title}</Heading>
               {subtitle && (
                 <div className={styles.subtitle}>
                   <Text size="large" variation="subdued">

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -150,3 +150,36 @@ exports[`renders a Page 1`] = `
   </div>
 </div>
 `;
+
+exports[`when title is a component renders a Page with a component title 1`] = `
+<div>
+  <div
+    class="page standard"
+  >
+    <div
+      class="padded base"
+    >
+      <div
+        class="padded base"
+      >
+        <div
+          class="titleBar small medium large"
+        >
+          <div>
+            <h3>
+              <strong>
+                Notifications as a custom component
+              </strong>
+            </h3>
+          </div>
+        </div>
+      </div>
+      <div
+        class="padded base"
+      >
+        Sup
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -106,6 +106,45 @@ exports[`When actions are provided renders a Page with action buttons and a menu
 </div>
 `;
 
+exports[`When intro is provided with links When titleMetaData is provided renders the title with metadata 1`] = `
+<div>
+  <div
+    class="page standard"
+  >
+    <div
+      class="padded base"
+    >
+      <div
+        class="padded base"
+      >
+        <div
+          class="titleBar small medium large"
+        >
+          <div>
+            <h1
+              class="base black jumbo heading"
+            >
+              The Eye
+            </h1>
+            Extra component by the title
+          </div>
+        </div>
+        <p
+          class="base regular large text"
+        >
+          Huh, guess so.
+        </p>
+      </div>
+      <div
+        class="padded base"
+      >
+        Sup
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders a Page 1`] = `
 <div>
   <div

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -150,36 +150,3 @@ exports[`renders a Page 1`] = `
   </div>
 </div>
 `;
-
-exports[`when title is a component renders a Page with a component title 1`] = `
-<div>
-  <div
-    class="page standard"
-  >
-    <div
-      class="padded base"
-    >
-      <div
-        class="padded base"
-      >
-        <div
-          class="titleBar small medium large"
-        >
-          <div>
-            <h3>
-              <strong>
-                Notifications as a custom component
-              </strong>
-            </h3>
-          </div>
-        </div>
-      </div>
-      <div
-        class="padded base"
-      >
-        Sup
-      </div>
-    </div>
-  </div>
-</div>
-`;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

For Campaigns designs we want to include a status label after the title text.  
<img width="515" alt="image" src="https://github.com/GetJobber/atlantis/assets/6363412/079dc23f-395b-4fa8-b1aa-3b9c9872b117">

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
The page component title is now a ReactNode rather than a mere string. A string value will still format in the same way

### Changed

- The page component title prop is now a ReactNode


## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
