### PR TITLE
fix(design): use correct payments onSurface value

### DIFF
--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -98,7 +98,7 @@
 
   --color-payments: var(--color-invoice);
   --color-payments--surface: var(--color-invoice--surface);
-  --color-payments--onSurface: var(--color-invoice--surface);
+  --color-payments--onSurface: var(--color-invoice--onSurface);
 
   --color-client: var(--color-base-taupe--700);
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

`payments--onSurface` was referencing `invoice--surface` instead of `onSurface`, so if you used them together as intended, it would be quite illegible
![image](https://github.com/GetJobber/atlantis/assets/39704901/0e31f936-341f-4fff-908b-03ae3debd3db)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- `payments--onSurface` used on `payments--surface` will now be legible

![image](https://github.com/GetJobber/atlantis/assets/39704901/f265c8d9-769d-4f72-b01d-869c1d80955e)

## Testing

Run `npm run bootstrap` and check the colors docs. (or check [here](https://fix-typo-in-payments-color.atlantis.pages.dev/?path=/docs/design-colors--page))

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
