### PR TITLE
feat(components): update interactive borders and avatar [JOB-97530]

### DIFF
--- a/packages/components/src/Avatar/Avatar.css
+++ b/packages/components/src/Avatar/Avatar.css
@@ -15,7 +15,7 @@
   color: var(--color-heading);
   font-size: var(--avatar-size);
   -webkit-font-smoothing: antialiased;
-  background: no-repeat center center var(--color-greyBlue);
+  background: no-repeat center center var(--color-base-blue--600);
   background-size: cover;
 }
 
@@ -34,7 +34,7 @@
 }
 
 .isDark {
-  color: var(--color-text--reverse);
+  color: var(--color-base-white);
 }
 
 .initials {
@@ -49,7 +49,7 @@
 .hasBorder {
   width: calc(var(--avatar-size) - (var(--avatar-border-size) * 2));
   height: calc(var(--avatar-size) - (var(--avatar-border-size) * 2));
-  box-shadow: 0 0 0 var(--border-thick) var(--color-white) inset;
+  box-shadow: 0 0 0 var(--border-thick) var(--color-surface) inset;
   border-style: solid;
   border-width: var(--avatar-border-size);
 }

--- a/packages/components/src/Button/Button.css
+++ b/packages/components/src/Button/Button.css
@@ -99,7 +99,7 @@ a.button:active {
 
 .secondary,
 .subtle.primary {
-  border-color: var(--color-border);
+  border-color: var(--color-border--interactive);
 }
 
 .subtle.primary:hover,

--- a/packages/components/src/Checkbox/Checkbox.css
+++ b/packages/components/src/Checkbox/Checkbox.css
@@ -1,7 +1,7 @@
 .checkBoxParent {
   --checkbox--size: 20px;
   --checkbox--border--checked: var(--color-interactive);
-  --checkbox--border--unchecked: var(var(--color-border--interactive));
+  --checkbox--border--unchecked: var(--color-border--interactive);
   --checkbox--border--hover: var(--color-interactive);
   display: inline-block;
 }

--- a/packages/components/src/Checkbox/Checkbox.css
+++ b/packages/components/src/Checkbox/Checkbox.css
@@ -1,7 +1,7 @@
 .checkBoxParent {
   --checkbox--size: 20px;
   --checkbox--border--checked: var(--color-interactive);
-  --checkbox--border--unchecked: var(--color-border);
+  --checkbox--border--unchecked: var(var(--color-border--interactive));
   --checkbox--border--hover: var(--color-interactive);
   display: inline-block;
 }

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -107,7 +107,7 @@
 }
 
 .subtle {
-  border: var(--border-base) solid var(--color-border);
+  border: var(--border-base) solid var(--color-border--interactive);
   background-color: var(--color-surface);
   --chip--gradient-color-variation: var(--color-surface);
 }

--- a/packages/components/src/Chips/InternalChip.css
+++ b/packages/components/src/Chips/InternalChip.css
@@ -17,7 +17,7 @@
   max-width: 100%;
   box-sizing: border-box;
   padding: var(--space-small);
-  border: var(--border-base) solid var(--color-border);
+  border: var(--border-base) solid var(--color-border--interactive);
   border-radius: var(--radius-larger);
   color: var(--color-text--secondary);
   text-align: left;

--- a/packages/components/src/FormField/FormField.css
+++ b/packages/components/src/FormField/FormField.css
@@ -10,7 +10,7 @@
 
   --field--placeholder-color: var(--color-base-blue--600);
   --field--value-color: var(--color-heading);
-  --field--border-color: var(--color-border);
+  --field--border-color: var(--color-border--interactive);
 
   --postfix-right: var(--space-base);
 }

--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -13,8 +13,8 @@
 
 .dropZone {
   padding: var(--space-base);
-  border: var(--color-border) dashed var(--border-thick);
-  border-radius: var(--radius-larger);
+  border: var(--border-thick) dashed var(--color-border--interactive);
+  border-radius: var(--radius-large);
   text-align: center;
 }
 

--- a/packages/components/src/RadioGroup/RadioGroup.css
+++ b/packages/components/src/RadioGroup/RadioGroup.css
@@ -26,7 +26,7 @@
   height: var(--radio-diameter);
   box-sizing: border-box;
   margin-right: var(--space-small);
-  border: var(--border-thick) solid var(--color-border);
+  border: var(--border-thick) solid var(--color-border--interactive);
   border-radius: 100%;
   background-color: var(--color-surface);
   transition: all var(--timing-quick) ease-out;

--- a/packages/components/src/Select/Select.css
+++ b/packages/components/src/Select/Select.css
@@ -15,9 +15,9 @@
   height: inherit;
   padding-left: var(--inset);
   padding-right: var(--inset);
-  border: var(--border-base) solid var(--color-border);
+  border: var(--border-base) solid var(--color-border--interactive);
   border-radius: var(--radius-base);
-  color: var(--color-blue);
+  color: var(--color-heading);
   font-size: 14px;
   background-color: transparent;
   appearance: none;

--- a/packages/components/src/Switch/Switch.css
+++ b/packages/components/src/Switch/Switch.css
@@ -16,7 +16,7 @@
   width: var(--switch--width);
   height: calc(var(--switch--width) / 2);
   padding: 0;
-  border: var(--border-thick) solid var(--color-border);
+  border: var(--border-thick) solid var(--color-border--interactive);
   border-radius: var(--switch--pipSize);
   overflow: hidden;
   line-height: normal;

--- a/packages/design/src/colors.css
+++ b/packages/design/src/colors.css
@@ -57,7 +57,7 @@
   --color-surface--active: var(--color-base-taupe--300);
 
   --color-border: var(--color-base-blue--300);
-  --color-border--interactive: var(--color-base-blue--500);
+  --color-border--interactive: var(--color-base-blue--300);
   --color-border--section: var(--color-base-blue--900);
 
   --color-overlay: rgba(var(--color-black--rgb), 0.32);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We need to be able to target the borders of interactive elements for theming, and for future improvements to accessibility of interactive elements.

Also want to be able to do this iteratively, so we can implement the "hook" before we use the "hook".

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Underlying semantic value for borders of interactive elements
- Also made the text color in Avatar _non-semantic_ as there are computations being done in that component to determine whether the text should be light or dark based on background color.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
