### PR TITLE
fix(components): Adjust style of section headings in autocomplete

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.css
+++ b/packages/components/src/Autocomplete/Autocomplete.css
@@ -24,7 +24,7 @@
 
 .options h5 {
   padding: var(--space-small) 0 var(--space-smaller) var(--space-small);
-  border-bottom: var(--border-base) solid var(--color-border--section);
+  border-bottom: var(--border-base) solid var(--color-border);
 }
 
 .options.visible {
@@ -68,7 +68,7 @@
   outline-color: transparent;
 }
 
-.autocomplete .heading:not(:first-child) {
+.options .heading:not(:first-child) {
   padding-top: var(--space-small);
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To make a sectioned `Autocomplete` component look more similar to other Atlantis items such as `Menu` and `Combobox`

## Changes

### Changed

- Changed styling of section headings in `Autocomplete` component to use default border color for their seperator. 
- Fixed selector bug that was preventing section headings from getting appropriate spacing

Before:
![Screenshot 2024-06-12 at 4 33 20 PM](https://github.com/GetJobber/atlantis/assets/59584307/14ce99f0-2450-43e2-81d9-1fdb8e981809)

After:
![Screenshot 2024-06-12 at 4 33 08 PM](https://github.com/GetJobber/atlantis/assets/59584307/4ffa7f76-f35e-4a87-8209-69ea56ed3de9)


## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
