### PR TITLE
feat: allow thumbnails on gallery

### DIFF
--- a/docs/components/Gallery/Web.stories.tsx
+++ b/docs/components/Gallery/Web.stories.tsx
@@ -22,7 +22,8 @@ const files = [
     type: "image/png",
     size: 213402324,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
   {
     key: "def",
@@ -30,7 +31,8 @@ const files = [
     type: "image/png",
     size: 124525234,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
   {
     key: "efg",
@@ -38,7 +40,8 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
   {
     key: "jkl",
@@ -46,7 +49,8 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
   {
     key: "mno",
@@ -54,7 +58,8 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
   {
     key: "pqr",
@@ -62,7 +67,8 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
   {
     key: "pQ=",
@@ -70,7 +76,8 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
   {
     key: "fGr",
@@ -78,7 +85,8 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
   {
     key: "AM=",
@@ -86,7 +94,8 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
-    src: "https://picsum.photos/250",
+    thumbnailSrc: "https://picsum.photos/250",
+    src: "https://picsum.photos/550",
   },
 ];
 

--- a/packages/components/src/Gallery/Gallery.test.tsx
+++ b/packages/components/src/Gallery/Gallery.test.tsx
@@ -175,7 +175,7 @@ describe("when a non-image is clicked", () => {
 
 describe("Thumbnails", () => {
   it.each(files.map(file => [file.name, file.thumbnailSrc]))(
-    "should display the thumbnailSrc as thumbnails for %s",
+    "should use the thumbnailSrc as the image source for %s",
     async (fileName, src) => {
       const { getByAltText } = render(<Gallery files={files} />);
       const thumbnailImage = getByAltText(fileName);
@@ -187,7 +187,7 @@ describe("Thumbnails", () => {
   );
 
   it.each(files.map(file => [file.name, file.src]))(
-    "should display the src as thumbnails for %s when thumbnailSrc is not provided",
+    "should use the src as image source for %s when thumbnailSrc is not provided",
     async (fileName, src) => {
       const { getByAltText } = render(
         <Gallery

--- a/packages/components/src/Gallery/Gallery.test.tsx
+++ b/packages/components/src/Gallery/Gallery.test.tsx
@@ -9,6 +9,7 @@ const files = [
     type: "image/png",
     size: 213402324,
     progress: 1,
+    thumbnailSrc: "https://source.unsplash.com/50x50",
     src: "https://source.unsplash.com/250x250",
   },
   {
@@ -17,6 +18,7 @@ const files = [
     type: "image/png",
     size: 124525234,
     progress: 1,
+    thumbnailSrc: "https://source.unsplash.com/50x50",
     src: "https://source.unsplash.com/250x250",
   },
   {
@@ -25,6 +27,7 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
+    thumbnailSrc: "https://source.unsplash.com/50x50",
     src: "https://source.unsplash.com/250x250",
   },
   {
@@ -33,6 +36,7 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
+    thumbnailSrc: "https://source.unsplash.com/50x50",
     src: "https://source.unsplash.com/250x250",
   },
   {
@@ -41,6 +45,7 @@ const files = [
     type: "image/png",
     size: 233411234,
     progress: 1,
+    thumbnailSrc: "https://source.unsplash.com/50x50",
     src: "https://source.unsplash.com/250x250",
   },
 ];
@@ -166,4 +171,34 @@ describe("when a non-image is clicked", () => {
       expect(window.open).toHaveBeenCalledWith(pdfSrc, "_blank");
     });
   });
+});
+
+describe("Thumbnails", () => {
+  it.each(files.map(file => [file.name, file.thumbnailSrc]))(
+    "should display the thumbnailSrc as thumbnails for %s",
+    async (fileName, src) => {
+      const { getByAltText } = render(<Gallery files={files} />);
+      const thumbnailImage = getByAltText(fileName);
+
+      await waitFor(() => {
+        expect(thumbnailImage).toHaveAttribute("src", src);
+      });
+    },
+  );
+
+  it.each(files.map(file => [file.name, file.src]))(
+    "should display the src as thumbnails for %s when thumbnailSrc is not provided",
+    async (fileName, src) => {
+      const { getByAltText } = render(
+        <Gallery
+          files={files.map(file => ({ ...file, thumbnailSrc: undefined }))}
+        />,
+      );
+      const thumbnailImage = getByAltText(fileName);
+
+      await waitFor(() => {
+        expect(thumbnailImage).toHaveAttribute("src", src);
+      });
+    },
+  );
 });

--- a/packages/components/src/Gallery/Gallery.tsx
+++ b/packages/components/src/Gallery/Gallery.tsx
@@ -22,7 +22,10 @@ export function Gallery({ files, size = "base", max, onDelete }: GalleryProps) {
           return (
             <FormatFile
               key={file.key}
-              file={{ ...file, src: () => Promise.resolve(file.src) }}
+              file={{
+                ...file,
+                src: () => Promise.resolve(file.thumbnailSrc || file.src),
+              }}
               display="compact"
               displaySize={size}
               onClick={() => {
@@ -32,6 +35,7 @@ export function Gallery({ files, size = "base", max, onDelete }: GalleryProps) {
             />
           );
         })}
+
         {max && files.length > max && !displayPastMax && (
           <div
             className={classNames(

--- a/packages/components/src/Gallery/GalleryTypes.ts
+++ b/packages/components/src/Gallery/GalleryTypes.ts
@@ -36,6 +36,11 @@ export interface GalleryProps {
 export interface File
   extends Pick<FileUpload, "key" | "name" | "type" | "size" | "progress"> {
   /**
+   * The thumbnail url of the file.
+   */
+  readonly thumbnailSrc?: string;
+
+  /**
    * The data url of the file.
    */
   readonly src: string;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When using the gallery component, the thumbnail is the source image. It's all well and good until you pass in a large image that the browser needs to download. Furthermore, the user could be downloading a large image that they don't intend to view as they could've viewed it before and don't care about it.

This PR adds the ability to load a smaller thumbnail image on the gallery view so we keep the initial load small and thus speed up the wait that user would have to do

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- allow files in gallery to pass in thumbnail urls

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
