### PR TITLE
fix(components): make `Select` options readable in dark mode

### DIFF
--- a/packages/components/src/Select/Select.css
+++ b/packages/components/src/Select/Select.css
@@ -23,6 +23,10 @@
   appearance: none;
 }
 
+.select option {
+  background-color: var(--field--background-color);
+}
+
 /**
  * Hides arrow in IE10 and up, the arrow is replaced by a custom font later on
  */

--- a/packages/components/src/Select/Select.css
+++ b/packages/components/src/Select/Select.css
@@ -24,6 +24,7 @@
 }
 
 .select option {
+  text-decoration-skip: box-decoration;
   background-color: var(--field--background-color);
 }
 

--- a/packages/components/src/Select/Select.css
+++ b/packages/components/src/Select/Select.css
@@ -24,7 +24,6 @@
 }
 
 .select option {
-  text-decoration-skip: box-decoration;
   background-color: var(--field--background-color);
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In Windows, when the color theme changes, the select `option` elements were not picking up changes in theme. This has the potential to render the options unreadable:
![image](https://github.com/GetJobber/atlantis/assets/39704901/d620497d-d65b-4ba1-aacb-3b431bbd44fe)


## Changes

### Changed

- Added a more explicit selector to ensure the `option` elements pick up a semantically-themed background-color.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Select is readable in other color modes (ie dark mode)
![image](https://github.com/GetJobber/atlantis/assets/39704901/bb3a50b6-fc89-4aef-b6c1-b6d1715269b6)

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
