### PR TITLE
feat(components): Update Page component to accept a titleMetaData component [JOB-97759]

### DIFF
--- a/docs/components/Page/Web.stories.tsx
+++ b/docs/components/Page/Web.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { StatusLabel } from "@jobber/components";
 import { Page } from "@jobber/components/Page";
 import { Content } from "@jobber/components/Content";
 import { Text } from "@jobber/components/Text";
@@ -19,6 +20,14 @@ const BasicTemplate: ComponentStory<typeof Page> = args => (
       <Text>Page content here</Text>
     </Content>
   </Page>
+);
+
+const titleMetaData = (
+  <StatusLabel
+    label={"Success"}
+    alignment={"start"}
+    status={"success"}
+  ></StatusLabel>
 );
 
 export const Basic = BasicTemplate.bind({});
@@ -72,6 +81,15 @@ export const WithSubtitle = BasicTemplate.bind({});
 WithSubtitle.args = {
   title: "Notifications",
   subtitle: "Notify me of all the work",
+  intro:
+    "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
+};
+
+export const WithTitleMetaData = BasicTemplate.bind({});
+WithTitleMetaData.args = {
+  title: "Notifications",
+  subtitle: "Notify me of all the work",
+  titleMetaData: titleMetaData,
   intro:
     "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
 };

--- a/docs/components/Page/Web.stories.tsx
+++ b/docs/components/Page/Web.stories.tsx
@@ -23,11 +23,7 @@ const BasicTemplate: ComponentStory<typeof Page> = args => (
 );
 
 const titleMetaData = (
-  <StatusLabel
-    label={"Success"}
-    alignment={"start"}
-    status={"success"}
-  ></StatusLabel>
+  <StatusLabel label={"In Progress"} alignment={"start"} status={"warning"} />
 );
 
 export const Basic = BasicTemplate.bind({});
@@ -77,19 +73,20 @@ WithActions.args = {
   ],
 };
 
-export const WithSubtitle = BasicTemplate.bind({});
-WithSubtitle.args = {
+export const WithIntro = BasicTemplate.bind({});
+WithIntro.args = {
   title: "Notifications",
   subtitle: "Notify me of all the work",
   intro:
     "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
+  externalIntroLinks: true,
 };
 
-export const WithTitleMetaData = BasicTemplate.bind({});
-WithTitleMetaData.args = {
-  title: "Notifications",
-  subtitle: "Notify me of all the work",
+export const WithAdditionalTitleFields = BasicTemplate.bind({});
+WithAdditionalTitleFields.args = {
+  title: "Kitchen Renovation Project",
+  subtitle: "Everything but the Kitchen Sink",
   titleMetaData: titleMetaData,
   intro:
-    "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
+    "**Building the greatest kitchen one will ever see**. The _entire_ kitchen will be redone for this renovation.",
 };

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -25,7 +25,11 @@
 }
 
 .titleRow {
+  display: flex;
   margin-bottom: var(--space-base);
+  flex-wrap: wrap;
+  gap: var(--space-base);
+  align-items: center;
 }
 
 .titleBar > .actionGroup {

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -22,6 +22,9 @@
 
 .titleBar h1 {
   flex: 0 1 auto;
+}
+
+.titleRow {
   margin-bottom: var(--space-base);
 }
 
@@ -85,8 +88,4 @@
 
 .titleBar .subtitle {
   margin-bottom: var(--space-base);
-}
-
-.titleRowAlignment {
-  align-items: center;
 }

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -22,6 +22,7 @@
 
 .titleBar h1 {
   flex: 0 1 auto;
+  margin-bottom: var(--space-base);
 }
 
 .titleRow {
@@ -30,6 +31,10 @@
   flex-wrap: wrap;
   gap: var(--space-base);
   align-items: center;
+}
+
+.titleRow h1 {
+  margin-bottom: 0;
 }
 
 .titleBar > .actionGroup {

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -86,3 +86,7 @@
 .titleBar .subtitle {
   margin-bottom: var(--space-base);
 }
+
+.titleRowAlignment {
+  align-items: center;
+}

--- a/packages/components/src/Page/Page.css.d.ts
+++ b/packages/components/src/Page/Page.css.d.ts
@@ -4,6 +4,7 @@ declare const styles: {
   readonly "standard": string;
   readonly "narrow": string;
   readonly "titleBar": string;
+  readonly "titleRow": string;
   readonly "actionGroup": string;
   readonly "large": string;
   readonly "medium": string;

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
+import { StatusLabel } from "@jobber/components/StatusLabel";
 import { Page } from ".";
 import { SectionProps } from "../Menu";
 
@@ -185,5 +186,28 @@ describe("When intro is provided with links", () => {
     const renderedLink = getByRole("link");
     expect(renderedLink.textContent).toBe("click me, I dare you");
     expect(renderedLink.getAttribute("target")).toBe("_blank");
+  });
+});
+
+describe("When titleMetaData is provided", () => {
+  it("should render the component", () => {
+    const titleMetaDataTestId = "titleMetaDataTestId";
+    const pageTitle = "The greatest page";
+
+    const { getByText, getByTestId } = render(
+      <Page
+        title={pageTitle}
+        titleMetaData={
+          <div data-testid={titleMetaDataTestId}>
+            <StatusLabel label={"Success"} status={"success"} />
+          </div>
+        }
+      >
+        Sup
+      </Page>,
+    );
+
+    expect(getByText(pageTitle)).toBeDefined();
+    expect(getByTestId(titleMetaDataTestId)).toBeDefined();
   });
 });

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -134,10 +134,12 @@ export function Page({
         <Content>
           <div className={titleBarClasses} ref={titleBarRef}>
             <div>
-              <Flex template={["shrink", "shrink"]}>
-                <Heading level={1}>{title}</Heading>
-                {titleMetaData}
-              </Flex>
+              <div className={styles.titleRow}>
+                <Flex template={["shrink", "shrink"]}>
+                  <Heading level={1}>{title}</Heading>
+                  {titleMetaData}
+                </Flex>
+              </div>
               {subtitle && (
                 <div className={styles.subtitle}>
                   <Text size="large" variation="subdued">

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -5,6 +5,7 @@ import {
   Breakpoints,
   useResizeObserver,
 } from "@jobber/hooks/useResizeObserver";
+import { Flex } from "@jobber/components/Flex";
 import styles from "./Page.css";
 import { Heading } from "../Heading";
 import { Text } from "../Text";
@@ -21,6 +22,12 @@ interface PageFoundationProps {
    * Title of the page.
    */
   readonly title: string;
+
+  /**
+   * TitleMetaData component to be displayed
+   * next to the title.
+   */
+  readonly titleMetaData?: ReactNode;
 
   /**
    * Subtitle of the page.
@@ -80,6 +87,7 @@ export type PageProps = XOR<PageFoundationProps, PageWithIntroProps>;
 // eslint-disable-next-line max-statements
 export function Page({
   title,
+  titleMetaData,
   intro,
   externalIntroLinks,
   subtitle,
@@ -126,7 +134,10 @@ export function Page({
         <Content>
           <div className={titleBarClasses} ref={titleBarRef}>
             <div>
-              <Heading level={1}>{title}</Heading>
+              <Flex template={["shrink", "shrink"]}>
+                <Heading level={1}>{title}</Heading>
+                {titleMetaData}
+              </Flex>
               {subtitle && (
                 <div className={styles.subtitle}>
                   <Text size="large" variation="subdued">

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -5,7 +5,6 @@ import {
   Breakpoints,
   useResizeObserver,
 } from "@jobber/hooks/useResizeObserver";
-import { Flex } from "@jobber/components/Flex";
 import styles from "./Page.css";
 import { Heading } from "../Heading";
 import { Text } from "../Text";
@@ -135,10 +134,8 @@ export function Page({
           <div className={titleBarClasses} ref={titleBarRef}>
             <div>
               <div className={styles.titleRow}>
-                <Flex template={["shrink", "shrink"]}>
-                  <Heading level={1}>{title}</Heading>
-                  {titleMetaData}
-                </Flex>
+                <Heading level={1}>{title}</Heading>
+                {titleMetaData}
               </div>
               {subtitle && (
                 <div className={styles.subtitle}>

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -133,10 +133,14 @@ export function Page({
         <Content>
           <div className={titleBarClasses} ref={titleBarRef}>
             <div>
-              <div className={styles.titleRow}>
+              {titleMetaData ? (
+                <div className={styles.titleRow}>
+                  <Heading level={1}>{title}</Heading>
+                  {titleMetaData}
+                </div>
+              ) : (
                 <Heading level={1}>{title}</Heading>
-                {titleMetaData}
-              </div>
+              )}
               {subtitle && (
                 <div className={styles.subtitle}>
                   <Text size="large" variation="subdued">

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -15,15 +15,11 @@ exports[`When actions are provided renders a Page with action buttons and a menu
           class="titleBar small medium large"
         >
           <div>
-            <div
-              class="titleRow"
+            <h1
+              class="base black jumbo heading"
             >
-              <h1
-                class="base black jumbo heading"
-              >
-                Notifications
-              </h1>
-            </div>
+              Notifications
+            </h1>
           </div>
           <div
             class="actionGroup"
@@ -125,15 +121,11 @@ exports[`renders a Page 1`] = `
           class="titleBar small medium large"
         >
           <div>
-            <div
-              class="titleRow"
+            <h1
+              class="base black jumbo heading"
             >
-              <h1
-                class="base black jumbo heading"
-              >
-                Notifications
-              </h1>
-            </div>
+              Notifications
+            </h1>
           </div>
         </div>
         <p

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -16,14 +16,18 @@ exports[`When actions are provided renders a Page with action buttons and a menu
         >
           <div>
             <div
-              class="flexible baseGap centerAlign"
-              style="grid-template-columns: max-content max-content;"
+              class="titleRow"
             >
-              <h1
-                class="base black jumbo heading"
+              <div
+                class="flexible baseGap centerAlign"
+                style="grid-template-columns: max-content max-content;"
               >
-                Notifications
-              </h1>
+                <h1
+                  class="base black jumbo heading"
+                >
+                  Notifications
+                </h1>
+              </div>
             </div>
           </div>
           <div
@@ -127,14 +131,18 @@ exports[`renders a Page 1`] = `
         >
           <div>
             <div
-              class="flexible baseGap centerAlign"
-              style="grid-template-columns: max-content max-content;"
+              class="titleRow"
             >
-              <h1
-                class="base black jumbo heading"
+              <div
+                class="flexible baseGap centerAlign"
+                style="grid-template-columns: max-content max-content;"
               >
-                Notifications
-              </h1>
+                <h1
+                  class="base black jumbo heading"
+                >
+                  Notifications
+                </h1>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -18,16 +18,11 @@ exports[`When actions are provided renders a Page with action buttons and a menu
             <div
               class="titleRow"
             >
-              <div
-                class="flexible baseGap centerAlign"
-                style="grid-template-columns: max-content max-content;"
+              <h1
+                class="base black jumbo heading"
               >
-                <h1
-                  class="base black jumbo heading"
-                >
-                  Notifications
-                </h1>
-              </div>
+                Notifications
+              </h1>
             </div>
           </div>
           <div
@@ -133,16 +128,11 @@ exports[`renders a Page 1`] = `
             <div
               class="titleRow"
             >
-              <div
-                class="flexible baseGap centerAlign"
-                style="grid-template-columns: max-content max-content;"
+              <h1
+                class="base black jumbo heading"
               >
-                <h1
-                  class="base black jumbo heading"
-                >
-                  Notifications
-                </h1>
-              </div>
+                Notifications
+              </h1>
             </div>
           </div>
         </div>

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -15,11 +15,16 @@ exports[`When actions are provided renders a Page with action buttons and a menu
           class="titleBar small medium large"
         >
           <div>
-            <h1
-              class="base black jumbo heading"
+            <div
+              class="flexible baseGap centerAlign"
+              style="grid-template-columns: max-content max-content;"
             >
-              Notifications
-            </h1>
+              <h1
+                class="base black jumbo heading"
+              >
+                Notifications
+              </h1>
+            </div>
           </div>
           <div
             class="actionGroup"
@@ -121,11 +126,16 @@ exports[`renders a Page 1`] = `
           class="titleBar small medium large"
         >
           <div>
-            <h1
-              class="base black jumbo heading"
+            <div
+              class="flexible baseGap centerAlign"
+              style="grid-template-columns: max-content max-content;"
             >
-              Notifications
-            </h1>
+              <h1
+                class="base black jumbo heading"
+              >
+                Notifications
+              </h1>
+            </div>
           </div>
         </div>
         <p


### PR DESCRIPTION
## Motivations

The Campaigns team requires a status label to be present beside the Heading within a page component. Designs can be found [here](https://www.figma.com/design/DjVmtJjQKATkgC5UxFAleU/Automated-Campaigns-v1?node-id=759-135655&t=KOm5iwuUkaZNYCb8-4). 

This could have been implemented without using the Page component, but we determined that it would be beneficial to allow a custom component to be appended to the end of the title. Then, other teams can take advantage of the change, and that the campaigns component using this implementation will maintain consistency with the design system over time (eg: in the case that the Page component style for the design system were to change).

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Updated the Page component to accept an optional ReactNode to display beside the title of the Page.
- Added a new story for all title related fields

#### Implementation Details
At first, I was hopeful that I could use the `Flex` component, however, this did not allow for the elements to wrap to the next row on small screen sizes.
Next, I attempted to use the `Box` component, but that kept both elements on the same line, but wrapped the individual components, which did not look visually pleasing. 

This is what it looked like using `Box`
![Screenshot 2024-06-19 at 17 05 41](https://github.com/GetJobber/atlantis/assets/6353164/1f035be7-ea42-4764-97bd-6d29a7342a7e)

I settled for using custom CSS to achieve the desired responsiveness, and style.

<img width="951" alt="Screenshot 2024-06-19 at 15 57 05" src="https://github.com/GetJobber/atlantis/assets/6353164/96844ac8-a854-404c-bb1f-cb959259e14a">


## Testing

Testing can be achieved by navigating to the story `WithAdditionalTitleFields`.
It is also possible to follow local setup steps and test this out with JO. See directions [here](https://atlantis.getjobber.com/?path=/docs/introduction--page#local-testing).

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
