### PR TITLE
fix(components): handle nested input names in form inputs

### DIFF
--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -8,14 +8,18 @@ import React, {
   useImperativeHandle,
   useState,
 } from "react";
-import { Controller, useForm, useFormContext } from "react-hook-form";
+import {
+  Controller,
+  FieldErrors,
+  useForm,
+  useFormContext,
+} from "react-hook-form";
+import get from "lodash/get";
 import { FormFieldProps } from "./FormFieldTypes";
 import styles from "./FormField.css";
 import { FormFieldWrapper } from "./FormFieldWrapper";
 import { FormFieldPostFix } from "./FormFieldPostFix";
 
-// Added 13th statement to accommodate getErrorMessage function
-/*eslint max-statements: ["error", 13]*/
 export function FormField(props: FormFieldProps) {
   const {
     actionsRef,
@@ -80,8 +84,7 @@ export function FormField(props: FormFieldProps) {
     },
   }));
 
-  const message = errors[controlledName]?.message;
-  const error = getErrorMessage();
+  const error = extractErrorMessage(errors, controlledName);
   useEffect(() => handleValidation(), [error]);
 
   return (
@@ -226,14 +229,6 @@ export function FormField(props: FormFieldProps) {
     />
   );
 
-  function getErrorMessage() {
-    if (typeof message === "string") {
-      return message;
-    }
-
-    return "";
-  }
-
   function handleValidation() {
     onValidation && onValidation(error);
   }
@@ -249,4 +244,14 @@ function setAutocomplete(
   }
 
   return autocompleteSetting;
+}
+
+function extractErrorMessage(errors: FieldErrors, fieldName: string): string {
+  // we use lodash.get to access nested properties
+  // nested properties have a format of `parent.0.child`
+  // react-hook-form recommends it themselves at
+  // https://www.react-hook-form.com/advanced-usage/#ErrorMessages
+  const error = get(errors, fieldName);
+
+  return String(error?.message || "");
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- form inputs rely on react-hook-form
- errors for 'nested' input names (like `parent.0.child`) have a nested structure
- currently Atlantis assumes a 'flat' structure which is incompatible with nested input names
- this change fixes that

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- fixed the extraction of error messages to also handle a nested structure

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
