### PR TITLE
feat(components-native): Add testID prop to components-native Icon

### DIFF
--- a/packages/components-native/src/Icon/Icon.test.tsx
+++ b/packages/components-native/src/Icon/Icon.test.tsx
@@ -37,3 +37,13 @@ it("renders quote icon with themed color", () => {
   const tree = render(<Icon name="quote" color="brand" />).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+it("applies testID prop to svg element", () => {
+  const { getByTestId } = render(<Icon name="home" testID="home-icon" />);
+  expect(getByTestId("home-icon")).toBeDefined();
+});
+
+it("applies name prop as testID when testID prop is not provided", () => {
+  const { getByTestId } = render(<Icon name="home" />);
+  expect(getByTestId("home")).toBeDefined();
+});

--- a/packages/components-native/src/Icon/Icon.tsx
+++ b/packages/components-native/src/Icon/Icon.tsx
@@ -32,6 +32,11 @@ export interface IconProps {
    * Sets a custom color for the icon. Can be a rgb() or hex value.
    */
   readonly customColor?: string;
+
+  /**
+   * Used to locate this view in end-to-end tests
+   */
+  readonly testID?: string;
 }
 
 export function Icon({
@@ -39,6 +44,7 @@ export function Icon({
   color,
   size = "base",
   customColor,
+  testID,
 }: IconProps): JSX.Element {
   const { svgClassNames, pathClassNames, paths, viewBox } = getIcon({
     name,
@@ -67,7 +73,7 @@ export function Icon({
   });
 
   return (
-    <Svg style={svgStyle} testID={name} viewBox={viewBox}>
+    <Svg style={svgStyle} testID={testID || name} viewBox={viewBox}>
       {icon}
     </Svg>
   );


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Allow a pass-through of a testID prop

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

<!-- new features -->
- new `testID` prop on `components-native` `Icon`
- tests for: using the `testID` prop & the situation where someone has used name as `data-testid` instead.

### Why I did what I did

#### Keeping `testID || name` 
In `components-native` where we have `suffix`, `prefix` or components like `Button` where we have `icon` as a prop:

```
interface ButtonFoundationProps {
 ...
  readonly icon?: IconNames;
```

We're bringing in `IconNames` and teams are using _that_ to test that an `Icon` is being used in these components as prefixes, etc.  So, only having `testID` here is not only more of a breaking change than I originally thought. I don't think we should expect consumers of `Button` to put a `testID` on a nested `Icon` that's being rendered as a prop.

## Testing

<!-- How to test your changes. -->

Nothing fails in external mobile repo: https://github.com/GetJobber/jobber-mobile/pull/9365

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
