### PR TITLE
fix(components): make DataList and DataTable sorting interactions match

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css
@@ -6,18 +6,14 @@
 
 .sortIcon path {
   fill: var(--color-interactive--subtle);
-  transition: all var(--timing-base) ease;
-}
-
-.sortIcon path.active {
-  fill: var(--color-heading);
+  transition: opacity var(--timing-base) ease;
 }
 
 .sortIcon path.inactive {
-  fill: var(--color-inactive--surface);
+  opacity: 0.5;
 }
 
+.sortIcon path.active,
 .sortIcon:hover path {
-  fill: var(--color-interactive--subtle);
-  transition: all var(--timing-base) ease;
+  opacity: 1;
 }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css
@@ -10,10 +10,14 @@
 }
 
 .sortIcon path.inactive {
-  opacity: 0.5;
+  opacity: 0.4;
 }
 
 .sortIcon path.active,
 .sortIcon:hover path {
   opacity: 1;
+}
+
+.sortIcon:hover path.inactive {
+  opacity: 0.6;
 }

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css.d.ts
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css.d.ts
@@ -1,7 +1,7 @@
 declare const styles: {
   readonly "sortIcon": string;
-  readonly "active": string;
   readonly "inactive": string;
+  readonly "active": string;
 };
 export = styles;
 

--- a/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.tsx
@@ -46,7 +46,7 @@ export function DataListSortingOptions({
         >
           {option.label}
           {option.label === selectedOption?.label && (
-            <Icon name="checkmark" color="blue" />
+            <Icon name="checkmark" color="interactiveSubtle" />
           )}
         </li>
       ))}

--- a/packages/components/src/DataTable/SortIcon.css
+++ b/packages/components/src/DataTable/SortIcon.css
@@ -2,13 +2,16 @@
   padding-right: var(--space-small);
 }
 .sortIcon path {
-  fill: var(--color-greyBlue);
-}
-
-.sortIcon path.active {
-  fill: var(--color-blue);
+  fill: var(--color-interactive--subtle);
+  opacity: 0.5;
+  transition: opacity var(--timing-base) ease;
 }
 
 .sortIcon path.inactive {
-  fill: var(--color-greyBlue--lighter);
+  opacity: 0.5;
+}
+
+.sortIcon path.active,
+.sortIcon:hover path {
+  opacity: 1;
 }

--- a/packages/components/src/DataTable/SortIcon.css
+++ b/packages/components/src/DataTable/SortIcon.css
@@ -3,15 +3,19 @@
 }
 .sortIcon path {
   fill: var(--color-interactive--subtle);
-  opacity: 0.5;
+  opacity: 0.4;
   transition: opacity var(--timing-base) ease;
 }
 
 .sortIcon path.inactive {
-  opacity: 0.5;
+  opacity: 0.4;
 }
 
 .sortIcon path.active,
 .sortIcon:hover path {
   opacity: 1;
+}
+
+.sortIcon:hover path.inactive {
+  opacity: 0.6;
 }

--- a/packages/components/src/DataTable/SortIcon.css.d.ts
+++ b/packages/components/src/DataTable/SortIcon.css.d.ts
@@ -1,7 +1,7 @@
 declare const styles: {
   readonly "sortIcon": string;
-  readonly "active": string;
   readonly "inactive": string;
+  readonly "active": string;
 };
 export = styles;
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

`DataList` and `DataTable`, despite having _almost_ identical interactions to sort columns, have their UI built styled differently. I'm not addressing the _built_ bit here, as there's some functionality to untangle, but I am making the interactions of the sort arrows work and feel the same.

- active sort arrow is `--color-interactive--subtle`
- inactive sort arrow is `--color-interactive--subtle` at 0.4 opacity
- inactive arrow **while hovered** is 0.6 opacity

This allows the user to observe
- arrows are hovered
- while the arrows are being clicked, the user can perceive the changing sort order

https://github.com/GetJobber/atlantis/assets/39704901/708bd99a-e5f4-4691-ba09-8dc864d14974


## Changes

### Changed

- CSS for both DataList and DataTable's sort arrows

### Fixed

- Sort arrow interactions are now consistent across the DataList and DataTable

## Testing

The split view in Arc like you see in my video is pretty handy. Recommend pulling into Jobber to test in dark mode.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
