### PR TITLE
fix(components): Update FormField to avoid useId StrictMode problem

### DIFF
--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`it should display headers when headers are passed in 1`] = `
           >
             <label
               class="label"
-              for=":r6:"
+              for=":r3:"
             >
               placeholder_name
             </label>
@@ -31,7 +31,7 @@ exports[`it should display headers when headers are passed in 1`] = `
               <input
                 autocomplete="off"
                 class="input"
-                id=":r6:"
+                id=":r3:"
                 type="text"
                 value=""
               />

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -14,8 +14,21 @@ import styles from "./FormField.css";
 import { FormFieldWrapper } from "./FormFieldWrapper";
 import { FormFieldPostFix } from "./FormFieldPostFix";
 
-// eslint-disable-next-line max-statements
 export function FormField(props: FormFieldProps) {
+  // Warning: do not move useId into FormFieldInternal. This must be here to avoid
+  // a problem where useId isn't stable across multiple StrictMode renders.
+  // https://github.com/facebook/react/issues/27103
+  const id = useId();
+
+  return <FormFieldInternal {...props} id={id} />;
+}
+
+type FormFieldInternalProps = FormFieldProps & {
+  readonly id: string;
+};
+
+// eslint-disable-next-line max-statements
+function FormFieldInternal(props: FormFieldInternalProps) {
   const {
     actionsRef,
     autocomplete = true,
@@ -23,6 +36,7 @@ export function FormField(props: FormFieldProps) {
     defaultValue,
     description,
     disabled,
+    id,
     inputRef,
     inline,
     keyboard,
@@ -52,16 +66,13 @@ export function FormField(props: FormFieldProps) {
       : // If there isn't a Form Context being provided, get a form for this field.
         useForm({ mode: "onTouched" });
 
-  const [identifier] = useState(useId());
-  const [descriptionIdentifier] = useState(`descriptionUUID--${useId()}`);
+  const descriptionIdentifier = `descriptionUUID--${id}`;
   /**
    * Generate a name if one is not supplied, this is the name
    * that will be used for react-hook-form and not neccessarily
    * attached to the DOM
    */
-  const [controlledName] = useState(
-    name ? name : `generatedName--${identifier}`,
-  );
+  const [controlledName] = useState(name ? name : `generatedName--${id}`);
 
   useEffect(() => {
     if (value != undefined) {
@@ -95,7 +106,7 @@ export function FormField(props: FormFieldProps) {
 
   const fieldProps = {
     ...rest,
-    id: identifier,
+    id,
     className: styles.input,
     name: (validations || name) && controllerName,
     disabled: disabled,
@@ -120,7 +131,7 @@ export function FormField(props: FormFieldProps) {
       {...props}
       value={rest.value}
       error={errorMessage}
-      identifier={identifier}
+      identifier={id}
       descriptionIdentifier={descriptionIdentifier}
       clearable={clearable}
       onClear={handleClear}

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -42,7 +42,7 @@ function FormFieldInternal(props: FormFieldInternalProps) {
     max,
     maxLength,
     min,
-    name,
+    name: nameProp,
     readonly,
     rows,
     loading,
@@ -71,30 +71,25 @@ function FormFieldInternal(props: FormFieldInternalProps) {
    * that will be used for react-hook-form and not neccessarily
    * attached to the DOM
    */
-  const controlledName = name ? name : `generatedName--${id}`;
+  const name = nameProp ? nameProp : `generatedName--${id}`;
 
   useEffect(() => {
     if (value != undefined) {
-      setValue(controlledName, value);
+      setValue(name, value);
     }
-  }, [value, watch(controlledName)]);
+  }, [value, watch(name)]);
 
   useImperativeHandle(actionsRef, () => ({
     setValue: newValue => {
-      setValue(controlledName, newValue, { shouldValidate: true });
+      setValue(name, newValue, { shouldValidate: true });
     },
   }));
 
   const {
-    field: {
-      onChange: onControllerChange,
-      onBlur: onControllerBlur,
-      name: controllerName,
-      ...rest
-    },
+    field: { onChange: onControllerChange, onBlur: onControllerBlur, ...rest },
     fieldState: { error },
   } = useController({
-    name: controlledName,
+    name,
     control,
     rules: validations,
     defaultValue: value ?? defaultValue ?? "",
@@ -107,7 +102,7 @@ function FormFieldInternal(props: FormFieldInternalProps) {
     ...rest,
     id,
     className: styles.input,
-    name: (validations || name) && controllerName,
+    name: (validations || nameProp) && name,
     disabled: disabled,
     readOnly: readonly,
     inputMode: keyboard,
@@ -178,7 +173,7 @@ function FormFieldInternal(props: FormFieldInternalProps) {
 
   function handleClear() {
     handleBlur();
-    setValue(controlledName, "", { shouldValidate: true });
+    setValue(name, "", { shouldValidate: true });
     onChange && onChange("");
     inputRef?.current?.focus();
   }

--- a/packages/components/src/FormField/FormField.tsx
+++ b/packages/components/src/FormField/FormField.tsx
@@ -6,7 +6,6 @@ import React, {
   useEffect,
   useId,
   useImperativeHandle,
-  useState,
 } from "react";
 import { useController, useForm, useFormContext } from "react-hook-form";
 import { FormFieldProps } from "./FormFieldTypes";
@@ -72,7 +71,7 @@ function FormFieldInternal(props: FormFieldInternalProps) {
    * that will be used for react-hook-form and not neccessarily
    * attached to the DOM
    */
-  const [controlledName] = useState(name ? name : `generatedName--${id}`);
+  const controlledName = name ? name : `generatedName--${id}`;
 
   useEffect(() => {
     if (value != undefined) {

--- a/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
+++ b/packages/components/src/FormField/__snapshots__/FormField.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`FormField when small renders 1`] = `
           >
             <input
               class="input"
-              id=":r8:"
+              id=":r4:"
               type="text"
               value=""
             />

--- a/packages/components/src/InputText/InputText.test.tsx
+++ b/packages/components/src/InputText/InputText.test.tsx
@@ -66,7 +66,7 @@ it("renders a textarea", () => {
             >
               <label
                 class="label"
-                for=":r2:"
+                for=":r1:"
               >
                 Describe your favourite colour?
               </label>
@@ -76,7 +76,7 @@ it("renders a textarea", () => {
               >
                 <textarea
                   class="input"
-                  id=":r2:"
+                  id=":r1:"
                   rows="3"
                 />
               </div>
@@ -113,7 +113,7 @@ it("renders a textarea with 4 rows", () => {
             >
               <label
                 class="label"
-                for=":r4:"
+                for=":r2:"
               >
                 Describe your favourite colour?
               </label>
@@ -123,7 +123,7 @@ it("renders a textarea with 4 rows", () => {
               >
                 <textarea
                   class="input"
-                  id=":r4:"
+                  id=":r2:"
                   rows="4"
                 />
               </div>

--- a/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/Select/__snapshots__/Select.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders a Select with many options 1`] = `
           >
             <select
               class="input"
-              id=":r4:"
+              id=":r2:"
             >
               <option>
                 Foo
@@ -126,7 +126,7 @@ exports[`renders a Select with one option 1`] = `
           >
             <select
               class="input"
-              id=":r2:"
+              id=":r1:"
             >
               <option>
                 Foo
@@ -176,7 +176,7 @@ exports[`renders correctly as large 1`] = `
           >
             <select
               class="input"
-              id=":r8:"
+              id=":r4:"
             >
               <option>
                 Foo
@@ -226,7 +226,7 @@ exports[`renders correctly as small 1`] = `
           >
             <select
               class="input"
-              id=":r6:"
+              id=":r3:"
             >
               <option>
                 Foo
@@ -277,7 +277,7 @@ exports[`renders correctly when disabled 1`] = `
             <select
               class="input"
               disabled=""
-              id=":ra:"
+              id=":r5:"
             >
               <option>
                 Foo
@@ -327,7 +327,7 @@ exports[`renders correctly when invalid 1`] = `
           >
             <select
               class="input"
-              id=":rc:"
+              id=":r6:"
             >
               <option>
                 Foo


### PR DESCRIPTION
## Motivations


Eric found that React's built-in `useId` is not stable across renders when within a `StrictMode` tree (only affects local development). I confirmed this using his [branch](https://github.com/GetJobber/atlantis/compare/master...ec/rhf-stable-id-fix) for testing.

**Why is this a problem?**

Because we rely on `useId()` to generate a unique stable identifier when the parent component chooses not to pass a `name` prop to FormField. This id/name is passed to react-hook-form's controller and if it's not stable between renders, this breaks the form's validation logic.

**Why is this a _new_ problem?**

A recent [PR](https://github.com/GetJobber/atlantis/pull/1942/files) merged that updated `FormField` to use `useController` from `react-hook-form` instead of `<Controller>`. `useController` is more flexible and allows pulling out/storing state where `<Controller>` can't.

This change revealed this problem in one of our forms because:
* The inputs didn't have a `name` prop being passed to them, so they generated ids internally
* It's within a `StrictMode` tree 
* The old `<Controller>` component seems to have internal caching outside of React's state so the old way didn't run into this.

Eric also came up with a solution that works great! See [comment](https://github.com/GetJobber/atlantis/pull/1950#discussion_r1655452592) for more info.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- `FormField` problems in `StrictMode` when `name` prop isn't supplied

## Testing

I tried to add a unit test for this but unfortunately there isn't a way to validate the expectation. RHF's controller logic isn't exposed by `FormField` so we can't easily inspect that internal state. I did attempt to verify the `name` prop doesn't change in `StrictMode`... but that doesn't work as both cases still result in the same final generated id... the only difference is that RHF's internal state is now correct when it wasn't before.

To manually verify this:

1. Edit `docs/components/InputText/Web.stories.tsx` and paste the below script
2. Add a log to `FormField` around line 68: `console.log('RHF', control._fields);`
3. Visit http://localhost:6005/?path=/story/components-forms-and-inputs-inputtext-web--multiple
4. Observe that there are only 2 field names: `firstName` and `generatedName--:r3:`
    * If there are 3 names (2 being generated) this is the bug!

```tsx
export const Multiple = () => {
  return (
    <StrictMode>
      <Form>
        <InputText
          name="firstName"
          validations={{
            required: "Required",
          }}
          placeholder="First Name"
        />
        <InputText
          placeholder="Last Name"
          validations={{
            required: "Required",
          }}
        />

        <button type="submit">Submit</button>
      </Form>
    </StrictMode>
  );
};
```

