### PR TITLE
fix(components): Prevent LightBox from duplicating content when the page is printed

### DIFF
--- a/packages/components/src/LightBox/LightBox.css
+++ b/packages/components/src/LightBox/LightBox.css
@@ -3,7 +3,7 @@
  * When the user tries to print the page, this prevents the LightBox content
  * from being duplicated multiple times.
  */
-:global(html.atlantisLightboxActive) {
+:global(html.atlantisLightBoxActive) {
   @media print {
     overflow: hidden;
 

--- a/packages/components/src/LightBox/LightBox.test.tsx
+++ b/packages/components/src/LightBox/LightBox.test.tsx
@@ -108,7 +108,7 @@ test("Lightbox displays the selected imageIndex", () => {
 });
 
 describe("print styles", () => {
-  test("toggles the atlantisLightboxActive class on the html element", () => {
+  test("toggles the atlantisLightBoxActive class on the html element", () => {
     const props = {
       images: [
         {
@@ -124,12 +124,12 @@ describe("print styles", () => {
 
     rerender(<LightBox open={true} {...props} />);
     expect(document.documentElement.classList).toContain(
-      "atlantisLightboxActive",
+      "atlantisLightBoxActive",
     );
 
     rerender(<LightBox open={false} {...props} />);
     expect(document.documentElement.classList).not.toContain(
-      "atlantisLightboxActive",
+      "atlantisLightBoxActive",
     );
   });
 });

--- a/packages/components/src/LightBox/LightBox.tsx
+++ b/packages/components/src/LightBox/LightBox.tsx
@@ -247,9 +247,9 @@ function NextButton({ onClick }: NavButtonProps) {
 function togglePrintStyles(open: boolean) {
   try {
     if (open) {
-      document.documentElement.classList.add("atlantisLightboxActive");
+      document.documentElement.classList.add("atlantisLightBoxActive");
     } else {
-      document.documentElement.classList.remove("atlantisLightboxActive");
+      document.documentElement.classList.remove("atlantisLightBoxActive");
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Motivations

When opening a LightBox and then trying to print the page, the print preview dialog shows multiple pages of duplicated content will be printed. This is not what users are expecting.

This PR prevents that from happening and reduces it down to 1 single page as expected. 

### How it works

When toggling the LightBox, a class is toggled on the root html element. This class contains print-only styles that affect the html & body elements to guarantee they are fixed height and prevent overflowing content from causing multiple pages unnecessarily. 

### Risks

The risk is very low as these changes _only affect print-mode_ and not normal browser behaviour!

## Changes

### Fixed

- Add print-mode styles when LightBox is active to prevent duplication of content


## Testing

See this comment for how I tested this: https://github.com/GetJobber/atlantis/pull/1951/files#r1666006525

You can also manually test this behaviour in JO by uploading a file to a job and injecting this script in the console:

```js
const style = document.createElement("style");
style.textContent = `
html.atlantisLightboxPrintStyles {
  @media print {
    overflow: hidden;

    body {
      position: absolute;
      height: 100%;
      overflow: hidden;
    }
  }
}
`;
document.head.append(style);
document.documentElement.classList.add("atlantisLightboxPrintStyles");
```

Or even better, check out my JO PR with the pre-release bump and confirm it works there!


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

