### PR TITLE
fix(components): Fix Rollup Config File Names

### DIFF
--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -64,12 +64,15 @@ export default {
     }),
     copy({
       targets: [
-        { src: "src/Card/colors.css.d.ts", dest: "dist/Card" },
+        { src: "src/Card/cardcolors.css.d.ts", dest: "dist/Card" },
         { src: "src/Content/Spacing.css.d.ts", dest: "dist/Content" },
         { src: "src/Gallery/Gallery.css.d.ts", dest: "dist/Gallery" },
         { src: "src/Grid/GridAlign.css.d.ts", dest: "dist/Grid" },
-        { src: "src/Modal/Sizes.css.d.ts", dest: "dist/Modal" },
-        { src: "src/ProgressBar/Sizes.css.d.ts", dest: "dist/ProgressBar" },
+        { src: "src/Modal/ModalSizes.css.d.ts", dest: "dist/Modal" },
+        {
+          src: "src/ProgressBar/ProgressBarSizes.css.d.ts",
+          dest: "dist/ProgressBar",
+        },
         {
           src: "src/Typography/css/Emphasis.css.d.ts",
           dest: "dist/Typography/css",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

types were getting very confused when being consumed outside this project

specifically `Card` `Modal` and `ProgressBar`

types derived from styles in this way
`Card`
```
import colors from "./cardcolors.css";

  readonly accent?: keyof typeof colors;
```

would not correctly find a type that had keys of actual color values. instead it would seemingly fallback to a definition that says any css import is a string, and therefore `keyof string` would give string prototype values like `match` or `indexOf`

<img width="866" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/5a5ae604-e307-4f0b-9c4b-4f4080654b82">


Glimmer wasn't experiencing this problem and uses the same pattern of `keyof typeof size` so I went to see what was different. found the rollup config and noticed the file names in there for Card, Modal and ProgressBar didn't match their actual file names. maybe we updated them at one point and forgot to update the rollup value.

fixing the names results in the built bundle/package/whatever having the correct types
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

updated the rollup config to use the correct names

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->
you'll need to build & import this branch into another project. preferably `jobber` since it has tons of invocations of these components.

you'll also need my other PR to do this
https://github.com/GetJobber/atlantis/pull/1952

otherwise it will yell at you about dependencies

once that's been installed, everything should just be happy. instances of `Card` `Modal` and `ProgressBar` should NOT be upset about incorrect values being given to them from existing implementations! if you want, you can inspect the type definitions and yeah they should be the expected values and not `String` methods/keys

<img width="584" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/e8f439fd-f70d-42c4-8152-2a82da728875">



Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
