### PR TITLE
docs: Update border color of sidebar search

### DIFF
--- a/.storybook/assets/css/manager.css
+++ b/.storybook/assets/css/manager.css
@@ -8,6 +8,10 @@ body,
   color: var(--color-text--reverse--secondary) !important;
 }
 
+.sidebar-container .search-field input {
+  border-color: var(--color-border);
+}
+
 .sidebar-container .search-field input:focus {
   color: var(--color-text) !important;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Sidebar search was looking a little dim with the Storybook 7 upgrade

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

<!-- changes in existing functionality -->
- gave the `search-field` `input` `border-color: var(--color-border);` so it would stand out more

### Before

![Screenshot 2024-07-16 at 5 52 12 PM](https://github.com/user-attachments/assets/95253d29-7dbf-4575-801e-061d248b21e1)


### After

![Screenshot 2024-07-16 at 5 58 15 PM](https://github.com/user-attachments/assets/2cce1bfe-21a4-4524-a25d-1cb8a574aa95)


### Testing

You might have to restart storybook to see the change

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
