### PR TITLE
feat(components): Add onClick to Chip Suffix

### DIFF
--- a/docs/components/Chip/Web.stories.tsx
+++ b/docs/components/Chip/Web.stories.tsx
@@ -36,6 +36,18 @@ const SuffixTemplate: ComponentStory<typeof Chip> = args => {
   return (
     <Content>
       <Chip {...args} onClick={() => alert("you clicked the Chip!")}>
+        <Chip.Suffix>
+          <Icon name="add" size="small" />
+        </Chip.Suffix>
+      </Chip>
+    </Content>
+  );
+};
+
+const ClickableSuffixTemplate: ComponentStory<typeof Chip> = args => {
+  return (
+    <Content>
+      <Chip {...args} onClick={() => alert("you clicked the Chip!")}>
         <Chip.Suffix
           onClick={() => alert("you clicked the suffix!")}
           ariaLabel="dismiss"
@@ -191,6 +203,12 @@ export const Suffix = SuffixTemplate.bind({});
 Suffix.args = {
   ...defaultArgs,
   label: "Chip With Suffix",
+};
+
+export const ClickableSuffix = ClickableSuffixTemplate.bind({});
+ClickableSuffix.args = {
+  ...defaultArgs,
+  label: "Clickable Chip With Suffix",
 };
 
 export const Prefix = PrefixTemplate.bind({});

--- a/docs/components/Chip/Web.stories.tsx
+++ b/docs/components/Chip/Web.stories.tsx
@@ -35,8 +35,11 @@ const BasicTemplate: ComponentStory<typeof Chip> = args => {
 const SuffixTemplate: ComponentStory<typeof Chip> = args => {
   return (
     <Content>
-      <Chip {...args} onClick={() => alert("you clicked me!")}>
-        <Chip.Suffix onClick={() => alert("you clicked the suffix!")}>
+      <Chip {...args} onClick={() => alert("you clicked the Chip!")}>
+        <Chip.Suffix
+          onClick={() => alert("you clicked the suffix!")}
+          ariaLabel="dismiss"
+        >
           <Icon name="cross" size="small" />
         </Chip.Suffix>
       </Chip>

--- a/docs/components/Chip/Web.stories.tsx
+++ b/docs/components/Chip/Web.stories.tsx
@@ -36,7 +36,7 @@ const SuffixTemplate: ComponentStory<typeof Chip> = args => {
   return (
     <Content>
       <Chip {...args} onClick={() => alert("you clicked me!")}>
-        <Chip.Suffix>
+        <Chip.Suffix onClick={() => alert("you clicked the suffix!")}>
           <Icon name="cross" size="small" />
         </Chip.Suffix>
       </Chip>

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -31,6 +31,24 @@
   box-shadow: var(--shadow-focus);
 }
 
+.chip .suffixClick {
+  display: flex;
+  width: var(--space-large);
+  height: var(--space-large);
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-circle);
+  align-items: center;
+  justify-content: center;
+}
+
+.chip .suffix,
+.chip .suffixClick {
+  margin-left: var(--space-small);
+  margin-right: calc(-1 * var(--space-small));
+  background-color: var(--color-surface);
+}
+
 .chip .suffixClick:focus,
 .chip .suffixClick:focus-visible {
   box-shadow: var(--shadow-focus);
@@ -44,13 +62,6 @@
   margin-right: var(--space-small);
 }
 
-.chip .suffix,
-.chip .suffixClick {
-  margin-left: var(--space-small);
-  margin-right: calc(-1 * var(--space-small));
-  background-color: var(--color-surface);
-}
-
 .chip .prefix,
 .chip .suffix {
   display: flex;
@@ -60,17 +71,6 @@
   border-radius: var(--radius-circle);
   align-items: center;
   justify-content: center;
-}
-
-.chip .suffixClick {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--space-large);
-  height: var(--space-large);
-  border-radius: var(--radius-circle);
-  padding: 0;
-  border: none;
 }
 
 .chip .prefix.empty,

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -25,7 +25,7 @@
 .chip:focus,
 .chip:focus-visible,
 .clickableSuffix:focus-visible {
-  outline: none;
+  outline: transparent;
 }
 
 .chip .clickableSuffix {

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -31,12 +31,21 @@
   box-shadow: var(--shadow-focus);
 }
 
+.chip .suffixClick:focus,
+.chip .suffixClick:focus-visible {
+  box-shadow: var(--shadow-focus);
+  /* Use the same box-shadow as the chip */
+  outline: none;
+  /* Remove default outline */
+}
+
 .chip .prefix {
   margin-left: calc(-1 * var(--space-small));
   margin-right: var(--space-small);
 }
 
-.chip .suffix {
+.chip .suffix,
+.chip .suffixClick {
   margin-left: var(--space-small);
   margin-right: calc(-1 * var(--space-small));
   background-color: var(--color-surface);
@@ -51,6 +60,17 @@
   border-radius: var(--radius-circle);
   align-items: center;
   justify-content: center;
+}
+
+.chip .suffixClick {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--space-large);
+  height: var(--space-large);
+  border-radius: var(--radius-circle);
+  padding: 0;
+  border: none;
 }
 
 .chip .prefix.empty,
@@ -101,9 +121,7 @@
 .subtle.invalid:focus-visible {
   background-color: var(--color-surface--background--hover);
   --chip--gradient-color-variation: var(--color-surface--background--hover);
-  --chip--gradient-color-variation--hover: var(
-    --color-surface--background--hover
-  );
+  --chip--gradient-color-variation--hover: var(--color-surface--background--hover);
 }
 
 .subtle {
@@ -164,11 +182,11 @@
   flex-wrap: nowrap;
 }
 
-.chipContent > * {
+.chipContent>* {
   flex: 0 0 auto;
 }
 
-.chipContent > p {
+.chipContent>p {
   overflow: hidden;
   white-space: nowrap;
 }
@@ -179,20 +197,16 @@
   right: 0;
   width: var(--space-base);
   height: 100%;
-  background: linear-gradient(
-    to left,
-    var(--chip--gradient-color-variation) 5%,
-    rgba(255, 255, 255, 0)
-  );
+  background: linear-gradient(to left,
+      var(--chip--gradient-color-variation) 5%,
+      rgba(255, 255, 255, 0));
 }
 
 .chip:focus-visible .truncateGradient,
 .chip:hover .truncateGradient {
-  background: linear-gradient(
-    to left,
-    var(--chip--gradient-color-variation--hover) 5%,
-    rgba(255, 255, 255, 0)
-  );
+  background: linear-gradient(to left,
+      var(--chip--gradient-color-variation--hover) 5%,
+      rgba(255, 255, 255, 0));
 }
 
 .chipLabelRef {

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -23,7 +23,8 @@
 }
 
 .chip:focus,
-.chip:focus-visible {
+.chip:focus-visible,
+.clickableSuffix:focus-visible {
   outline: none;
 }
 

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -27,43 +27,22 @@
   outline: none;
 }
 
-.chip:focus-visible {
-  box-shadow: var(--shadow-focus);
-}
-
-.chip .suffixClick {
-  display: flex;
-  width: var(--space-large);
-  height: var(--space-large);
+.chip .clickableSuffix {
   padding: 0;
   border: none;
-  border-radius: var(--radius-circle);
-  align-items: center;
-  justify-content: center;
+  cursor: pointer;
 }
 
 .chip .suffix,
-.chip .suffixClick {
+.chip .clickableSuffix {
   margin-left: var(--space-small);
   margin-right: calc(-1 * var(--space-small));
   background-color: var(--color-surface);
 }
 
-.chip .suffixClick:focus,
-.chip .suffixClick:focus-visible {
-  box-shadow: var(--shadow-focus);
-  /* Use the same box-shadow as the chip */
-  outline: none;
-  /* Remove default outline */
-}
-
-.chip .prefix {
-  margin-left: calc(-1 * var(--space-small));
-  margin-right: var(--space-small);
-}
-
 .chip .prefix,
-.chip .suffix {
+.chip .suffix,
+.chip .clickableSuffix {
   display: flex;
   width: var(--space-large);
   height: var(--space-large);
@@ -71,6 +50,16 @@
   border-radius: var(--radius-circle);
   align-items: center;
   justify-content: center;
+}
+
+.chip:focus-visible,
+.chip .clickableSuffix:focus-visible {
+  box-shadow: var(--shadow-focus);
+}
+
+.chip .prefix {
+  margin-left: calc(-1 * var(--space-small));
+  margin-right: var(--space-small);
 }
 
 .chip .prefix.empty,

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -53,6 +53,10 @@
   justify-content: center;
 }
 
+.clickableSuffix:hover {
+  background-color: var(--color-surface--hover);
+}
+
 .chip:focus-visible,
 .chip .clickableSuffix:focus-visible {
   box-shadow: var(--shadow-focus);

--- a/packages/components/src/Chip/Chip.css
+++ b/packages/components/src/Chip/Chip.css
@@ -121,7 +121,9 @@
 .subtle.invalid:focus-visible {
   background-color: var(--color-surface--background--hover);
   --chip--gradient-color-variation: var(--color-surface--background--hover);
-  --chip--gradient-color-variation--hover: var(--color-surface--background--hover);
+  --chip--gradient-color-variation--hover: var(
+    --color-surface--background--hover
+  );
 }
 
 .subtle {
@@ -182,11 +184,11 @@
   flex-wrap: nowrap;
 }
 
-.chipContent>* {
+.chipContent > * {
   flex: 0 0 auto;
 }
 
-.chipContent>p {
+.chipContent > p {
   overflow: hidden;
   white-space: nowrap;
 }
@@ -197,16 +199,20 @@
   right: 0;
   width: var(--space-base);
   height: 100%;
-  background: linear-gradient(to left,
-      var(--chip--gradient-color-variation) 5%,
-      rgba(255, 255, 255, 0));
+  background: linear-gradient(
+    to left,
+    var(--chip--gradient-color-variation) 5%,
+    rgba(255, 255, 255, 0)
+  );
 }
 
 .chip:focus-visible .truncateGradient,
 .chip:hover .truncateGradient {
-  background: linear-gradient(to left,
-      var(--chip--gradient-color-variation--hover) 5%,
-      rgba(255, 255, 255, 0));
+  background: linear-gradient(
+    to left,
+    var(--chip--gradient-color-variation--hover) 5%,
+    rgba(255, 255, 255, 0)
+  );
 }
 
 .chipLabelRef {

--- a/packages/components/src/Chip/Chip.css.d.ts
+++ b/packages/components/src/Chip/Chip.css.d.ts
@@ -1,8 +1,8 @@
 declare const styles: {
   readonly "chip": string;
   readonly "suffixClick": string;
-  readonly "prefix": string;
   readonly "suffix": string;
+  readonly "prefix": string;
   readonly "empty": string;
   readonly "chipBar": string;
   readonly "selected": string;

--- a/packages/components/src/Chip/Chip.css.d.ts
+++ b/packages/components/src/Chip/Chip.css.d.ts
@@ -1,6 +1,6 @@
 declare const styles: {
   readonly "chip": string;
-  readonly "suffixClick": string;
+  readonly "clickableSuffix": string;
   readonly "suffix": string;
   readonly "prefix": string;
   readonly "empty": string;

--- a/packages/components/src/Chip/Chip.css.d.ts
+++ b/packages/components/src/Chip/Chip.css.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "chip": string;
+  readonly "suffixClick": string;
   readonly "prefix": string;
   readonly "suffix": string;
   readonly "empty": string;

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
@@ -34,7 +34,7 @@ describe("Chip Suffix", () => {
   });
 
   describe("when onClick prop is passed", () => {
-    it("should call onClick when suffix is clicked", () => {
+    it("should call onClick when suffix is clicked", async () => {
       const onClick = jest.fn();
       const { getByTestId } = render(
         <Chip.Suffix onClick={onClick} testID="ATL-Chip-Suffix">
@@ -42,7 +42,7 @@ describe("Chip Suffix", () => {
         </Chip.Suffix>,
       );
 
-      getByTestId("ATL-Chip-Suffix")?.click();
+      await userEvent.click(getByTestId("ATL-Chip-Suffix"));
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
@@ -5,8 +5,8 @@ import styles from "../../Chip.css";
 import { Avatar } from "../../../Avatar";
 import { Icon } from "../../../Icon";
 
-describe("Chip Compound Components", () => {
-  it("renders Suffix", () => {
+describe("Chip Suffix", () => {
+  it("renders suffix", () => {
     const { container } = render(
       <Chip.Suffix>
         <Avatar initials="" />
@@ -16,7 +16,7 @@ describe("Chip Compound Components", () => {
     expect(container.querySelector("." + styles.suffix)).toBeInTheDocument();
   });
 
-  it("suffix renders only one valid child", () => {
+  it("renders only one valid child", () => {
     const { container } = render(
       <Chip.Suffix>
         <Icon name="cross" />
@@ -30,5 +30,38 @@ describe("Chip Compound Components", () => {
     const { container } = render(<Chip.Suffix>Yo!</Chip.Suffix>);
     const elem = container.querySelector("." + styles.empty);
     expect(elem).toBeInTheDocument();
+  });
+
+  it("renders suffix as button element when onClick is passed", () => {
+    const { container } = render(
+      <Chip.Suffix onClick={jest.fn()}>
+        <Icon name="cross" />
+      </Chip.Suffix>,
+    );
+
+    expect(container.querySelector("button")).toBeInTheDocument();
+  });
+
+  it("renders suffix as a span element when onClick is not passed", () => {
+    const { container } = render(
+      <Chip.Suffix>
+        <Icon name="cross" />
+      </Chip.Suffix>,
+    );
+
+    expect(container.querySelector("span")).toBeInTheDocument();
+    expect(container.querySelector("button")).not.toBeInTheDocument();
+  });
+
+  it("should call onClick when suffix is clicked when onClick is passed", () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <Chip.Suffix onClick={onClick}>
+        <Icon name="cross" />
+      </Chip.Suffix>,
+    );
+
+    container.querySelector("button")?.click();
+    expect(onClick).toHaveBeenCalled();
   });
 });

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Chip } from "../../Chip";
 import styles from "../../Chip.css";
 import { Avatar } from "../../../Avatar";
@@ -32,47 +33,72 @@ describe("Chip Suffix", () => {
     expect(elem).toBeInTheDocument();
   });
 
-  it("renders suffix as button element when onClick is passed", () => {
-    const { container } = render(
-      <Chip.Suffix onClick={jest.fn()}>
-        <Icon name="cross" />
-      </Chip.Suffix>,
-    );
+  describe("when onClick prop is passed", () => {
+    it("should call onClick when suffix is clicked", () => {
+      const onClick = jest.fn();
+      const { getByTestId } = render(
+        <Chip.Suffix onClick={onClick} testID="ATL-Chip-Suffix">
+          <Icon name="cross" />
+        </Chip.Suffix>,
+      );
 
-    expect(container.querySelector("button")).toBeInTheDocument();
-  });
+      getByTestId("ATL-Chip-Suffix")?.click();
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
 
-  it("renders suffix as a span element when onClick is not passed", () => {
-    const { container } = render(
-      <Chip.Suffix>
-        <Icon name="cross" />
-      </Chip.Suffix>,
-    );
+    it("should call onClick when suffix is keypressed", async () => {
+      const onClick = jest.fn();
+      const { getByTestId } = render(
+        <Chip.Suffix onClick={onClick} testID="ATL-Chip-Suffix">
+          <Icon name="cross" />
+        </Chip.Suffix>,
+      );
 
-    expect(container.querySelector("span")).toBeInTheDocument();
-    expect(container.querySelector("button")).not.toBeInTheDocument();
-  });
+      const spanElement = getByTestId("ATL-Chip-Suffix");
+      expect(spanElement).not.toBeNull();
 
-  it("should call onClick when suffix is clicked when onClick is passed", () => {
-    const onClick = jest.fn();
-    const { container } = render(
-      <Chip.Suffix onClick={onClick}>
-        <Icon name="cross" />
-      </Chip.Suffix>,
-    );
+      if (spanElement) {
+        spanElement.focus();
+        await userEvent.keyboard("{enter}");
+      }
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
 
-    container.querySelector("button")?.click();
-    expect(onClick).toHaveBeenCalled();
-  });
+    it("renders a testID", () => {
+      const onClick = jest.fn();
+      const { getByTestId } = render(
+        <Chip.Suffix onClick={onClick} testID="ATL-Chip-Suffix">
+          <Icon name="cross" />
+        </Chip.Suffix>,
+      );
 
-  it("renders a testID when onClick is passed", () => {
-    const onClick = jest.fn();
-    const { getByTestId } = render(
-      <Chip.Suffix onClick={onClick} testID="ATL-Chip-Suffix">
-        <Icon name="cross" />
-      </Chip.Suffix>,
-    );
+      expect(getByTestId("ATL-Chip-Suffix")).toBeInTheDocument();
+    });
 
-    expect(getByTestId("ATL-Chip-Suffix")).toBeInTheDocument();
+    it("applies accessible and semantic attributes", () => {
+      const onClick = jest.fn();
+      const { container } = render(
+        <Chip.Suffix onClick={onClick} ariaLabel="dismiss">
+          <Icon name="cross" />
+        </Chip.Suffix>,
+      );
+
+      const chipSuffix = container.querySelector("span");
+      expect(chipSuffix).toHaveAttribute("aria-label", "dismiss");
+      expect(chipSuffix).toHaveAttribute("role", "button");
+    });
+
+    it("should apply the correct styles", () => {
+      const onClick = jest.fn();
+      const { getByTestId } = render(
+        <Chip.Suffix onClick={onClick} testID="ATL-Chip-Suffix">
+          <Icon name="cross" />
+        </Chip.Suffix>,
+      );
+
+      const suffix = getByTestId("ATL-Chip-Suffix");
+      expect(suffix).toHaveClass(styles.clickableSuffix);
+      expect(suffix).not.toHaveClass(styles.suffix);
+    });
   });
 });

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
@@ -55,7 +55,7 @@ describe("Chip Suffix", () => {
       );
 
       const spanElement = getByTestId("ATL-Chip-Suffix");
-      expect(spanElement).not.toBeNull();
+      expect(spanElement).toBeInTheDocument();
 
       if (spanElement) {
         spanElement.focus();

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
@@ -48,19 +48,14 @@ describe("Chip Suffix", () => {
 
     it("should call onClick when suffix is keypressed", async () => {
       const onClick = jest.fn();
-      const { getByTestId } = render(
+      render(
         <Chip.Suffix onClick={onClick} testID="ATL-Chip-Suffix">
           <Icon name="cross" />
         </Chip.Suffix>,
       );
 
-      const spanElement = getByTestId("ATL-Chip-Suffix");
-      expect(spanElement).toBeInTheDocument();
-
-      if (spanElement) {
-        spanElement.focus();
-        await userEvent.keyboard("{enter}");
-      }
+      await userEvent.tab();
+      await userEvent.keyboard("{enter}");
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
@@ -77,13 +77,17 @@ describe("Chip Suffix", () => {
 
     it("applies accessible and semantic attributes", () => {
       const onClick = jest.fn();
-      const { container } = render(
-        <Chip.Suffix onClick={onClick} ariaLabel="dismiss">
+      const { getByTestId } = render(
+        <Chip.Suffix
+          onClick={onClick}
+          ariaLabel="dismiss"
+          testID="ATL-Chip-Suffix"
+        >
           <Icon name="cross" />
         </Chip.Suffix>,
       );
 
-      const chipSuffix = container.querySelector("span");
+      const chipSuffix = getByTestId("ATL-Chip-Suffix");
       expect(chipSuffix).toHaveAttribute("aria-label", "dismiss");
       expect(chipSuffix).toHaveAttribute("role", "button");
     });

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.test.tsx
@@ -64,4 +64,15 @@ describe("Chip Suffix", () => {
     container.querySelector("button")?.click();
     expect(onClick).toHaveBeenCalled();
   });
+
+  it("renders a testID when onClick is passed", () => {
+    const onClick = jest.fn();
+    const { getByTestId } = render(
+      <Chip.Suffix onClick={onClick} testID="ATL-Chip-Suffix">
+        <Icon name="cross" />
+      </Chip.Suffix>,
+    );
+
+    expect(getByTestId("ATL-Chip-Suffix")).toBeInTheDocument();
+  });
 });

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -8,6 +8,7 @@ export function ChipSuffix({
   children,
   className,
   onClick: onSuffixClick,
+  testID,
 }: ChipSuffixProps) {
   let singleChild = useChildComponent(children, d => d.type === Icon);
 
@@ -15,53 +16,38 @@ export function ChipSuffix({
     singleChild = undefined;
   }
 
-  // Common props for both span and button to avoid repetition
-  const commonProps = {
-    className: classNames(
-      styles.suffix,
-      className,
-      !singleChild && styles.empty,
-    ),
-    children: singleChild,
-  };
-
-  return onSuffixClick ? (
-    <button
-      {...commonProps}
-      onClick={ev => {
-        ev.stopPropagation(); // Prevent the event from bubbling up
-        onSuffixClick(ev);
-      }}
-      type="button" // Specify the button type for accessibility
-      aria-label="Suffix button" // Provide an accessible label
-    />
-  ) : (
-    <span {...commonProps} />
-  );
+  if (onSuffixClick) {
+    return (
+      <button
+        className={styles.suffixClick}
+        onClick={ev => {
+          ev.stopPropagation();
+          onSuffixClick(ev);
+        }}
+        data-testid={testID}
+      >
+        {singleChild}
+      </button>
+    );
+  } else {
+    return (
+      <span
+        className={classNames(
+          styles.suffix,
+          className,
+          !singleChild && styles.empty,
+        )}
+      >
+        {singleChild}
+      </span>
+    );
+  }
 }
-
-//   return (
-//     <span
-//       className={classNames(
-//         styles.suffix,
-//         className,
-//         !singleChild && styles.empty,
-//       )}
-//        onClick={(ev) => {
-//         ev.stopPropagation(); // Prevent the event from bubbling up to the Chip's onClick
-//         if (onSuffixClick) {
-//           onSuffixClick(ev);
-//         }
-//       }}
-//     >
-//       {singleChild}
-//     </span>
-//   );
-// }
 
 export interface ChipSuffixProps extends PropsWithChildren {
   readonly className?: string;
-  readonly onClick?: (ev: React.MouseEvent<HTMLSpanElement>) => void;
+  readonly testID?: string;
+  readonly onClick?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const allowedSuffixIcons = ["cross", "add", "checkmark", "arrowDown"];

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -4,28 +4,64 @@ import { Icon } from "@jobber/components/Icon";
 import { useChildComponent } from "../../hooks";
 import styles from "../../Chip.css";
 
-export function ChipSuffix({ children, className }: ChipSuffixProps) {
+export function ChipSuffix({
+  children,
+  className,
+  onClick: onSuffixClick,
+}: ChipSuffixProps) {
   let singleChild = useChildComponent(children, d => d.type === Icon);
 
   if (!allowedSuffixIcons.includes(singleChild?.props?.name)) {
     singleChild = undefined;
   }
 
-  return (
-    <span
-      className={classNames(
-        styles.suffix,
-        className,
-        !singleChild && styles.empty,
-      )}
-    >
-      {singleChild}
-    </span>
+  // Common props for both span and button to avoid repetition
+  const commonProps = {
+    className: classNames(
+      styles.suffix,
+      className,
+      !singleChild && styles.empty,
+    ),
+    children: singleChild,
+  };
+
+  return onSuffixClick ? (
+    <button
+      {...commonProps}
+      onClick={ev => {
+        ev.stopPropagation(); // Prevent the event from bubbling up
+        onSuffixClick(ev);
+      }}
+      type="button" // Specify the button type for accessibility
+      aria-label="Suffix button" // Provide an accessible label
+    />
+  ) : (
+    <span {...commonProps} />
   );
 }
 
+//   return (
+//     <span
+//       className={classNames(
+//         styles.suffix,
+//         className,
+//         !singleChild && styles.empty,
+//       )}
+//        onClick={(ev) => {
+//         ev.stopPropagation(); // Prevent the event from bubbling up to the Chip's onClick
+//         if (onSuffixClick) {
+//           onSuffixClick(ev);
+//         }
+//       }}
+//     >
+//       {singleChild}
+//     </span>
+//   );
+// }
+
 export interface ChipSuffixProps extends PropsWithChildren {
   readonly className?: string;
+  readonly onClick?: (ev: React.MouseEvent<HTMLSpanElement>) => void;
 }
 
 export const allowedSuffixIcons = ["cross", "add", "checkmark", "arrowDown"];

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -7,8 +7,9 @@ import styles from "../../Chip.css";
 export function ChipSuffix({
   children,
   className,
-  onClick: onSuffixClick,
+  onClick: onClickSuffix,
   testID,
+  ariaLabel,
 }: ChipSuffixProps) {
   let singleChild = useChildComponent(children, d => d.type === Icon);
 
@@ -16,15 +17,16 @@ export function ChipSuffix({
     singleChild = undefined;
   }
 
-  if (onSuffixClick) {
+  if (onClickSuffix) {
     return (
       <button
-        className={styles.suffixClick}
-        onClick={ev => {
-          ev.stopPropagation();
-          onSuffixClick(ev);
+        className={styles.clickableSuffix}
+        onClick={event => {
+          event.stopPropagation();
+          onClickSuffix(event);
         }}
         data-testid={testID}
+        aria-label={ariaLabel}
       >
         {singleChild}
       </button>
@@ -47,7 +49,8 @@ export function ChipSuffix({
 export interface ChipSuffixProps extends PropsWithChildren {
   readonly className?: string;
   readonly testID?: string;
-  readonly onClick?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
+  readonly ariaLabel?: string;
+  readonly onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const allowedSuffixIcons = ["cross", "add", "checkmark", "arrowDown"];

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -7,20 +7,24 @@ import styles from "../../Chip.css";
 export function ChipSuffix({
   children,
   className,
-  onClick: onClickSuffix,
+  onClick,
   testID,
   ariaLabel,
 }: ChipSuffixProps) {
   let singleChild = useChildComponent(children, d => d.type === Icon);
 
   const handleClick = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    event:
+      | React.MouseEvent<HTMLSpanElement, MouseEvent>
+      | React.KeyboardEvent<HTMLSpanElement>,
   ) => {
+    if (!onClick) {
+      return;
+    }
+    event.preventDefault();
     event.stopPropagation();
-    onClickSuffix?.(event);
+    onClick(event);
   };
-
-  const isClickable = Boolean(onClickSuffix);
 
   if (!allowedSuffixIcons.includes(singleChild?.props?.name)) {
     singleChild = undefined;
@@ -28,26 +32,30 @@ export function ChipSuffix({
 
   const tagProps = {
     className: classNames(
-      isClickable ? styles.clickableSuffix : styles.suffix,
+      onClick ? styles.clickableSuffix : styles.suffix,
       className,
       !singleChild && styles.empty,
     ),
-    onClick: isClickable ? handleClick : undefined,
-    type: isClickable ? ("button" as const) : undefined,
+    onClick: handleClick,
+    onKeyPress: handleClick,
+    ...(onClick ? { role: "button" } : {}),
+    ...(onClick ? { tabIndex: 0 } : {}),
     "data-testid": testID,
     "aria-label": ariaLabel,
   };
 
-  const Tag = onClickSuffix ? "button" : "span";
-
-  return <Tag {...tagProps}>{singleChild}</Tag>;
+  return <span {...tagProps}>{singleChild}</span>;
 }
 
 export interface ChipSuffixProps extends PropsWithChildren {
   readonly className?: string;
   readonly testID?: string;
   readonly ariaLabel?: string;
-  readonly onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  readonly onClick?: (
+    event:
+      | React.MouseEvent<HTMLSpanElement, MouseEvent>
+      | React.KeyboardEvent<HTMLSpanElement>,
+  ) => void;
 }
 
 export const allowedSuffixIcons = ["cross", "add", "checkmark", "arrowDown"];

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -13,38 +13,34 @@ export function ChipSuffix({
 }: ChipSuffixProps) {
   let singleChild = useChildComponent(children, d => d.type === Icon);
 
+  const handleClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    event.stopPropagation();
+    onClickSuffix?.(event);
+  };
+
+  const isClickable = Boolean(onClickSuffix);
+
   if (!allowedSuffixIcons.includes(singleChild?.props?.name)) {
     singleChild = undefined;
   }
 
-  if (onClickSuffix) {
-    return (
-      <button
-        className={styles.clickableSuffix}
-        onClick={event => {
-          event.stopPropagation();
-          onClickSuffix(event);
-        }}
-        data-testid={testID}
-        aria-label={ariaLabel}
-        type="button"
-      >
-        {singleChild}
-      </button>
-    );
-  } else {
-    return (
-      <span
-        className={classNames(
-          styles.suffix,
-          className,
-          !singleChild && styles.empty,
-        )}
-      >
-        {singleChild}
-      </span>
-    );
-  }
+  const tagProps = {
+    className: classNames(
+      isClickable ? styles.clickableSuffix : styles.suffix,
+      className,
+      !singleChild && styles.empty,
+    ),
+    onClick: isClickable ? handleClick : undefined,
+    type: isClickable ? ("button" as const) : undefined,
+    "data-testid": testID,
+    "aria-label": ariaLabel,
+  };
+
+  const Tag = onClickSuffix ? "button" : "span";
+
+  return <Tag {...tagProps}>{singleChild}</Tag>;
 }
 
 export interface ChipSuffixProps extends PropsWithChildren {

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -30,21 +30,23 @@ export function ChipSuffix({
     singleChild = undefined;
   }
 
-  const tagProps = {
-    className: classNames(
-      onClick ? styles.clickableSuffix : styles.suffix,
-      className,
-      !singleChild && styles.empty,
-    ),
-    onClick: handleClick,
-    onKeyPress: handleClick,
-    ...(onClick ? { role: "button" } : {}),
-    ...(onClick ? { tabIndex: 0 } : {}),
-    "data-testid": testID,
-    "aria-label": ariaLabel,
-  };
-
-  return <span {...tagProps}>{singleChild}</span>;
+  return (
+    <span
+      className={classNames(
+        onClick ? styles.clickableSuffix : styles.suffix,
+        className,
+        !singleChild && styles.empty,
+      )}
+      onClick={handleClick}
+      onKeyPress={handleClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      data-testid={testID}
+      aria-label={ariaLabel}
+    >
+      {singleChild}
+    </span>
+  );
 }
 
 export interface ChipSuffixProps extends PropsWithChildren {

--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -27,6 +27,7 @@ export function ChipSuffix({
         }}
         data-testid={testID}
         aria-label={ariaLabel}
+        type="button"
       >
         {singleChild}
       </button>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`Chip.Suffix` should have an `onClick` so that a custom event can be triggered, separate from clicking the `Chip` itself

![Kapture 2024-07-22 at 19 53 56](https://github.com/user-attachments/assets/d35742e6-48d2-4558-b440-10b140411ea1)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

1. `onClick` optional prop to `Chip.Suffix`
If `<Chip.Suffix />` receives an `onClick`, the element becomes a `button`.  If no `onClick` is provided, the suffix remains a `span` element.  I decided on this solution to maintain a semantically correct element whether there's an `onClick` or not.

2. `testID` optional prop to `Chip.Suffix`
I think it's safe to assume that if any consumer of `Chip` wants to add a clickable suffix, they'll also want to test that interaction.

3. `ariaLabel` optional prop to `Chip.Suffix`
To provide as much flexibility as possible, we're passing an `ariaLabel` for clarity to screen readers. For example:
<img width="344" alt="Screenshot 2024-07-21 at 8 46 16 PM" src="https://github.com/user-attachments/assets/b4adf0ee-21d5-48bd-8ae3-e176732e00a1">

4. a new web story for `ClickableSuffix`, while keeping a `Suffix` story without the `onClick`

5. more tests for `Chip.Suffix`:
- renders suffix as `button` when `onClick` is passed
- renders suffix as `span` when `onClick` is not passed
- should call `onClick` when suffix is clicked and `onClick` is passed


## Testing

<!-- How to test your changes. -->

Draft PR [here](https://github.com/GetJobber/Jobber/pull/48679) to test `onClick` within `Chip.Suffix`

Use the `Clickable Suffix` and `Suffix` stories to test:
- [ ] an `onClick` can be passed to the `Chip.Suffix`
- [ ] `onClick` behaviour on the suffix does not affect `onClick` behaviour of the parent Chip
- [ ] when the suffix is clickable it is announced via screenreader, has the correct role & can receive focus 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
