### PR TITLE
docs(components): Disambiguate Drawer and SideDrawer

### DIFF
--- a/docs/components/Drawer/Drawer.stories.mdx
+++ b/docs/components/Drawer/Drawer.stories.mdx
@@ -10,15 +10,16 @@ Users can interact with the main content while the drawer is visible.
 
 ## Related components
 
-Drawer is similar in some ways to Card and Modal.
+Use [SideDrawer](../?path=/docs/components-overlays-sidedrawer--docs) if you
+need to overlay the page's content and block user interaction with the page,
+while still maintaining visibilty of the page's primary contents.
 
-For an experience where the user can only interact with one "mode" of content
-(the main view _or_ the contents of the component) use
-[Modal.](../?path=/docs/components-overlays-modal--docs)
+Use [Modal](../?path=/docs/components-overlays-Modal--docs) if you need to
+overlay the page's content and block user interaction with the page, and do not
+need the user to have visibilty of the page's primary contents.
 
-For an inline grouping of content that is relevant within the main view and
-non-dismissible, use
-[Card.](../?path=/docs/components-layouts-and-structure-card--docs)
+Use [Card](../?path=/docs/components-layouts-and-structure-card--docs) to group
+content inline, within the main view, in a non-dismissible way.
 
 ## Accessibility
 

--- a/docs/components/Modal/Modal.stories.mdx
+++ b/docs/components/Modal/Modal.stories.mdx
@@ -13,3 +13,7 @@ the rest of the application until a specific action is taken.
 Use [SideDrawer](../?path=/docs/components-overlays-sidedrawer--docs) if you
 need to overlay the page's content and block user interaction with the page,
 while still maintaining visibilty of the page's primary contents.
+
+Use
+[ConfirmationModal](../?path=/docs/components-overlays-confirmationmodal--docs)
+to allow users to confirm or cancel actions that they are performing.

--- a/docs/components/Modal/Modal.stories.mdx
+++ b/docs/components/Modal/Modal.stories.mdx
@@ -7,3 +7,9 @@ import { Meta } from "@storybook/addon-docs";
 Modals are overlays that allow users to view, edit, or show informations that
 doesn't require a page to be built. It also prevent users from interacting with
 the rest of the application until a specific action is taken.
+
+## Related components
+
+Use [SideDrawer](../?path=/docs/components-overlays-sidedrawer--docs) if you
+need to overlay the page's content and block user interaction with the page,
+while still maintaining visibilty of the page's primary contents.

--- a/docs/components/SideDrawer/SideDrawer.stories.mdx
+++ b/docs/components/SideDrawer/SideDrawer.stories.mdx
@@ -5,8 +5,19 @@ import { SideDrawer } from "@jobber/components/SideDrawer";
 
 # Side Drawer
 
-SideDrawers are overlays that allow users to view or edit information that
-doesn't require a page to be built.
+SideDrawers are overlays that allow users to view or edit information while
+maintaining visibilisty of the page's primary contents. Users cannot interact
+with the page's contents while the SideDrawer overlay is open.
+
+## Related components
+
+Use [Drawer](../?path=/docs/components-layouts-and-structure-drawer--docs) if
+you need to allow users to view supplementary content while still allowing users
+to interact with the main contents of the page.
+
+Use [Modal](../?path=/docs/components-overlays-Modal--docs) if you need to
+overlay the page's content and block user interaction with the page, and do not
+need the user to have visibilty of the page's primary contents.
 
 ## Implementation guidelines
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Multiple questions around when to use Drawer vs SideDrawer

## Changes

### Added

- Added or improved "Related components" sections in the docs for Drawer, SideDrawer, and also Modal 

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
