### PR TITLE
fix(components): implement keyboard navigation for Tabs [#652]

### DIFF
--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -107,6 +107,21 @@ describe("Tabs", () => {
     expect(queryByText("🧀")).not.toBeInTheDocument();
   });
 
+  it("should navigate tabs with arrow keys", () => {
+    const { getByRole, getAllByRole } = render(omelet);
+
+    const tablist = getByRole("tablist");
+    const [eggsTab, cheeseTab] = getAllByRole("tab");
+
+    // Navigate right
+    fireEvent.keyDown(tablist, { key: "ArrowRight" });
+    expect(cheeseTab).toHaveFocus();
+
+    // Navigate left
+    fireEvent.keyDown(tablist, { key: "ArrowLeft" });
+    expect(eggsTab).toHaveFocus();
+  });
+
   describe("overflow", () => {
     beforeAll(() => {
       Object.defineProperty(HTMLElement.prototype, "clientWidth", {

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -122,6 +122,20 @@ describe("Tabs", () => {
     expect(eggsTab).toHaveFocus();
   });
 
+  it("should navigate focus correctly between tab and panel on Tab key", () => {
+    const { getByRole, getAllByRole } = render(omelet);
+    const [eggsTab] = getAllByRole("tab");
+    const eggsPanel = getByRole("tabpanel", { name: "Eggs" });
+
+    // Ensure focus starts on the eggs tab
+    eggsTab.focus();
+    expect(eggsTab).toHaveFocus();
+
+    // Press Tab key to move focus to panel
+    fireEvent.keyDown(eggsTab, { key: "Tab" });
+    expect(eggsPanel).toHaveFocus();
+  });
+
   describe("overflow", () => {
     beforeAll(() => {
       Object.defineProperty(HTMLElement.prototype, "clientWidth", {

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -39,6 +39,7 @@ export function Tabs({ children, defaultTab = 0, onTabChange }: TabsProps) {
   });
 
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const panelRefs = useRef<(HTMLElement | null)[]>([]);
 
   const activateTab = (index: number) => {
     return () => {
@@ -52,14 +53,24 @@ export function Tabs({ children, defaultTab = 0, onTabChange }: TabsProps) {
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
-    if (event.key === "ArrowRight") {
+    const { key, shiftKey } = event;
+
+    if (key === "ArrowRight") {
       setActiveTab(prev => (prev + 1) % React.Children.count(children));
-    } else if (event.key === "ArrowLeft") {
+    } else if (key === "ArrowLeft") {
       setActiveTab(
         prev =>
           (prev - 1 + React.Children.count(children)) %
           React.Children.count(children),
       );
+    } else if (key === "Tab") {
+      event.preventDefault();
+
+      if (shiftKey) {
+        tabRefs.current[activeTab]?.focus();
+      } else {
+        panelRefs.current[activeTab]?.focus();
+      }
     }
   };
 
@@ -71,11 +82,8 @@ export function Tabs({ children, defaultTab = 0, onTabChange }: TabsProps) {
     if (activeTab > React.Children.count(children) - 1) {
       setActiveTab(activeTabInitialValue);
     }
-  }, [React.Children.count(children)]);
-
-  useEffect(() => {
     tabRefs.current[activeTab]?.focus();
-  }, [activeTab]);
+  }, [activeTab, React.Children.count(children)]);
 
   return (
     <div className={styles.tabs}>
@@ -88,6 +96,7 @@ export function Tabs({ children, defaultTab = 0, onTabChange }: TabsProps) {
         >
           {React.Children.map(children, (tab, index) => (
             <InternalTab
+              key={tab.props.label}
               label={tab.props.label}
               selected={activeTab === index}
               activateTab={activateTab(index)}
@@ -101,6 +110,8 @@ export function Tabs({ children, defaultTab = 0, onTabChange }: TabsProps) {
         role="tabpanel"
         className={styles.tabContent}
         aria-label={activeTabProps?.label}
+        tabIndex={0}
+        ref={el => (panelRefs.current[activeTab] = el)}
       >
         {activeTabProps?.children}
       </section>

--- a/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -16,9 +16,11 @@ exports[`Tabs renders Tabs 1`] = `
           role="presentation"
         >
           <button
+            aria-selected="true"
             class="tab selected"
             id="Eggs"
             role="tab"
+            tabindex="0"
             type="button"
           >
             <span
@@ -32,9 +34,11 @@ exports[`Tabs renders Tabs 1`] = `
           role="presentation"
         >
           <button
+            aria-selected="false"
             class="tab"
             id="Cheese"
             role="tab"
+            tabindex="-1"
             type="button"
           >
             <span

--- a/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`Tabs renders Tabs 1`] = `
       aria-label="Eggs"
       class="tabContent"
       role="tabpanel"
+      tabindex="0"
     >
       <p>
         🍳


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
The `Tab` component's accessibility and user experience can be significantly improved by refining keyboard navigation. Implementing arrow key navigation, along with Tab and Shift+Tab key functionality, enhances usability for all users, including those who rely on keyboard navigation.


<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
- Implemented arrow key navigation for tabs, allowing users to switch tabs using the left and right arrow keys.
- Added functionality for `Tab` and `Shift+Tab` keys to navigate focus between the active tab and its content.
- Added tests to validate the arrow key navigation and Tab key functionality.


### Changed
- Updated focus behavior to enhance accessibility and user experience.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed
- Ensured the tab content and navigation comply with accessibility standards.

### Security

- <!-- in case of vulnerabilities -->

## Testing
- Added tests to validate the arrow key navigation and Tab key functionality.
- Manually tested to ensure the improved navigation works as expected.
<!-- How to test your changes. -->
### Files Changed
- `packages/components/src/Tabs/Tabs.tsx`
- `packages/components/src/Tabs/Tabs.test.tsx`
- `packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap`
Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
