### PR TITLE
fix(components): Adjust z-index of clickable areas in FormatFile

### DIFF
--- a/docs/components/FormatFile/Web.stories.tsx
+++ b/docs/components/FormatFile/Web.stories.tsx
@@ -42,3 +42,18 @@ Collapsed.args = {
   displaySize: "large",
   onDelete: () => alert("Deleted"),
 };
+
+export const ExpandedWithDelete = BasicTemplate.bind({});
+ExpandedWithDelete.args = {
+  file: {
+    key: "abc",
+    name: "image_of_something.png",
+    type: "image/png",
+    size: 213402324,
+    progress: 1,
+    src: () => Promise.resolve("https://picsum.photos/250"),
+  },
+  display: "expanded",
+  onDelete: () => alert("Deleted"),
+  onClick: () => alert("Clicked"),
+};

--- a/docs/components/FormatFile/Web.stories.tsx
+++ b/docs/components/FormatFile/Web.stories.tsx
@@ -54,6 +54,6 @@ ExpandedWithDelete.args = {
     src: () => Promise.resolve("https://picsum.photos/250"),
   },
   display: "expanded",
-  onDelete: () => alert("Deleted"),
+  onDelete: () => console.log("Deleted"),
   onClick: () => alert("Clicked"),
 };

--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -77,6 +77,10 @@
   box-shadow: var(--shadow-focus);
 }
 
+.deleteButton {
+  z-index: 1;
+}
+
 .expanded .thumbnail {
   border-right: none;
   border-bottom-left-radius: var(--radius-base);

--- a/packages/components/src/FormatFile/FormatFile.css.d.ts
+++ b/packages/components/src/FormatFile/FormatFile.css.d.ts
@@ -6,11 +6,11 @@ declare const styles: {
   readonly "large": string;
   readonly "base": string;
   readonly "thumbnail": string;
+  readonly "deleteButton": string;
   readonly "clickable": string;
   readonly "hoverable": string;
   readonly "progress": string;
   readonly "contentBlock": string;
-  readonly "deleteButton": string;
   readonly "deleteable": string;
 };
 export = styles;

--- a/packages/components/src/FormatFile/FormatFileDeleteButton.tsx
+++ b/packages/components/src/FormatFile/FormatFileDeleteButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import styles from "./FormatFile.css";
 import { Button } from "../Button";
 import { ConfirmationModal } from "../ConfirmationModal";
 
@@ -12,7 +13,7 @@ export function FormatFileDeleteButton({ size, onDelete }: DeleteButtonProps) {
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
 
   return (
-    <>
+    <div className={styles.deleteButton}>
       <Button
         onClick={() => setDeleteConfirmationOpen(true)}
         variation="destructive"
@@ -30,6 +31,6 @@ export function FormatFileDeleteButton({ size, onDelete }: DeleteButtonProps) {
         onConfirm={() => onDelete?.()}
         onRequestClose={() => setDeleteConfirmationOpen(false)}
       />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`FormatFile` has an issue when both `onClick` and `onDelete` are present, where you cannot click the delete Icon immediately after clicking the `FormatFile` component itself.  Instead, you'd have to remove focus from the `FormatFile` in order to click the delete Icon.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- a new `ExpandedwithDelete` story; good for testing this functionality but also, we should have a story with the `onDelete`
- added a `deleteButton` class so that we can raise the z-index of that element

### Fixed

#### Before

When an `onClick` & an `onDelete` are both present, you cannot click the delete button immediately after triggering the `onClick` (volume up):

https://github.com/user-attachments/assets/abaded2d-d0df-4f8d-9c89-8f1e940e6f9b

#### After

When `onClick` & `onDelete` are both present, you can trigger the `onClick` and then trigger the `onDelete` without removing focus/tabbing (volume up):


https://github.com/user-attachments/assets/7fbf334e-fe35-42e1-86a5-60eb8e3f1c2d





## Testing

<!-- How to test your changes. -->
- test this in the new `ExpandedwithDelete` story
- pre-release sent in slack msg



---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
