### PR TITLE
feat(design): Design Token Redo - Better Icon Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37329,9 +37329,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
-      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
+      "integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"

--- a/packages/components-native/src/Button/Button.test.tsx
+++ b/packages/components-native/src/Button/Button.test.tsx
@@ -209,7 +209,7 @@ describe("Button", () => {
     it("renders an icon Button with same color as the Button text", () => {
       const { iconColor, textColor } = getIconAndTextColorFromRender({});
 
-      expect(iconColor).toBe("{color.icon}");
+      expect(iconColor).toBe("rgba(255, 255, 255, 1)");
       expect(textColor).toBe(tokens["color-white"]);
     });
 
@@ -218,7 +218,7 @@ describe("Button", () => {
         variation: "learning",
         type: "secondary",
       });
-      expect(iconColor).toBe("{color.icon}");
+      expect(iconColor).toBe("hsl(198, 35%, 21%)");
       expect(textColor).toBe(tokens["color-interactive--subtle"]);
     });
 
@@ -227,7 +227,7 @@ describe("Button", () => {
         variation: "destructive",
         type: "secondary",
       });
-      expect(iconColor).toBe("{color.icon}");
+      expect(iconColor).toBe("hsl(6, 64%, 51%)");
       expect(textColor).toBe(tokens["color-destructive"]);
     });
 
@@ -236,7 +236,7 @@ describe("Button", () => {
         variation: "cancel",
         type: "tertiary",
       });
-      expect(iconColor).toBe("{color.icon}");
+      expect(iconColor).toBe("hsl(198, 35%, 21%)");
       expect(textColor).toBe("hsl(198, 35%, 21%)");
     });
 

--- a/packages/components-native/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
+++ b/packages/components-native/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`renders a Disclosure with a header and a content when open is true 1`] 
           style={
             {
               "display": "flex",
-              "fill": "{color.icon}",
+              "fill": "",
               "height": 24,
               "verticalAlign": "middle",
               "width": 24,
@@ -110,7 +110,7 @@ exports[`renders a Disclosure with a header and a content when open is true 1`] 
         >
           <Path
             d="M16.297 14.709a.996.996 0 0 0 1.41-.001.994.994 0 0 0 0-1.41l-5-5.005a.998.998 0 0 0-1.415 0l-5 5a.994.994 0 0 0 0 1.41.996.996 0 0 0 1.411.001L12 10.416l4.297 4.293Z"
-            fill="{color.icon}"
+            fill="hsl(0, 0%, 72%)"
           />
         </SVGMock>
       </View>
@@ -270,7 +270,7 @@ exports[`renders a Disclosure with a header and with a content of size 0 when cl
           style={
             {
               "display": "flex",
-              "fill": "{color.icon}",
+              "fill": "",
               "height": 24,
               "verticalAlign": "middle",
               "width": 24,
@@ -281,7 +281,7 @@ exports[`renders a Disclosure with a header and with a content of size 0 when cl
         >
           <Path
             d="M16.297 14.709a.996.996 0 0 0 1.41-.001.994.994 0 0 0 0-1.41l-5-5.005a.998.998 0 0 0-1.415 0l-5 5a.994.994 0 0 0 0 1.41.996.996 0 0 0 1.411.001L12 10.416l4.297 4.293Z"
-            fill="{color.icon}"
+            fill="hsl(0, 0%, 72%)"
           />
         </SVGMock>
       </View>

--- a/packages/components-native/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
+++ b/packages/components-native/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`renders a Disclosure with a header and a content when open is true 1`] 
           style={
             {
               "display": "flex",
-              "fill": "",
+              "fill": "hsl(0, 0%, 72%)",
               "height": 24,
               "verticalAlign": "middle",
               "width": 24,
@@ -270,7 +270,7 @@ exports[`renders a Disclosure with a header and with a content of size 0 when cl
           style={
             {
               "display": "flex",
-              "fill": "",
+              "fill": "hsl(0, 0%, 72%)",
               "height": 24,
               "verticalAlign": "middle",
               "width": 24,

--- a/packages/components-native/src/Icon/Icon.tsx
+++ b/packages/components-native/src/Icon/Icon.tsx
@@ -37,14 +37,14 @@ export function Icon({
   customColor,
   testID,
 }: IconProps): JSX.Element {
-  const { svgStyle, paths, viewBox } = getIcon({
+  const { svgStyle, pathStyle, paths, viewBox } = getIcon({
     name,
     color,
     size,
+    format: "js",
   });
-
   const icon = paths.map((path: string) => {
-    return <Path key={path} d={path} fill={customColor || svgStyle.fill} />;
+    return <Path key={path} d={path} fill={customColor || pathStyle.fill} />;
   });
 
   return (

--- a/packages/components-native/src/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/components-native/src/Icon/__snapshots__/Icon.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`renders apple icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "",
+        "fill": "hsl(198, 35%, 21%)",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -36,7 +36,7 @@ exports[`renders apple icon 1`] = `
   <RNSVGGroup
     fill={
       {
-        "payload": 4278190080,
+        "payload": 4280499528,
         "type": 0,
       }
     }
@@ -81,7 +81,7 @@ exports[`renders home icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "",
+        "fill": "hsl(198, 35%, 21%)",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -100,7 +100,7 @@ exports[`renders home icon 1`] = `
   <RNSVGGroup
     fill={
       {
-        "payload": 4278190080,
+        "payload": 4280499528,
         "type": 0,
       }
     }
@@ -145,7 +145,7 @@ exports[`renders large arrowDown icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "",
+        "fill": "hsl(198, 35%, 21%)",
         "height": 32,
         "verticalAlign": "middle",
         "width": 32,
@@ -164,7 +164,7 @@ exports[`renders large arrowDown icon 1`] = `
   <RNSVGGroup
     fill={
       {
-        "payload": 4278190080,
+        "payload": 4280499528,
         "type": 0,
       }
     }
@@ -209,7 +209,7 @@ exports[`renders quote icon with themed color 1`] = `
       },
       {
         "display": "flex",
-        "fill": "",
+        "fill": "hsl(348, 40%, 41%)",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -228,7 +228,7 @@ exports[`renders quote icon with themed color 1`] = `
   <RNSVGGroup
     fill={
       {
-        "payload": 4278190080,
+        "payload": 4287774543,
         "type": 0,
       }
     }
@@ -287,7 +287,7 @@ exports[`renders small more icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "",
+        "fill": "hsl(198, 35%, 21%)",
         "height": 16,
         "verticalAlign": "middle",
         "width": 16,
@@ -306,7 +306,7 @@ exports[`renders small more icon 1`] = `
   <RNSVGGroup
     fill={
       {
-        "payload": 4278190080,
+        "payload": 4280499528,
         "type": 0,
       }
     }
@@ -351,7 +351,7 @@ exports[`renders star icon with custom color 1`] = `
       },
       {
         "display": "flex",
-        "fill": "",
+        "fill": "hsl(198, 35%, 21%)",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -370,7 +370,7 @@ exports[`renders star icon with custom color 1`] = `
   <RNSVGGroup
     fill={
       {
-        "payload": 4278190080,
+        "payload": 4280499528,
         "type": 0,
       }
     }
@@ -415,7 +415,7 @@ exports[`renders thumbsDown icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "",
+        "fill": "hsl(198, 35%, 21%)",
         "height": 24,
         "transform": "scaleY(-1)",
         "verticalAlign": "middle",
@@ -435,7 +435,7 @@ exports[`renders thumbsDown icon 1`] = `
   <RNSVGGroup
     fill={
       {
-        "payload": 4278190080,
+        "payload": 4280499528,
         "type": 0,
       }
     }

--- a/packages/components-native/src/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/components-native/src/Icon/__snapshots__/Icon.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`renders apple icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "{color.icon}",
+        "fill": "",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -34,7 +34,12 @@ exports[`renders apple icon 1`] = `
   vbWidth={24}
 >
   <RNSVGGroup
-    fill={null}
+    fill={
+      {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
     propList={
       [
         "fill",
@@ -43,7 +48,12 @@ exports[`renders apple icon 1`] = `
   >
     <RNSVGPath
       d="M18.467 12.754c-.027-2.996 2.453-4.453 2.566-4.52-1.404-2.048-3.581-2.328-4.346-2.35-1.828-.193-3.601 1.094-4.533 1.094-.95 0-2.384-1.076-3.93-1.044-1.988.03-3.849 1.182-4.87 2.97C1.25 12.55 2.82 17.91 4.838 20.856c1.01 1.443 2.189 3.055 3.733 2.998 1.51-.062 2.074-.963 3.897-.963 1.806 0 2.335.963 3.91.927 1.62-.026 2.641-1.45 3.615-2.907 1.166-1.654 1.635-3.283 1.653-3.367-.038-.013-3.147-1.2-3.178-4.79Zm-2.974-8.81c.812-1.015 1.368-2.397 1.213-3.8-1.175.053-2.646.814-3.492 1.807-.75.876-1.418 2.31-1.246 3.66 1.321.099 2.677-.666 3.525-1.666Z"
-      fill={null}
+      fill={
+        {
+          "payload": 4278190080,
+          "type": 0,
+        }
+      }
       propList={
         [
           "fill",
@@ -71,7 +81,7 @@ exports[`renders home icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "{color.icon}",
+        "fill": "",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -88,7 +98,12 @@ exports[`renders home icon 1`] = `
   vbWidth={24}
 >
   <RNSVGGroup
-    fill={null}
+    fill={
+      {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
     propList={
       [
         "fill",
@@ -97,7 +112,12 @@ exports[`renders home icon 1`] = `
   >
     <RNSVGPath
       d="M13.147 3.582a2 2 0 0 0-2.294 0l-9.426 6.599a1 1 0 1 0 1.147 1.638L5 10.121V18a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3v-7.88l2.427 1.7a1 1 0 0 0 1.146-1.64l-9.426-6.598ZM17 8.721V18a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V8.72l5-3.5 5 3.5Z"
-      fill={null}
+      fill={
+        {
+          "payload": 4278190080,
+          "type": 0,
+        }
+      }
       propList={
         [
           "fill",
@@ -125,7 +145,7 @@ exports[`renders large arrowDown icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "{color.icon}",
+        "fill": "",
         "height": 32,
         "verticalAlign": "middle",
         "width": 32,
@@ -142,7 +162,12 @@ exports[`renders large arrowDown icon 1`] = `
   vbWidth={24}
 >
   <RNSVGGroup
-    fill={null}
+    fill={
+      {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
     propList={
       [
         "fill",
@@ -151,7 +176,12 @@ exports[`renders large arrowDown icon 1`] = `
   >
     <RNSVGPath
       d="M7.703 8.291a.996.996 0 0 0-1.41.001.994.994 0 0 0 0 1.41l5 5.005a.998.998 0 0 0 1.415 0l5-5a.994.994 0 0 0 0-1.41.995.995 0 0 0-1.411-.001L12 12.584 7.703 8.291Z"
-      fill={null}
+      fill={
+        {
+          "payload": 4278190080,
+          "type": 0,
+        }
+      }
       propList={
         [
           "fill",
@@ -179,7 +209,7 @@ exports[`renders quote icon with themed color 1`] = `
       },
       {
         "display": "flex",
-        "fill": "{color.quote}",
+        "fill": "",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -196,7 +226,12 @@ exports[`renders quote icon with themed color 1`] = `
   vbWidth={24}
 >
   <RNSVGGroup
-    fill={null}
+    fill={
+      {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
     propList={
       [
         "fill",
@@ -205,7 +240,12 @@ exports[`renders quote icon with themed color 1`] = `
   >
     <RNSVGPath
       d="M14 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm-2 0a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
-      fill={null}
+      fill={
+        {
+          "payload": 4285702157,
+          "type": 0,
+        }
+      }
       propList={
         [
           "fill",
@@ -214,7 +254,12 @@ exports[`renders quote icon with themed color 1`] = `
     />
     <RNSVGPath
       d="M3.586 6C3.196 6.39 3 6.902 3 7.414c0 .512.195 1.024.586 1.414l.99.991C4.315 10.554 4 11.175 4 12a7 7 0 0 0 7 7h9v1a1 1 0 1 0 2 0v-2a1 1 0 0 0-1-1h-3v-5a7 7 0 0 0-7-7c-.825 0-1.446.314-2.18.577l-.992-.991A1.994 1.994 0 0 0 6.414 4c-.512 0-1.023.195-1.414.586L3.586 6Zm3.393.565A7.041 7.041 0 0 0 5.565 7.98L5 7.414 6.414 6l.565.565ZM11 7a5 5 0 0 1 5 5v5h-5a5 5 0 0 1 0-10Z"
-      fill={null}
+      fill={
+        {
+          "payload": 4285702157,
+          "type": 0,
+        }
+      }
       propList={
         [
           "fill",
@@ -242,7 +287,7 @@ exports[`renders small more icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "{color.icon}",
+        "fill": "",
         "height": 16,
         "verticalAlign": "middle",
         "width": 16,
@@ -259,7 +304,12 @@ exports[`renders small more icon 1`] = `
   vbWidth={24}
 >
   <RNSVGGroup
-    fill={null}
+    fill={
+      {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
     propList={
       [
         "fill",
@@ -268,7 +318,12 @@ exports[`renders small more icon 1`] = `
   >
     <RNSVGPath
       d="M4 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm8-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
-      fill={null}
+      fill={
+        {
+          "payload": 4278190080,
+          "type": 0,
+        }
+      }
       propList={
         [
           "fill",
@@ -296,7 +351,7 @@ exports[`renders star icon with custom color 1`] = `
       },
       {
         "display": "flex",
-        "fill": "{color.icon}",
+        "fill": "",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -313,7 +368,12 @@ exports[`renders star icon with custom color 1`] = `
   vbWidth={24}
 >
   <RNSVGGroup
-    fill={null}
+    fill={
+      {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
     propList={
       [
         "fill",
@@ -355,7 +415,7 @@ exports[`renders thumbsDown icon 1`] = `
       },
       {
         "display": "flex",
-        "fill": "{color.icon}",
+        "fill": "",
         "height": 24,
         "transform": "scaleY(-1)",
         "verticalAlign": "middle",
@@ -373,7 +433,12 @@ exports[`renders thumbsDown icon 1`] = `
   vbWidth={24}
 >
   <RNSVGGroup
-    fill={null}
+    fill={
+      {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
     matrix={
       [
         1,
@@ -392,7 +457,12 @@ exports[`renders thumbsDown icon 1`] = `
   >
     <RNSVGPath
       d="M8 11.78V19h8l3-5.76v-1.29h-7.639l1.036-7.944L8 11.78ZM6.134 11l4.555-8.034c1.124-1.846 3.971-.844 3.691 1.299l-.74 5.685h6.86a.5.5 0 0 1 .5.5v3a1 1 0 0 1-.084.4l-3.276 6.648a.95.95 0 0 1-.44.453c-.132.065-.276.049-.423.049H4c-1.105 0-2-1.045-2-2.15V13a2 2 0 0 1 2-2h2.134ZM6 13H4v6h2v-6Z"
-      fill={null}
+      fill={
+        {
+          "payload": 4278190080,
+          "type": 0,
+        }
+      }
       propList={
         [
           "fill",

--- a/packages/components-native/src/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/components-native/src/Icon/__snapshots__/Icon.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`renders quote icon with themed color 1`] = `
       },
       {
         "display": "flex",
-        "fill": "hsl(348, 40%, 41%)",
+        "fill": "hsl(79, 85%, 34%)",
         "height": 24,
         "verticalAlign": "middle",
         "width": 24,
@@ -228,7 +228,7 @@ exports[`renders quote icon with themed color 1`] = `
   <RNSVGGroup
     fill={
       {
-        "payload": 4287774543,
+        "payload": 4285702157,
         "type": 0,
       }
     }

--- a/packages/components-native/src/Menu/Menu.test.tsx
+++ b/packages/components-native/src/Menu/Menu.test.tsx
@@ -133,7 +133,7 @@ describe("Menu", () => {
         { backgroundColor: "transparent", borderWidth: 0 },
         {
           display: "flex",
-          fill: "",
+          fill: "hsl(6, 64%, 51%)",
           height: 24,
           verticalAlign: "middle",
           width: 24,

--- a/packages/components-native/src/Menu/Menu.test.tsx
+++ b/packages/components-native/src/Menu/Menu.test.tsx
@@ -133,7 +133,7 @@ describe("Menu", () => {
         { backgroundColor: "transparent", borderWidth: 0 },
         {
           display: "flex",
-          fill: "{color.icon}",
+          fill: "",
           height: 24,
           verticalAlign: "middle",
           width: 24,

--- a/packages/components/src/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/components/src/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`displays an icon if no image and no initials are set 1`] = `
   >
     <svg
       data-testid="person"
-      style="fill: var(--color-client); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+      style="fill: var(--color-white); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`renders a banner with a primary 'learning' action when the type is 'not
       >
         <svg
           data-testid="starburst"
-          style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
+          style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -89,7 +89,7 @@ exports[`renders a banner with a primary action 1`] = `
       >
         <svg
           data-testid="checkmark"
-          style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
+          style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -164,7 +164,7 @@ exports[`renders a notice banner 1`] = `
       >
         <svg
           data-testid="starburst"
-          style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
+          style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -225,7 +225,7 @@ exports[`renders a success banner 1`] = `
       >
         <svg
           data-testid="checkmark"
-          style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
+          style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -286,7 +286,7 @@ exports[`renders a warning banner 1`] = `
       >
         <svg
           data-testid="help"
-          style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
+          style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -351,7 +351,7 @@ exports[`renders an error banner 1`] = `
       >
         <svg
           data-testid="alert"
-          style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
+          style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/packages/components/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/src/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 1`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -74,7 +74,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 1`]
           >
             <svg
               data-testid="minus2"
-              style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+              style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -178,7 +178,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 2`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -223,7 +223,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 2`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -269,7 +269,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 2`]
           >
             <svg
               data-testid="minus2"
-              style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+              style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -373,7 +373,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 3`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -418,7 +418,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 3`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -464,7 +464,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 3`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -511,7 +511,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 3`]
           >
             <svg
               data-testid="checkmark"
-              style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+              style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -615,7 +615,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -660,7 +660,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -706,7 +706,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -751,7 +751,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -797,7 +797,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 4`]
           >
             <svg
               data-testid="checkmark"
-              style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+              style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -901,7 +901,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -946,7 +946,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -992,7 +992,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1037,7 +1037,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1083,7 +1083,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1130,7 +1130,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 5`]
           >
             <svg
               data-testid="minus2"
-              style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+              style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -1234,7 +1234,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1279,7 +1279,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1325,7 +1325,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1370,7 +1370,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1416,7 +1416,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1461,7 +1461,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1507,7 +1507,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 6`]
           >
             <svg
               data-testid="minus2"
-              style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+              style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -1611,7 +1611,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1656,7 +1656,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1702,7 +1702,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1747,7 +1747,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1793,7 +1793,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1838,7 +1838,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1884,7 +1884,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1931,7 +1931,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 7`]
           >
             <svg
               data-testid="checkmark"
-              style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+              style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -2035,7 +2035,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2080,7 +2080,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2126,7 +2126,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2171,7 +2171,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2217,7 +2217,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2262,7 +2262,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             >
               <svg
                 data-testid="minus2"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2308,7 +2308,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2353,7 +2353,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2399,7 +2399,7 @@ exports[`renders each variation of checked, defaultChecked and indeterminate 8`]
           >
             <svg
               data-testid="checkmark"
-              style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+              style="fill: var(--color-surface); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >

--- a/packages/components/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
+++ b/packages/components/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders a Disclosure 1`] = `
         >
           <svg
             data-testid="arrowDown"
-            style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 32px; height: 32px;"
+            style="fill: var(--color-green); display: inline-block; vertical-align: middle; width: 32px; height: 32px;"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
+++ b/packages/components/src/FormatFile/__snapshots__/FormatFile.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`renders a FormatFile 1`] = `
         >
           <svg
             data-testid="file"
-            style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+            style="fill: var(--color-greyBlue); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -45,20 +45,9 @@ export function Icon({
     size,
   });
 
-  const tokenStyleToCss = (token?: string | number) => {
-    const tokenAsString = typeof token === "string" ? token : token?.toString();
-
-    return tokenAsString
-      ?.replace(/\{/g, "var(--")
-      .replace(/\./g, "-")
-      .replace(/\}/g, ")");
-  };
-  svgStyle.fill = tokenStyleToCss(svgStyle.fill);
-
   if (name === "truck") {
     icon = getTruck(pathStyle, customColor);
   } else {
-    pathStyle.fill = tokenStyleToCss(pathStyle.fill) as string;
     icon = paths.map((path: string) => (
       <path key={path} style={{ ...pathStyle }} d={path} fill={customColor} />
     ));

--- a/packages/components/src/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/components/src/Icon/__snapshots__/Icon.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`renders truck icon 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <g
-      style="fill: {color.green};"
+      style="fill: var(--color-green);"
       transform="translate(233.000000, 0.000000)"
     >
       <path

--- a/packages/components/src/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/components/src/Icon/__snapshots__/Icon.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`renders truck icon 1`] = `
 <div>
   <svg
     data-testid="truck"
-    style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+    style="fill: var(--color-green); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
     viewBox="0 0 1024 1024"
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/packages/components/src/InputAvatar/__snapshots__/InputAvatar.test.tsx.snap
+++ b/packages/components/src/InputAvatar/__snapshots__/InputAvatar.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`renders 1`] = `
       >
         <svg
           data-testid="person"
-          style="fill: var(--color-client); display: inline-block; vertical-align: middle; width: 32px; height: 32px;"
+          style="fill: var(--color-white); display: inline-block; vertical-align: middle; width: 32px; height: 32px;"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/packages/components/src/InputValidation/InputValidation.test.tsx
+++ b/packages/components/src/InputValidation/InputValidation.test.tsx
@@ -17,7 +17,7 @@ it("renders the input validation messages", () => {
         >
           <svg
             data-testid="alert"
-            style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
+            style="fill: var(--color-critical); display: inline-block; vertical-align: middle; width: 16px; height: 16px;"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`renders 1 List item with all the props 1`] = `
             >
               <svg
                 data-testid="checkmark"
-                style="fill: var(--color-success); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                style="fill: var(--color-green); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >

--- a/packages/design/src/__tests__/getIcon.test.ts
+++ b/packages/design/src/__tests__/getIcon.test.ts
@@ -8,7 +8,7 @@ describe("Hello!", () => {
     });
     expect(svgStyle).toStrictEqual({
       display: "inline-block",
-      fill: "{color.icon}",
+      fill: "var(--color-icon)",
       height: 24,
       verticalAlign: "middle",
       width: 24,
@@ -24,7 +24,7 @@ describe("Hello!", () => {
     });
     expect(svgStyle).toStrictEqual({
       display: "inline-block",
-      fill: "{color.icon}",
+      fill: "var(--color-icon)",
       height: 24,
       verticalAlign: "middle",
       width: 24,
@@ -42,7 +42,7 @@ describe("Hello!", () => {
     });
     expect(svgStyle).toStrictEqual({
       display: "inline-block",
-      fill: "{color.icon}",
+      fill: "var(--color-icon)",
       height: 32,
       verticalAlign: "middle",
       width: 32,
@@ -59,7 +59,7 @@ describe("Hello!", () => {
     });
     expect(svgStyle).toStrictEqual({
       display: "inline-block",
-      fill: "{color.icon}",
+      fill: "var(--color-icon)",
       height: 24,
       transform: "scaleY(-1)",
       verticalAlign: "middle",
@@ -78,7 +78,7 @@ describe("Hello!", () => {
     });
     expect(svgStyle).toStrictEqual({
       display: "inline-block",
-      fill: "{color.icon}",
+      fill: "var(--color-icon)",
       height: 16,
       verticalAlign: "middle",
       width: 16,
@@ -94,7 +94,7 @@ describe("Hello!", () => {
     });
     expect(svgStyle).toStrictEqual({
       display: "inline-block",
-      fill: "{color.icon}",
+      fill: "var(--color-icon)",
       height: 24,
       verticalAlign: "middle",
       width: 24,
@@ -114,7 +114,7 @@ describe("Hello!", () => {
       animationName: "spinning",
       animationTimingFunction: "linear",
       display: "inline-block",
-      fill: "{color.icon}",
+      fill: "var(--color-icon)",
       height: 24,
       verticalAlign: "middle",
       width: 24,

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -138,9 +138,9 @@ export function getIcon({
 
   if (format === "js") {
     pathStyle.fill = tokenStyleToJs((colorStyle as { value: string })?.value);
-    svgStyle.fill = tokenStyleToJs(svgStyle.fill);
+    svgStyle.fill = pathStyle.fill || tokenStyleToJs(svgStyle.fill);
   } else {
-    svgStyle.fill = tokenStyleToCss(svgStyle.fill);
+    svgStyle.fill = pathStyle.fill || tokenStyleToCss(svgStyle.fill);
   }
 
   return { svgStyle, pathStyle, paths, viewBox } as const;

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -135,11 +135,12 @@ export function getIcon({
   const pathStyle = {
     fill: tokenStyleToCss((colorStyle as { value: string })?.value),
   };
-  svgStyle.fill = tokenStyleToCss(svgStyle.fill);
 
   if (format === "js") {
     pathStyle.fill = tokenStyleToJs((colorStyle as { value: string })?.value);
     svgStyle.fill = tokenStyleToJs(svgStyle.fill);
+  } else {
+    svgStyle.fill = tokenStyleToCss(svgStyle.fill);
   }
 
   return { svgStyle, pathStyle, paths, viewBox } as const;

--- a/packages/design/src/scripts/buildTokens.ts
+++ b/packages/design/src/scripts/buildTokens.ts
@@ -28,8 +28,16 @@ const writeColorTokens = () => {
   const cssFileContents = createCSSFileFromSubset(["color"]);
   writeFile("dist/color.css", cssFileContents);
 
-  const semanticJSCotent = createTokenFileFromSubset(["semantic-color"]);
-  writeFile("src/assets/tokens.semantic.ts", semanticJSCotent);
+  const semanticJSContent = createTokenFileFromSubset(["semantic-color"]);
+  writeFile("src/assets/tokens.semantic.ts", semanticJSContent);
+
+  const allJSColorContent = createTokenFileFromSubset([
+    "workflow",
+    "semantic-color",
+    "color",
+    "base-color",
+  ]);
+  writeFile("src/assets/tokens.all.colors.ts", allJSColorContent);
 
   const semanticCSSContent = createCSSFileFromSubset(["semantic-color"]);
   writeFile("dist/semantic.css", semanticCSSContent);


### PR DESCRIPTION

## Motivations

- The original design token redo PR has poor support for icons on mobile. It was the last thing I worked on before tossing it over the fence and it wasn't complete.
- This PR comes back and tries to complete the icon color/style work on the mobile side, and tidy up the implementation in general.

## Changes

- When you call getIcon you are no longer responsible for translating your own token values. You either get the token variables back as CSS custom properties `var(--token-name)` by passing 'css' or as a direct token value `rgba(0,0,0,0)` by passing 'js'
- Some logic was updating to pick which icon color to pick when. The logic as I see it as follows:

1. If provided a custom color. Use that.
2. If there is a color associated to the icon name, use that.
3. If there is a neither a custom color, nor a color associated to the icon name, use the base icon color. (from semantic colors)

### Added

- allColors file for all of our colors (not just the base colors like the other color file is)

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
