### PR TITLE
fix(components-native): Add support for italics in Atlantis `Typography` component (JOB-101940)

### DIFF
--- a/packages/components-native/src/Typography/Typography.style.ts
+++ b/packages/components-native/src/Typography/Typography.style.ts
@@ -64,6 +64,10 @@ export const typographyTokens: { [index: string]: TextStyle } = {
   // { fontFamily }{ fontStyle }{ fontWeight }
   ...fonts,
 
+  italic: {
+    fontStyle: "italic",
+  },
+
   startAlign: {
     textAlign: "left",
   },

--- a/packages/components-native/src/Typography/Typography.tsx
+++ b/packages/components-native/src/Typography/Typography.tsx
@@ -156,6 +156,11 @@ function InternalTypography<T extends FontFamily = "base">({
   if (strikeThrough) {
     style.push(styles.strikeThrough);
   }
+
+  if (fontStyle === "italic") {
+    style.push(styles.italic);
+  }
+
   const numberOfLinesForNativeText = maxNumberOfLines[maxLines];
 
   const text = getTransformedText(children, transform);

--- a/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
@@ -226,6 +226,9 @@ exports[`renders text with bold weight and italic style 1`] = `
       {
         "letterSpacing": 0,
       },
+      {
+        "fontStyle": "italic",
+      },
     ]
   }
 >
@@ -423,6 +426,9 @@ exports[`renders text with italic style 1`] = `
       },
       {
         "letterSpacing": 0,
+      },
+      {
+        "fontStyle": "italic",
       },
     ]
   }


### PR DESCRIPTION
## Motivations
We discovered that the Atlantis' Typography native component was missing italics support (when we set the `fontStyle` prop to italics, it was still rendering regular text). The Web component supports this prop. This functionality will be required for the Markdown component that we are planning on introducing to support italicized text.

To this end, this PR to `packages/components-native` introduces support for italic text styling in the Typography component.

# Before
**Italic**
<img width="696" alt="image" src="https://github.com/user-attachments/assets/ec849882-8ea2-4f13-8ab9-6d4d82beaf51">

**Regular**
<img width="696" alt="image" src="https://github.com/user-attachments/assets/d131b4a1-1603-41c2-93bd-5b85dd710467">

# After
**Italic**
<img width="701" alt="image" src="https://github.com/user-attachments/assets/538e83bc-9c4a-4e98-841d-d08f48151877">

**Regular**
<img width="696" alt="image" src="https://github.com/user-attachments/assets/e849940d-9c8c-4b1a-8500-ff714afd9f97">

## Changes
### Fixed
- Added an `italic` style to the typography tokens.
- Updated the `InternalTypography` function to apply the `italic` style conditionally based on the `fontStyle` prop.
- Snapshot updated

# QA
You can test this in Storybook to ensure the style is applied. Or alternatively, install into the Jobber Mobile app locally and test that way for more higher fidelity testing.