### PR TITLE
feat(components): Update positioning of dropzone content

### DIFF
--- a/packages/components/src/InputFile/InputFile.css
+++ b/packages/components/src/InputFile/InputFile.css
@@ -31,3 +31,10 @@
   display: flex;
   flex-direction: column;
 }
+
+.dropzoneContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}

--- a/packages/components/src/InputFile/InputFile.css.d.ts
+++ b/packages/components/src/InputFile/InputFile.css.d.ts
@@ -4,6 +4,7 @@ declare const styles: {
   readonly "active": string;
   readonly "error": string;
   readonly "validationErrors": string;
+  readonly "dropzoneContent": string;
 };
 export = styles;
 

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -235,14 +235,16 @@ export function InputFile({
         <input {...getInputProps()} />
 
         {variation === "dropzone" && (
-          <Content spacing="small">
-            <Button label={buttonLabel} size="small" type="secondary" />
-            {size === "base" && (
-              <Typography size="small" textColor="textSecondary">
-                {hintText}
-              </Typography>
-            )}
-          </Content>
+          <div className={styles.dropzoneContent}>
+            <Content spacing="small">
+              <Button label={buttonLabel} size="small" type="secondary" />
+              {size === "base" && (
+                <Typography size="small" textColor="textSecondary">
+                  {hintText}
+                </Typography>
+              )}
+            </Content>
+          </div>
         )}
 
         {variation === "button" && (

--- a/packages/components/src/InputFile/__snapshots__/InputFile.test.tsx.snap
+++ b/packages/components/src/InputFile/__snapshots__/InputFile.test.tsx.snap
@@ -14,23 +14,27 @@ exports[`Post Requests renders an InputFile 1`] = `
       type="file"
     />
     <div
-      class="padded small"
+      class="dropzoneContent"
     >
-      <button
-        class="button small work secondary"
-        type="button"
+      <div
+        class="padded small"
       >
-        <span
-          class="base semiBold base base"
+        <button
+          class="button small work secondary"
+          type="button"
         >
-          Upload File
-        </span>
-      </button>
-      <p
-        class="base regular small textSecondary"
-      >
-        or drag a file here to upload
-      </p>
+          <span
+            class="base semiBold base base"
+          >
+            Upload File
+          </span>
+        </button>
+        <p
+          class="base regular small textSecondary"
+        >
+          or drag a file here to upload
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -52,23 +56,27 @@ exports[`Post Requests renders an InputFile with multiple images allowed 1`] = `
       type="file"
     />
     <div
-      class="padded small"
+      class="dropzoneContent"
     >
-      <button
-        class="button small work secondary"
-        type="button"
+      <div
+        class="padded small"
       >
-        <span
-          class="base semiBold base base"
+        <button
+          class="button small work secondary"
+          type="button"
         >
-          Upload Images
-        </span>
-      </button>
-      <p
-        class="base regular small textSecondary"
-      >
-        or drag images here to upload
-      </p>
+          <span
+            class="base semiBold base base"
+          >
+            Upload Images
+          </span>
+        </button>
+        <p
+          class="base regular small textSecondary"
+        >
+          or drag images here to upload
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -89,23 +97,27 @@ exports[`Post Requests renders an InputFile with multiple uploads 1`] = `
       type="file"
     />
     <div
-      class="padded small"
+      class="dropzoneContent"
     >
-      <button
-        class="button small work secondary"
-        type="button"
+      <div
+        class="padded small"
       >
-        <span
-          class="base semiBold base base"
+        <button
+          class="button small work secondary"
+          type="button"
         >
-          Upload Files
-        </span>
-      </button>
-      <p
-        class="base regular small textSecondary"
-      >
-        or drag files here to upload
-      </p>
+          <span
+            class="base semiBold base base"
+          >
+            Upload Files
+          </span>
+        </button>
+        <p
+          class="base regular small textSecondary"
+        >
+          or drag files here to upload
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -126,23 +138,27 @@ exports[`Post Requests renders an InputFile with only images allowed 1`] = `
       type="file"
     />
     <div
-      class="padded small"
+      class="dropzoneContent"
     >
-      <button
-        class="button small work secondary"
-        type="button"
+      <div
+        class="padded small"
       >
-        <span
-          class="base semiBold base base"
+        <button
+          class="button small work secondary"
+          type="button"
         >
-          Upload Image
-        </span>
-      </button>
-      <p
-        class="base regular small textSecondary"
-      >
-        or drag an image here to upload
-      </p>
+          <span
+            class="base semiBold base base"
+          >
+            Upload Image
+          </span>
+        </button>
+        <p
+          class="base regular small textSecondary"
+        >
+          or drag an image here to upload
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -162,23 +178,27 @@ exports[`Post Requests renders an InputFile with proper variations 1`] = `
       type="file"
     />
     <div
-      class="padded small"
+      class="dropzoneContent"
     >
-      <button
-        class="button small work secondary"
-        type="button"
+      <div
+        class="padded small"
       >
-        <span
-          class="base semiBold base base"
+        <button
+          class="button small work secondary"
+          type="button"
         >
-          Upload File
-        </span>
-      </button>
-      <p
-        class="base regular small textSecondary"
-      >
-        or drag a file here to upload
-      </p>
+          <span
+            class="base semiBold base base"
+          >
+            Upload File
+          </span>
+        </button>
+        <p
+          class="base regular small textSecondary"
+        >
+          or drag a file here to upload
+        </p>
+      </div>
     </div>
   </div>
   <div
@@ -193,18 +213,22 @@ exports[`Post Requests renders an InputFile with proper variations 1`] = `
       type="file"
     />
     <div
-      class="padded small"
+      class="dropzoneContent"
     >
-      <button
-        class="button small work secondary"
-        type="button"
+      <div
+        class="padded small"
       >
-        <span
-          class="base semiBold base base"
+        <button
+          class="button small work secondary"
+          type="button"
         >
-          Upload File
-        </span>
-      </button>
+          <span
+            class="base semiBold base base"
+          >
+            Upload File
+          </span>
+        </button>
+      </div>
     </div>
   </div>
   <div


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
When `InputFile` is within a tall container and is stretched to fill the space, the dropzone content (`Button`, `hintText`) should be centered vertically and horizontally.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- new styles for `dropzoneContent`

### Changed

Instead of the dropzone content sticking to the top of a tall `InputFile`, that content is now in the center. 

#### Before

![Screenshot 2024-08-07 at 8 51 33 PM](https://github.com/user-attachments/assets/6b2ccc46-838a-44cd-adb9-9ab1034a1473)

#### After

![Screenshot 2024-08-07 at 8 39 03 PM](https://github.com/user-attachments/assets/5d1901c0-eb52-4874-b520-9580039ed7eb)

If the `InputFile` is set to `size="small"` (so only a button shows up), this is what we see:

![Screenshot 2024-08-07 at 8 54 33 PM](https://github.com/user-attachments/assets/20442959-1e53-494c-adc9-ab76a8a335b1)

Note that any `InputFile` not stretched within a tall container retains the same styling as before:

![Screenshot 2024-08-07 at 8 56 25 PM](https://github.com/user-attachments/assets/75ab8100-f089-487e-aa5b-b37323915092)



## Testing

Pre-release showing prod example will be in separate PR tagged in slack msg

To see this in storybook, update the StatefulTemplate in `docs/components/InputFile/Web.stories.tsx` and see the screenshots above:

```
const StatefulTemplate: ComponentStory<typeof InputFile> = args => {
  const [files, setFiles] = useState<FileUpload[]>([]);

  return (
      <>
      <div style={{ height: '220px', width: '620px', display: 'flex', flexDirection: 'column' }}>
        <div style={{ flexGrow: 1, display: 'flex' }}>
        <InputFile
          {...args}
          onUploadStart={handleUpload}
          onUploadProgress={handleUpload}
          onUploadComplete={handleUpload}
          style={{ flexGrow: 1 }}
        />
        </div>
        </div>
        {files.map(file => (
          <FormatFile file={file} key={file.key} />
        ))}
      </>
  );

  function handleUpload(file: FileUpload) {
    setFiles(oldFiles => updateFiles(file, oldFiles));
  }
};
```

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
