### PR TITLE
feat(components): Use token in FormatFile delete button

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -78,7 +78,7 @@
 }
 
 .deleteButton {
-  z-index: 1;
+  z-index: var(--elevation-base);
 }
 
 .expanded .thumbnail {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

Follow up to the `FormatFile` [change](https://github.com/GetJobber/atlantis/pull/1975) earlier today where I should have used a token instead of a number for the `deleteButton` z-index

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

```
.deleteButton {
  z-index: 1;
}
```

becomes

```
.deleteButton {
  z-index: var(--elevation-base);
}
```

## Testing

<!-- How to test your changes. -->
Should behave as before:
- click on `FormatFile` and then immediately click on the delete button in [this story](http://localhost:6005/?path=/story/components-images-and-icons-formatfile-web--expanded-with-delete)
- you can tab/focus/select the delete button with no issue

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
