### PR TITLE
build: Remove underscore from pre-release version name

### DIFF
--- a/.github/workflows/trigger-qa-build.yml
+++ b/.github/workflows/trigger-qa-build.yml
@@ -47,7 +47,7 @@ jobs:
           PUBLISH_SETTING: ${{ github.event.inputs.workflow }}
         run: |
           # Generates a preId from the branch name. Removes characters that can't be used in a preId
-          ATLANTIS_BRANCH_NAME=$(echo ${ATLANTIS_BRANCH_NAME_RAW:0:10} | sed 's/\///g')
+          ATLANTIS_BRANCH_NAME=$(echo ${ATLANTIS_BRANCH_NAME_RAW:0:10} | sed 's/[_\/]//g')
           if [ "$PUBLISH_SETTING" == "Publish Pre-release (Recommended)" ]; then
             npm run publish:prerelease:githubAction -- --y --preid $ATLANTIS_BRANCH_NAME
           else


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We have a branch that contains an underscore `_` and our pre-release action is failing due to that character.

## Changes


### Fixed

- Updated our CI pre-release action to remove underscores


Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)
