### PR TITLE
fix(components): Always show delete button on the FormatFile when on a small screen

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -137,8 +137,10 @@
   right: var(--space-smaller);
 }
 
-.deleteable ~ .deleteButton {
-  visibility: hidden;
+@media (--medium-screens-and-up) {
+  .deleteable ~ .deleteButton {
+    visibility: hidden;
+  }
 }
 
 .deleteButton:focus-within,

--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -141,11 +141,11 @@
   .deleteable ~ .deleteButton {
     visibility: hidden;
   }
-}
 
-.deleteButton:focus-within,
-.deleteButton:hover,
-.deleteable:hover ~ .deleteButton,
-.deleteable:focus ~ .deleteButton {
-  visibility: visible;
+  .deleteButton:focus-within,
+  .deleteButton:hover,
+  .deleteable:hover ~ .deleteButton,
+  .deleteable:focus ~ .deleteButton {
+    visibility: visible;
+  }
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

On mobile breakpoints if a `FormatFile` was in displaying in `compact` with an onDelete the delete icon would not display all the time. This would make deleting files hard if there was an `onClick` action on the `FormatFile`

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- fix(components): Have the compact `FormatFile`s always display the delete button when on a mobile breakpoint
### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->
 - Verify compact formatFile doesn't display the delete button when the thumbnail isn't hovered on non-mobile breakpoints
 - Verify the compact fomatFile will always display the delete button when on a mobile breakpoint

See mentioned PR for to test the pre-release in JO

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
