### PR TITLE
fix(components): improve coherence of StatusLabel "critical" variant

### DIFF
--- a/packages/components/src/StatusLabel/StatusLabel.css
+++ b/packages/components/src/StatusLabel/StatusLabel.css
@@ -1,5 +1,6 @@
 .statusLabelRow {
   --labelBackgroundColor: var(--color-success--surface);
+  --labelTextColor: var(--color-success--onSurface);
 
   display: flex;
   width: fit-content;
@@ -13,26 +14,32 @@
 
 .success {
   --labelBackgroundColor: var(--color-success--surface);
+  --labelTextColor: var(--color-success--onSurface);
 }
 
 .warning {
   --labelBackgroundColor: var(--color-warning--surface);
+  --labelTextColor: var(--color-warning--onSurface);
 }
 
 .critical {
   --labelBackgroundColor: var(--color-critical--surface);
+  --labelTextColor: var(--color-critical--onSurface);
 }
 
 .inactive {
   --labelBackgroundColor: var(--color-inactive--surface);
+  --labelTextColor: var(--color-inactive--onSurface);
 }
 
 .informative {
   --labelBackgroundColor: var(--color-informative--surface);
+  --labelTextColor: var(--color-informative--onSurface);
 }
 
 /* Reset the <Text> line height so we can reliably get 24px tall */
 .statusLabelRow p {
+  color: var(--labelTextColor);
   line-height: 1;
 }
 

--- a/packages/components/src/StatusLabel/StatusLabel.tsx
+++ b/packages/components/src/StatusLabel/StatusLabel.tsx
@@ -48,7 +48,7 @@ export function StatusLabel({
         <StatusIndicator status={status} />
       </div>
 
-      <Typography size="small" textColor={status} align={alignment}>
+      <Typography size="small" align={alignment}>
         {label}
       </Typography>
     </div>

--- a/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/components/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`renders a critical StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small critical"
+      class="base regular small"
     >
       Foo
     </p>
@@ -38,7 +38,7 @@ exports[`renders a successful StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small success"
+      class="base regular small"
     >
       Foo
     </p>
@@ -61,7 +61,7 @@ exports[`renders a warning StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small warning"
+      class="base regular small"
     >
       Foo
     </p>
@@ -84,7 +84,7 @@ exports[`renders an end-aligned StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small informative end"
+      class="base regular small end"
     >
       Foo
     </p>
@@ -107,7 +107,7 @@ exports[`renders an inactive StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small inactive"
+      class="base regular small"
     >
       Foo
     </p>
@@ -130,7 +130,7 @@ exports[`renders an informative StatusLabel 1`] = `
       />
     </div>
     <p
-      class="base regular small informative"
+      class="base regular small"
     >
       Foo
     </p>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The label for StatusLabel's "critical" uses the `critical` color for its' text, whereas all other variants use the `{status}--onSurface` color. This leads to a more vibrant label with lower contrast against its' container than the others, which is particularly notable in mixed-status views like a Datalist.

## Changes

![image](https://github.com/user-attachments/assets/85a07d4c-55e6-4bab-940f-6bbc4530fdcc)

### Added

- new CSS var in the StatusLabel component for text color 

### Changed

- extended the status-specific classes to manipulate the new text color variable

### Removed

- usage of the textColor prop from the Typography instance in StatusLabel

### Fixed

- improves the coherence of the text/background contrast across StatusLabels

## Testing

Test in Storybook and via pre-release

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
