### PR TITLE
feat(components): Add action menu to FormatFile

### DIFF
--- a/docs/components/FormatFile/Web.stories.tsx
+++ b/docs/components/FormatFile/Web.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { FormatFile } from "@jobber/components/FormatFile";
-import { Icon } from "@jobber/components/Icon";
 
 export default {
   title: "Components/Images and Icons/FormatFile/Web",
@@ -20,18 +19,18 @@ export const Menu = BasicTemplate.bind({});
 Menu.args = {
   file: {
     key: "abc",
-    name: "image_of_something.png",
     type: "image/png",
     size: 213402324,
     progress: 1,
     src: () => Promise.resolve("https://picsum.photos/250"),
+    name: "image_of_something.png",
   },
   actions: [
     {
       label: "Delete",
       onClick: () => alert("Deleted"),
       icon: "trash",
-      destructive: true,
+      // destructive: true,
     },
     {
       label: "Download",

--- a/docs/components/FormatFile/Web.stories.tsx
+++ b/docs/components/FormatFile/Web.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { FormatFile } from "@jobber/components/FormatFile";
+import { Icon } from "@jobber/components/Icon";
 
 export default {
   title: "Components/Images and Icons/FormatFile/Web",
@@ -14,6 +15,31 @@ export default {
 const BasicTemplate: ComponentStory<typeof FormatFile> = args => (
   <FormatFile {...args} />
 );
+
+export const Menu = BasicTemplate.bind({});
+Menu.args = {
+  file: {
+    key: "abc",
+    name: "image_of_something.png",
+    type: "image/png",
+    size: 213402324,
+    progress: 1,
+    src: () => Promise.resolve("https://picsum.photos/250"),
+  },
+  actions: [
+    {
+      label: "Delete",
+      onClick: () => alert("Deleted"),
+      icon: "trash",
+      destructive: true,
+    },
+    {
+      label: "Download",
+      onClick: () => alert("Downloaded"),
+      icon: "download",
+    },
+  ],
+};
 
 export const Expanded = BasicTemplate.bind({});
 Expanded.args = {

--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -77,7 +77,8 @@
   box-shadow: var(--shadow-focus);
 }
 
-.deleteButton {
+.deleteButton,
+.menu {
   z-index: var(--elevation-base);
 }
 
@@ -135,6 +136,35 @@
   position: absolute;
   top: var(--space-smaller);
   right: var(--space-smaller);
+}
+
+.menuList {
+  list-style-type: none;
+  position: absolute;
+  right: 0;
+  max-width: var(--popover--width);
+  box-shadow: var(--shadow-base);
+  margin-top: var(--space-smaller);
+  padding: var(--space-small);
+  border: var(--border-base) solid var(--color-border);
+  border-radius: var(--radius-base);
+  background: var(--color-surface);
+  align-items: flex-start;
+}
+
+.menuItem {
+  display: flex;
+  box-sizing: border-box;
+  padding: var(--space-small);
+  border-radius: var(--radius-small);
+  font-family: var(--typography--fontFamily-normal);
+  font-size: var(--typography--fontSize-base);
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-smaller);
 }
 
 @media (--medium-screens-and-up) {

--- a/packages/components/src/FormatFile/FormatFile.css
+++ b/packages/components/src/FormatFile/FormatFile.css
@@ -132,7 +132,8 @@
   white-space: nowrap;
 }
 
-.compact .deleteButton {
+.compact .deleteButton,
+.compact .menu {
   position: absolute;
   top: var(--space-smaller);
   right: var(--space-smaller);
@@ -154,17 +155,19 @@
 
 .menuItem {
   display: flex;
+  width: 100%;
   box-sizing: border-box;
   padding: var(--space-small);
   border-radius: var(--radius-small);
-  font-family: var(--typography--fontFamily-normal);
-  font-size: var(--typography--fontSize-base);
-  font-weight: 500;
   white-space: nowrap;
   cursor: pointer;
-  align-items: center;
   justify-content: space-between;
   gap: var(--space-smaller);
+}
+
+.menuItem:hover,
+.menuItem:focus {
+  background-color: var(--color-surface--hover);
 }
 
 @media (--medium-screens-and-up) {

--- a/packages/components/src/FormatFile/FormatFile.css.d.ts
+++ b/packages/components/src/FormatFile/FormatFile.css.d.ts
@@ -7,10 +7,13 @@ declare const styles: {
   readonly "base": string;
   readonly "thumbnail": string;
   readonly "deleteButton": string;
+  readonly "menu": string;
   readonly "clickable": string;
   readonly "hoverable": string;
   readonly "progress": string;
   readonly "contentBlock": string;
+  readonly "menuList": string;
+  readonly "menuItem": string;
   readonly "deleteable": string;
 };
 export = styles;

--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -4,6 +4,7 @@ import getHumanReadableFileSize from "filesize";
 import styles from "./FormatFile.css";
 import { FormatFileDeleteButton } from "./FormatFileDeleteButton";
 import { InternalThumbnail } from "./InternalThumbnail";
+import { Action, FormatFileMenu } from "./FormatFileMenu";
 import { FileUpload } from "../InputFile";
 import { Text } from "../Text";
 import { ProgressBar } from "../ProgressBar";
@@ -37,6 +38,11 @@ interface FormatFileProps {
    * onDelete callback - this function will be called when the delete action is triggered
    */
   onDelete?(): void;
+
+  /**
+   * Actions to display on the file
+   */
+  readonly actions?: Action[];
 }
 
 export function FormatFile({
@@ -45,6 +51,7 @@ export function FormatFile({
   displaySize = "base",
   onDelete,
   onClick,
+  actions,
 }: FormatFileProps) {
   const isComplete = file.progress >= 1;
   const fileSize = getHumanReadableFileSize(file.size);
@@ -108,6 +115,9 @@ export function FormatFile({
             onDelete={onDelete}
           />
         </div>
+      )}
+      {isComplete && actions && actions?.length > 0 && (
+        <FormatFileMenu actions={actions} />
       )}
     </div>
   );

--- a/packages/components/src/FormatFile/FormatFileMenu.tsx
+++ b/packages/components/src/FormatFile/FormatFileMenu.tsx
@@ -54,7 +54,9 @@ export function FormatFileMenu({ actions }: FormatFileMenuProps) {
               className={styles.menuItem}
               onClick={action.onClick}
             >
-              <Typography textColor="heading">{action.label}</Typography>
+              <Typography fontWeight="medium" textColor="heading">
+                {action.label}
+              </Typography>
               {action.icon && <Icon name={action.icon} />}
             </li>
           ))}

--- a/packages/components/src/FormatFile/FormatFileMenu.tsx
+++ b/packages/components/src/FormatFile/FormatFileMenu.tsx
@@ -1,9 +1,8 @@
 import { IconNames } from "@jobber/design";
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import styles from "./FormatFile.css";
 import { Button } from "../Button";
-import { Icon } from "../Icon";
-import { Typography } from "../Typography";
+import { Menu, SectionProps } from "../Menu";
 
 export interface Action {
   readonly icon?: IconNames;
@@ -16,52 +15,29 @@ interface FormatFileMenuProps {
 }
 
 export function FormatFileMenu({ actions }: FormatFileMenuProps) {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  const toggleMenu = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const handleClickOutside = (event: MouseEvent) => {
-    if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-      setIsOpen(false);
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
+  const items: SectionProps[] = [
+    {
+      actions: actions.map(action => ({
+        label: action.label,
+        icon: action.icon,
+        onClick: action.onClick,
+      })),
+    },
+  ];
 
   return (
-    <div ref={menuRef} className={styles.menu}>
-      <Button
-        onClick={toggleMenu}
-        icon="more"
-        type="secondary"
-        variation="subtle"
-        ariaLabel="Actions Menu"
+    <div className={styles.menu}>
+      <Menu
+        activator={
+          <Button
+            icon="more"
+            type="secondary"
+            variation="subtle"
+            ariaLabel="Actions Menu"
+          />
+        }
+        items={items}
       />
-      {isOpen && (
-        <ul className={styles.menuList}>
-          {actions.map((action, index) => (
-            <li
-              key={index}
-              className={styles.menuItem}
-              onClick={action.onClick}
-            >
-              <Typography fontWeight="medium" textColor="heading">
-                {action.label}
-              </Typography>
-              {action.icon && <Icon name={action.icon} />}
-            </li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 }

--- a/packages/components/src/FormatFile/FormatFileMenu.tsx
+++ b/packages/components/src/FormatFile/FormatFileMenu.tsx
@@ -1,0 +1,65 @@
+import { IconNames } from "@jobber/design";
+import React, { useEffect, useRef } from "react";
+import styles from "./FormatFile.css";
+import { Button } from "../Button";
+import { Icon } from "../Icon";
+import { Typography } from "../Typography";
+
+export interface Action {
+  readonly icon?: IconNames;
+  readonly label: string;
+  onClick(): void;
+}
+
+interface FormatFileMenuProps {
+  readonly actions: Action[];
+}
+
+export function FormatFileMenu({ actions }: FormatFileMenuProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const toggleMenu = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div ref={menuRef} className={styles.menu}>
+      <Button
+        onClick={toggleMenu}
+        icon="more"
+        type="secondary"
+        variation="subtle"
+        ariaLabel="Actions Menu"
+      />
+      {isOpen && (
+        <ul className={styles.menuList}>
+          {actions.map((action, index) => (
+            <li
+              key={index}
+              className={styles.menuItem}
+              onClick={action.onClick}
+            >
+              <Typography textColor="heading">{action.label}</Typography>
+              {action.icon && <Icon name={action.icon} />}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
This is a POC to see what an actions menu would involve on `FormatFile`. 

There may be more actions than just `delete` moving forward on the `FormatFile` component (ex. `download`).  

Instead of adding an `onDownload` prop which is just another callback, we can open up a menu to allow for endless customizable options in the future.

### Added

<!-- new features -->
- added a `FormatFileMenu` component within `FormatFile`

### Not done yet/future considerations

- focus state/accessibility/keyboard events
- deprecating `onDelete`
- should there be a menu even if there's only one action? Right now the logic is if `actions?.length > 0`
- further styling (colour of text on destructive, etc)
- size of the menu button while `compact` & `base` props are in effect


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
