### PR TITLE
feat(components): use text color for menu items

### DIFF
--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -299,11 +299,7 @@ function Action({
       {icon && (
         <Icon color={destructive ? "destructive" : undefined} name={icon} />
       )}
-      <Typography
-        element="span"
-        fontWeight="semiBold"
-        textColor="textSecondary"
-      >
+      <Typography element="span" fontWeight="semiBold" textColor="text">
         {sectionLabel && (
           <span className={styles.screenReaderOnly}>{sectionLabel}</span>
         )}

--- a/packages/components/src/Typography/css/TextColors.css
+++ b/packages/components/src/Typography/css/TextColors.css
@@ -74,6 +74,10 @@
   color: var(--color-interactive);
 }
 
+.destructive {
+  color: var(--color-destructive);
+}
+
 .disabled {
   color: var(--color-disabled);
 }

--- a/packages/components/src/Typography/css/TextColors.css.d.ts
+++ b/packages/components/src/Typography/css/TextColors.css.d.ts
@@ -18,6 +18,7 @@ declare const styles: {
   readonly "informative": string;
   readonly "success": string;
   readonly "interactive": string;
+  readonly "destructive": string;
   readonly "disabled": string;
 };
 export = styles;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Because the menu items are not "secondary" to any other content, they should just use the default text color.

## Changes

### Changed

- Menu items use `text` color instead of `textSecondary`
- Also noticed that Typography doesn't have access to `destructive` so included that as well

## Testing

Test in Storybook and via prerelease

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
