### PR TITLE
fix(components):  Update description of title prop in Disclosure component

### DIFF
--- a/docs/components/Disclosure/Disclosure.stories.mdx
+++ b/docs/components/Disclosure/Disclosure.stories.mdx
@@ -35,11 +35,15 @@ to change but is not required to.
   - This can either be a string or a React component. If a React component is
     used (containing multiple children), it should be wrapped in a container
     element and not a `<Fragment>` to maintain correct UI styling.
-  - The elements passed as a `title` can be any heading content, plain text, or
-    HTML that can be used within a paragraph (AKA
+    - Caveat: The container element should NOT be `<div>` as it would break the
+      semantics of the `<summary>` element. Instead, use a `<span>` or `<p>`
+      tag.
+  - The elements passed as a `title` can be plain text, or HTML that can be used
+    within a paragraph (AKA
     ["phrasing content"](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content))
     to ensure that the title is accessible and can be properly read by screen
-    readers.
+    readers. A heading may also be used but will not be treated as a heading by
+    assistive technologies.
 - `children` should be actionable and clear. The contents of a Disclosure can
   be:
   - plain text

--- a/docs/components/Disclosure/Disclosure.stories.mdx
+++ b/docs/components/Disclosure/Disclosure.stories.mdx
@@ -31,7 +31,14 @@ to change but is not required to.
 ## Content guidelines
 
 - `title` should be informative and label the type of content grouped in the
-  body of the Disclosure
+  body of the Disclosure.
+  - This can either be a string or a React component. If a React component is
+    used (containing multiple children), it should be wrapped in a container
+    element and not a `<Fragment>` to maintain correct UI styling.
+  - The elements passed as a `title` should ideally be of a
+    ["phrasing content"](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content)
+    type to ensure that the title is accessible and can be properly read by
+    screen readers.
 - `children` should be actionable and clear. The contents of a Disclosure can
   be:
   - plain text

--- a/docs/components/Disclosure/Disclosure.stories.mdx
+++ b/docs/components/Disclosure/Disclosure.stories.mdx
@@ -35,10 +35,11 @@ to change but is not required to.
   - This can either be a string or a React component. If a React component is
     used (containing multiple children), it should be wrapped in a container
     element and not a `<Fragment>` to maintain correct UI styling.
-  - The elements passed as a `title` should ideally be of a
-    ["phrasing content"](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content)
-    type to ensure that the title is accessible and can be properly read by
-    screen readers.
+  - The elements passed as a `title` can be any heading content, plain text, or
+    HTML that can be used within a paragraph (AKA
+    ["phrasing content"](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content))
+    to ensure that the title is accessible and can be properly read by screen
+    readers.
 - `children` should be actionable and clear. The contents of a Disclosure can
   be:
   - plain text
@@ -50,8 +51,13 @@ to change but is not required to.
 
 - Users should be able to use their keyboard and toggle the component's
   open/close state
-- Headings are permitted in `summary` elements to provide in-page navigational
-  assistance
+- A single Heading element is permitted in `summary` elements, however, it might
+  lose some accessibility benefits, since according to
+  [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary#summaries_as_headings):
+  > Warning: Because the `<summary>` element has a default role of button (which
+  > strips all roles from child elements), this example will not work for users
+  > of assistive technologies such as screen readers. The `<h4>` will have its
+  > role removed and thus will not be treated as a heading for these users.
 - Include aria-expanded attribute on the trigger to communicate to assistive
   technology
 - Include aria-controls attribute ties on the trigger to the content it controls

--- a/docs/components/Disclosure/Web.stories.tsx
+++ b/docs/components/Disclosure/Web.stories.tsx
@@ -35,7 +35,7 @@ CustomTitle.args = {
   title: (
     <Flex template={["shrink", "grow"]} gap="small">
       <Icon name="sparkles" />
-      <Heading level={5} element="h4">
+      <Heading level={5} element="span">
         Jobber Pro Tips
       </Heading>
     </Flex>

--- a/packages/components/src/Disclosure/Disclosure.tsx
+++ b/packages/components/src/Disclosure/Disclosure.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactElement, ReactNode, useEffect, useState } from "react";
 import {
   Breakpoints,
   useResizeObserver,
@@ -16,8 +16,9 @@ interface DisclosureProps {
 
   /**
    * Title for the disclosure pane.
+   * If ReactElement[] is provided, it must be wrapped in a container element (not a Fragment).
    */
-  readonly title: string | ReactNode | ReactNode[];
+  readonly title: string | ReactElement | ReactElement[];
 
   /**
    * This sets the default open state of the disclosure.


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This PR provides a better documentation and example of the acceptable way to pass `title` to the `Disclosure` component in case it's not just a string, but a React Component

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Better description of the the `title` prop in the Storybook Docs.
- Better description of the the `title` in the <Disclosure> component prop interface.

### Changed

- Storybook example to pass `span` instead of `h4`, since this component appears inside of `<summary`, hence the content should be of ["phrasing content"](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content) type, which was added to the docs.
- Change the typing for the `title` prop to be `ReactElement` and `ReactElement[]` instead of `ReactNode` and `ReactNode[]`, since type `string` IS a `ReactNode`.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Verify that the Storybook Docs for the `Disclosure` component provide a comprehensive explanation of what can be passed as a `title`.
- Verify that the `CustomTitle` story behaves and looks as expected.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
