### PR TITLE
docs(design): update swatches and fix broken base colors

### DIFF
--- a/.storybook/assets/css/preview.css
+++ b/.storybook/assets/css/preview.css
@@ -1,16 +1,22 @@
 :focus,
 :focus-visible {
-  outline: none;
+  outline: transparent;
 }
 
-a {
+:global(a) {
   color: var(--color-interactive);
   font-family: inherit;
   font-size: inherit;
 }
 
-a:hover {
+:global(a:hover) {
   color: var(--color-interactive--hover);
+}
+
+:global(.sb-show-main code) {
+  border: var(--color-surface--background);
+  color: var(--color-text);
+  background-color: var(--color-surface--background);
 }
 
 :global(.sbdocs-table) {

--- a/.storybook/components/ColorSwatches/ColorSwatches.module.css
+++ b/.storybook/components/ColorSwatches/ColorSwatches.module.css
@@ -1,28 +1,19 @@
-.colorbar {
-  display: flex;
-  width: 100%;
-}
-
-.color {
-  flex: 1;
-  text-align: center;
+:root {
+  --swatchSize: 64px;
 }
 
 .swatch {
   position: relative;
+  width: var(--swatchSize);
+  height: var(--swatchSize);
+  box-shadow:
+    0px 0px 0px 2px var(--color-surface),
+    0px 0px 0px 3px var(--color-border);
   box-sizing: border-box;
-  height: var(--space-extravagant);
-  margin-bottom: var(--space-small);
-}
-
-.button {
-  position: absolute;
-  top: var(--space-smaller);
-  right: var(--space-smaller);
+  border-radius: var(--radius-base);
 }
 
 .pre {
-  display: inline-block;
   margin: 0 0 var(--space-smaller);
   padding: var(--space-smallest) var(--space-small);
   border-radius: var(--radius-base);

--- a/.storybook/components/ColorSwatches/ColorSwatches.module.css.d.ts
+++ b/.storybook/components/ColorSwatches/ColorSwatches.module.css.d.ts
@@ -1,8 +1,5 @@
 declare const styles: {
-  readonly "colorbar": string;
-  readonly "color": string;
   readonly "swatch": string;
-  readonly "button": string;
   readonly "pre": string;
 };
 export = styles;

--- a/.storybook/components/ColorSwatches/ColorSwatches.tsx
+++ b/.storybook/components/ColorSwatches/ColorSwatches.tsx
@@ -1,48 +1,52 @@
 import React from "react";
 import { Button } from "@jobber/components/Button";
+import { Tooltip } from "@jobber/components/Tooltip";
+import { Flex } from "@jobber/components/Flex";
+import { Text } from "@jobber/components/Text";
+import { Content } from "@jobber/components/Content";
 import { showToast } from "@jobber/components/Toast";
 import styles from "./ColorSwatches.module.css";
 
 interface ColorSwatchesProps {
   readonly colors: string[];
+  readonly description?: string;
 }
 
 export function ColorSwatches({ colors }: ColorSwatchesProps) {
   return (
-    <div className={styles.colorbar}>
+    <Content>
       {colors.map((color: string) => (
         <Color key={color} color={color} />
       ))}
-    </div>
+    </Content>
   );
 }
 
 interface ColorProps {
   readonly color: string;
+  readonly description?: string;
 }
 
-function Color({ color }: ColorProps) {
-  const colorsWithBorders = [
-    "--color-overlay--dimmed",
-    "--color-surface",
-    "--color-text--reverse",
-  ];
+function Color({ color, description }: ColorProps) {
+
   const style = {
     backgroundColor: `var(${color})`,
-    border: colorsWithBorders.includes(color)
-      ? "1px solid var(--color-border)"
-      : undefined,
   };
 
   return (
-    <div className={styles.color}>
+    <Flex gap="small" align="center" template={["shrink", "shrink"]}>
       <div key={color} style={style} className={styles.swatch}>
-        <div className={styles.button}>
-          <Button size="small" icon="copy" onClick={handleClick} ariaLabel="Copy" />
-        </div>
       </div>
-      <pre className={styles.pre}>{color}</pre>
-    </div>
+      <Content spacing="small">
+        { description && (<Text>{description}</Text>) }
+        <Flex gap="smaller" align="center" template={["shrink", "shrink"]}>
+          <pre className={styles.pre}>{color}</pre>
+          <Tooltip message="Copy">
+            <Button size="small" variation="subtle" type="tertiary" icon="copy" onClick={handleClick} ariaLabel="Copy" />
+          </Tooltip>
+        </Flex>
+      </Content>
+    </Flex>
   );
 
   function handleClick() {

--- a/docs/design/Colors.stories.mdx
+++ b/docs/design/Colors.stories.mdx
@@ -100,16 +100,7 @@ different.
 
 #### Focus
 
-<div
-  style={{
-    width: "100%",
-    height: `var(--space-extravagant)`,
-    backgroundColor: `var(--color-surface)`,
-    boxShadow: `var(--shadow-focus)`,
-  }}
-></div>
-
-`--color-focus`
+<Swatch colors={["--color-focus"]} />
 
 Used by the `--shadow-focus` property to indicate that an element has received
 focus. Avoid using `--color-focus` directly on UI elements.
@@ -241,34 +232,21 @@ Defining the edges of elements on the same elevation plane, border colors are
 the subtle maintainers of layout structure. Learn more about borders in our
 [Borders guide.](../?path=/docs/design-borders--docs)
 
-<div
-  style={{
-    width: "100%",
-    height: `var(--space-extravagant)`,
-    backgroundColor: `var(--color-surface)`,
-    border: `var(--border-base) solid var(--color-border)`,
-  }}
-></div>
-
-`--color-border`
+<Swatch
+  colors={[
+    "--color-border",
+    "--color-border--section",
+    "--color-border--interactive",
+  ]}
+/>
 
 Most borders should use `--color-border` for subtle definition.
 
-#### Border--Section
-
-<div
-  style={{
-    width: "100%",
-    height: `var(--space-extravagant)`,
-    backgroundColor: `var(--color-surface)`,
-    border: `var(--border-base) solid var(--color-border--section)`,
-  }}
-></div>
-
-`--color-border--section`
-
 Use `--color-border--section` where other bordered content is being further
 sectioned, such as table headers or list sections.
+
+Use `--color-border--interactive` for interactive elements to ensure accessible
+contrast.
 
 ### Brand
 
@@ -291,6 +269,116 @@ caution, it’s _bright!_
 <br />
 <br />
 
-## Swatch list
+## Base colors
 
-<ColorSwatches colors={colors} />
+This is the underlying color palette that powers our semantic system.
+
+Direct use of these colors should be avoided, as they do not respond to theming
+or systemic changes.
+
+<Swatch
+  colors={[
+    "--color-base-taupe--100",
+    "--color-base-taupe--200",
+    "--color-base-taupe--300",
+    "--color-base-taupe--400",
+    "--color-base-taupe--500",
+    "--color-base-taupe--600",
+    "--color-base-taupe--700",
+    "--color-base-taupe--800",
+    "--color-base-taupe--900",
+    "--color-base-taupe--1000",
+    "--color-base-grey--100",
+    "--color-base-grey--200",
+    "--color-base-grey--300",
+    "--color-base-grey--400",
+    "--color-base-grey--500",
+    "--color-base-grey--600",
+    "--color-base-grey--700",
+    "--color-base-grey--800",
+    "--color-base-grey--900",
+    "--color-base-grey--1000",
+    "--color-base-red--100",
+    "--color-base-red--200",
+    "--color-base-red--300",
+    "--color-base-red--400",
+    "--color-base-red--500",
+    "--color-base-red--600",
+    "--color-base-red--700",
+    "--color-base-red--800",
+    "--color-base-red--900",
+    "--color-base-red--1000",
+    "--color-base-pink--100",
+    "--color-base-pink--200",
+    "--color-base-pink--300",
+    "--color-base-pink--400",
+    "--color-base-pink--500",
+    "--color-base-pink--600",
+    "--color-base-pink--700",
+    "--color-base-pink--800",
+    "--color-base-pink--900",
+    "--color-base-pink--1000",
+    "--color-base-orange--100",
+    "--color-base-orange--200",
+    "--color-base-orange--300",
+    "--color-base-orange--400",
+    "--color-base-orange--500",
+    "--color-base-orange--600",
+    "--color-base-orange--700",
+    "--color-base-orange--800",
+    "--color-base-orange--900",
+    "--color-base-orange--1000",
+    "--color-base-yellow--100",
+    "--color-base-yellow--200",
+    "--color-base-yellow--300",
+    "--color-base-yellow--400",
+    "--color-base-yellow--500",
+    "--color-base-yellow--600",
+    "--color-base-yellow--700",
+    "--color-base-yellow--800",
+    "--color-base-yellow--900",
+    "--color-base-yellow--1000",
+    "--color-base-lime--100",
+    "--color-base-lime--200",
+    "--color-base-lime--300",
+    "--color-base-lime--400",
+    "--color-base-lime--500",
+    "--color-base-lime--600",
+    "--color-base-lime--700",
+    "--color-base-lime--800",
+    "--color-base-lime--900",
+    "--color-base-lime--1000",
+    "--color-base-green--100",
+    "--color-base-green--200",
+    "--color-base-green--300",
+    "--color-base-green--400",
+    "--color-base-green--500",
+    "--color-base-green--600",
+    "--color-base-green--700",
+    "--color-base-green--800",
+    "--color-base-green--900",
+    "--color-base-green--1000",
+    "--color-base-lightBlue--100",
+    "--color-base-lightBlue--200",
+    "--color-base-lightBlue--300",
+    "--color-base-lightBlue--400",
+    "--color-base-lightBlue--500",
+    "--color-base-lightBlue--600",
+    "--color-base-lightBlue--700",
+    "--color-base-lightBlue--800",
+    "--color-base-lightBlue--900",
+    "--color-base-lightBlue--1000",
+    "--color-base-blue--100",
+    "--color-base-blue--200",
+    "--color-base-blue--300",
+    "--color-base-blue--400",
+    "--color-base-blue--500",
+    "--color-base-blue--600",
+    "--color-base-blue--700",
+    "--color-base-blue--800",
+    "--color-base-blue--900",
+    "--color-base-blue--1000",
+    "--color-base-white",
+    "--color-base-black",
+  ]}
+/>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Base color palette was rendering extremely incorrectly
![image](https://github.com/user-attachments/assets/f6cd3493-ba7b-4d03-a860-47a754566da7)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Presentation of color swatches 
![image](https://github.com/user-attachments/assets/6bd0dd72-71bb-4a0f-b26a-02a8b39db17e)

### Removed

- Use of automagic "pull all the colors" component because it wasn't playing nice with our new token tooling

### Fixed

- Base palette renders again
![image](https://github.com/user-attachments/assets/aebc9b15-4b5f-4907-8901-9fc246281eae)

## Testing

View color docs locally or on Cloudflare build

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
