### PR TITLE
fix(components): match Glimmer mobile styles to web

### DIFF
--- a/packages/components-native/src/Glimmer/Glimmer.style.ts
+++ b/packages/components-native/src/Glimmer/Glimmer.style.ts
@@ -5,7 +5,7 @@ export const shineWidth = tokens["space-largest"];
 
 export const styles = StyleSheet.create({
   container: {
-    backgroundColor: tokens["color-surface--background"],
+    backgroundColor: "rgba(0, 0, 0, 0.05)",
     overflow: "hidden",
     position: "relative",
     width: "100%",

--- a/packages/components-native/src/Glimmer/Glimmer.tsx
+++ b/packages/components-native/src/Glimmer/Glimmer.tsx
@@ -83,15 +83,9 @@ export function Glimmer({
         <Svg>
           <Defs>
             <LinearGradient id="gradientShine" x1={0} y1={0.5} x2={1} y2={0.5}>
-              <Stop
-                offset="0%"
-                stopColor={tokens["color-surface--background"]}
-              />
+              <Stop offset="0%" stopColor="rgba(255,255,255,0)" />
               <Stop offset="50%" stopColor={tokens["color-surface"]} />
-              <Stop
-                offset="100%"
-                stopColor={tokens["color-surface--background"]}
-              />
+              <Stop offset="100%" stopColor="rgba(255,255,255,0)" />
             </LinearGradient>
           </Defs>
           <Rect fill="url(#gradientShine)" height="100%" width="100%" />

--- a/packages/components-native/src/Glimmer/Glimmer.tsx
+++ b/packages/components-native/src/Glimmer/Glimmer.tsx
@@ -83,9 +83,21 @@ export function Glimmer({
         <Svg>
           <Defs>
             <LinearGradient id="gradientShine" x1={0} y1={0.5} x2={1} y2={0.5}>
-              <Stop offset="0%" stopColor="rgba(255,255,255,0)" />
-              <Stop offset="50%" stopColor={tokens["color-surface"]} />
-              <Stop offset="100%" stopColor="rgba(255,255,255,0)" />
+              <Stop
+                offset="0%"
+                stopColor="rgba(255,255,255,0)"
+                stopOpacity="0"
+              />
+              <Stop
+                offset="50%"
+                stopColor="rgba(255,255,255,1)"
+                stopOpacity="1"
+              />
+              <Stop
+                offset="100%"
+                stopColor="rgba(255,255,255,0)"
+                stopOpacity="0"
+              />
             </LinearGradient>
           </Defs>
           <Rect fill="url(#gradientShine)" height="100%" width="100%" />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Because the Glimmer was using a `surface--background` token, it was actually quite difficult to parse when used overtop `surface--background` or other `surface--` variants.

In addition, it was inconsistent with the web Glimmer, which uses a neutral value.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- semantic color tokens to rgb value so the Glimmer works better overlaid across assorted surfaces

### Fixed

- mobile Glimmer works better across various surface types

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
