### PR TITLE
fix(components): update Disclosure focus and hover styling

### DIFF
--- a/packages/components/src/Disclosure/Disclosure.css
+++ b/packages/components/src/Disclosure/Disclosure.css
@@ -9,13 +9,17 @@
 }
 
 .summary {
-  padding: var(--space-smaller) 0 var(--space-smallest) 0;
+  --disclosure--interactionOffset: var(--space-smaller);
+  margin-left: calc(-1 * var(--disclosure--interactionOffset));
+  padding: var(--space-smaller) 0 var(--space-smallest)
+    var(--disclosure--interactionOffset);
   border: none;
+  border-radius: var(--radius-small);
   list-style: none;
   cursor: pointer;
-  outline-color: none;
+  outline-color: transparent;
   transition:
-    background var(--timing-quick),
+    background-color var(--timing-base) ease-out,
     box-shadow var(--timing-base);
 }
 
@@ -24,15 +28,18 @@
 }
 
 .summary:hover,
-.summary:focus {
-  background: var(--color-surface--hover);
+.summary:focus-visible {
+  background-color: var(--color-surface--hover);
 }
 
 .summary:focus,
 .summary:active {
-  box-shadow: var(--shadow-focus);
   border: none;
-  outline: none;
+  outline: transparent;
+}
+
+.summary:focus-visible {
+  box-shadow: var(--shadow-focus);
 }
 
 .summary * {

--- a/packages/components/src/Disclosure/Disclosure.tsx
+++ b/packages/components/src/Disclosure/Disclosure.tsx
@@ -59,7 +59,7 @@ export function Disclosure({
             isTitleString={isTitleString}
           />
           <span className={styles.arrowIconWrapper}>
-            <Icon size="large" name="arrowDown" color="green" />
+            <Icon name="arrowDown" color="interactive" />
           </span>
         </div>
       </summary>

--- a/packages/components/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
+++ b/packages/components/src/Disclosure/__snapshots__/Disclosure.test.tsx.snap
@@ -21,13 +21,13 @@ exports[`renders a Disclosure 1`] = `
         >
           <svg
             data-testid="arrowDown"
-            style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 32px; height: 32px;"
+            style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M7.703 8.291a.996.996 0 0 0-1.41.001.994.994 0 0 0 0 1.41l5 5.005a.998.998 0 0 0 1.415 0l5-5a.994.994 0 0 0 0-1.41.995.995 0 0 0-1.411-.001L12 12.584 7.703 8.291Z"
-              style="fill: var(--color-green);"
+              style="fill: var(--color-interactive);"
             />
           </svg>
         </span>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Improve the appearance of hover and focus states and make them more consistent with other Atlantis elements

## Changes

### Changed

- Apply a `radius` of small to Disclosure (as it is typically a child component)
- Adjust how the left alignment of the Disclosure works so that on hover and focus-visible, the title is not flush to the edge of the changing surface

### Fixed

- fix transitions on background-color and focus shadow
- changed outline color to transparent to support high-contrast modes

## Testing

Test in Storybook and via prerelease

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
