### PR TITLE
fix(components): Add ref prop to primary and secondary actions on Page component

### DIFF
--- a/docs/components/Page/Web.stories.tsx
+++ b/docs/components/Page/Web.stories.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { StatusLabel } from "@jobber/components";
 import { Page } from "@jobber/components/Page";
 import { Content } from "@jobber/components/Content";
 import { Text } from "@jobber/components/Text";
+import { Popover } from "@jobber/components/Popover";
 
 export default {
   title: "Components/Layouts and Structure/Page/Web",
@@ -22,6 +23,52 @@ const BasicTemplate: ComponentStory<typeof Page> = args => (
   </Page>
 );
 
+const PopoverTemplate: ComponentStory<typeof Page> = args => {
+  const primaryDivRef = useRef(null);
+  const [showPrimaryPopover, setShowPrimaryPopover] = useState(false);
+
+  const secondaryDivRef = useRef(null);
+  const [showSecondaryPopover, setShowSecondaryPopover] = useState(false);
+
+  return (
+    <>
+      <Page
+        primaryAction={{
+          label: "Trigger Food Popover",
+          onClick: () => setShowPrimaryPopover(true),
+          ref: primaryDivRef,
+        }}
+        secondaryAction={{
+          label: "Trigger Drink Popover",
+          onClick: () => setShowSecondaryPopover(true),
+          ref: secondaryDivRef,
+        }}
+        {...args}
+      >
+        <Content>
+          <Text>Page content here</Text>
+        </Content>
+      </Page>
+      <Popover
+        attachTo={primaryDivRef}
+        open={showPrimaryPopover}
+        onRequestClose={() => setShowPrimaryPopover(false)}
+        preferredPlacement="bottom"
+      >
+        <Content>Your food order: 🥨</Content>
+      </Popover>
+      <Popover
+        attachTo={secondaryDivRef}
+        open={showSecondaryPopover}
+        onRequestClose={() => setShowSecondaryPopover(false)}
+        preferredPlacement="bottom"
+      >
+        <Content>Your drink order: 🍹</Content>
+      </Popover>
+    </>
+  );
+};
+
 const titleMetaData = (
   <StatusLabel label={"In Progress"} alignment={"start"} status={"warning"} />
 );
@@ -33,12 +80,10 @@ Basic.args = {
     "Improve job completion rates, stop chasing payments, and boost your customer service by automatically communicating with your clients at key points before, during, and after a job. Read more about Notifications by visiting our [Help Center](https://help.getjobber.com/hc/en-us).",
 };
 
-export const WithActions = BasicTemplate.bind({});
+export const WithActions = PopoverTemplate.bind({});
 WithActions.args = {
   title: "Notification Settings",
   intro: "This isn't just talk. Get into action with some buttons and menus.",
-  primaryAction: { label: "Send Food Alert", onClick: () => alert("🥨") },
-  secondaryAction: { label: "Send Drink Alert", onClick: () => alert("🍹") },
   moreActionsMenu: [
     {
       actions: [

--- a/packages/components/src/Page/Page.css
+++ b/packages/components/src/Page/Page.css
@@ -39,6 +39,7 @@
 
 .titleBar > .actionGroup {
   flex: 1 0 auto;
+  align-self: baseline;
 }
 
 .titleBar.large,

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import { StatusLabel } from "@jobber/components/StatusLabel";
 import { Page } from ".";
+import { ButtonActionProps, getActionProps } from "./Page";
 import { SectionProps } from "../Menu";
+import { ButtonProps } from "../Button";
 
 jest.mock("@jobber/hooks", () => {
   return {
@@ -105,6 +107,23 @@ describe("When actions are provided", () => {
 
     fireEvent.click(getByText("Second Do"));
     expect(handleSecondaryAction).toHaveBeenCalledTimes(1);
+  });
+
+  describe("getActionProps", () => {
+    it("given action props, it returns the correct props", () => {
+      const buttonActionProps = {
+        label: "Label",
+      } as ButtonProps;
+      const buttonActionWithRefProps = {
+        label: "Label",
+        ref: { current: null },
+      } as ButtonActionProps;
+
+      expect(getActionProps(buttonActionProps)).toEqual(buttonActionProps);
+      expect(getActionProps(buttonActionWithRefProps)).toEqual(
+        buttonActionProps,
+      );
+    });
   });
 });
 

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -2,9 +2,8 @@ import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import { StatusLabel } from "@jobber/components/StatusLabel";
 import { Page } from ".";
-import { ButtonActionProps, getActionProps } from "./Page";
+import { getActionProps } from "./Page";
 import { SectionProps } from "../Menu";
-import { ButtonProps } from "../Button";
 
 jest.mock("@jobber/hooks", () => {
   return {
@@ -113,11 +112,11 @@ describe("When actions are provided", () => {
     it("given action props, it returns the correct props", () => {
       const buttonActionProps = {
         label: "Label",
-      } as ButtonProps;
+      };
       const buttonActionWithRefProps = {
         label: "Label",
         ref: { current: null },
-      } as ButtonActionProps;
+      };
 
       expect(getActionProps(buttonActionProps)).toEqual(buttonActionProps);
       expect(getActionProps(buttonActionWithRefProps)).toEqual(

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -14,6 +14,10 @@ import { Button, ButtonProps } from "../Button";
 import { Menu, SectionProps } from "../Menu";
 import { Emphasis } from "../Emphasis";
 
+export type ButtonActionProps = ButtonProps & {
+  ref?: React.RefObject<HTMLDivElement>;
+};
+
 interface PageFoundationProps {
   readonly children: ReactNode | ReactNode[];
 
@@ -49,13 +53,13 @@ interface PageFoundationProps {
   /**
    * Page title primary action button settings.
    */
-  readonly primaryAction?: ButtonProps;
+  readonly primaryAction?: ButtonActionProps;
 
   /**
    * Page title secondary action button settings.
    *   Only shown if there is a primaryAction.
    */
-  readonly secondaryAction?: ButtonProps;
+  readonly secondaryAction?: ButtonActionProps;
 
   /**
    * Page title Action menu.
@@ -154,13 +158,16 @@ export function Page({
             {showActionGroup && (
               <div className={styles.actionGroup}>
                 {primaryAction && (
-                  <div className={styles.primaryAction}>
-                    <Button {...primaryAction} />
+                  <div className={styles.primaryAction} ref={primaryAction.ref}>
+                    <Button {...getActionProps(primaryAction)} />
                   </div>
                 )}
                 {secondaryAction && (
-                  <div className={styles.actionButton}>
-                    <Button {...secondaryAction} />
+                  <div
+                    className={styles.actionButton}
+                    ref={secondaryAction.ref}
+                  >
+                    <Button {...getActionProps(secondaryAction)} />
                   </div>
                 )}
                 {showMenu && (
@@ -186,3 +193,10 @@ export function Page({
     </div>
   );
 }
+
+export const getActionProps = (actionProps: ButtonActionProps): ButtonProps => {
+  const buttonProps = { ...actionProps };
+  if (actionProps.ref) delete buttonProps.ref;
+
+  return buttonProps;
+};


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
I needed a popover on a button, but the button was a page primary action. 
<!-- Why did you do what you did? -->

## Changes
<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed
- added `ref` to div wrapping primary and secondary action buttons
- modified storybook to show example of change
- added test to make sure the `ref` prop is not passed into the button component
<!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing
- Open `Page` "With Actions" storybook
- Click the primary and secondary actions to see the Popover 

<img width="1266" alt="Screenshot 2024-09-04 at 10 15 49 AM" src="https://github.com/user-attachments/assets/2dc91111-8d0c-4cf8-9319-289d27409694">

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
