### PR TITLE
fix(components): Display Datalist checkbox based on device type instead of breakpoint

### DIFF
--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -175,7 +175,7 @@
   transition: opacity var(--transition-properties);
   --transition-properties: var(--timing-quick) ease-in-out;
 
-  @media (--medium-screens-and-up) {
+  @media (--medium-screens-and-up) and (any-pointer: fine) {
     padding-top: 0;
     opacity: 0;
   }

--- a/packages/components/src/DataList/DataList.css
+++ b/packages/components/src/DataList/DataList.css
@@ -175,7 +175,7 @@
   transition: opacity var(--transition-properties);
   --transition-properties: var(--timing-quick) ease-in-out;
 
-  @media (--medium-screens-and-up) and (any-pointer: fine) {
+  @media (any-pointer: fine) {
     padding-top: 0;
     opacity: 0;
   }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
On touch screen devices that were wider than our `--medium-screens-and-up` the DataList checkbox wouldn't be displayed because the user wouldn't be able to hover over the row, this PR works to fix that.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- components: Display DataList checkboxes on touch screen devices that are medium screen sized and up.

### Security

- <!-- in case of vulnerabilities -->

## Testing

Can be tested in storybook here: https://5607bc22.atlantis.pages.dev/iframe?args=&id=components-lists-and-tables-datalist-web--basic&viewMode=story


Can also be tested in JO, see the PR mentioning this one.

To test enable responsive mode in your browser inspector (this is wider screen with touch simulation enabled):
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1e06f51e-515d-4f5d-8359-7c3b4d294313">

Verify:
 -  When on the medium-screens-and-up size the check box appears when touch simulation is enabled
 - Verify the checkboxes do not appear on the medium-screens-and-up size when touch simulation is disabled
 - Verify smaller breakpoints work as expected when touch simulation is enabled / disabled

Wider screen with touch simulation disabled (hovering on a row):
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/0a80517e-01cf-4e4a-ac02-51529be801c5">

Smaller screen with touch simulation disabled:
<img width="540" alt="image" src="https://github.com/user-attachments/assets/1ba69f7a-e753-43d0-bba3-5faf4cfd72e3">

Smaller screen with touch simulation enabled:
<img width="519" alt="image" src="https://github.com/user-attachments/assets/433868cd-8442-4e92-83f0-fd4ed40dcb74">



Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
