### PR TITLE
feat(components): small improvement to focus state of DataList headers

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.css
@@ -4,12 +4,13 @@
   align-items: center;
   padding: 0;
   border: none;
+  border-radius: var(--radius-small);
   background-color: transparent;
 }
 
 .headerLabel:focus,
 .headerLabel:focus-visible {
-  outline: none;
+  outline: transparent;
 }
 
 .headerLabel:focus-visible {

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.css
@@ -2,8 +2,8 @@
   display: flex;
   position: relative;
   align-items: center;
-  padding: 0 var(--space-smallest);
   margin: 0 calc(-1 * var(--space-smallest));
+  padding: 0 var(--space-smallest);
   border: none;
   border-radius: var(--radius-small);
   background-color: transparent;

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.css
@@ -2,10 +2,12 @@
   display: flex;
   position: relative;
   align-items: center;
-  padding: 0;
+  padding: 0 var(--space-smallest);
+  margin: 0 calc(-1 * var(--space-smallest));
   border: none;
   border-radius: var(--radius-small);
   background-color: transparent;
+  transition: all var(--timing-base) ease-out;
 }
 
 .headerLabel:focus,

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.css
@@ -1,7 +1,6 @@
 .sortIcon {
-  width: var(--space-large);
-  height: var(--space-large);
-  margin-right: var(--space-small);
+  width: 18px;
+  height: 24px;
 }
 
 .sortIcon path {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The focus state for DataList headers looked a little unfinished with no radius

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- DataList interactive headers now have a small radius in their focused state
![image](https://github.com/user-attachments/assets/78ee6f46-a412-4688-ab09-86a5178564df)

### Fixed

- Sortable headers on right-aligned columns now align properly to their columns' contents

## Testing

You can test in [Cloudflare](https://add-radius-to-datalist-heade.atlantis.pages.dev/?path=/story/components-lists-and-tables-datalist-web--basic) or locally by tabbing through the interface and observing the slightly rounded corners.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
