### PR TITLE
docs(design): add subtle background usage to color docs

### DIFF
--- a/docs/design/Colors.stories.mdx
+++ b/docs/design/Colors.stories.mdx
@@ -205,6 +205,18 @@ state.
 
 A slightly darker surface gives a receded appearance relative to main surfaces.
 
+#### Surface--Background--Subtle
+
+<Swatch
+  colors={[
+    "--color-surface--background--subtle",
+    "--color-surface--background--subtle--hover",
+  ]}
+/>
+
+Use when you need a surface that's distinct from the main `surface` without
+appearing _too_ receded.
+
 #### Surface--Reverse
 
 <Swatch colors={["--color-surface--reverse"]} />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

It was confusing that we had a semantic color that wasn't documented!
<img width="586" alt="image" src="https://github.com/user-attachments/assets/9442ad99-bb0f-44fe-9114-57da1004980d">

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- `--color-surface--background--subtle` is now documented in Colors

## Testing

Check the docs! Locally or in Cloudflare

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
