### PR TITLE
feat(components): Add description prop to InputFile

### DIFF
--- a/docs/components/InputFile/InputFile.stories.mdx
+++ b/docs/components/InputFile/InputFile.stories.mdx
@@ -81,12 +81,12 @@ function fileSizeValidator(file: File) {
 }
 ```
 
-### supportText
+### description
 
-`supportText` is a string that can be used to provide additional information to
-the user. A common use case is to provide the accepted file types and maximum
-size for each file. With helpful `supportText`, users are more aware of the
-limitations and requirements of the file upload.
+The `description` prop is a string that can be used to provide additional
+information to the user. A common use case is to provide the accepted file types
+and maximum size for each file. With a helpful `description`, users are more
+aware of the limitations and requirements of the file upload.
 
 #### Notes
 

--- a/docs/components/InputFile/InputFile.stories.mdx
+++ b/docs/components/InputFile/InputFile.stories.mdx
@@ -81,6 +81,13 @@ function fileSizeValidator(file: File) {
 }
 ```
 
+### supportText
+
+`supportText` is a string that can be used to provide additional information to
+the user. A common use case is to provide the accepted file types and maximum
+size for each file. With helpful `supportText`, users are more aware of the
+limitations and requirements of the file upload.
+
 #### Notes
 
 If you would like to restrict specific file types, it is advised that you use

--- a/docs/components/InputFile/Web.stories.tsx
+++ b/docs/components/InputFile/Web.stories.tsx
@@ -63,10 +63,10 @@ const VariationsAndSizesTemplate: ComponentStory<typeof InputFile> = args => {
         getUploadParams={fetchUploadParams}
       />
       <InputFile
-        buttonLabel="Dropzone Uploader with supportText"
+        buttonLabel="Dropzone Uploader with description"
         getUploadParams={fetchUploadParams}
         allowedTypes="images"
-        supportText="JPEG, HEIC, PNG up to 5MB each"
+        description="JPEG, HEIC, PNG up to 5MB each"
       />
       <InputFile
         size="small"
@@ -109,9 +109,9 @@ ImagesOnly.args = {
   getUploadParams: () => Promise.resolve({ url: "https://httpbin.org/post" }),
 };
 
-export const SupportText = StatefulTemplate.bind({});
-SupportText.args = {
+export const WithDescription = StatefulTemplate.bind({});
+WithDescription.args = {
   allowMultiple: true,
   getUploadParams: () => Promise.resolve({ url: "https://httpbin.org/post" }),
-  supportText: "JPEG, HEIC, PNG up to 5MB each",
+  description: "JPEG, HEIC, PNG up to 5MB each",
 };

--- a/docs/components/InputFile/Web.stories.tsx
+++ b/docs/components/InputFile/Web.stories.tsx
@@ -108,3 +108,10 @@ ImagesOnly.args = {
   allowedTypes: "images",
   getUploadParams: () => Promise.resolve({ url: "https://httpbin.org/post" }),
 };
+
+export const SupportText = StatefulTemplate.bind({});
+SupportText.args = {
+  allowMultiple: true,
+  getUploadParams: () => Promise.resolve({ url: "https://httpbin.org/post" }),
+  supportText: "JPEG, HEIC, PNG up to 5MB each",
+};

--- a/docs/components/InputFile/Web.stories.tsx
+++ b/docs/components/InputFile/Web.stories.tsx
@@ -63,6 +63,12 @@ const VariationsAndSizesTemplate: ComponentStory<typeof InputFile> = args => {
         getUploadParams={fetchUploadParams}
       />
       <InputFile
+        buttonLabel="Dropzone Uploader with supportText"
+        getUploadParams={fetchUploadParams}
+        allowedTypes="images"
+        supportText="JPEG, HEIC, PNG up to 5MB each"
+      />
+      <InputFile
         size="small"
         getUploadParams={fetchUploadParams}
         buttonLabel="Small Dropzone Uploader"

--- a/docs/components/InputFile/Web.stories.tsx
+++ b/docs/components/InputFile/Web.stories.tsx
@@ -65,6 +65,7 @@ const VariationsAndSizesTemplate: ComponentStory<typeof InputFile> = args => {
       <InputFile
         buttonLabel="Dropzone Uploader with description"
         getUploadParams={fetchUploadParams}
+        allowMultiple
         allowedTypes="images"
         description="JPEG, HEIC, PNG up to 5MB each"
       />

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -124,9 +124,9 @@ interface InputFileProps {
   readonly allowMultiple?: boolean;
 
   /**
-   * Support text to display in the dropzone.
+   * Further description of the input.
    */
-  readonly supportText?: string;
+  readonly description?: string;
 
   /**
    * A callback that receives a file object and returns a `UploadParams` needed
@@ -186,7 +186,7 @@ export function InputFile({
   buttonLabel: providedButtonLabel,
   allowMultiple = false,
   allowedTypes = "all",
-  supportText,
+  description,
   getUploadParams,
   onUploadStart,
   onUploadProgress,
@@ -247,9 +247,9 @@ export function InputFile({
               {size === "base" && (
                 <>
                   <Typography size="small">{hintText}</Typography>
-                  {supportText && (
+                  {description && (
                     <Typography size="small" textColor="textSecondary">
-                      {supportText}
+                      {description}
                     </Typography>
                   )}
                 </>

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -124,6 +124,11 @@ interface InputFileProps {
   readonly allowMultiple?: boolean;
 
   /**
+   * Support text to display in the dropzone.
+   */
+  readonly supportText?: string;
+
+  /**
    * A callback that receives a file object and returns a `UploadParams` needed
    * to upload the file.
    *
@@ -181,6 +186,7 @@ export function InputFile({
   buttonLabel: providedButtonLabel,
   allowMultiple = false,
   allowedTypes = "all",
+  supportText,
   getUploadParams,
   onUploadStart,
   onUploadProgress,
@@ -239,9 +245,14 @@ export function InputFile({
             <Content spacing="small">
               <Button label={buttonLabel} size="small" type="secondary" />
               {size === "base" && (
-                <Typography size="small" textColor="textSecondary">
-                  {hintText}
-                </Typography>
+                <>
+                  <Typography size="small">{hintText}</Typography>
+                  {supportText && (
+                    <Typography size="small" textColor="textSecondary">
+                      {supportText}
+                    </Typography>
+                  )}
+                </>
               )}
             </Content>
           </div>
@@ -358,14 +369,14 @@ function getLabels(
 ) {
   let buttonLabel = multiple ? "Upload Files" : "Upload File";
   let hintText = multiple
-    ? "or drag files here to upload"
-    : "or drag a file here to upload";
+    ? "Select or drag files here to upload"
+    : "Select or drag a file here to upload";
 
   if (allowedTypes === "images" || allowedTypes === "basicImages") {
     buttonLabel = multiple ? "Upload Images" : "Upload Image";
     hintText = multiple
-      ? "or drag images here to upload"
-      : "or drag an image here to upload";
+      ? "Select or drag images here to upload"
+      : "Select or drag an image here to upload";
   }
 
   if (providedButtonLabel) buttonLabel = providedButtonLabel;

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -367,17 +367,15 @@ function getLabels(
   multiple: boolean,
   allowedTypes: string | string[],
 ) {
-  let buttonLabel = multiple ? "Upload Files" : "Upload File";
-  let hintText = multiple
-    ? "Select or drag files here to upload"
-    : "Select or drag a file here to upload";
-
-  if (allowedTypes === "images" || allowedTypes === "basicImages") {
-    buttonLabel = multiple ? "Upload Images" : "Upload Image";
-    hintText = multiple
-      ? "Select or drag images here to upload"
-      : "Select or drag an image here to upload";
-  }
+  const fileType =
+    allowedTypes === "images" || allowedTypes === "basicImages"
+      ? "Image"
+      : "File";
+  let buttonLabel = multiple ? `Upload ${fileType}s` : `Upload ${fileType}`;
+  const fileTypeDeterminer = fileType === "Image" ? "an" : "a";
+  const hintText = multiple
+    ? `Select or drag ${fileType.toLowerCase()}s here to upload`
+    : `Select or drag ${fileTypeDeterminer} ${fileType.toLowerCase()} here to upload`;
 
   if (providedButtonLabel) buttonLabel = providedButtonLabel;
 

--- a/packages/components/src/InputFile/__snapshots__/InputFile.test.tsx.snap
+++ b/packages/components/src/InputFile/__snapshots__/InputFile.test.tsx.snap
@@ -30,9 +30,9 @@ exports[`Post Requests renders an InputFile 1`] = `
           </span>
         </button>
         <p
-          class="base regular small textSecondary"
+          class="base regular small"
         >
-          or drag a file here to upload
+          Select or drag a file here to upload
         </p>
       </div>
     </div>
@@ -72,9 +72,9 @@ exports[`Post Requests renders an InputFile with multiple images allowed 1`] = `
           </span>
         </button>
         <p
-          class="base regular small textSecondary"
+          class="base regular small"
         >
-          or drag images here to upload
+          Select or drag images here to upload
         </p>
       </div>
     </div>
@@ -113,9 +113,9 @@ exports[`Post Requests renders an InputFile with multiple uploads 1`] = `
           </span>
         </button>
         <p
-          class="base regular small textSecondary"
+          class="base regular small"
         >
-          or drag files here to upload
+          Select or drag files here to upload
         </p>
       </div>
     </div>
@@ -154,9 +154,9 @@ exports[`Post Requests renders an InputFile with only images allowed 1`] = `
           </span>
         </button>
         <p
-          class="base regular small textSecondary"
+          class="base regular small"
         >
-          or drag an image here to upload
+          Select or drag an image here to upload
         </p>
       </div>
     </div>
@@ -194,9 +194,9 @@ exports[`Post Requests renders an InputFile with proper variations 1`] = `
           </span>
         </button>
         <p
-          class="base regular small textSecondary"
+          class="base regular small"
         >
-          or drag a file here to upload
+          Select or drag a file here to upload
         </p>
       </div>
     </div>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
The purpose behind adding `supportText` is to communicate to a user, the permitted file types and max file size when uploading files via `InputFile` dropzone.  This can help in avoiding upload errors that need to be rectified after a failed upload.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

1. `supportText` prop, which is a string. Why a string?
- Although the motivation behind adding this prop is to display file types and size limit for files, I feel that keeping this as customizable as possible, allows for flexibility moving forward
- Allowing for a string also makes localization easier on the consumer side

![Screenshot 2024-09-11 at 5 53 46 PM](https://github.com/user-attachments/assets/4434bf80-ac26-4020-8e3f-3c70b2eb9052)

[Figma](https://www.figma.com/design/rIIhulZvcp9M82lNOCGv16/branch/FRyCZpCX92n6dzD6alwyKj/Product%2FOnline?m=auto&node-id=13630-0&t=JI0ecH7XrhDzgHw6-1)

Why not dynamically use `allowedTypes` here?  
Thinking about instances where consumers are putting `allowedTypes` into an array, if they allow DOCX files, that looks like this: `"application/vnd.openxmlformats-officedocument.wordprocessingml.document"`.  I personally do not think it's worth having all possible MIME types (there's too many) mapped in this component, just to convert them to uppercase and then a string to be displayed with a file size that is set in the consumers component.  This would not only be adding a lot of logic to this component, but I can foresee that becoming brittle. 

2. Added an example of `supportText` to the Variations and Sizes story, as well as a stand alone Support Text story

### Changed

The `hintText` is no longer combined with the Button text.  That sentence format spanning across button and `hintText` will not scale well with various languages in the future.

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
