### PR TITLE
feat(components-native): Add underline support to Text/Typography components for mobile (JOB-104505)

### DIFF
--- a/packages/components-native/src/Text/Text.test.tsx
+++ b/packages/components-native/src/Text/Text.test.tsx
@@ -142,3 +142,9 @@ it("renders text that is inaccessible", () => {
     }),
   );
 });
+
+it("renders text with underline styling", () => {
+  const text = render(<Text underline="dashed">Test Text</Text>);
+
+  expect(text.toJSON()).toMatchSnapshot();
+});

--- a/packages/components-native/src/Text/Text.tsx
+++ b/packages/components-native/src/Text/Text.tsx
@@ -73,7 +73,7 @@ interface TextProps
   /**
    * Underline text
    */
-  readonly underline?: "solid" | "dashed";
+  readonly underline?: "solid" | "dotted";
 
   /**
    * This will make the text inaccessible to the screen reader.

--- a/packages/components-native/src/Text/Text.tsx
+++ b/packages/components-native/src/Text/Text.tsx
@@ -71,7 +71,9 @@ interface TextProps
   readonly italic?: boolean;
 
   /**
-   * Underline text
+   * Underline style to use for the text. The non-solid style is only supported
+   * on iOS, as per React Native's Text component's limitations.
+   * https://reactnative.dev/docs/text-style-props#textdecorationstyle-ios
    */
   readonly underline?: "solid" | "dotted";
 

--- a/packages/components-native/src/Text/Text.tsx
+++ b/packages/components-native/src/Text/Text.tsx
@@ -71,6 +71,11 @@ interface TextProps
   readonly italic?: boolean;
 
   /**
+   * Underline text
+   */
+  readonly underline?: "solid" | "dashed";
+
+  /**
    * This will make the text inaccessible to the screen reader.
    * This should be avoided unless there is a good reason.
    * For example this is used in InputText to make it so the label isn't
@@ -118,6 +123,7 @@ export function Text({
   italic = false,
   hideFromScreenReader = false,
   maxFontScaleSize,
+  underline,
   selectable,
 }: TextProps): JSX.Element {
   const accessibilityRole: TextAccessibilityRole = "text";
@@ -130,6 +136,7 @@ export function Text({
       fontWeight={getFontWeight({ level, emphasis })}
       maxFontScaleSize={maxFontScaleSize || TEXT_MAX_SCALED_FONT_SIZES[level]}
       selectable={selectable}
+      underline={underline}
       {...{
         ...levelStyles[level],
         allowFontScaling,

--- a/packages/components-native/src/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/components-native/src/Text/__snapshots__/Text.test.tsx.snap
@@ -546,6 +546,47 @@ exports[`renders text with success variation reverseTheme true 1`] = `
 </Text>
 `;
 
+exports[`renders text with underline styling 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  maxFontSizeMultiplier={3.125}
+  selectable={true}
+  selectionColor="hsl(86, 100%, 46%)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "hsl(198, 35%, 21%)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+      {
+        "textDecorationStyle": "dashed",
+      },
+      {
+        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationLine": "underline",
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
 exports[`renders text with warn variation 1`] = `
 <Text
   accessibilityRole="text"

--- a/packages/components-native/src/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/components-native/src/Text/__snapshots__/Text.test.tsx.snap
@@ -577,7 +577,7 @@ exports[`renders text with underline styling 1`] = `
         "textDecorationStyle": "dashed",
       },
       {
-        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationColor": "hsl(197, 15%, 45%)",
         "textDecorationLine": "underline",
       },
     ]

--- a/packages/components-native/src/Typography/Typography.style.ts
+++ b/packages/components-native/src/Typography/Typography.style.ts
@@ -88,6 +88,11 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     fontStyle: "italic",
   },
 
+  underline: {
+    textDecorationColor: tokens["color-base-grey--300"],
+    textDecorationLine: "underline",
+  },
+
   startAlign: {
     textAlign: "left",
   },

--- a/packages/components-native/src/Typography/Typography.style.ts
+++ b/packages/components-native/src/Typography/Typography.style.ts
@@ -89,7 +89,7 @@ export const typographyTokens: { [index: string]: TextStyle } = {
   },
 
   underline: {
-    textDecorationColor: tokens["color-base-grey--300"],
+    textDecorationColor: tokens["color-text--secondary"],
     textDecorationLine: "underline",
   },
 

--- a/packages/components-native/src/Typography/Typography.test.tsx
+++ b/packages/components-native/src/Typography/Typography.test.tsx
@@ -217,3 +217,16 @@ it("renders text that is inaccessible", () => {
     }),
   );
 });
+
+describe("underline", () => {
+  it.each(["solid", "double", "dotted", "dashed"] as const)(
+    "renders text with %s underline",
+    underlineStyle => {
+      const typography = render(
+        <Typography underline={underlineStyle}>Test Text</Typography>,
+      );
+
+      expect(typography.toJSON()).toMatchSnapshot();
+    },
+  );
+});

--- a/packages/components-native/src/Typography/Typography.tsx
+++ b/packages/components-native/src/Typography/Typography.tsx
@@ -85,7 +85,9 @@ export interface TypographyProps<T extends FontFamily>
   readonly fontStyle?: T extends "base" ? BaseStyle : DisplayStyle;
 
   /**
-   * Style of underline for the text
+   * Underline style to use for the text. The non-solid style is only supported
+   * on iOS, as per React Native's Text component's limitations.
+   * https://reactnative.dev/docs/text-style-props#textdecorationstyle-ios
    */
   readonly underline?: "solid" | "double" | "dotted" | "dashed" | undefined;
 

--- a/packages/components-native/src/Typography/Typography.tsx
+++ b/packages/components-native/src/Typography/Typography.tsx
@@ -7,6 +7,7 @@ import {
   // eslint-disable-next-line no-restricted-imports
   Text,
   TextProps,
+  TextStyle,
   ViewStyle,
 } from "react-native";
 import { TypographyGestureDetector } from "./TypographyGestureDetector";
@@ -84,6 +85,11 @@ export interface TypographyProps<T extends FontFamily>
   readonly fontStyle?: T extends "base" ? BaseStyle : DisplayStyle;
 
   /**
+   * Style of underline for the text
+   */
+  readonly underline?: "solid" | "double" | "dotted" | "dashed" | undefined;
+
+  /**
    * Font weight
    */
   readonly fontWeight?: T extends "base" ? BaseWeight : DisplayWeight;
@@ -124,6 +130,7 @@ const maxNumberOfLines = {
 
 export const Typography = React.memo(InternalTypography);
 
+// eslint-disable-next-line max-statements
 function InternalTypography<T extends FontFamily = "base">({
   fontFamily,
   fontStyle,
@@ -143,6 +150,7 @@ function InternalTypography<T extends FontFamily = "base">({
   hideFromScreenReader = false,
   accessibilityRole = "text",
   strikeThrough = false,
+  underline,
   selectable = true,
 }: TypographyProps<T>): JSX.Element {
   const sizeAndHeight = getSizeAndHeightStyle(size, lineHeight);
@@ -160,6 +168,11 @@ function InternalTypography<T extends FontFamily = "base">({
 
   if (fontStyle === "italic") {
     style.push(styles.italic);
+  }
+
+  if (underline) {
+    const underlineTextStyle: TextStyle = { textDecorationStyle: underline };
+    style.push(underlineTextStyle, styles.underline);
   }
 
   const numberOfLinesForNativeText = maxNumberOfLines[maxLines];

--- a/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
@@ -868,3 +868,163 @@ exports[`renders text with white color 1`] = `
   Test Text
 </Text>
 `;
+
+exports[`underline renders text with dashed underline 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="hsl(86, 100%, 46%)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "hsl(197, 15%, 45%)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+      {
+        "textDecorationStyle": "dashed",
+      },
+      {
+        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationLine": "underline",
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`underline renders text with dotted underline 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="hsl(86, 100%, 46%)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "hsl(197, 15%, 45%)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+      {
+        "textDecorationStyle": "dotted",
+      },
+      {
+        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationLine": "underline",
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`underline renders text with double underline 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="hsl(86, 100%, 46%)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "hsl(197, 15%, 45%)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+      {
+        "textDecorationStyle": "double",
+      },
+      {
+        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationLine": "underline",
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
+exports[`underline renders text with solid underline 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="hsl(86, 100%, 46%)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "hsl(197, 15%, 45%)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+      {
+        "textDecorationStyle": "solid",
+      },
+      {
+        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationLine": "underline",
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;

--- a/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
@@ -899,7 +899,7 @@ exports[`underline renders text with dashed underline 1`] = `
         "textDecorationStyle": "dashed",
       },
       {
-        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationColor": "hsl(197, 15%, 45%)",
         "textDecorationLine": "underline",
       },
     ]
@@ -939,7 +939,7 @@ exports[`underline renders text with dotted underline 1`] = `
         "textDecorationStyle": "dotted",
       },
       {
-        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationColor": "hsl(197, 15%, 45%)",
         "textDecorationLine": "underline",
       },
     ]
@@ -979,7 +979,7 @@ exports[`underline renders text with double underline 1`] = `
         "textDecorationStyle": "double",
       },
       {
-        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationColor": "hsl(197, 15%, 45%)",
         "textDecorationLine": "underline",
       },
     ]
@@ -1019,7 +1019,7 @@ exports[`underline renders text with solid underline 1`] = `
         "textDecorationStyle": "solid",
       },
       {
-        "textDecorationColor": "hsl(0, 0%, 87%)",
+        "textDecorationColor": "hsl(197, 15%, 45%)",
         "textDecorationLine": "underline",
       },
     ]


### PR DESCRIPTION
## Motivations
This PR adds the ability to add underlining to the Text component for the native-components.

## Visual Changes 
**Android**
<img width="373" alt="image" src="https://github.com/user-attachments/assets/6931d7ed-1105-40ba-9acf-0c0367288133">

<img width="374" alt="image" src="https://github.com/user-attachments/assets/d47b7d2a-4f07-48c2-a9f2-c73c87307a37">

**iOS**
<img width="383" alt="image" src="https://github.com/user-attachments/assets/7d0472d1-db27-4828-a572-2cd983b3fd26">


## Discussion
The underline styles here (dashed, etc) are not implemented yet on the Android side. For this reason Android defaults to the basic underline style regardless of what value is passed in. For iOS, the proper dashed style should be displayed.

### Added
- Added `underline` prop to `TextProps` with options `"solid"` or `"dashed"`
- Added `underline` prop to `TypographyProps` with options `"solid"`, `"double"`, `"dotted"`, or `"dashed"` (I covered more than what is exposed from Text, because this is an internal component; if the reviewer thinks this is unnecessary, I can change it to support only the solid/dashed cases that we need)
- Added underline styles to `typographyTokens`

## Testing
To test locally, run `npm run pack @jobber/components-native` and then install into the mobile repo via `npm i /path/to/atlantis/jobber-components-native-x.x.x.tgz`. Then change a `Text` component to pass an underline prop value.

For the screenshots above, I used the branch `JOB-103929-jobber-mobile-implement-explainability-ui` at commit `2c1c74b7c4c9f7b5ae569f4121c3505968e9bed3` and just locally installed the version of Atlantis that was packed from the command above.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
