### PR TITLE
feat(components): Expose variation prop for Chip used in Chips component

### DIFF
--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -36,10 +36,10 @@ const BasicTemplate: ComponentStory<typeof Chips> = args => {
         onChange={setSelected}
         type="singleselect"
       >
-        <Chip label="Amazing" value="Amazing" />
-        <Chip label="Wonderful" value="Wonderful" />
-        <Chip label="Brilliant" value="Brilliant" />
-        <Chip label="Magnificent" value="Magnificent" />
+        <Chip label="Amazing" variation="subtle" value="Amazing" />
+        <Chip label="Wonderful" variation="subtle" value="Wonderful" />
+        <Chip label="Brilliant" variation="subtle" value="Brilliant" />
+        <Chip label="Magnificent" variation="subtle" value="Magnificent" />
       </Chips>
     </Content>
   );
@@ -62,10 +62,10 @@ const MultiSelectTemplate: ComponentStory<typeof Chips> = args => {
         selected={selected}
         onChange={setSelected}
       >
-        <Chip label="Amazing" value="Amazing" />
-        <Chip label="Wonderful" value="Wonderful" />
-        <Chip label="Brilliant" value="Brilliant" />
-        <Chip label="Magnificent" value="Magnificent" />
+        <Chip label="Amazing" variation="subtle" value="Amazing" />
+        <Chip label="Wonderful" variation="subtle" value="Wonderful" />
+        <Chip label="Brilliant" variation="subtle" value="Brilliant" />
+        <Chip label="Magnificent" variation="subtle" value="Magnificent" />
       </Chips>
     </Content>
   );
@@ -97,7 +97,7 @@ const SelectionTemplate: ComponentStory<typeof Chips> = args => {
       onLoadMore={handleLoadMore}
     >
       {options.map(name => (
-        <Chip key={name} label={name} value={name} />
+        <Chip key={name} label={name} variation="subtle" value={name} />
       ))}
     </Chips>
   );

--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -36,10 +36,10 @@ const BasicTemplate: ComponentStory<typeof Chips> = args => {
         onChange={setSelected}
         type="singleselect"
       >
-        <Chip label="Amazing" variation="subtle" value="Amazing" />
-        <Chip label="Wonderful" variation="subtle" value="Wonderful" />
-        <Chip label="Brilliant" variation="subtle" value="Brilliant" />
-        <Chip label="Magnificent" variation="subtle" value="Magnificent" />
+        <Chip label="Amazing" value="Amazing" />
+        <Chip label="Wonderful" value="Wonderful" />
+        <Chip label="Brilliant" value="Brilliant" />
+        <Chip label="Magnificent" value="Magnificent" />
       </Chips>
     </Content>
   );
@@ -62,10 +62,10 @@ const MultiSelectTemplate: ComponentStory<typeof Chips> = args => {
         selected={selected}
         onChange={setSelected}
       >
-        <Chip label="Amazing" variation="subtle" value="Amazing" />
-        <Chip label="Wonderful" variation="subtle" value="Wonderful" />
-        <Chip label="Brilliant" variation="subtle" value="Brilliant" />
-        <Chip label="Magnificent" variation="subtle" value="Magnificent" />
+        <Chip label="Amazing" value="Amazing" />
+        <Chip label="Wonderful" value="Wonderful" />
+        <Chip label="Brilliant" value="Brilliant" />
+        <Chip label="Magnificent" value="Magnificent" />
       </Chips>
     </Content>
   );
@@ -97,7 +97,7 @@ const SelectionTemplate: ComponentStory<typeof Chips> = args => {
       onLoadMore={handleLoadMore}
     >
       {options.map(name => (
-        <Chip key={name} label={name} variation="subtle" value={name} />
+        <Chip key={name} label={name} value={name} />
       ))}
     </Chips>
   );

--- a/packages/components/src/Chips/Chip.tsx
+++ b/packages/components/src/Chips/Chip.tsx
@@ -3,7 +3,10 @@ import { useAssert } from "@jobber/hooks/useAssert";
 import { InternalChipProps } from "./ChipTypes";
 
 export interface ChipProps
-  extends Pick<InternalChipProps, "label" | "prefix" | "disabled" | "invalid"> {
+  extends Pick<
+    InternalChipProps,
+    "label" | "prefix" | "disabled" | "invalid" | "variation"
+  > {
   /**
    * The value that gets returned on the `<Chips>`'s onChange callback.
    */

--- a/packages/components/src/Chips/Chip.tsx
+++ b/packages/components/src/Chips/Chip.tsx
@@ -3,10 +3,7 @@ import { useAssert } from "@jobber/hooks/useAssert";
 import { InternalChipProps } from "./ChipTypes";
 
 export interface ChipProps
-  extends Pick<
-    InternalChipProps,
-    "label" | "prefix" | "disabled" | "invalid" | "variation"
-  > {
+  extends Pick<InternalChipProps, "label" | "prefix" | "disabled" | "invalid"> {
   /**
    * The value that gets returned on the `<Chips>`'s onChange callback.
    */

--- a/packages/components/src/Chips/ChipTypes.tsx
+++ b/packages/components/src/Chips/ChipTypes.tsx
@@ -2,6 +2,7 @@ import { KeyboardEvent, MouseEvent, ReactElement } from "react";
 import { ChipButtonProps } from "./InternalChipButton";
 import { AvatarProps } from "../Avatar";
 import { IconProps } from "../Icon";
+import { ChipVariations } from "../Chip/Chip.types";
 
 export interface InternalChipProps {
   /**
@@ -68,4 +69,10 @@ export interface InternalChipProps {
    * Callback for keyboard interaction with chips (e.g., chip deletion).
    */
   onKeyDown?(event: KeyboardEvent<HTMLDivElement | HTMLButtonElement>): void;
+
+  /**
+   * Button style variation. Does not affect functionality.
+   * @default "base"
+   */
+  readonly variation?: ChipVariations;
 }

--- a/packages/components/src/Chips/ChipTypes.tsx
+++ b/packages/components/src/Chips/ChipTypes.tsx
@@ -2,7 +2,6 @@ import { KeyboardEvent, MouseEvent, ReactElement } from "react";
 import { ChipButtonProps } from "./InternalChipButton";
 import { AvatarProps } from "../Avatar";
 import { IconProps } from "../Icon";
-import { ChipVariations } from "../Chip/Chip.types";
 
 export interface InternalChipProps {
   /**
@@ -69,10 +68,4 @@ export interface InternalChipProps {
    * Callback for keyboard interaction with chips (e.g., chip deletion).
    */
   onKeyDown?(event: KeyboardEvent<HTMLDivElement | HTMLButtonElement>): void;
-
-  /**
-   * Button style variation. Does not affect functionality.
-   * @default "base"
-   */
-  readonly variation?: ChipVariations;
 }

--- a/packages/components/src/Chips/InternalChip.tsx
+++ b/packages/components/src/Chips/InternalChip.tsx
@@ -12,6 +12,7 @@ export function InternalChip({
   ariaLabel,
   onClick,
   onKeyDown,
+  variation,
 }: InternalChipProps) {
   return (
     <Chip
@@ -20,6 +21,7 @@ export function InternalChip({
       onKeyDown={onKeyDown}
       testID="ATL-InternalChip"
       ariaLabel={ariaLabel}
+      variation={variation}
       tabIndex={tabIndex}
       role={tabIndex !== undefined ? "option" : undefined}
       onClick={onClick ? (_, ev) => onClick(ev) : undefined}

--- a/packages/components/src/Chips/InternalChip.tsx
+++ b/packages/components/src/Chips/InternalChip.tsx
@@ -12,7 +12,6 @@ export function InternalChip({
   ariaLabel,
   onClick,
   onKeyDown,
-  variation,
 }: InternalChipProps) {
   return (
     <Chip
@@ -21,7 +20,6 @@ export function InternalChip({
       onKeyDown={onKeyDown}
       testID="ATL-InternalChip"
       ariaLabel={ariaLabel}
-      variation={variation}
       tabIndex={tabIndex}
       role={tabIndex !== undefined ? "option" : undefined}
       onClick={onClick ? (_, ev) => onClick(ev) : undefined}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

During our separate Chip from Chips PR https://github.com/GetJobber/atlantis/pull/1995 we unintentionally changed the default background color of the `Chip` used in the `Chips` component, this PR allows the setting of a `variation` which will allow `subtle` Chip components which will have a "white" background

Subtle Chips component:
<img width="539" alt="image" src="https://github.com/user-attachments/assets/9a03bdce-5934-4c43-ac94-4a2c52d2b8e5">

Subtle multiselect
<img width="564" alt="image" src="https://github.com/user-attachments/assets/fcea6daf-1937-4620-8bbd-542f8fe3659b">

Subtle dismissable
<img width="352" alt="image" src="https://github.com/user-attachments/assets/e22e3c73-a007-4e65-8638-64e414f6e6ab">


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- components: Expose `variation` prop in the `Chip` component used in `Chips`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

`git revert 9a66fd4495033a0cba44254325ae01b8fdae3d61` to allow you to interact with the Chips stories that make use of the new variation prop in Storybook  

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
