### PR TITLE
fix(components): Fix row actions being inaccessible on touch screen devices

### DIFF
--- a/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
@@ -39,17 +39,17 @@ export function DataListItem<T extends DataListObject>({
   const isContextMenuVisible = Boolean(contextPosition);
   const isMultiselectModeActive =
     Array.isArray(selected) && selected.length > 0;
-  const hoveringSelectedByPass =
+  const hoveringSelectedBypass =
     isMultiselectModeActive && selected.length === 1 && selected[0] === item.id;
 
   const shouldShowContextMenu =
     showMenu &&
     isContextMenuVisible &&
     hasActions &&
-    (!isMultiselectModeActive || hoveringSelectedByPass);
+    (!isMultiselectModeActive || hoveringSelectedBypass);
 
   const shouldShowHoverMenu =
-    (!isMultiselectModeActive || hoveringSelectedByPass) &&
+    (!isMultiselectModeActive || hoveringSelectedBypass) &&
     showMenu &&
     hasActions &&
     !hasInLayoutActions &&

--- a/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
@@ -46,10 +46,10 @@ export function DataListItem<T extends DataListObject>({
     showMenu &&
     isContextMenuVisible &&
     hasActions &&
-    (!isMultiselectModeActive || hoveringSelectedBypass);
+    (!isMultiselectModeActive || isSingleRowSelected);
 
   const shouldShowHoverMenu =
-    (!isMultiselectModeActive || hoveringSelectedBypass) &&
+    (!isMultiselectModeActive || isSingleRowSelected) &&
     showMenu &&
     hasActions &&
     !hasInLayoutActions &&

--- a/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
@@ -37,12 +37,19 @@ export function DataListItem<T extends DataListObject>({
 
   const { actions, hasActions } = useGetItemActions<T>(item);
   const isContextMenuVisible = Boolean(contextPosition);
-  const isMultiselectModeActive = Array.isArray(selected) && !!selected.length;
+  const isMultiselectModeActive =
+    Array.isArray(selected) && selected.length > 0;
+  const hoveringSelectedByPass =
+    isMultiselectModeActive && selected.length === 1 && selected[0] === item.id;
 
   const shouldShowContextMenu =
-    showMenu && isContextMenuVisible && hasActions && !isMultiselectModeActive;
+    showMenu &&
+    isContextMenuVisible &&
+    hasActions &&
+    (!isMultiselectModeActive || hoveringSelectedByPass);
+
   const shouldShowHoverMenu =
-    !isMultiselectModeActive &&
+    (!isMultiselectModeActive || hoveringSelectedByPass) &&
     showMenu &&
     hasActions &&
     !hasInLayoutActions &&

--- a/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
+++ b/packages/components/src/DataList/components/DataListItem/DataListItem.tsx
@@ -39,7 +39,7 @@ export function DataListItem<T extends DataListObject>({
   const isContextMenuVisible = Boolean(contextPosition);
   const isMultiselectModeActive =
     Array.isArray(selected) && selected.length > 0;
-  const hoveringSelectedBypass =
+  const isSingleRowSelected =
     isMultiselectModeActive && selected.length === 1 && selected[0] === item.id;
 
   const shouldShowContextMenu =


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
In https://github.com/GetJobber/atlantis/pull/2012 there was a concern that uses on a touch screen device that was in a larger breakpoint would lose the ability to select a row action. This PR fixes that by allowing the actions menu to be visible on hover if the user is hovering over the currently selected item and only one item is selected.

Done as a part of JOB-97132

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fix row actions being hidden on touch screen devices in the DataList

### Security

- <!-- in case of vulnerabilities -->

## Testing

Verify the row actions display when on a touch screen device and the option is selected

<details><summary>Device with hover</summary>

https://github.com/user-attachments/assets/7807bdc8-8169-4c47-a1d5-c6365ff34c43


</details> 

<details><summary>Device without hover</summary>

https://github.com/user-attachments/assets/5fe98fd3-9b7b-4611-9789-88ee87f425b1


</details> 

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
