### PR TITLE
refactor(components): Add semantic colors to typography on mobile [97200]

### DIFF
--- a/packages/components-native/src/Typography/Typography.style.ts
+++ b/packages/components-native/src/Typography/Typography.style.ts
@@ -250,7 +250,7 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     color: tokens["color-critical"],
   },
 
-  criticalSurace: {
+  criticalSurface: {
     color: tokens["color-critical--surface"],
   },
 
@@ -327,10 +327,6 @@ export const typographyTokens: { [index: string]: TextStyle } = {
 
   disabledSecondary: {
     color: tokens["color-disabled--secondary"],
-  },
-
-  surface: {
-    color: tokens["color-surface"],
   },
 
   // Workflow

--- a/packages/components-native/src/Typography/Typography.style.ts
+++ b/packages/components-native/src/Typography/Typography.style.ts
@@ -93,6 +93,10 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     textDecorationLine: "underline",
   },
 
+  /**
+   * Alignments
+   */
+
   startAlign: {
     textAlign: "left",
   },
@@ -109,9 +113,11 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     textAlign: "justify",
   },
 
-  blue: {
-    color: tokens["color-heading"],
-  },
+  /**
+   * Colors
+   */
+
+  // Base colors for backwards compatibility
 
   blueDark: {
     color: tokens["color-blue--dark"],
@@ -205,12 +211,9 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     color: tokens["color-navy"],
   },
 
+  // Typography
   heading: {
     color: tokens["color-heading"],
-  },
-
-  headingReverse: {
-    color: tokens["color-text--reverse"],
   },
 
   text: {
@@ -229,52 +232,267 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     color: tokens["color-text--reverse--secondary"],
   },
 
-  success: {
-    color: tokens["color-success--onSurface"],
+  // Statuses
+
+  inactive: {
+    color: tokens["color-inactive"],
   },
 
-  error: {
-    color: tokens["color-critical"],
+  inactiveSurface: {
+    color: tokens["color-inactive--surface"],
   },
 
-  base: {
-    color: tokens["color-text"],
-  },
-
-  subdued: {
-    color: tokens["color-text--secondary"],
-  },
-
-  warn: {
-    color: tokens["color-warning--onSurface"],
-  },
-
-  info: {
-    color: tokens["color-informative--onSurface"],
+  inactiveOnSurface: {
+    color: tokens["color-inactive--onSurface"],
   },
 
   critical: {
     color: tokens["color-critical"],
   },
 
-  successReverse: {
-    color: tokens["color-success"],
+  criticalSurace: {
+    color: tokens["color-critical--surface"],
   },
 
-  errorReverse: {
-    color: tokens["color-critical"],
+  criticalOnSurface: {
+    color: tokens["color-critical--onSurface"],
+  },
+
+  warning: {
+    color: tokens["color-warning"],
+  },
+
+  warningSurface: {
+    color: tokens["color-warning--surface"],
+  },
+
+  warningOnSurface: {
+    color: tokens["color-warning--onSurface"],
+  },
+
+  informative: {
+    color: tokens["color-informative"],
+  },
+
+  informativeSurface: {
+    color: tokens["color-informative--surface"],
+  },
+
+  informativeOnSurface: {
+    color: tokens["color-informative--onSurface"],
+  },
+
+  // To be uncommented once success in Deprecated is removed
+  // success: {
+  //   color: tokens["color-success"],
+  // },
+
+  successSurface: {
+    color: tokens["color-success--surface"],
+  },
+
+  successOnSurface: {
+    color: tokens["color-success--onSurface"],
+  },
+
+  // Interactions
+
+  interactive: {
+    color: tokens["color-interactive"],
+  },
+
+  interactiveHover: {
+    color: tokens["color-interactive--hover"],
+  },
+
+  interactiveSubtle: {
+    color: tokens["color-interactive--subtle"],
+  },
+
+  interactiveSubtleHover: {
+    color: tokens["color-interactive--subtle--hover"],
+  },
+
+  destructive: {
+    color: tokens["color-destructive"],
+  },
+
+  destructiveHover: {
+    color: tokens["color-destructive--hover"],
+  },
+
+  disabled: {
+    color: tokens["color-disabled"],
+  },
+
+  disabledSecondary: {
+    color: tokens["color-disabled--secondary"],
+  },
+
+  surface: {
+    color: tokens["color-surface"],
+  },
+
+  // Workflow
+
+  request: {
+    color: tokens["color-request"],
+  },
+
+  requestSurface: {
+    color: tokens["color-request--surface"],
+  },
+
+  requestOnSurface: {
+    color: tokens["color-request--onSurface"],
+  },
+
+  quote: {
+    color: tokens["color-quote"],
+  },
+
+  quoteSurface: {
+    color: tokens["color-quote--surface"],
+  },
+
+  job: {
+    color: tokens["color-job"],
+  },
+
+  jobSurface: {
+    color: tokens["color-job--surface"],
+  },
+
+  jobOnSurface: {
+    color: tokens["color-job--onSurface"],
+  },
+
+  visit: {
+    color: tokens["color-visit"],
+  },
+
+  visitSurface: {
+    color: tokens["color-visit--surface"],
+  },
+
+  visitOnSurface: {
+    color: tokens["color-visit--onSurface"],
+  },
+
+  task: {
+    color: tokens["color-task"],
+  },
+
+  taskSurface: {
+    color: tokens["color-task--surface"],
+  },
+
+  taskOnSurface: {
+    color: tokens["color-task--onSurface"],
+  },
+
+  event: {
+    color: tokens["color-event"],
+  },
+
+  eventSurface: {
+    color: tokens["color-event--surface"],
+  },
+
+  eventOnSurface: {
+    color: tokens["color-event--onSurface"],
+  },
+
+  invoice: {
+    color: tokens["color-invoice"],
+  },
+
+  invoiceSurface: {
+    color: tokens["color-invoice--surface"],
+  },
+
+  invoiceOnSurface: {
+    color: tokens["color-invoice--onSurface"],
+  },
+
+  payments: {
+    color: tokens["color-payments"],
+  },
+
+  paymentsSurface: {
+    color: tokens["color-payments--surface"],
+  },
+
+  paymentsOnSurface: {
+    color: tokens["color-payments--onSurface"],
+  },
+
+  client: {
+    color: tokens["color-client"],
+  },
+
+  // Miscellaneous
+
+  icon: {
+    color: tokens["color-icon"],
+  },
+
+  brand: {
+    color: tokens["color-brand"],
+  },
+
+  // Deprecated
+
+  blue: {
+    color: tokens["color-heading"],
+  },
+
+  base: {
+    color: tokens["color-text"],
   },
 
   baseReverse: {
     color: tokens["color-text--reverse"],
   },
 
-  subduedReverse: {
-    color: tokens["color-text--reverse--secondary"],
+  headingReverse: {
+    color: tokens["color-text--reverse"],
+  },
+
+  error: {
+    color: tokens["color-critical"],
+  },
+
+  errorReverse: {
+    color: tokens["color-critical"],
+  },
+
+  success: {
+    color: tokens["color-success--onSurface"],
+  },
+
+  successReverse: {
+    color: tokens["color-success"],
+  },
+
+  warn: {
+    color: tokens["color-warning--onSurface"],
   },
 
   warnReverse: {
     color: tokens["color-warning"],
+  },
+
+  subdued: {
+    color: tokens["color-text--secondary"],
+  },
+
+  subduedReverse: {
+    color: tokens["color-text--reverse--secondary"],
+  },
+
+  info: {
+    color: tokens["color-informative--onSurface"],
   },
 
   infoReverse: {
@@ -283,14 +501,6 @@ export const typographyTokens: { [index: string]: TextStyle } = {
 
   criticalReverse: {
     color: tokens["color-critical"],
-  },
-
-  interactive: {
-    color: tokens["color-interactive"],
-  },
-
-  destructive: {
-    color: tokens["color-destructive"],
   },
 
   learning: {
@@ -305,9 +515,9 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     color: tokens["color-surface"],
   },
 
-  disabled: {
-    color: tokens["color-disabled"],
-  },
+  /**
+   * Sizes
+   */
 
   smallestSize: {
     fontSize: tokens["typography--fontSize-smallest"],
@@ -354,6 +564,10 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     lineHeight: extravagantLineHeight,
   },
 
+  /**
+   * Line Heights
+   */
+
   extravagantLineHeight: {
     lineHeight: extravagantLineHeight,
   },
@@ -380,6 +594,10 @@ export const typographyTokens: { [index: string]: TextStyle } = {
   tightLineHeight: {
     lineHeight: tightLineHeight,
   },
+
+  /**
+   * Letter Spacings
+   */
 
   baseLetterSpacing: {
     letterSpacing: tokens["typography--letterSpacing-base"],

--- a/packages/components-native/src/Typography/Typography.style.ts
+++ b/packages/components-native/src/Typography/Typography.style.ts
@@ -351,6 +351,10 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     color: tokens["color-quote--surface"],
   },
 
+  quoteOnSurface: {
+    color: tokens["color-quote--onSurface"],
+  },
+
   job: {
     color: tokens["color-job"],
   },

--- a/packages/components-native/src/Typography/Typography.test.tsx
+++ b/packages/components-native/src/Typography/Typography.test.tsx
@@ -89,6 +89,13 @@ it("renders text with green color", () => {
   expect(typography.toJSON()).toMatchSnapshot();
 });
 
+it("renders text with semantic color", () => {
+  const typography = render(
+    <Typography color="inactiveOnSurface">Test Text</Typography>,
+  );
+  expect(typography.toJSON()).toMatchSnapshot();
+});
+
 it("renders text with default color", () => {
   const typography = render(<Typography color="default">Test Text</Typography>);
   expect(typography.toJSON()).toMatchSnapshot();

--- a/packages/components-native/src/Typography/Typography.tsx
+++ b/packages/components-native/src/Typography/Typography.tsx
@@ -365,7 +365,6 @@ export type TextColor =
   | "interactiveSubtleHover"
   | "destructiveHover"
   | "disabledSecondary"
-  | "surface"
 
   // Workflow
   | "request"

--- a/packages/components-native/src/Typography/Typography.tsx
+++ b/packages/components-native/src/Typography/Typography.tsx
@@ -417,7 +417,7 @@ export type TextVariation =
   | "base" // Use "text" instead
   | "subdued" // Use "textSecondary" instead
   | "error" // Use "critical" instead
-  | "warn" // Use "warning" instead
+  | "warn" // Use "warningOnSurface" instead
   | "info"; // Use "informativeOnSurface" instead
 
 export type TextTransform = "uppercase" | "lowercase" | "capitalize" | "none";

--- a/packages/components-native/src/Typography/Typography.tsx
+++ b/packages/components-native/src/Typography/Typography.tsx
@@ -310,8 +310,8 @@ export type DisplayStyle = Extract<FontStyle, "regular">;
 
 export type TextColor =
   | TextVariation
+  // Base colors for backwards compatibility
   | "default"
-  | "blue"
   | "blueDark"
   | "white"
   | "green"
@@ -335,30 +335,90 @@ export type TextColor =
   | "tealDark"
   | "indigoDark"
   | "navy"
-  | "text"
+
+  // Typography
   | "heading"
+  | "text"
   | "textSecondary"
   | "textReverse"
   | "textReverseSecondary"
-  | "interactive"
-  | "interactiveSubtle"
-  | "destructive"
-  | "learning"
-  | "subtle"
-  | "onPrimary";
 
-export type TextVariation =
+  // Statuses
+  | "inactive"
+  | "inactiveSurface"
+  | "inactiveOnSurface"
+  | "critical"
+  | "criticalSurface"
+  | "criticalOnSurface"
+  | "warning"
+  | "warningSurface"
+  | "warningOnSurface"
+  | "informative"
+  | "informativeSurface"
+  | "informativeOnSurface"
   | "success"
+  | "successSurface"
+  | "successOnSurface"
+
+  // Interactions
+  | "interactiveHover"
+  | "interactiveSubtleHover"
+  | "destructiveHover"
+  | "disabledSecondary"
+  | "surface"
+
+  // Workflow
+  | "request"
+  | "requestSurface"
+  | "requestOnSurface"
+  | "quote"
+  | "quoteSurface"
+  | "quoteOnSurface"
+  | "job"
+  | "jobSurface"
+  | "jobOnSurface"
+  | "visit"
+  | "visitSurface"
+  | "visitOnSurface"
+  | "task"
+  | "taskSurface"
+  | "taskOnSurface"
+  | "event"
+  | "eventSurface"
+  | "eventOnSurface"
+  | "invoice"
+  | "invoiceSurface"
+  | "invoiceOnSurface"
+  | "payments"
+  | "paymentsSurface"
+  | "paymentsOnSurface"
+  | "client"
+
+  // Deprecated
+  | "blue" // Use "heading" instead
+  | "learning" // Use "informative" instead
+  | "subtle" // Use "interactiveSubtle" instead
+  | "onPrimary"; // Use "subtle" instead
+
+// A subset of colors that can be used with the Text component
+export type TextVariation =
+  | "text"
+  | "textSecondary"
   | "interactive"
   | "interactiveSubtle"
-  | "error"
-  | "base"
-  | "subdued"
-  | "warn"
-  | "info"
+  | "successOnSurface"
+  | "critical"
+  | "warning"
+  | "informativeOnSurface"
   | "disabled"
   | "destructive"
-  | "critical";
+
+  // Deprecated
+  | "base" // Use "text" instead
+  | "subdued" // Use "textSecondary" instead
+  | "error" // Use "critical" instead
+  | "warn" // Use "warning" instead
+  | "info"; // Use "informativeOnSurface" instead
 
 export type TextTransform = "uppercase" | "lowercase" | "capitalize" | "none";
 

--- a/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/packages/components-native/src/Typography/__snapshots__/Typography.test.tsx.snap
@@ -734,6 +734,39 @@ exports[`renders text with reverseTheme true with reversible color 1`] = `
 </Text>
 `;
 
+exports[`renders text with semantic color 1`] = `
+<Text
+  accessibilityRole="text"
+  adjustsFontSizeToFit={false}
+  allowFontScaling={true}
+  collapsable={false}
+  selectable={true}
+  selectionColor="hsl(86, 100%, 46%)"
+  style={
+    [
+      {
+        "fontFamily": "inter-regular",
+      },
+      {
+        "color": "hsl(197, 90%, 12%)",
+      },
+      {
+        "textAlign": "left",
+      },
+      {
+        "fontSize": 16,
+        "lineHeight": 20,
+      },
+      {
+        "letterSpacing": 0,
+      },
+    ]
+  }
+>
+  Test Text
+</Text>
+`;
+
 exports[`renders text with small size 1`] = `
 <Text
   accessibilityRole="text"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

All of the semantic colors should be available for Typography on mobile

## Changes

Adds missing semantic colors to Typography.style.ts. Also reorganizes the colors to make it easier to find the color you need in the future and makes deprecated colors clear.

### Added

Missing semantic colors for mobile typography

### Changed

Re-organizes the colors

### Deprecated

Groups various colors to be deprecated in the near future

### Removed

No colors were removed

### Fixed

N/A

### Security

N/A

## Testing

Open up storybook via the pre-release branch and locally tp play around with new colors/existing colors to ensure they all work

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
