### PR TITLE
docs: Dark Mode applied in Storybook controls

### DIFF
--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -53,11 +53,11 @@ export const darkTheme = create({
   barSelectedColor: tokens["color-base-blue--100"],
 
  // UI
- appBg: '#ddffff',
- appContentBg: 'var(--color-surface)',
- appPreviewBg: 'var(--color-surface)',
- appBorderColor: '#585C6D',
- appBorderRadius: 4,
+  appBg: tokens["color-base-blue--1000"],
+  appContentBg: tokens["color-base-blue--900"],
+  appPreviewBg: tokens["color-base-blue--900"],
+  appBorderColor: tokens["color-base-blue--700"],
+  appBorderRadius: tokens["radius-base"],
 
 
   /**


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
The controls section in stories didn't have Dark Mode applied and it made it difficult to read the props, etc.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- adjusted tokens in `theme.ts` so the controls section can be viewed in Dark Mode

### Before

<img width="916" alt="Screenshot 2024-09-17 at 10 44 09 PM" src="https://github.com/user-attachments/assets/b762e7dd-6ed1-4dc9-83fe-f755a912cf1e">


### After

<img width="1245" alt="Screenshot 2024-09-17 at 10 42 31 PM" src="https://github.com/user-attachments/assets/4832ea0d-30d5-40cc-87a0-65d2ef8bb211">


## Testing

<!-- How to test your changes. -->
Look at any story, and make sure the controls section (with the props) responds to the sun/moon theme toggle in the top nav

<img width="200" alt="Screenshot 2024-09-17 at 10 41 11 PM" src="https://github.com/user-attachments/assets/201167e5-6fc6-4701-9c0a-34780096409b">


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
