### PR TITLE
fix(components): Fix DataListOverflowFade spacing

### DIFF
--- a/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.css
+++ b/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.css
@@ -1,5 +1,5 @@
 .fadeContainer {
-  --overflow-fade--offset: 0;
+  --overflow-fade--offset: var(--space-smaller);
 
   align-self: center;
   position: relative;

--- a/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.css
+++ b/packages/components/src/DataList/components/DataListOverflowFade/DataListOverflowFade.css
@@ -1,5 +1,6 @@
 .fadeContainer {
   --overflow-fade--offset: var(--space-smaller);
+  --overflow-fade--negative-offset: calc(var(--overflow-fade--offset) * -1);
 
   align-self: center;
   position: relative;
@@ -19,7 +20,7 @@
 }
 
 .overflowGrid {
-  margin: var(--overflow-fade--offset);
+  margin: var(--overflow-fade--negative-offset);
   padding: var(--overflow-fade--offset);
   overflow-x: auto;
   overflow-y: visible;
@@ -45,10 +46,10 @@
 }
 
 .overflowLeft::before {
-  left: var(--overflow-fade--offset);
+  left: var(--overflow-fade--negative-offset);
 }
 
 .overflowRight::after {
   --data-list-overflow-shadow-angle: to left;
-  right: var(--overflow-fade--offset);
+  right: var(--overflow-fade--negative-offset);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

Reverting some css changes from[ this PR](https://github.com/GetJobber/atlantis/pull/1915/files#diff-2e47ed917e3fb0e72f31e95ba28e39e9147a9fefa74908b54edf8bff1731e937) (specifically from DataListOverflowFade.css)

### Fixed

https://github.com/user-attachments/assets/43357125-e880-4a04-958d-9b12f8cf72fa

Why I'm also bringing back ` --overflow-fade--negative-offset`:

https://github.com/user-attachments/assets/08481855-c4a7-4551-ace1-e57a9340adf2



## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
