### PR TITLE
feat(components): Create FileTypes enum for InputFile and use in validation error

### DIFF
--- a/docs/components/InputFile/InputFile.stories.mdx
+++ b/docs/components/InputFile/InputFile.stories.mdx
@@ -116,6 +116,22 @@ information to the user. A common use case is to provide the accepted file types
 and maximum size for each file. With a helpful `description`, users are more
 aware of the limitations and requirements of the file upload.
 
+### allowedTypes
+
+The `allowedTypes` prop determines the types of files that can be uploaded.
+`allowedTypes` accepts `images`, `basicImages` or an array of customized file
+types. If the `allowedTypes` prop is not provided, all types will be accepted.
+
+Using the `FileTypes` enum, you can customize the types of files that are
+allowed to be uploaded.
+
+```ts
+<InputFile
+  ...
+  allowedTypes={["JPEG", "PNG", "HEIC", "PDF", "DOCX"]}
+/>
+```
+
 #### Notes
 
 If you would like to restrict specific file types, it is advised that you use

--- a/docs/components/InputFile/Web.stories.tsx
+++ b/docs/components/InputFile/Web.stories.tsx
@@ -186,6 +186,13 @@ ImagesOnly.args = {
   getUploadParams: () => Promise.resolve({ url: "https://httpbin.org/post" }),
 };
 
+export const CustomAllowedTypes = StatefulTemplate.bind({});
+CustomAllowedTypes.args = {
+  allowMultiple: true,
+  allowedTypes: ["JPEG", "PNG", "PDF", "DOCX"],
+  getUploadParams: () => Promise.resolve({ url: "https://httpbin.org/post" }),
+};
+
 export const MaxFilesLimit = MaxFilesTemplate.bind({});
 MaxFilesLimit.args = {
   allowMultiple: true,

--- a/packages/components/src/InputFile/FileTypes.ts
+++ b/packages/components/src/InputFile/FileTypes.ts
@@ -26,7 +26,11 @@ export const convertToMimeTypes = (types: string[]): string[] => {
 };
 
 export function formatMimeTypes(types: string[]): string {
-  if (types.length <= 1) return types.join(", ");
-
-  return `${types.slice(0, -1).join(", ")} or ${types[types.length - 1]}`;
+  if (types.length === 0) {
+    return "";
+  } else if (types.length === 1) {
+    return types[0];
+  } else {
+    return `${types.slice(0, -1).join(", ")} or ${types[types.length - 1]}`;
+  }
 }

--- a/packages/components/src/InputFile/FileTypes.ts
+++ b/packages/components/src/InputFile/FileTypes.ts
@@ -1,0 +1,32 @@
+export enum FileTypes {
+  JPEG = "image/jpeg",
+  JPG = "image/jpg",
+  PNG = "image/png",
+  HEIC = "image/heic",
+  PDF = "application/pdf",
+  DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+
+export const BASIC_IMAGE_TYPES = ["PNG", "JPEG", "JPG"];
+
+// Converts a MIME type to its readable format
+export const mimeTypeToReadable = (mimeType: string): string => {
+  const entry = Object.entries(FileTypes).find(
+    ([, value]) => value === mimeType,
+  );
+
+  return entry ? entry[0] : mimeType;
+};
+
+// Converts an array of readable file type names to their corresponding MIME types
+export const convertToMimeTypes = (types: string[]): string[] => {
+  return types.map(
+    type => FileTypes[type.toUpperCase() as keyof typeof FileTypes] || type,
+  );
+};
+
+export function formatMimeTypes(types: string[]): string {
+  if (types.length <= 1) return types.join(", ");
+
+  return `${types.slice(0, -1).join(", ")} or ${types[types.length - 1]}`;
+}

--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -259,6 +259,31 @@ describe("Post Requests", () => {
       expect(axios.request).not.toHaveBeenCalled();
     });
   });
+
+  describe("when allowedTypes uses FileTypes enum", () => {
+    it("sets the correct MIME types for allowedTypes prop", () => {
+      const { container } = render(
+        <InputFile
+          getUploadParams={fetchUploadParams}
+          allowedTypes={["JPEG", "PNG", "HEIC", "PDF", "DOCX"]}
+        />,
+      );
+
+      const input = container.querySelector(
+        "input[type=file]",
+      ) as HTMLInputElement;
+
+      const expectedMimeTypes = [
+        "image/jpeg",
+        "image/png",
+        "image/heic",
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ].join(",");
+
+      expect(input.accept).toBe(expectedMimeTypes);
+    });
+  });
 });
 
 describe("PUT requests", () => {

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -5,7 +5,6 @@ import axios, { AxiosRequestConfig } from "axios";
 import styles from "./InputFile.css";
 import {
   BASIC_IMAGE_TYPES,
-  // FileTypes,
   convertToMimeTypes,
   formatMimeTypes,
   mimeTypeToReadable,

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -3,6 +3,13 @@ import classnames from "classnames";
 import { DropzoneOptions, FileError, useDropzone } from "react-dropzone";
 import axios, { AxiosRequestConfig } from "axios";
 import styles from "./InputFile.css";
+import {
+  BASIC_IMAGE_TYPES,
+  // FileTypes,
+  convertToMimeTypes,
+  formatMimeTypes,
+  mimeTypeToReadable,
+} from "./FileTypes";
 import { InputValidation } from "../InputValidation";
 import { Button } from "../Button";
 import { Content } from "../Content";
@@ -245,13 +252,17 @@ export function InputFile({
   if (allowedTypes === "images") {
     options.accept = "image/*";
   } else if (allowedTypes === "basicImages") {
-    options.accept = "image/png, image/jpg, image/jpeg";
+    options.accept = convertToMimeTypes(BASIC_IMAGE_TYPES).join(",");
   } else if (Array.isArray(allowedTypes)) {
-    options.accept = allowedTypes.join(",");
+    options.accept = convertToMimeTypes(allowedTypes).join(",");
   }
 
   const { getRootProps, getInputProps, isDragActive, fileRejections } =
     useDropzone(options);
+
+  const allowedTypesString = Array.isArray(allowedTypes)
+    ? formatMimeTypes(allowedTypes.map(mimeTypeToReadable))
+    : allowedTypes;
 
   const validationErrors = fileRejections?.reduce((acc, { file, errors }) => {
     errors.forEach(error => {
@@ -262,6 +273,28 @@ export function InputFile({
             message: `Cannot exceed a maximum of ${maxFiles} files.`,
           });
         }
+      } else if (error.code === "file-invalid-type") {
+        let formatMessage;
+
+        if (allowedTypes === "basicImages") {
+          formatMessage = formatMimeTypes(
+            BASIC_IMAGE_TYPES.map(mimeTypeToReadable),
+          );
+        } else if (allowedTypes === "images") {
+          formatMessage = "an image";
+        } else {
+          formatMessage = allowedTypesString;
+        }
+
+        const message =
+          allowedTypes === "images"
+            ? `${file.name} must be ${formatMessage}.`
+            : `${file.name} must be in ${formatMessage} format.`;
+
+        acc.push({
+          code: error.code,
+          message: message,
+        });
       } else {
         acc.push({
           code: error.code,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
If consumers are setting `allowedTypes` on `InputFile` to be `string[]`, it's possible they might end up with an array like this (where the last string is for DOCX files):

```
allowedTypes={[
    "image/jpeg",
    "image/png",
    "image/heic",
    "application/pdf",
    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
  ]}
```

When a user then tries to upload a non-allowed file type, they'd see this behemoth validation error:

<img width="1047" alt="Screenshot 2024-09-24 at 11 06 11 PM" src="https://github.com/user-attachments/assets/c9e2714a-d064-47cd-b2f3-d29cead3e82e">

and that is **not** what we want to see.  Let's clean up the validation errors that surface when a non-allowed file type tries to be uploaded.  

_**Also,**_ then consumers can then implement `allowedTypes` like this:

```
allowedTypes={["JPEG", "PNG", "HEIC", "PDF", "DOCX"]}
```
Existing implementations that use the long strings within `allowedTypes`, will still be converted properly. See mentioned test PR in prod.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

I added a new `FileTypes.ts` file which holds a `FileTypes` enum of common MIME types & their corresponding readable format.  Moving forward, if teams need a new file type, it can easily be added to this enum.

The file provides utility functions to convert MIME types to readable formats (`mimeTypeToReadable`), convert readable file type names to their corresponding MIME types (`convertToMimeTypes`), and format a list of MIME types into a human-readable string (`formatMimeTypes`).

I also added a Custom Allowed Types story, along with some documentation going over `allowedTypes`.

### Changed

Note: When `allowedTypes={images}`, that can include a long long list of possible MIME types. I'm making the assumption that we don't want _all_ the potential MIME types to appear in the error because that would be long and unnecessary. So I've made the error message simple.

| `allowedTypes`  | Before        | After           |
| ---------------- | ----------- | ----------- |
| `images`            | <img width="303" alt="Screenshot 2024-09-24 at 11 01 54 PM" src="https://github.com/user-attachments/assets/5d84d55c-aa2d-49c6-8d69-9083eb87e5bb"> | <img width="268" alt="Screenshot 2024-09-24 at 10 59 00 PM" src="https://github.com/user-attachments/assets/89517581-b007-49ad-b7bc-36d5e9374119"> |
| `basicImages`   | <img width="432" alt="Screenshot 2024-09-24 at 11 02 51 PM" src="https://github.com/user-attachments/assets/5e833b1b-217d-4189-b90d-ba438c6e2adc"> | <img width="374" alt="Screenshot 2024-09-24 at 10 59 35 PM" src="https://github.com/user-attachments/assets/1cb3e251-9377-4eef-bc0c-978046e93e14"> |
| `string[]`           | <img width="1047" alt="Screenshot 2024-09-24 at 11 06 11 PM" src="https://github.com/user-attachments/assets/e66fd5a3-ba3b-4f35-a099-0020b81920b4"> | <img width="414" alt="Screenshot 2024-09-24 at 11 00 25 PM" src="https://github.com/user-attachments/assets/3549fb8f-8934-4660-8b8b-d856171f2b20"> |

If a different file type needs to be added to the `FileTypes` enum, that is a simple process teams can do on their own, moving forward. 

## Testing

<!-- How to test your changes. -->

https://github.com/user-attachments/assets/70713ef5-b3c5-4b4b-9901-004438e88125


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
