### PR TITLE
fix(docx): Fix regex in Playground for the code tab to work correctly

### DIFF
--- a/.storybook/components/Playground/Playground.tsx
+++ b/.storybook/components/Playground/Playground.tsx
@@ -192,20 +192,22 @@ function getSingleModuleImport(
 }
 
 function parseSourceStringForImports(source: string, extraImports: string[]) {
-  // Grab the first word after <
-  // and only if there isn't a "use" or "type " in front of it
-  // This is to avoid maptching hook typings (e.g. `useState<SomeInterface>` or `useRef<HTMLDivElement>`)
-  // as well as type definitions (e.g. `type SomeType<T> = { ... }`).
-  const matchingComponents = source?.match(/(?<!use\w*|type\s*\w*)<(\w+)/gm);
+  // Grab the first word after "<" tag that starts with a capital letter (to avoid matching HTML tags)
+  // only if there isn't a "use" or "type " in front of it (with the help of negative lookahead).
+  // This is to avoid matching hook typings (e.g. `useState<SomeInterface>` or `useRef<HTMLDivElement>`)
+  // as well as TS type definitions (e.g. `type SomeType<T> = { ... }`).
+  const regex = /(?:\W)(?!use\w*|type\s*\w*)<([A-Z]\w+)/gm;
+  const matchingComponents = source?.match(regex);
 
   const componentNames = matchingComponents
     // replace: remove < and >
-    // split: get the first word which is the component name
-    ?.map(component => component.replace(/<|>/g, "").split(" ")[0])
+    // split: get the first word which is the component name (at index 1)
+    // The regex above return components with a space in front of them
+    // (e.g. [' <MyComponent', ' <OtherComponent]). So we need to grab the 2nd element after split.
+    // This is a workaround, since the negative lookbehind is not supported in Cloudflare's JS engine
+    ?.map(component => component.replace(/<|>/g, "").split(" ")[1])
     // Remove duplicates
     .filter((component, index, self) => self.indexOf(component) === index)
-    // Only get components that start with a capital letter. This removes the HTML tags.
-    .filter(component => /[A-Z]/.test(component[0]))
     // Filter out extra imports not in @jobber/components
     .filter(component => !extraImports.includes(component));
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Fixed regex to use negative lookahead instead of negative lookbehind, since the latter doesn't seem to be supported by the Cloudflare JS engine.
- Improve existing regex to select words that start with capital letter (to match React components, and not HTML tags), which would remove at least one loop.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Check the `code` tab (e.g. in `DataList` "Clear All Filters" story.
- Make sure it's rendered, since it's currently broken on `master`:
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/9659c516-f966-4c50-a9e6-117a5083f49f">
- Verify that there are no unused/weird imports, such as 

```
import { T } from "@jobber/components/T";
import { SelectedFilters } from "@jobber/components/SelectedFilters";
```


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
