### PR TITLE
fix(components-native): Restore success Text variation type

### DIFF
--- a/packages/components-native/src/Typography/Typography.tsx
+++ b/packages/components-native/src/Typography/Typography.tsx
@@ -411,9 +411,9 @@ export type TextVariation =
   | "disabled"
   | "destructive"
 
-  // Deprecated (except for when reverseTheme=true)
+  // Deprecated
   | "base" // Use "text" instead
-  | "success" // Use "successOnSurface" instead
+  | "success" // Use "successOnSurface" instead (except for when reverseTheme=true)
   | "subdued" // Use "textSecondary" instead
   | "error" // Use "critical" instead
   | "warn" // Use "warningOnSurface" instead


### PR DESCRIPTION

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Two cases of `Text` in JM use `variation=success` with `reverseTheme=true` and that results in the `successReverse` color being used which is `--color-success`. We don't yet have another variation that matches that color, so we need to add this back for now to unblock the JM version bump PR.

## Changes

### Fixed

- Restored `success` Text variation

## Testing

See my comment with before/after screenshots below. 

In Storybook, load the [Text Basic](http://localhost:6005/?path=/story/components-text-and-typography-text-mobile--basic) story, set `variation=success` and `reverseTheme=true`. The text should appear green and match `--color-success`.

<!-- How to test your changes. -->

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

