### PR TITLE
DRAFT: SPA Bucket changes

### DIFF
--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -665,4 +665,38 @@ describe("DataList", () => {
       expect(screen.getByText(bannerText)).toBeInTheDocument();
     });
   });
+  describe("Search", () => {
+    it("should be shown when visible is true", () => {
+      const mockOnSearch = jest.fn();
+      render(
+        <DataList
+          data={Array.from({ length: MAX_DATA_COUNT + 1 }, (_, id) => ({
+            id,
+          }))}
+          headers={{ id: "ID" }}
+        >
+          <DataList.Search onSearch={mockOnSearch} visible={true} />
+        </DataList>,
+      );
+
+      expect(screen.getByLabelText("Close search bar")).toBeInTheDocument();
+    });
+    it("should be hidden when visible is false", () => {
+      const mockOnSearch = jest.fn();
+      render(
+        <DataList
+          data={Array.from({ length: MAX_DATA_COUNT + 1 }, (_, id) => ({
+            id,
+          }))}
+          headers={{ id: "ID" }}
+        >
+          <DataList.Search onSearch={mockOnSearch} visible={false} />
+        </DataList>,
+      );
+
+      expect(
+        screen.queryByLabelText("Close search bar"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -213,6 +213,8 @@ export interface DataListSearchProps {
   readonly initialValue?: string;
 
   readonly onSearch: (value: string) => void;
+
+  readonly visible?: boolean;
 }
 
 export interface DataListFiltersProps {

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.tsx
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import debounce from "lodash/debounce";
 import classNames from "classnames";
 import { tokens } from "@jobber/design";
@@ -23,10 +23,17 @@ export function DataListSearch(_: DataListSearchProps) {
  */
 export function InternalDataListSearch() {
   const inputRef = useRef<InputTextRef>(null);
-  const [visible, setVisible] = useState(false);
-
   const { searchComponent, filterComponent, sorting, title } =
     useDataListContext();
+
+  const [visibleInternal, setVisibleInternal] = useState(
+    searchComponent?.props.visible,
+  );
+
+  const visible =
+    useMemo(() => {
+      return searchComponent?.props.visible ?? visibleInternal;
+    }, [visibleInternal, searchComponent]) ?? false;
 
   const debouncedSearch = useCallback(
     debounce(
@@ -96,7 +103,7 @@ export function InternalDataListSearch() {
 
   function toggleSearch() {
     const visibility = !visible;
-    setVisible(visibility);
+    setVisibleInternal(visibility);
 
     if (visibility && inputRef.current) {
       setTimeout(inputRef.current.focus, tokens["timing-quick"]);


### PR DESCRIPTION
## Motivations

This is a super branch to house SPA changes while we work on them. As changes are deemed functional, we'll peel them out of this branch and into their own tickets and into mainline Atlantis.

## Changes

1. DataList.Search now supports a `visible` prop.


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
