### PR TITLE
fix(components): Fix icons shrinking in the page menu with longer titles

### DIFF
--- a/packages/components/src/Menu/Menu.module.css
+++ b/packages/components/src/Menu/Menu.module.css
@@ -70,6 +70,7 @@
   padding: var(--menu-space);
   border: none;
   border-radius: var(--radius-base);
+  text-align: start;
   background-color: transparent;
   cursor: pointer;
   align-items: center;
@@ -86,6 +87,10 @@
 .action span {
   /* match appearance of Button labels */
   -webkit-font-smoothing: antialiased;
+}
+
+.action svg {
+  flex-shrink: 0;
 }
 
 .action.destructive > span {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The Jobs `More Actions...` menu has added 2 new `Import` actions.
The second one being `Import Google Calendar` which is a long enough title that `flex` starts to shrink the icon, leaving the menu looking a little scewed.
![image](https://github.com/user-attachments/assets/f845e89f-7cd9-4a0e-8c12-e20cfbf2dafd)


## Changes

Adding `flex-shrink: 0` to the `svg` to stop the icon from changing size.
I also found that the text in storybook was `center` aligned when it got to multiple lines, so I added `text-align:start` to stop this.
Though I wasn't sure if that was the right move.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->
I've only tested this in storybook for now
Before:
![image](https://github.com/user-attachments/assets/b3c8e9bd-800b-4ab2-bae1-6343cf65186b)

After:
![image](https://github.com/user-attachments/assets/8c484ca7-f87c-4616-bfa2-8a8697ff8fb3)


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
