### PR TITLE
fix(components-native): Assistive text alignment on `Select`

### DIFF
--- a/packages/components-native/src/Select/Select.style.ts
+++ b/packages/components-native/src/Select/Select.style.ts
@@ -44,6 +44,10 @@ export const styles = StyleSheet.create({
     borderColor: tokens["color-critical"],
   },
 
+  assistiveText: {
+    paddingLeft: tokens["space-base"],
+  },
+
   errorMessageWrapperIcon: {
     flex: 0,
     flexBasis: "auto",

--- a/packages/components-native/src/Select/Select.tsx
+++ b/packages/components-native/src/Select/Select.tsx
@@ -176,13 +176,15 @@ export function Select({
         </SelectInternalPicker>
 
         {assistiveText && (
-          <Text
-            level="textSupporting"
-            variation={textVariation}
-            hideFromScreenReader={true}
-          >
-            {assistiveText}
-          </Text>
+          <View style={styles.assistiveText}>
+            <Text
+              level="textSupporting"
+              variation={textVariation}
+              hideFromScreenReader={true}
+            >
+              {assistiveText}
+            </Text>
+          </View>
         )}
       </View>
     </InputFieldWrapper>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
- Assistive text is misaligned on `Select`.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed
- Added left padding to the assistive text.

| Before | After |
| ----- | ----- |
| <img width="320" alt="image" src="https://github.com/user-attachments/assets/accab3fd-a115-4fdf-b3e5-a49bcb154ce0"> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/82ebe7ae-32e0-4f22-a2b6-0d3806024e0a"> |
### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
