### PR TITLE
fix(docx): Fix bug in PR title generator 

### DIFF
--- a/.storybook/components/PullRequestGenerator/PullRequestGenerator.tsx
+++ b/.storybook/components/PullRequestGenerator/PullRequestGenerator.tsx
@@ -33,14 +33,19 @@ export function PullRequestGenerator() {
               <Option value="refactor">doesn't fix a bug or introduce a new feature</Option>
             </Select>
             <Text>in our...</Text>
-            <Select value={type} onChange={(val: string) => setScope(val)}>
+            <Select value={scope} onChange={(val: string) => setScope(val)}>
               <Option value="---">---</Option>
               <Option value="components">component library</Option>
+              <Option value="components-native">component native library</Option>
               <Option value="hooks">hooks library</Option>
               <Option value="design">design foundation system</Option>
-              <Option value="eslint-config">eslint config</Option>
-              <Option value="stylelint-config">stylelint config</Option>
+              <Option value="eslint">eslint config</Option>
+              <Option value="stylelint">stylelint config</Option>
               <Option value="generators">generators</Option>
+              <Option value="formatters">formatters</Option>
+              <Option value="deps">dependencies</Option>
+              <Option value="deps-dev">dev dependencies</Option>
+              <Option value="docx">docx</Option>
             </Select>
           </Content>
           <Divider />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

As I showed [here](https://getjobber.slack.com/archives/C03BKPST4KC/p1728432648402599) there was a bug in the PR title generator where the selected scope would not show up as having been selected. Also, the list of scope values did not match the accepted list of scopes so it was possible that the title generator gave you an invalid title.

## Changes

- Change the value on the scope selector from type to scope
- Updates to the list of options for scopes so that only valid scopes can be selected

### Added

A couple of new scope values

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

Only valid scopes can be selected and they now show up in the scope selector

### Security

- <!-- in case of vulnerabilities -->

## Testing

Play around with the [PR Title Generator](http://localhost:6005/?path=/docs/guides-pull-request-title-generator--docs) to verify things are looking good.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
