### PR TITLE
feat(components): Allow Fully Custom Combobox Activator

### DIFF
--- a/docs/components/Combobox/Combobox.stories.mdx
+++ b/docs/components/Combobox/Combobox.stories.mdx
@@ -66,7 +66,7 @@ needs, you may instead provide a function as the child to `Combobox.Activator`.
 
 As arguments, the function will receive the toggle method to swap between open
 and closed states, as well as accessibility attributes required for a Combobox.
-_You must implement these yourself_. See the custom example for reference.
+**You must implement these yourself**. See the custom example for reference.
 
 The render function must return a single, valid JSX Element (it can of course
 have children, it simply must have a single wrapping tag). Ensure that tabindex,

--- a/docs/components/Combobox/Combobox.stories.mdx
+++ b/docs/components/Combobox/Combobox.stories.mdx
@@ -66,7 +66,9 @@ needs, you may instead provide a function as the child to `Combobox.Activator`.
 
 As arguments, the function will receive the toggle method to swap between open
 and closed states, as well as accessibility attributes required for a Combobox.
-**You must implement these yourself**. See the custom example for reference.
+**You must implement these yourself**. See the
+[render function example](../?path=/story/components-selections-combobox-web--custom-activator)
+for reference.
 
 The render function must return a single, valid JSX Element (it can of course
 have children, it simply must have a single wrapping tag). Ensure that tabindex,

--- a/docs/components/Combobox/Combobox.stories.mdx
+++ b/docs/components/Combobox/Combobox.stories.mdx
@@ -36,6 +36,9 @@ initiate option selection.
 
 ##### Default activator
 
+To use the default activator simply omit any kind of `Combobox.Activator`
+subcomponent in your instance.
+
 Examples of using a default activator can be found in the
 [single-select](../?path=/story/components-selections-combobox-web--single-select)
 and
@@ -50,14 +53,25 @@ activator.
 ##### Custom activator
 
 The custom activator should be used in any instance where the default activator
-is not suitable. Your custom activator should be a child of
-`<Combobox.Activator />`. An example of using a custom activator can be found in
-the
+is not suitable.
+
+**Child React Component:** To use a customized `Chip` or `Button` your custom
+activator should be a child of `<Combobox.Activator />`. An example of using a
+custom activator can be found in the
 [custom activator](../?path=/story/components-selections-combobox-web--custom-activator)
 story.
 
-Omitting a custom activator subcomponent will result in the default activator
-being used.
+**Child Render Function:** If neither a Chip nor a Button is sufficient for your
+needs, you may instead provide a function as the child to `Combobox.Activator`.
+
+As arguments, the function will receive the toggle method to swap between open
+and closed states, as well as accessibility attributes required for a Combobox.
+_You must implement these yourself_. See the custom example for reference.
+
+The render function must return a single, valid JSX Element (it can of course
+have children, it simply must have a single wrapping tag). Ensure that tabindex,
+focus, and keyboard interactivity are considered and handled appropriately if a
+non traditionally interactive element such as a div is used.
 
 #### Content
 

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Combobox, ComboboxOption } from "@jobber/components/Combobox";
+import {
+  Combobox,
+  ComboboxCustomActivatorProps,
+  ComboboxOption,
+} from "@jobber/components/Combobox";
 import { Button } from "@jobber/components/Button";
 import { Typography } from "@jobber/components/Typography";
 import { Chip } from "@jobber/components/Chip";
@@ -180,7 +184,7 @@ const ComboboxCustomActivator: ComponentStory<typeof Combobox> = args => {
       </Typography>
       <Combobox {...args} onSelect={setSelected} selected={selected}>
         <Combobox.Activator>
-          {activatorAPI => (
+          {(activatorAPI: ComboboxCustomActivatorProps) => (
             <div
               role={activatorAPI.role}
               tabIndex={0}

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -180,15 +180,27 @@ const ComboboxCustomActivator: ComponentStory<typeof Combobox> = args => {
       </Typography>
       <Combobox {...args} onSelect={setSelected} selected={selected}>
         <Combobox.Activator>
-          <button
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-            }}
-          >
-            <Heading level={2}>Heading Two</Heading>
-            <Icon name={"arrowDown"} />
-          </button>
+          {activatorAPI => (
+            <div
+              role={activatorAPI.role}
+              tabIndex={0}
+              aria-controls={activatorAPI.ariaControls}
+              aria-expanded={activatorAPI.ariaExpanded}
+              onClick={activatorAPI.toggleOpen}
+              onKeyDown={e => {
+                if (e.key === "Enter" || e.key === " ") {
+                  activatorAPI.toggleOpen();
+                }
+              }}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+              }}
+            >
+              <Heading level={2}>Heading Two</Heading>
+              <Icon name={"arrowDown"} />
+            </div>
+          )}
         </Combobox.Activator>
         <Combobox.Option id="1" label="13%" />
         <Combobox.Option id="2" label="15%" />

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -180,7 +180,7 @@ const ComboboxCustomActivator: ComponentStory<typeof Combobox> = args => {
       </Typography>
       <Combobox {...args} onSelect={setSelected} selected={selected}>
         <Combobox.Activator>
-          <div
+          <button
             style={{
               display: "inline-flex",
               alignItems: "center",
@@ -188,7 +188,7 @@ const ComboboxCustomActivator: ComponentStory<typeof Combobox> = args => {
           >
             <Heading level={2}>Heading Two</Heading>
             <Icon name={"arrowDown"} />
-          </div>
+          </button>
         </Combobox.Activator>
         <Combobox.Option id="1" label="13%" />
         <Combobox.Option id="2" label="15%" />

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -8,6 +8,7 @@ import { Icon } from "@jobber/components/Icon";
 import { StatusIndicator } from "@jobber/components/StatusIndicator";
 import { Content } from "@jobber/components/Content";
 import { Card } from "@jobber/components/Card";
+import { Heading } from "@jobber/components/Heading";
 import { useFakeQuery } from "./storyUtils";
 
 export default {
@@ -161,6 +162,33 @@ const ComboboxCustomActivator: ComponentStory<typeof Combobox> = args => {
               <Icon name={"arrowDown"} size={"large"} />
             </Chip.Suffix>
           </Chip>
+        </Combobox.Activator>
+        <Combobox.Option id="1" label="13%" />
+        <Combobox.Option id="2" label="15%" />
+        <Combobox.Option id="3" label="20%" />
+
+        <Combobox.Action
+          label="Add Tax Rate"
+          onClick={() => {
+            alert("Added a new tax rate ✅");
+          }}
+        />
+      </Combobox>
+      <br />
+      <Typography element={"h3"} fontFamily={"display"}>
+        Custom Activator using a div
+      </Typography>
+      <Combobox {...args} onSelect={setSelected} selected={selected}>
+        <Combobox.Activator>
+          <div
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+            }}
+          >
+            <Heading level={2}>Heading Two</Heading>
+            <Icon name={"arrowDown"} />
+          </div>
         </Combobox.Activator>
         <Combobox.Option id="1" label="13%" />
         <Combobox.Option id="2" label="15%" />

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -176,7 +176,7 @@ const ComboboxCustomActivator: ComponentStory<typeof Combobox> = args => {
       </Combobox>
       <br />
       <Typography element={"h3"} fontFamily={"display"}>
-        Custom Activator using a div
+        Custom Activator using div and render function
       </Typography>
       <Combobox {...args} onSelect={setSelected} selected={selected}>
         <Combobox.Activator>

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -56,6 +56,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
       handleClose={handleClose}
       shouldScroll={shouldScroll}
       searchValue={searchValue}
+      label={props.label}
     >
       <div ref={wrapperRef} className={styles.wrapper}>
         {open && (

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -32,8 +32,8 @@ export function Combobox(props: ComboboxProps): JSX.Element {
     searchValue,
     setSearchValue,
     open,
-    setOpen,
     handleClose,
+    handleOpen,
     handleSelection,
     internalFilteredOptions,
     handleSearchChange,
@@ -52,7 +52,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
       selected={selectedOptions}
       selectionHandler={handleSelection}
       open={open}
-      setOpen={setOpen}
+      handleOpen={handleOpen}
       handleClose={handleClose}
       shouldScroll={shouldScroll}
       searchValue={searchValue}
@@ -79,7 +79,6 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           setSearchValue={setSearchValue}
           wrapperRef={wrapperRef}
           open={open}
-          setOpen={setOpen}
           options={props.onSearch ? options : internalFilteredOptions}
           loading={props.loading}
           handleSearchChange={handleSearchChange}

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -33,8 +33,8 @@ export function Combobox(props: ComboboxProps): JSX.Element {
     setSearchValue,
     open,
     handleClose,
-    handleOpen,
     handleSelection,
+    toggleOpen,
     internalFilteredOptions,
     handleSearchChange,
   } = useCombobox(
@@ -52,7 +52,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
       selected={selectedOptions}
       selectionHandler={handleSelection}
       open={open}
-      handleOpen={handleOpen}
+      toggleOpen={toggleOpen}
       handleClose={handleClose}
       shouldScroll={shouldScroll}
       searchValue={searchValue}

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -149,11 +149,6 @@ export interface ComboboxContentProps {
   readonly open: boolean;
 
   /**
-   * Setter for the open state of the Combobox.
-   */
-  readonly setOpen: (open: boolean) => void;
-
-  /**
    * The full set of options for the Combobox in the shape of data, not elements.
    */
   readonly options: ComboboxOption[];

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -60,8 +60,44 @@ export interface ComboboxProps {
   readonly loading?: boolean;
 }
 
+export interface ComboboxCustomActivatorProps {
+  /**
+   * Required to describe the expanded state of the Combobox.
+   * Automatically updates as open state is toggled.
+   */
+  ariaExpanded: boolean;
+
+  /**
+   * Required to describe the relationship between the toggle-able Combobox Menu and the activator.
+   */
+  ariaControls: string;
+
+  /**
+   * The aria-label attribute for the Combobox activator.
+   */
+  ariaLabel?: string;
+
+  /**
+   * Required to describe the interactive element which toggles the Combobox's visibility.
+   */
+  role: "combobox";
+
+  /**
+   * Method to toggle the open state of the Combobox.
+   * All callbacks and cleanup will be handled when toggled to closed.
+   */
+  toggleOpen: () => void;
+}
+
+export type ComboboxActivatorAccessibility = Omit<
+  ComboboxCustomActivatorProps,
+  "toggleOpen"
+>;
+
 export interface ComboboxActivatorProps {
-  readonly children: React.ReactElement;
+  readonly children:
+    | React.ReactElement
+    | ((props: ComboboxCustomActivatorProps) => React.ReactElement);
 }
 
 export interface ComboboxTriggerProps

--- a/packages/components/src/Combobox/ComboboxProvider.tsx
+++ b/packages/components/src/Combobox/ComboboxProvider.tsx
@@ -6,8 +6,8 @@ export interface ComboboxProviderProps {
   readonly selected: ComboboxOption[];
   readonly selectionHandler: (option: ComboboxOption) => void;
   readonly open: boolean;
-  readonly handleOpen: () => void;
   readonly handleClose: () => void;
+  readonly toggleOpen: () => void;
   readonly shouldScroll: MutableRefObject<boolean>;
   readonly searchValue: string;
   readonly label?: string;

--- a/packages/components/src/Combobox/ComboboxProvider.tsx
+++ b/packages/components/src/Combobox/ComboboxProvider.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, MutableRefObject, SetStateAction } from "react";
+import React, { MutableRefObject } from "react";
 import { ComboboxOption } from "./Combobox.types";
 
 export interface ComboboxProviderProps {
@@ -6,7 +6,7 @@ export interface ComboboxProviderProps {
   readonly selected: ComboboxOption[];
   readonly selectionHandler: (option: ComboboxOption) => void;
   readonly open: boolean;
-  readonly setOpen: Dispatch<SetStateAction<boolean>>;
+  readonly handleOpen: () => void;
   readonly handleClose: () => void;
   readonly shouldScroll: MutableRefObject<boolean>;
   readonly searchValue: string;

--- a/packages/components/src/Combobox/ComboboxProvider.tsx
+++ b/packages/components/src/Combobox/ComboboxProvider.tsx
@@ -10,6 +10,7 @@ export interface ComboboxProviderProps {
   readonly handleClose: () => void;
   readonly shouldScroll: MutableRefObject<boolean>;
   readonly searchValue: string;
+  readonly label?: string;
 }
 
 export const ComboboxContext = React.createContext(

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
@@ -5,11 +5,11 @@ import { Chip } from "@jobber/components/Chip";
 import { ComboboxActivator } from "./ComboboxActivator";
 import { ComboboxContextProvider } from "../../ComboboxProvider";
 
-const setOpen = jest.fn();
+const handleOpen = jest.fn();
 const handleClose = jest.fn();
 
 afterEach(() => {
-  setOpen.mockClear();
+  handleOpen.mockClear();
   handleClose.mockClear();
 });
 
@@ -29,7 +29,7 @@ describe("ComboboxActivator", () => {
   });
 
   describe("when open is false", () => {
-    it("should call setOpen when the activator is clicked", () => {
+    it("should call handleOpen when the activator is clicked", () => {
       const { getByRole } = renderComboboxActivator(
         <Button label="Teammates" />,
         false,
@@ -38,7 +38,7 @@ describe("ComboboxActivator", () => {
 
       activator.click();
 
-      expect(setOpen).toHaveBeenCalled();
+      expect(handleOpen).toHaveBeenCalled();
     });
   });
   it("can render a Button with role 'combobox' and onClick handler", () => {
@@ -74,7 +74,7 @@ describe("ComboboxActivator", () => {
 function renderComboboxActivator(child: ReactElement, open: boolean) {
   return render(
     <ComboboxContextProvider
-      setOpen={setOpen}
+      handleOpen={handleOpen}
       handleClose={handleClose}
       selectionHandler={jest.fn()}
       shouldScroll={{ current: false }}

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
@@ -5,17 +5,17 @@ import { Chip } from "@jobber/components/Chip";
 import { ComboboxActivator } from "./ComboboxActivator";
 import { ComboboxContextProvider } from "../../ComboboxProvider";
 
-const handleOpen = jest.fn();
+const toggleOpen = jest.fn();
 const handleClose = jest.fn();
 
 afterEach(() => {
-  handleOpen.mockClear();
+  toggleOpen.mockClear();
   handleClose.mockClear();
 });
 
 describe("ComboboxActivator", () => {
   describe("when open is true", () => {
-    it("should call handleClose when the activator is clicked", () => {
+    it("should call toggleOpen when the activator is clicked", () => {
       const { getByRole } = renderComboboxActivator(
         <Button label="Teammates" />,
         true,
@@ -24,12 +24,12 @@ describe("ComboboxActivator", () => {
 
       activator.click();
 
-      expect(handleClose).toHaveBeenCalled();
+      expect(toggleOpen).toHaveBeenCalled();
     });
   });
 
   describe("when open is false", () => {
-    it("should call handleOpen when the activator is clicked", () => {
+    it("should call toggleOpen when the activator is clicked", () => {
       const { getByRole } = renderComboboxActivator(
         <Button label="Teammates" />,
         false,
@@ -38,7 +38,7 @@ describe("ComboboxActivator", () => {
 
       activator.click();
 
-      expect(handleOpen).toHaveBeenCalled();
+      expect(toggleOpen).toHaveBeenCalled();
     });
   });
   it("can render a Button with role 'combobox' and onClick handler", () => {
@@ -74,7 +74,7 @@ describe("ComboboxActivator", () => {
 function renderComboboxActivator(child: ReactElement, open: boolean) {
   return render(
     <ComboboxContextProvider
-      handleOpen={handleOpen}
+      toggleOpen={toggleOpen}
       handleClose={handleClose}
       selectionHandler={jest.fn()}
       shouldScroll={{ current: false }}

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
@@ -7,11 +7,9 @@ import { ComboboxContextProvider } from "../../ComboboxProvider";
 import { ComboboxCustomActivatorProps } from "../../Combobox.types";
 
 const toggleOpen = jest.fn();
-const handleClose = jest.fn();
 
 afterEach(() => {
   toggleOpen.mockClear();
-  handleClose.mockClear();
 });
 
 describe("ComboboxActivator", () => {
@@ -81,7 +79,7 @@ function renderComboboxActivator(
   return render(
     <ComboboxContextProvider
       toggleOpen={toggleOpen}
-      handleClose={handleClose}
+      handleClose={jest.fn()}
       selectionHandler={jest.fn()}
       shouldScroll={{ current: false }}
       open={open}

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
@@ -61,13 +61,13 @@ describe("ComboboxActivator", () => {
     expect(activator).toBeInTheDocument();
   });
 
-  it("renders without 'combobox' role if children are not a Chip or Button", () => {
+  it("renders provided element with 'combobox' role if children are not a Chip or Button", () => {
     const { getByText, queryByRole } = renderComboboxActivator(
       <div>Teammates</div>,
       true,
     );
     expect(getByText("Teammates")).toBeInTheDocument();
-    expect(queryByRole("combobox")).not.toBeInTheDocument();
+    expect(queryByRole("combobox")).toBeInTheDocument();
   });
 });
 

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
@@ -4,6 +4,7 @@ import { Button } from "@jobber/components/Button";
 import { Chip } from "@jobber/components/Chip";
 import { ComboboxActivator } from "./ComboboxActivator";
 import { ComboboxContextProvider } from "../../ComboboxProvider";
+import { ComboboxCustomActivatorProps } from "../../Combobox.types";
 
 const toggleOpen = jest.fn();
 const handleClose = jest.fn();
@@ -63,7 +64,9 @@ describe("ComboboxActivator", () => {
 
   it("renders provided element with 'combobox' role if children are not a Chip or Button", () => {
     const { getByText, queryByRole } = renderComboboxActivator(
-      <div>Teammates</div>,
+      (api: ComboboxCustomActivatorProps) => (
+        <div role={api.role}>Teammates</div>
+      ),
       true,
     );
     expect(getByText("Teammates")).toBeInTheDocument();
@@ -71,7 +74,10 @@ describe("ComboboxActivator", () => {
   });
 });
 
-function renderComboboxActivator(child: ReactElement, open: boolean) {
+function renderComboboxActivator(
+  child: ReactElement | ((args: ComboboxCustomActivatorProps) => JSX.Element),
+  open: boolean,
+) {
   return render(
     <ComboboxContextProvider
       toggleOpen={toggleOpen}

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
@@ -1,24 +1,19 @@
 import React from "react";
-import { Button } from "@jobber/components/Button";
-import { Chip } from "@jobber/components/Chip";
 import { ComboboxContext } from "../../ComboboxProvider";
 import { ComboboxActivatorProps } from "../../Combobox.types";
 
 export function ComboboxActivator(props: ComboboxActivatorProps) {
   const { handleClose, open, handleOpen } = React.useContext(ComboboxContext);
 
-  if (props.children.type === Button || props.children.type === Chip) {
-    return React.cloneElement(props.children, {
-      role: "combobox",
-      onClick: () => {
-        if (open) {
-          handleClose();
-        } else {
-          handleOpen();
-        }
-      },
-    });
-  }
-
-  return props.children;
+  return React.cloneElement(props.children, {
+    role: "combobox",
+    "aria-expanded": open,
+    onClick: () => {
+      if (open) {
+        handleClose();
+      } else {
+        handleOpen();
+      }
+    },
+  });
 }

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
@@ -1,14 +1,25 @@
 import React from "react";
+import { Button } from "@jobber/components/Button";
+import { Chip } from "@jobber/components/Chip";
 import { ComboboxContext } from "../../ComboboxProvider";
 import { ComboboxActivatorProps } from "../../Combobox.types";
 import { useComboboxActivatorAccessibility } from "../../hooks/useComboboxActivatorAccessibility";
 
 export function ComboboxActivator(props: ComboboxActivatorProps) {
   const { toggleOpen } = React.useContext(ComboboxContext);
-  const { htmlAttributes } = useComboboxActivatorAccessibility();
+  const accessibilityAttributes = useComboboxActivatorAccessibility();
 
-  return React.cloneElement(props.children, {
-    ...htmlAttributes,
-    onClick: toggleOpen,
-  });
+  if (
+    typeof props.children !== "function" &&
+    (props.children.type === Button || props.children.type === Chip)
+  ) {
+    return React.cloneElement(props.children, {
+      role: accessibilityAttributes.role,
+      onClick: toggleOpen,
+    });
+  } else if (typeof props.children === "function") {
+    return props.children({ ...accessibilityAttributes, toggleOpen });
+  }
+
+  return null;
 }

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
@@ -4,17 +4,11 @@ import { ComboboxActivatorProps } from "../../Combobox.types";
 import { useComboboxActivatorAccessibility } from "../../hooks/useComboboxActivatorAccessibility";
 
 export function ComboboxActivator(props: ComboboxActivatorProps) {
-  const { handleClose, open, handleOpen } = React.useContext(ComboboxContext);
+  const { toggleOpen } = React.useContext(ComboboxContext);
   const { htmlAttributes } = useComboboxActivatorAccessibility();
 
   return React.cloneElement(props.children, {
     ...htmlAttributes,
-    onClick: () => {
-      if (open) {
-        handleClose();
-      } else {
-        handleOpen();
-      }
-    },
+    onClick: toggleOpen,
   });
 }

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { ComboboxContext } from "../../ComboboxProvider";
 import { ComboboxActivatorProps } from "../../Combobox.types";
+import { useComboboxActivatorAccessibility } from "../../hooks/useComboboxActivatorAccessibility";
 
 export function ComboboxActivator(props: ComboboxActivatorProps) {
   const { handleClose, open, handleOpen } = React.useContext(ComboboxContext);
+  const { htmlAttributes } = useComboboxActivatorAccessibility();
 
   return React.cloneElement(props.children, {
-    role: "combobox",
-    "aria-expanded": open,
+    ...htmlAttributes,
     onClick: () => {
       if (open) {
         handleClose();

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
@@ -5,7 +5,7 @@ import { ComboboxContext } from "../../ComboboxProvider";
 import { ComboboxActivatorProps } from "../../Combobox.types";
 
 export function ComboboxActivator(props: ComboboxActivatorProps) {
-  const { handleClose, open, setOpen } = React.useContext(ComboboxContext);
+  const { handleClose, open, handleOpen } = React.useContext(ComboboxContext);
 
   if (props.children.type === Button || props.children.type === Chip) {
     return React.cloneElement(props.children, {
@@ -14,7 +14,7 @@ export function ComboboxActivator(props: ComboboxActivatorProps) {
         if (open) {
           handleClose();
         } else {
-          setOpen(true);
+          handleOpen();
         }
       },
     });

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -8,6 +8,7 @@ import { ComboboxContentHeader } from "./ComboboxContentHeader";
 import { useComboboxContent } from "../../hooks/useComboboxContent";
 import { useComboboxAccessibility } from "../../hooks/useComboboxAccessibility";
 import { ComboboxContentProps } from "../../Combobox.types";
+import { COMBOBOX_MENU_ID } from "../../constants";
 
 export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
   const optionsExist = props.options.length > 0;
@@ -24,8 +25,8 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
   const template = (
     <div
       ref={popperRef}
-      id="ATL-Combobox-Content"
-      data-testid="ATL-Combobox-Content"
+      id={COMBOBOX_MENU_ID}
+      data-testid={COMBOBOX_MENU_ID}
       data-elevation={"elevated"}
       tabIndex={0}
       className={classnames(styles.content, { [styles.hidden]: !props.open })}

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
@@ -5,32 +5,30 @@ import { ComboboxTrigger } from "./ComboboxTrigger";
 import { ComboboxContextProvider } from "../../ComboboxProvider";
 import { ComboboxOption } from "../../Combobox.types";
 
-const handleClose = jest.fn();
-const handleOpen = jest.fn();
+const toggleOpen = jest.fn();
 
 afterEach(() => {
-  handleClose.mockClear();
-  handleOpen.mockClear();
+  toggleOpen.mockClear();
 });
 
 describe("ComboboxTrigger", () => {
   describe("when open is false", () => {
-    it("calls handleOpen", async () => {
+    it("calls toggleOpen", async () => {
       renderTrigger();
       const trigger = screen.getByRole("combobox");
 
       await userEvent.click(trigger);
-      expect(handleOpen).toHaveBeenCalled();
+      expect(toggleOpen).toHaveBeenCalled();
     });
   });
 
   describe("when open is true", () => {
-    it("calls onClose", async () => {
+    it("calls toggleOpen", async () => {
       renderTrigger(true);
       const trigger = screen.getByRole("combobox");
 
       await userEvent.click(trigger);
-      expect(handleClose).toHaveBeenCalled();
+      expect(toggleOpen).toHaveBeenCalled();
     });
   });
 
@@ -126,8 +124,8 @@ function renderTrigger(
 ) {
   return render(
     <ComboboxContextProvider
-      handleOpen={handleOpen}
-      handleClose={handleClose}
+      toggleOpen={toggleOpen}
+      handleClose={jest.fn()}
       selected={[]}
       open={open}
       shouldScroll={{ current: false }}

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
@@ -6,21 +6,21 @@ import { ComboboxContextProvider } from "../../ComboboxProvider";
 import { ComboboxOption } from "../../Combobox.types";
 
 const handleClose = jest.fn();
-const setOpen = jest.fn();
+const handleOpen = jest.fn();
 
 afterEach(() => {
   handleClose.mockClear();
-  setOpen.mockClear();
+  handleOpen.mockClear();
 });
 
 describe("ComboboxTrigger", () => {
   describe("when open is false", () => {
-    it("calls setOpen", async () => {
+    it("calls handleOpen", async () => {
       renderTrigger();
       const trigger = screen.getByRole("combobox");
 
       await userEvent.click(trigger);
-      expect(setOpen).toHaveBeenCalled();
+      expect(handleOpen).toHaveBeenCalled();
     });
   });
 
@@ -126,7 +126,7 @@ function renderTrigger(
 ) {
   return render(
     <ComboboxContextProvider
-      setOpen={setOpen}
+      handleOpen={handleOpen}
       handleClose={handleClose}
       selected={[]}
       open={open}

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
@@ -8,7 +8,7 @@ export function ComboboxTrigger({
   label = "Select",
   selected,
 }: ComboboxTriggerProps) {
-  const { handleClose, open, setOpen } = React.useContext(ComboboxContext);
+  const { handleClose, open, handleOpen } = React.useContext(ComboboxContext);
 
   const hasSelection = selected.length;
   const selectedLabel = selected.map(option => option.label).join(", ");
@@ -23,7 +23,7 @@ export function ComboboxTrigger({
         if (open) {
           handleClose();
         } else {
-          setOpen(true);
+          handleOpen();
         }
       }}
       role="combobox"

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
@@ -8,7 +8,7 @@ export function ComboboxTrigger({
   label = "Select",
   selected,
 }: ComboboxTriggerProps) {
-  const { handleClose, open, handleOpen } = React.useContext(ComboboxContext);
+  const { toggleOpen } = React.useContext(ComboboxContext);
 
   const hasSelection = selected.length;
   const selectedLabel = selected.map(option => option.label).join(", ");
@@ -19,13 +19,7 @@ export function ComboboxTrigger({
       label={hasSelection ? selectedLabel : ""}
       ariaLabel={label}
       heading={label}
-      onClick={() => {
-        if (open) {
-          handleClose();
-        } else {
-          handleOpen();
-        }
-      }}
+      onClick={toggleOpen}
       role="combobox"
     >
       {!hasSelection && (

--- a/packages/components/src/Combobox/constants.ts
+++ b/packages/components/src/Combobox/constants.ts
@@ -1,0 +1,1 @@
+export const COMBOBOX_MENU_ID = "ATL-Combobox-Content";

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -44,8 +44,9 @@ export function useCombobox(
     [onSearch, debounceTime],
   );
 
-  const { handleClose, handleOpen, handleSelection } = useMakeComboboxHandlers(
+  const { handleClose, handleSelection, toggleOpen } = useMakeComboboxHandlers(
     setOpen,
+    open,
     setSearchValue,
     selected,
     shouldScroll,
@@ -64,12 +65,12 @@ export function useCombobox(
     searchValue,
     setSearchValue,
     open,
-    handleOpen,
     selectedOptions: selected,
     selectedStateSetter: onSelect,
     shouldScroll,
     handleClose,
     handleSelection,
+    toggleOpen,
     internalFilteredOptions,
     handleSearchChange: onSearch ? searchCallback : noop,
   };

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -18,7 +18,6 @@ type UseComboboxReturn = {
   searchValue: string;
   setSearchValue: Dispatch<React.SetStateAction<string>>;
   open: boolean;
-  setOpen: Dispatch<React.SetStateAction<boolean>>;
   selectedOptions: ComboboxOption[];
   selectedStateSetter: (selection: ComboboxOption[]) => void;
   shouldScroll: MutableRefObject<boolean>;
@@ -45,7 +44,7 @@ export function useCombobox(
     [onSearch, debounceTime],
   );
 
-  const { handleClose, handleSelection } = useMakeComboboxHandlers(
+  const { handleClose, handleOpen, handleSelection } = useMakeComboboxHandlers(
     setOpen,
     setSearchValue,
     selected,
@@ -65,7 +64,7 @@ export function useCombobox(
     searchValue,
     setSearchValue,
     open,
-    setOpen,
+    handleOpen,
     selectedOptions: selected,
     selectedStateSetter: onSelect,
     shouldScroll,

--- a/packages/components/src/Combobox/hooks/useComboboxActivatorAccessibility.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxActivatorAccessibility.ts
@@ -10,6 +10,7 @@ export function useComboboxActivatorAccessibility() {
       "aria-label": label,
       "aria-expanded": open,
       "aria-controls": COMBOBOX_MENU_ID,
+      tabindex: 0,
       role: "combobox",
     },
   };

--- a/packages/components/src/Combobox/hooks/useComboboxActivatorAccessibility.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxActivatorAccessibility.ts
@@ -1,0 +1,16 @@
+import { useContext } from "react";
+import { ComboboxContext } from "../ComboboxProvider";
+import { COMBOBOX_MENU_ID } from "../constants";
+
+export function useComboboxActivatorAccessibility() {
+  const { label, open } = useContext(ComboboxContext);
+
+  return {
+    htmlAttributes: {
+      "aria-label": label,
+      "aria-expanded": open,
+      "aria-controls": COMBOBOX_MENU_ID,
+      role: "combobox",
+    },
+  };
+}

--- a/packages/components/src/Combobox/hooks/useComboboxActivatorAccessibility.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxActivatorAccessibility.ts
@@ -1,17 +1,15 @@
 import { useContext } from "react";
 import { ComboboxContext } from "../ComboboxProvider";
 import { COMBOBOX_MENU_ID } from "../constants";
+import { ComboboxActivatorAccessibility } from "../Combobox.types";
 
-export function useComboboxActivatorAccessibility() {
+export function useComboboxActivatorAccessibility(): ComboboxActivatorAccessibility {
   const { label, open } = useContext(ComboboxContext);
 
   return {
-    htmlAttributes: {
-      "aria-label": label,
-      "aria-expanded": open,
-      "aria-controls": COMBOBOX_MENU_ID,
-      tabindex: 0,
-      role: "combobox",
-    },
+    ariaLabel: label,
+    ariaExpanded: open,
+    ariaControls: COMBOBOX_MENU_ID,
+    role: "combobox",
   };
 }

--- a/packages/components/src/Combobox/hooks/useComboboxValidation.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxValidation.ts
@@ -32,7 +32,7 @@ export function useComboboxValidation(children?: ComboboxProps["children"]): {
     ComboboxActivator,
     children,
   );
-
+  console.log(activatorElements[0]);
   const shouldThrowTriggerError = isInvalid(activatorElements);
 
   useAssert(shouldThrowTriggerError, COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);

--- a/packages/components/src/Combobox/hooks/useComboboxValidation.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxValidation.ts
@@ -32,7 +32,7 @@ export function useComboboxValidation(children?: ComboboxProps["children"]): {
     ComboboxActivator,
     children,
   );
-  console.log(activatorElements[0]);
+
   const shouldThrowTriggerError = isInvalid(activatorElements);
 
   useAssert(shouldThrowTriggerError, COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE);

--- a/packages/components/src/Combobox/hooks/useMakeComboboxHandlers.ts
+++ b/packages/components/src/Combobox/hooks/useMakeComboboxHandlers.ts
@@ -3,6 +3,7 @@ import { ComboboxOption } from "../Combobox.types";
 
 export interface UseMakeComboboxHandlersReturn {
   handleClose: () => void;
+  handleOpen: () => void;
   handleSelection: (selection: ComboboxOption) => void;
 }
 
@@ -28,6 +29,10 @@ export function useMakeComboboxHandlers(
     }
   }, [setOpen, setSearchValue, onClose, onSearch, selectedOptions.length]);
 
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+  }, [setOpen]);
+
   const handleSelection = useCallback(
     (selection: ComboboxOption) => {
       if (multiSelect) {
@@ -52,6 +57,7 @@ export function useMakeComboboxHandlers(
 
   return {
     handleClose,
+    handleOpen,
     handleSelection,
   };
 }

--- a/packages/components/src/Combobox/hooks/useMakeComboboxHandlers.ts
+++ b/packages/components/src/Combobox/hooks/useMakeComboboxHandlers.ts
@@ -3,12 +3,13 @@ import { ComboboxOption } from "../Combobox.types";
 
 export interface UseMakeComboboxHandlersReturn {
   handleClose: () => void;
-  handleOpen: () => void;
   handleSelection: (selection: ComboboxOption) => void;
+  toggleOpen: () => void;
 }
 
 export function useMakeComboboxHandlers(
   setOpen: (open: boolean) => void,
+  open: boolean,
   setSearchValue: (searchValue: string) => void,
   selectedOptions: ComboboxOption[],
   shouldScroll: React.MutableRefObject<boolean>,
@@ -32,6 +33,14 @@ export function useMakeComboboxHandlers(
   const handleOpen = useCallback(() => {
     setOpen(true);
   }, [setOpen]);
+
+  const toggleOpen = useCallback(() => {
+    if (open) {
+      handleClose();
+    } else {
+      handleOpen();
+    }
+  }, [setOpen, open]);
 
   const handleSelection = useCallback(
     (selection: ComboboxOption) => {
@@ -57,8 +66,8 @@ export function useMakeComboboxHandlers(
 
   return {
     handleClose,
-    handleOpen,
     handleSelection,
+    toggleOpen,
   };
 }
 

--- a/packages/components/src/Combobox/index.ts
+++ b/packages/components/src/Combobox/index.ts
@@ -1,3 +1,3 @@
 export * from "./Combobox";
 export { ComboboxContextProvider } from "./ComboboxProvider";
-export { ComboboxOption } from "./Combobox.types";
+export { ComboboxOption, ComboboxCustomActivatorProps } from "./Combobox.types";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Some designs call for even further customization beyond a Chip or Button.

To enable this, we are going to open up the Activator even further to allow more customization.

## Changes



### Added

Combobox Activator can accept custom markup. No longer limited to only Chip and Button.

### Changed

**toggleOpen & handleOpen**
regardless of if we want to expose the API through render props or not, calling `setOpen` directly can be risky. `setOpen(true)` is fine. `setOpen(false)` is not since we want to make sure to do all the cleanup and invoke all the callbacks in addition to closing the combobox. 

to that end, I've created an equivalent wrapper for `setOpen(true)`: `handleOpen`. if we ever want to add callbacks for `onOpen` then it will be easy to add it to one place over all the places we were using `setOpen(true)`. right now it's very bare bones.

by not making the setter directly available from the Context, or even exporting it from where we make the handlers, it is much harder to accidentally use it which we almost did with a recent change. additionally, if we end up exposing methods via render props it's much safer to expose the `handleOpen`

I went one step further and made a `toggleOpen` method that makes it even simpler where we call the toggle. rather than having the logic in a couple places, you just call this method. I could potentially be convinced to go back to handleClose/handleOpen. it's not a ton of logic to repeat and does offer more granular control, though I'm not too sure what you'd do any differently with it. you can only go back and forth between the states. calling open while it's open, or closed while it's closed make no sense.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
