### PR TITLE
fix(components-native): ContentOverlay Heading alignment should not change with presence of dismiss button

### DIFF
--- a/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.style.ts
@@ -54,18 +54,17 @@ export const styles = StyleSheet.create({
     opacity: 0,
   },
 
-  titleWithoutDismiss: {
-    flex: 1,
-    flexDirection: "row",
-    justifyContent: "center",
-    paddingTop: tokens["space-base"],
-    paddingHorizontal: tokens["space-base"],
-  },
-
-  titleWithDismiss: {
+  title: {
     flex: 1,
     justifyContent: "center",
     paddingLeft: tokens["space-base"],
+  },
+
+  titleWithoutDismiss: {
+    paddingRight: tokens["space-base"],
+  },
+
+  titleWithDismiss: {
     paddingRight: tokens["space-smaller"],
   },
 });

--- a/packages/components-native/src/ContentOverlay/ContentOverlay.tsx
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.tsx
@@ -222,11 +222,12 @@ function ContentOverlayInternal(
       <View onLayout={handleHeaderLayout} testID="ATL-Overlay-Header">
         <View style={headerStyles}>
           <View
-            style={
+            style={[
+              styles.title,
               shouldShowDismiss
                 ? styles.titleWithDismiss
-                : styles.titleWithoutDismiss
-            }
+                : styles.titleWithoutDismiss,
+            ]}
           >
             <Heading
               level="subtitle"

--- a/packages/components-native/src/ContentOverlay/ContentOverlay.tsx
+++ b/packages/components-native/src/ContentOverlay/ContentOverlay.tsx
@@ -231,7 +231,7 @@ function ContentOverlayInternal(
             <Heading
               level="subtitle"
               variation={loading ? "subdued" : "heading"}
-              align={shouldShowDismiss ? "start" : "center"}
+              align={"start"}
             >
               {title}
             </Heading>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Based on design review feedback in [this JM PR](https://github.com/GetJobber/jobber-mobile/pull/9716#discussion_r1803809106) it seems that design wants the `Heading` of the `ContentOverlay` to be start aligned whether or not the dismiss button is present. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `Header` without a dismiss button is now start aligned instead of being center aligned

| Before | After |
| -------| ----- |
| <img width="320" alt="image" src="https://github.com/user-attachments/assets/233cd564-ec3a-45fe-800c-e8dcd6a5fae7"> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/b07be005-fefb-493b-9ab3-dd2fbf499406"> |


### Security

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
