### PR TITLE
fix(components): Fixed issue where GridCell could no longer have no children

### DIFF
--- a/packages/components/src/Grid/GridCell/GridCell.tsx
+++ b/packages/components/src/Grid/GridCell/GridCell.tsx
@@ -19,7 +19,7 @@ export interface GridCellProps {
    * Set how many columns wide the cell is in the grid
    */
   readonly size: { [Breakpoint in Breakpoints]?: ColumnSizes };
-  readonly children: React.ReactNode;
+  readonly children?: React.ReactNode;
 }
 
 const MAX_COLUMNS = 12;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fixed regression where GridCell could not longer have no children which was used to create spacer cells for adding empty space to the start of a grid. [The change that caused this](https://github.com/GetJobber/atlantis/pull/2074/files#diff-0119fc0182d00d596c0314e898f3a6dea1dc55487b4ab5119195578390f0fc4eR22) removed the PropsWithChildren which used to allow no children to be passed with `<Grid.Cell size={...} />` which is no longer allowed
### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
