### PR TITLE
feat(components): Improve list composability [JOB-107035]

### DIFF
--- a/docs/components/List/List.stories.mdx
+++ b/docs/components/List/List.stories.mdx
@@ -21,8 +21,8 @@ find an object that leads to its full representation.
 
 The majority of list implementations can be achieved without needing to
 customize rendering. If your items conform to the `ListItemProps` interface, the
-component will render them automatically with the default behavior. The
-`ListItemProps` must be used when using default rendering.
+component will render them automatically with the default behavior. A prop of
+type `ListItemProps` must be used when using default rendering.
 
 #### Basic Flat List
 
@@ -97,13 +97,6 @@ their section and display them under section headers.
   </Card>
 </Canvas>
 
-#### Context Complexity
-
-The default full bleed (width) + bottom bordered style is preferred when the
-list item contains complex content where non-complex content would be something
-like Menu's content which has a different style but identical functionality
-otherwise.
-
 ### **Custom Rendering (Advanced Usage)**
 
 If you need more control over the rendering of list items, you can provide a
@@ -112,9 +105,6 @@ the default rendering of the `ListItem` component doesn’t meet your
 requirements. If a custom render function is provided onClick, url, and hover
 functionality will still work. Sectioned list functionality will also remain the
 same.
-
-Lastly, you will be required to implement the spacing, alignment and border
-bottom CSS logic.
 
 **Example: Custom Render Function with Custom Interface**
 
@@ -137,10 +127,10 @@ const items: ProductListItemProps[] = [
 
 
 const renderProductItem = (item: ProductListItemProps) => (
-    <div className="customContainer">
+    <Flex template={["shrink", "grow"]} align="start">
         <Text>{item.price}</Text>
         <Heading level={4}>{item.name}</Heading>
-    </div>
+    </Flex>
   </div>
 );
 
@@ -148,22 +138,6 @@ export const CustomRenderExample = () => (
   <List items={items} customRenderItem={renderProductItem} />
 );
 
-// *.module.css
-
-.customContainer {
-  display: flex;
-  alignItems: center;
-  justifyContent: flex-start;
-  text-align: left;
-}
-
-.customContainer > * {
-  padding: var(--space-small);
-}
-
-li > ul > li:not(:last-child) .customContainer {
-  border-bottom: var(--border-base) solid var(--color-border);
-}
 ```
 
 **In this example**:
@@ -172,7 +146,6 @@ li > ul > li:not(:last-child) .customContainer {
   `BaseListItemProps`.
 - The `customRenderItem` function provides complete control over how each item
   is rendered.
-- We replicate the padding, alignment and border logic
 
 **When to Use Custom Rendering:**
 
@@ -181,12 +154,22 @@ li > ul > li:not(:last-child) .customContainer {
 - Create your own interface extending `BaseListItemProps` to define the fields
   you need.
 
-##### Replicating Default List Styles
+#### Using Your own Custom Item Styles
 
-In the above example we must use `li > ul > li:not(:last-child) .{customClass}`
-because it is a sectioned list having nested ul and li elements.
+Some styles (such as hover and active item styles) are always applied to list
+items, even when using a custom render function. However, other styles (like
+padding, alignment, and border-bottom) are applied by default but can be
+disabled by setting `customItemStyles={true}` alongside `customRenderItem`. This
+option allows you to remove some of the default item styles and apply your own.
 
-For a non sectioned list `li:not(:last-child) .{customClass}` would suffice.
+For instance, in the Simple List with Custom Styles example, setting
+`customItemStyles={true}` allows for the creation of a list with rounded corners
+and no border-bottom. You can also experiment by toggling this prop in the other
+custom render examples to observe its impact.
 
-For the spacing, it is achieved with `small` padding on the item container, then
-an additional `small` padding on the elements inside.
+Note: The `customItemStyles` prop is only valid when a `customRenderItem`
+function is provided.
+
+```tsx
+
+```

--- a/docs/components/List/List.stories.mdx
+++ b/docs/components/List/List.stories.mdx
@@ -20,41 +20,11 @@ like billing or activity feed. The main purpose of a list is to help the user
 find an object that leads to its full representation.
 
 The majority of list implementations can be achieved without needing to
-customize rendering. If your items conform to the ListItemProps interface, the
-component will render them automatically with the default behavior.
+customize rendering. If your items conform to the `ListItemProps` interface, the
+component will render them automatically with the default behavior. The
+`ListItemProps` must be used when using default rendering.
 
-#### ListItemProps Interface
-
-When using the default rendering, your items must conform to the
-**`ListItemProps`** interface. Here’s a breakdown of the properties:
-
-**Required:**
-
-- **`id`**: A unique identifier for the list item. This is essential to ensure
-  proper rendering and handling of batch actions.
-
-**Optional:**
-
-- **`title`**: A heading or title for the item.
-
-- **`caption`**: Subdued text shown below the main content.
-
-- **`content`**: Main content, either a string or an array of strings. Supports
-  basic markdown (e.g., **bold** and _italic_).
-
-- **`icon`**: An icon to display on the left side of the content.
-
-- **`iconColor`**: Sets the color of the icon.
-
-- **`isActive`**: Highlights the list item to indicate it needs attention.
-
-- **`section`**: Used to group the list items into sections.
-
-- **`url`**: Makes the item clickable, rendering it as a link.
-
-- **`value`**: A numeric or string value aligned to the right of the item.
-
-- **`onClick`**: A callback function triggered when the item is clicked.
+**`ListItemProps`** interface.
 
 #### Basic Flat List
 

--- a/docs/components/List/List.stories.mdx
+++ b/docs/components/List/List.stories.mdx
@@ -24,8 +24,6 @@ customize rendering. If your items conform to the `ListItemProps` interface, the
 component will render them automatically with the default behavior. The
 `ListItemProps` must be used when using default rendering.
 
-**`ListItemProps`** interface.
-
 #### Basic Flat List
 
 <Canvas>
@@ -103,7 +101,11 @@ their section and display them under section headers.
 
 If you need more control over the rendering of list items, you can provide a
 **custom render function** using the `customRenderItem` prop. This is useful if
-the default `ListItem` component doesn’t meet your requirements.
+the default rendering of the `ListItem` component doesn’t meet your
+requirements. If a custom render function is provided onClick, url, and hover
+functionality will still work. Sectioned list functionality will also remain the
+same. Lastly, the styles wrapping the list items will match those of a `List`
+with no custom render function.
 
 **Example: Custom Render Function with Custom Interface**
 
@@ -113,11 +115,15 @@ import { List } from "./List";
 interface ProductListItemProps extends BaseListItemProps {
   readonly name: string;
   readonly price: string;
+  readonly section: string;
+  readonly onClick?: () => void;
 }
 
 const items: ProductListItemProps[] = [
-  { id: 1, name: "Lawn Mower", price: "$250.00" },
-  { id: 2, name: "Hedge Trimmer", price: "$85.00" },
+  { id: 1, name: "Lawn Mower", price: "$250.00", section: "Garden Tools", onClick: () => alert("Lawn Mower clicked") },
+  { id: 2, name: "Hedge Trimmer", price: "$85.00", section: "Garden Tools", onClick: () => alert("Hedge Trimmer clicked") },
+  { id: 3, name: "Drill", price: "$50.00", section: "Power Tools", onClick: () => alert("Drill clicked") },
+  { id: 4, name: "Screwdriver", price: "$10.00", section: "Hand Tools", onClick: () => alert("Screwdriver clicked") },
 ];
 
 const renderProductItem = (item: ProductListItemProps) => (

--- a/docs/components/List/List.stories.mdx
+++ b/docs/components/List/List.stories.mdx
@@ -1,9 +1,178 @@
 import { Meta } from "@storybook/addon-docs";
+import { Card } from "@jobber/components/Card";
+import { List } from "@jobber/components/List";
 
 <Meta title="Components/Lists and Tables/List" />
 
 # List
 
-Displays a collection of objects that are either the same type or related to one
-another, like billing or activity feed. The main purpose of a list is to help
-the user find an object that leads to its full representation.
+The `List` component renders a collection of items in a structured way. It
+supports both [flat lists](#basic-flat-list) and
+[sectioned lists](#sectioned-list), and allows for
+[custom rendering](#custom-rendering-advanced-usage) of list items via a render
+function.
+
+## Design and Usage Guidelines
+
+The `List` component is a great solution if you are looking to display a
+collection of objects that are either the same type or related to one another,
+like billing or activity feed. The main purpose of a list is to help the user
+find an object that leads to its full representation.
+
+The majority of list implementations can be achieved without needing to
+customize rendering. If your items conform to the ListItemProps interface, the
+component will render them automatically with the default behavior.
+
+#### ListItemProps Interface
+
+When using the default rendering, your items must conform to the
+**`ListItemProps`** interface. Here’s a breakdown of the properties:
+
+**Required:**
+
+- **`id`**: A unique identifier for the list item. This is essential to ensure
+  proper rendering and handling of batch actions.
+
+**Optional:**
+
+- **`title`**: A heading or title for the item.
+
+- **`caption`**: Subdued text shown below the main content.
+
+- **`content`**: Main content, either a string or an array of strings. Supports
+  basic markdown (e.g., **bold** and _italic_).
+
+- **`icon`**: An icon to display on the left side of the content.
+
+- **`iconColor`**: Sets the color of the icon.
+
+- **`isActive`**: Highlights the list item to indicate it needs attention.
+
+- **`section`**: Used to group the list items into sections.
+
+- **`url`**: Makes the item clickable, rendering it as a link.
+
+- **`value`**: A numeric or string value aligned to the right of the item.
+
+- **`onClick`**: A callback function triggered when the item is clicked.
+
+#### Basic Flat List
+
+<Canvas>
+  <Card>
+    <List
+      items={[
+        {
+          id: 1,
+          content: "Content",
+          icon: "work",
+          iconColor: "interactive",
+          title: "Title",
+          value: "Value",
+          onClick: () => alert("First list item clicked"),
+        },
+        {
+          id: 2,
+          content: "Content",
+          icon: "work",
+          iconColor: "interactive",
+          title: "Title",
+          value: "Value",
+          onClick: () => alert("Second list item clicked"),
+        },
+      ]}
+    />
+  </Card>
+</Canvas>
+
+#### Sectioned List
+
+If a section field is present in any item, the list will group the items by
+their section and display them under section headers.
+
+<Canvas>
+  <Card>
+    <List
+      items={[
+        {
+          id: 1,
+          content: "Content",
+          icon: "work",
+          iconColor: "interactive",
+          title: "Title",
+          value: "Value",
+          section: "Section 1",
+          onClick: () => alert("First list item clicked"),
+        },
+        {
+          id: 2,
+          content: "Content",
+          icon: "work",
+          iconColor: "interactive",
+          title: "Title",
+          value: "Value",
+          section: "Section 1",
+          onClick: () => alert("Second list item clicked"),
+        },
+        {
+          id: 3,
+          content: "Content",
+          icon: "work",
+          iconColor: "interactive",
+          title: "Title",
+          value: "Value",
+          section: "Section 2",
+          onClick: () => alert("Second list item clicked"),
+        },
+      ]}
+    />
+  </Card>
+</Canvas>
+
+### **Custom Rendering (Advanced Usage)**
+
+If you need more control over the rendering of list items, you can provide a
+**custom render function** using the `customRenderItem` prop. This is useful if
+the default `ListItem` component doesn’t meet your requirements.
+
+**Example: Custom Render Function with Custom Interface**
+
+```tsx
+import { List } from "./List";
+
+interface ProductListItemProps extends BaseListItemProps {
+  readonly name: string;
+  readonly price: string;
+}
+
+const items: ProductListItemProps[] = [
+  { id: 1, name: "Lawn Mower", price: "$250.00" },
+  { id: 2, name: "Hedge Trimmer", price: "$85.00" },
+];
+
+const renderProductItem = (item: ProductListItemProps) => (
+    <Flex template={["shrink", "grow"]} align="start">
+        <Text>{item.price}</Text>
+        <Heading level={4}>{item.name}</Heading>
+    </Flex>
+  </div>
+);
+
+export const CustomRenderExample = () => (
+  <List items={items} customRenderItem={renderProductItem} />
+);
+```
+
+**In this example**:
+
+- We define a custom interface (`ProductListItemProps`) that extends
+  `BaseListItemProps`.
+- The `customRenderItem` function provides complete control over how each item
+  is rendered.
+
+**When to Use Custom Rendering:**
+
+- Use a custom render function when you need complex layouts that the `ListItem`
+  component can’t provide.
+- Create your own interface extending `BaseListItemProps` to define the fields
+  you need.

--- a/docs/components/List/List.stories.mdx
+++ b/docs/components/List/List.stories.mdx
@@ -56,7 +56,11 @@ type `ListItemProps` must be used when using default rendering.
 #### Sectioned List
 
 If a section field is present in any item, the list will group the items by
-their section and display them under section headers.
+their section and display them under section headers. If even one section key
+exists in any of items then it will be expected that every object within that
+collection will have a section defined. If a section is missing, "Other" will be
+used, and any items with a section of "Other" will be grouped with that first
+occurrence that has no section.
 
 <Canvas>
   <Card>
@@ -147,7 +151,7 @@ export const CustomRenderExample = () => (
 - The `customRenderItem` function provides complete control over how each item
   is rendered.
 
-**When to Use Custom Rendering:**
+**About Custom Rendering:**
 
 - Use a custom render function when you need complex layouts that the `ListItem`
   component can’t provide.

--- a/docs/components/List/List.stories.mdx
+++ b/docs/components/List/List.stories.mdx
@@ -97,6 +97,13 @@ their section and display them under section headers.
   </Card>
 </Canvas>
 
+#### Context Complexity
+
+The default full bleed (width) + bottom bordered style is preferred when the
+list item contains complex content where non-complex content would be something
+like Menu's content which has a different style but identical functionality
+otherwise.
+
 ### **Custom Rendering (Advanced Usage)**
 
 If you need more control over the rendering of list items, you can provide a
@@ -104,8 +111,10 @@ If you need more control over the rendering of list items, you can provide a
 the default rendering of the `ListItem` component doesn’t meet your
 requirements. If a custom render function is provided onClick, url, and hover
 functionality will still work. Sectioned list functionality will also remain the
-same. Lastly, the styles wrapping the list items will match those of a `List`
-with no custom render function.
+same.
+
+Lastly, you will be required to implement the spacing, alignment and border
+bottom CSS logic.
 
 **Example: Custom Render Function with Custom Interface**
 
@@ -126,17 +135,35 @@ const items: ProductListItemProps[] = [
   { id: 4, name: "Screwdriver", price: "$10.00", section: "Hand Tools", onClick: () => alert("Screwdriver clicked") },
 ];
 
+
 const renderProductItem = (item: ProductListItemProps) => (
-    <Flex template={["shrink", "grow"]} align="start">
+    <div className="customContainer">
         <Text>{item.price}</Text>
         <Heading level={4}>{item.name}</Heading>
-    </Flex>
+    </div>
   </div>
 );
 
 export const CustomRenderExample = () => (
   <List items={items} customRenderItem={renderProductItem} />
 );
+
+// *.module.css
+
+.customContainer {
+  display: flex;
+  alignItems: center;
+  justifyContent: flex-start;
+  text-align: left;
+}
+
+.customContainer > * {
+  padding: var(--space-small);
+}
+
+li > ul > li:not(:last-child) .customContainer {
+  border-bottom: var(--border-base) solid var(--color-border);
+}
 ```
 
 **In this example**:
@@ -145,6 +172,7 @@ export const CustomRenderExample = () => (
   `BaseListItemProps`.
 - The `customRenderItem` function provides complete control over how each item
   is rendered.
+- We replicate the padding, alignment and border logic
 
 **When to Use Custom Rendering:**
 
@@ -152,3 +180,13 @@ export const CustomRenderExample = () => (
   component can’t provide.
 - Create your own interface extending `BaseListItemProps` to define the fields
   you need.
+
+##### Replicating Default List Styles
+
+In the above example we must use `li > ul > li:not(:last-child) .{customClass}`
+because it is a sectioned list having nested ul and li elements.
+
+For a non sectioned list `li:not(:last-child) .{customClass}` would suffice.
+
+For the spacing, it is achieved with `small` padding on the item container, then
+an additional `small` padding on the elements inside.

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -198,33 +198,17 @@ const serviceProviderListItems: SPListItemProps[] = [
   },
 ];
 
-const itemCSS = `
-  li:not(:last-child) .my-item {
-    border-bottom: var(--border-base) solid var(--color-border);
-  }
-
-  .my-item {
-    padding: var(--space-small);
-    display: flex;
-    align-items: center;
-    gap: var(--space-small);
-  }
-`;
-
 function RenderServiceProviderList({
   listItem,
 }: {
   readonly listItem: SPListItemProps;
 }) {
   return (
-    <div className="my-item">
-      <style>{itemCSS}</style>
+    <Flex template={["shrink", "grow", "shrink"]} align="center">
       <Avatar imageUrl={listItem.avatarUrl} />
       <Heading level={4}>{listItem.name}</Heading>
-      <div style={{ marginLeft: "auto" }}>
-        <Icon name="arrowRight" size="base" color="interactive" />
-      </div>
-    </div>
+      <Icon name="arrowRight" size="base" color="interactive" />
+    </Flex>
   );
 }
 

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -227,22 +227,41 @@ const productsList: ProductListItemProps[] = [
   },
 ];
 
+const sectionedCSS = `
+  .product-list-item > * {
+    padding: var(--space-small);
+  }
+
+  li > ul > li:not(:last-child) .product-list-item {
+    border-bottom: var(--border-base) solid var(--color-border);
+  }
+`;
+
 function RenderProductList({
   listItem,
 }: {
   readonly listItem: ProductListItemProps;
 }) {
   return (
-    <Flex template={["shrink", "grow"]} align="center">
+    <div
+      className="product-list-item"
+      style={{
+        display: "flex",
+        justifyContent: "flex-start",
+        textAlign: "left",
+        padding: "var(--space-small)",
+      }}
+    >
+      <style>{sectionedCSS}</style>
       <FormatFile file={listItem.image} display="compact" displaySize="base" />
-      <div style={{ marginBottom: "8px" }}>
+      <Flex template={["grow"]}>
         <Heading level={4}>{listItem.name}</Heading>
         <Flex template={["grow", "shrink"]} align="start">
           <Text>{listItem.description}</Text>
           <Text>{listItem.price}</Text>
         </Flex>
-      </div>
-    </Flex>
+      </Flex>
+    </div>
   );
 }
 

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -11,7 +11,7 @@ import { Text } from "@jobber/components/Text";
 import { Flex } from "@jobber/components/Flex";
 import { Avatar } from "@jobber/components/Avatar";
 import { Heading } from "@jobber/components/Heading";
-import { Icon } from "@jobber/components/Icon";
+import { Icon, IconNames } from "@jobber/components/Icon";
 import { FileUpload } from "@jobber/components/InputFile";
 import { FormatFile } from "@jobber/components/FormatFile";
 
@@ -29,6 +29,16 @@ const BasicTemplate: ComponentStory<typeof List> = args => (
   <Card>
     <List {...args} />
   </Card>
+);
+
+const SimpleTemplate: ComponentStory<typeof List> = args => (
+  <div style={{ width: "fit-content" }}>
+    <Card>
+      <div style={{ padding: "var(--space-small)" }}>
+        <List {...args} />
+      </div>
+    </Card>
+  </div>
 );
 
 export const Basic = BasicTemplate.bind({});
@@ -90,6 +100,64 @@ const sectionedListItems: ListItemProps[] = [
   },
 ];
 SectionedListItems.args = { items: sectionedListItems };
+
+export const SimpleListWithCustomRenderer = SimpleTemplate.bind({});
+const simpleListItems: ListItemProps[] = [
+  {
+    id: 1,
+    icon: "addNote",
+    content: ["Add Note"],
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+  {
+    id: 2,
+    icon: "checkmark",
+    iconColor: "green",
+    content: "Approve",
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+  {
+    id: 3,
+    icon: "cog",
+    content: "Settings",
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+];
+
+interface SimpleListItemProps extends BaseListItemProps {
+  readonly content: string;
+  icon: IconNames;
+}
+
+SimpleListWithCustomRenderer.args = {
+  items: simpleListItems,
+  customRenderItem: (item: SimpleListItemProps) => (
+    <RenderSimpleItem listItem={item} />
+  ),
+};
+
+function RenderSimpleItem({
+  listItem,
+}: {
+  readonly listItem: SimpleListItemProps;
+}) {
+  return (
+    <div
+      style={{
+        borderRadius: "var(--radius-base)",
+        padding: "var(--space-small)",
+        textAlign: "center",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        gap: "var(--space-small)",
+      }}
+    >
+      <Icon name={listItem.icon} />
+      <Text>{listItem.content}</Text>
+    </div>
+  );
+}
 
 interface SPListItemProps extends BaseListItemProps {
   readonly name: string;

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import groupBy from "lodash/groupBy";
 import {
   BaseListItemProps,
   List,
@@ -95,6 +94,7 @@ SectionedListItems.args = { items: sectionedListItems };
 interface SPListItemProps extends BaseListItemProps {
   readonly name: string;
   readonly avatarUrl: string;
+  readonly onClick?: () => void;
 }
 
 const serviceProviderListItems: SPListItemProps[] = [
@@ -102,26 +102,31 @@ const serviceProviderListItems: SPListItemProps[] = [
     id: 1,
     name: "Rob Lane",
     avatarUrl: "https://randomuser.me/api/portraits/men/1.jpg",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 2,
     name: "Marlene Hamilton",
     avatarUrl: "https://randomuser.me/api/portraits/women/2.jpg",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 3,
     name: "Miriam Graves",
     avatarUrl: "https://randomuser.me/api/portraits/women/3.jpg",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 4,
     name: "Milton Payne",
     avatarUrl: "https://randomuser.me/api/portraits/men/3.jpg",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 5,
     name: "Madison Simmons",
     avatarUrl: "https://randomuser.me/api/portraits/women/4.jpg",
+    onClick: () => alert("TODO: Implement onClick"),
   },
 ];
 
@@ -131,19 +136,11 @@ function RenderServiceProviderList({
   readonly listItem: SPListItemProps;
 }) {
   return (
-    <div
-      style={{
-        padding: "16px",
-        // If this was outside of Storybook :not(:last-child) would be used
-        borderBottom: listItem.id !== 5 ? "1px solid 	#dadfe2" : "none",
-      }}
-    >
-      <Flex template={["shrink", "grow", "shrink"]} align="center">
-        <Avatar imageUrl={listItem.avatarUrl} />
-        <Heading level={4}>{listItem.name}</Heading>
-        <Icon name="arrowRight" size="base" color="interactive" />
-      </Flex>
-    </div>
+    <Flex template={["shrink", "grow", "shrink"]} align="center">
+      <Avatar imageUrl={listItem.avatarUrl} />
+      <Heading level={4}>{listItem.name}</Heading>
+      <Icon name="arrowRight" size="base" color="interactive" />
+    </Flex>
   );
 }
 
@@ -161,6 +158,7 @@ interface ProductListItemProps extends BaseListItemProps {
   readonly image: FileUpload;
   readonly price: string;
   readonly section: string;
+  readonly onClick?: () => void;
 }
 
 const imageFile: FileUpload = {
@@ -180,6 +178,7 @@ const productsList: ProductListItemProps[] = [
     image: imageFile,
     price: "$250.00",
     section: "Products",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 2,
@@ -188,6 +187,7 @@ const productsList: ProductListItemProps[] = [
     image: imageFile,
     price: "$85.00",
     section: "Products",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 3,
@@ -196,6 +196,7 @@ const productsList: ProductListItemProps[] = [
     image: imageFile,
     price: "$30.00",
     section: "Products",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 4,
@@ -204,6 +205,7 @@ const productsList: ProductListItemProps[] = [
     image: imageFile,
     price: "$50.00",
     section: "Services",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 5,
@@ -212,6 +214,7 @@ const productsList: ProductListItemProps[] = [
     image: imageFile,
     price: "$40.00",
     section: "Services",
+    onClick: () => alert("TODO: Implement onClick"),
   },
   {
     id: 6,
@@ -220,6 +223,7 @@ const productsList: ProductListItemProps[] = [
     image: imageFile,
     price: "$75.00",
     section: "Services",
+    onClick: () => alert("TODO: Implement onClick"),
   },
 ];
 
@@ -229,75 +233,23 @@ function RenderProductList({
   readonly listItem: ProductListItemProps;
 }) {
   return (
-    <div
-      style={{
-        padding: "16px",
-        // If this was outside of Storybook :not(:last-child) would be used
-        borderBottom: listItem.id !== 6 ? "1px solid 	#dadfe2" : "none",
-      }}
-    >
-      <Flex template={["shrink", "grow"]} align="center">
-        <FormatFile
-          file={listItem.image}
-          display="compact"
-          displaySize="base"
-        />
-        <div style={{ marginBottom: "8px" }}>
-          <Heading level={4}>{listItem.name}</Heading>
-          <Flex template={["grow", "shrink"]} align="start">
-            <Text>{listItem.description}</Text>
-            <Text>{listItem.price}</Text>
-          </Flex>
-        </div>
-      </Flex>
-    </div>
-  );
-}
-
-interface ProductSectionProps extends BaseListItemProps {
-  readonly products: ProductListItemProps[];
-}
-
-function groupProductsBySection(
-  items: ProductListItemProps[],
-): ProductSectionProps[] {
-  const grouped = groupBy(items, "section");
-
-  return Object.entries(grouped).map(([section, products]) => ({
-    id: section,
-    products,
-  }));
-}
-
-function RenderProductSection({
-  listItem,
-}: {
-  readonly listItem: ProductSectionProps;
-}) {
-  return (
-    <div>
-      <div
-        style={{
-          padding: "10px 0px 10px 16px",
-          borderBottom: "1px solid black",
-        }}
-      >
-        <Heading level={4}>{listItem.id}</Heading>
+    <Flex template={["shrink", "grow"]} align="center">
+      <FormatFile file={listItem.image} display="compact" displaySize="base" />
+      <div style={{ marginBottom: "8px" }}>
+        <Heading level={4}>{listItem.name}</Heading>
+        <Flex template={["grow", "shrink"]} align="start">
+          <Text>{listItem.description}</Text>
+          <Text>{listItem.price}</Text>
+        </Flex>
       </div>
-      <List
-        items={listItem.products}
-        customRenderItem={(item: ProductListItemProps) => (
-          <RenderProductList listItem={item} />
-        )}
-      />
-    </div>
+    </Flex>
   );
 }
 
 export const SectionedListWithCustomRenderer = BasicTemplate.bind({});
 SectionedListWithCustomRenderer.args = {
-  items: groupProductsBySection(productsList),
-  customRenderItem: (item: ProductSectionProps) => (
-    <RenderProductSection listItem={item} />
+  items: productsList,
+  customRenderItem: (item: ProductListItemProps) => (
+    <RenderProductList listItem={item} />
   ),
 };

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -101,65 +101,6 @@ const sectionedListItems: ListItemProps[] = [
 ];
 SectionedListItems.args = { items: sectionedListItems };
 
-export const SimpleListWithCustomRenderer = SimpleTemplate.bind({});
-const simpleListItems: ListItemProps[] = [
-  {
-    id: 1,
-    icon: "addNote",
-    content: ["Add Note"],
-    onClick: () => alert("TODO: Implement onClick"),
-  },
-  {
-    id: 2,
-    icon: "checkmark",
-    iconColor: "green",
-    content: "Approve",
-    onClick: () => alert("TODO: Implement onClick"),
-  },
-  {
-    id: 3,
-    icon: "cog",
-    content: "Settings",
-    onClick: () => alert("TODO: Implement onClick"),
-  },
-];
-
-interface SimpleListItemProps extends BaseListItemProps {
-  readonly content: string;
-  icon: IconNames;
-}
-
-SimpleListWithCustomRenderer.args = {
-  items: simpleListItems,
-  customRenderItem: (item: SimpleListItemProps) => (
-    <RenderSimpleItem listItem={item} />
-  ),
-  customItemStyles: true,
-};
-
-function RenderSimpleItem({
-  listItem,
-}: {
-  readonly listItem: SimpleListItemProps;
-}) {
-  return (
-    <div
-      style={{
-        borderRadius: "var(--radius-base)",
-        padding: "var(--space-small)",
-        textAlign: "center",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        gap: "var(--space-small)",
-      }}
-    >
-      <Icon name={listItem.icon} />
-      <Text>{listItem.content}</Text>
-    </div>
-  );
-}
-
 interface SPListItemProps extends BaseListItemProps {
   readonly name: string;
   readonly avatarUrl: string;
@@ -322,3 +263,62 @@ SectionedListWithCustomRenderer.args = {
     <RenderProductList listItem={item} />
   ),
 };
+
+export const SimpleListWithCustomStyles = SimpleTemplate.bind({});
+const simpleListItems: ListItemProps[] = [
+  {
+    id: 1,
+    icon: "addNote",
+    content: ["Add Note"],
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+  {
+    id: 2,
+    icon: "checkmark",
+    iconColor: "green",
+    content: "Approve",
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+  {
+    id: 3,
+    icon: "cog",
+    content: "Settings",
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+];
+
+interface SimpleListItemProps extends BaseListItemProps {
+  readonly content: string;
+  icon: IconNames;
+}
+
+SimpleListWithCustomStyles.args = {
+  items: simpleListItems,
+  customRenderItem: (item: SimpleListItemProps) => (
+    <RenderSimpleItem listItem={item} />
+  ),
+  customItemStyles: true,
+};
+
+function RenderSimpleItem({
+  listItem,
+}: {
+  readonly listItem: SimpleListItemProps;
+}) {
+  return (
+    <div
+      style={{
+        borderRadius: "var(--radius-base)",
+        padding: "var(--space-small)",
+        textAlign: "center",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        gap: "var(--space-small)",
+      }}
+    >
+      <Icon name={listItem.icon} />
+      <Text>{listItem.content}</Text>
+    </div>
+  );
+}

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -130,17 +130,33 @@ const serviceProviderListItems: SPListItemProps[] = [
   },
 ];
 
+const itemCSS = `
+  li:not(:last-child) .my-item {
+    border-bottom: var(--border-base) solid var(--color-border);
+  }
+
+  .my-item {
+    padding: var(--space-small);
+    display: flex;
+    align-items: center;
+    gap: var(--space-small);
+  }
+`;
+
 function RenderServiceProviderList({
   listItem,
 }: {
   readonly listItem: SPListItemProps;
 }) {
   return (
-    <Flex template={["shrink", "grow", "shrink"]} align="center">
+    <div className="my-item">
+      <style>{itemCSS}</style>
       <Avatar imageUrl={listItem.avatarUrl} />
       <Heading level={4}>{listItem.name}</Heading>
-      <Icon name="arrowRight" size="base" color="interactive" />
-    </Flex>
+      <div style={{ marginLeft: "auto" }}>
+        <Icon name="arrowRight" size="base" color="interactive" />
+      </div>
+    </div>
   );
 }
 
@@ -228,6 +244,13 @@ const productsList: ProductListItemProps[] = [
 ];
 
 const sectionedCSS = `
+  .product-list-item {
+    display: flex;
+    justify-content: flex-start;
+    text-align: left;
+    padding: var(--space-small);
+  }
+
   .product-list-item > * {
     padding: var(--space-small);
   }
@@ -243,15 +266,7 @@ function RenderProductList({
   readonly listItem: ProductListItemProps;
 }) {
   return (
-    <div
-      className="product-list-item"
-      style={{
-        display: "flex",
-        justifyContent: "flex-start",
-        textAlign: "left",
-        padding: "var(--space-small)",
-      }}
-    >
+    <div className="product-list-item">
       <style>{sectionedCSS}</style>
       <FormatFile file={listItem.image} display="compact" displaySize="base" />
       <Flex template={["grow"]}>

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -1,7 +1,20 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { List, ListItem } from "@jobber/components/List";
+import groupBy from "lodash/groupBy";
+import {
+  BaseListItemProps,
+  List,
+  ListItem,
+  ListItemProps,
+} from "@jobber/components/List";
 import { Card } from "@jobber/components/Card";
+import { Text } from "@jobber/components/Text";
+import { Flex } from "@jobber/components/Flex";
+import { Avatar } from "@jobber/components/Avatar";
+import { Heading } from "@jobber/components/Heading";
+import { Icon } from "@jobber/components/Icon";
+import { FileUpload } from "@jobber/components/InputFile";
+import { FormatFile } from "@jobber/components/FormatFile";
 
 export default {
   title: "Components/Lists and Tables/List/Web",
@@ -20,63 +33,271 @@ const BasicTemplate: ComponentStory<typeof List> = args => (
 );
 
 export const Basic = BasicTemplate.bind({});
-Basic.args = {
-  items: [
-    {
-      id: 1,
-      icon: "wallet",
-      iconColor: "orange",
-      content: "Payment for Invoice #39",
-      value: "-$300.00",
-      caption: "Sep 25, 2019",
-      onClick: () => alert("TODO: Implement onClick"),
-    },
-    {
-      id: 3,
-      icon: "paidInvoice",
-      content: "Invoice #39",
-      value: "$300.00",
-      caption: "Sep 24, 2019",
-      onClick: () => alert("TODO: Implement onClick"),
-    },
-  ],
-};
+const basicItems: ListItemProps[] = [
+  {
+    id: 1,
+    icon: "wallet",
+    iconColor: "orange",
+    content: "Payment for Invoice #39",
+    value: "-$300.00",
+    caption: "Sep 25, 2019",
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+  {
+    id: 3,
+    icon: "paidInvoice",
+    content: "Invoice #39",
+    value: "$300.00",
+    caption: "Sep 24, 2019",
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+];
+Basic.args = { items: basicItems };
 
 export const SectionedListItems = BasicTemplate.bind({});
-SectionedListItems.args = {
-  items: [
-    {
-      id: 1,
-      icon: "addNote",
-      title: "Darryl Tec added a note",
-      content: [
-        "_'Called the client. Asked if they want the luxury package, they said yes!'_",
-        "Deck Build",
-      ],
-      caption: "1 minute ago",
-      section: "Today",
-      isActive: true,
-      onClick: () => alert("TODO: Implement onClick"),
-    },
-    {
-      id: 2,
-      icon: "checkmark",
-      iconColor: "green",
-      title: "Josh Elford completed a visit",
-      content: "Annual Maintenance",
-      caption: "2 hours ago",
-      section: "Today",
-      onClick: () => alert("TODO: Implement onClick"),
-    },
-    {
-      id: 3,
-      icon: "badInvoice",
-      title: "Payment failed",
-      content: "For services rendered",
-      value: "$300.00",
-      caption: "1 day ago",
-      onClick: () => alert("TODO: Implement onClick"),
-      section: "Yesterday",
-    },
-  ],
+const sectionedListItems: ListItemProps[] = [
+  {
+    id: 1,
+    icon: "addNote",
+    title: "Darryl Tec added a note",
+    content: [
+      "_'Called the client. Asked if they want the luxury package, they said yes!'_",
+      "Deck Build",
+    ],
+    caption: "1 minute ago",
+    section: "Today",
+    isActive: true,
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+  {
+    id: 2,
+    icon: "checkmark",
+    iconColor: "green",
+    title: "Josh Elford completed a visit",
+    content: "Annual Maintenance",
+    caption: "2 hours ago",
+    section: "Today",
+    onClick: () => alert("TODO: Implement onClick"),
+  },
+  {
+    id: 3,
+    icon: "badInvoice",
+    title: "Payment failed",
+    content: "For services rendered",
+    value: "$300.00",
+    caption: "1 day ago",
+    onClick: () => alert("TODO: Implement onClick"),
+    section: "Yesterday",
+  },
+];
+SectionedListItems.args = { items: sectionedListItems };
+
+interface SPListItemProps extends BaseListItemProps {
+  readonly name: string;
+  readonly avatarUrl: string;
+}
+
+const serviceProviderListItems: SPListItemProps[] = [
+  {
+    id: 1,
+    name: "Rob Lane",
+    avatarUrl: "https://randomuser.me/api/portraits/men/1.jpg",
+  },
+  {
+    id: 2,
+    name: "Marlene Hamilton",
+    avatarUrl: "https://randomuser.me/api/portraits/women/2.jpg",
+  },
+  {
+    id: 3,
+    name: "Miriam Graves",
+    avatarUrl: "https://randomuser.me/api/portraits/women/3.jpg",
+  },
+  {
+    id: 4,
+    name: "Milton Payne",
+    avatarUrl: "https://randomuser.me/api/portraits/men/3.jpg",
+  },
+  {
+    id: 5,
+    name: "Madison Simmons",
+    avatarUrl: "https://randomuser.me/api/portraits/women/4.jpg",
+  },
+];
+
+function RenderServiceProviderList({
+  listItem,
+}: {
+  readonly listItem: SPListItemProps;
+}) {
+  return (
+    <div
+      style={{
+        padding: "16px",
+        // If this was outside of Storybook :not(:last-child) would be used
+        borderBottom: listItem.id !== 5 ? "1px solid 	#dadfe2" : "none",
+      }}
+    >
+      <Flex template={["shrink", "grow", "shrink"]} align="center">
+        <Avatar imageUrl={listItem.avatarUrl} />
+        <Heading level={4}>{listItem.name}</Heading>
+        <Icon name="arrowRight" size="base" color="interactive" />
+      </Flex>
+    </div>
+  );
+}
+
+export const ListWithCustomRenderer = BasicTemplate.bind({});
+ListWithCustomRenderer.args = {
+  items: serviceProviderListItems,
+  customRenderItem: (item: SPListItemProps) => (
+    <RenderServiceProviderList listItem={item} />
+  ),
+};
+
+interface ProductListItemProps extends BaseListItemProps {
+  readonly name: string;
+  readonly description: string;
+  readonly image: FileUpload;
+  readonly price: string;
+  readonly section: string;
+}
+
+const imageFile: FileUpload = {
+  key: "abc",
+  name: "image_of_something.png",
+  type: "image/png",
+  size: 213402324,
+  progress: 1,
+  src: () => Promise.resolve("https://picsum.photos/250"),
+};
+
+const productsList: ProductListItemProps[] = [
+  {
+    id: 1,
+    name: "Lawn Mower",
+    description: "A reliable lawn mower for home or commercial use.",
+    image: imageFile,
+    price: "$250.00",
+    section: "Products",
+  },
+  {
+    id: 2,
+    name: "Hedge Trimmer",
+    description: "Electric hedge trimmer for precise shaping.",
+    image: imageFile,
+    price: "$85.00",
+    section: "Products",
+  },
+  {
+    id: 3,
+    name: "Garden Fertilizer",
+    description: "Premium fertilizer for healthy lawn growth.",
+    image: imageFile,
+    price: "$30.00",
+    section: "Products",
+  },
+  {
+    id: 4,
+    name: "Lawn Mowing Service",
+    description: "Keep your lawn tidy with regular mowing.",
+    image: imageFile,
+    price: "$50.00",
+    section: "Services",
+  },
+  {
+    id: 5,
+    name: "Weed Control Service",
+    description: "Prevent and eliminate unwanted weeds.",
+    image: imageFile,
+    price: "$40.00",
+    section: "Services",
+  },
+  {
+    id: 6,
+    name: "Hedge Trimming Service",
+    description: "Shape your hedges to perfection.",
+    image: imageFile,
+    price: "$75.00",
+    section: "Services",
+  },
+];
+
+function RenderProductList({
+  listItem,
+}: {
+  readonly listItem: ProductListItemProps;
+}) {
+  return (
+    <div
+      style={{
+        padding: "16px",
+        // If this was outside of Storybook :not(:last-child) would be used
+        borderBottom: listItem.id !== 5 ? "1px solid 	#dadfe2" : "none",
+      }}
+    >
+      <Flex template={["shrink", "grow"]} align="center">
+        <FormatFile
+          file={listItem.image}
+          display="compact"
+          displaySize="base"
+        />
+        <div style={{ marginBottom: "8px" }}>
+          <Heading level={4}>{listItem.name}</Heading>
+          <Flex template={["grow", "shrink"]} align="start">
+            <Text>{listItem.description}</Text>
+            <Text>{listItem.price}</Text>
+          </Flex>
+        </div>
+      </Flex>
+    </div>
+  );
+}
+
+interface ProductSectionProps extends BaseListItemProps {
+  readonly products: ProductListItemProps[];
+}
+
+function groupProductsBySection(
+  items: ProductListItemProps[],
+): ProductSectionProps[] {
+  const grouped = groupBy(items, "section");
+
+  return Object.entries(grouped).map(([section, products]) => ({
+    id: section,
+    products,
+  }));
+}
+
+function RenderProductSection({
+  listItem,
+}: {
+  readonly listItem: ProductSectionProps;
+}) {
+  return (
+    <div>
+      <div
+        style={{
+          padding: "10px 0px 10px 16px",
+          borderBottom: "1px solid black",
+        }}
+      >
+        <Heading level={4}>{listItem.id}</Heading>
+      </div>
+      <List
+        items={listItem.products}
+        customRenderItem={(item: ProductListItemProps) => (
+          <RenderProductList listItem={item} />
+        )}
+      />
+    </div>
+  );
+}
+
+export const SectionedListWithCustomRenderer = BasicTemplate.bind({});
+SectionedListWithCustomRenderer.args = {
+  items: groupProductsBySection(productsList),
+  customRenderItem: (item: ProductSectionProps) => (
+    <RenderProductSection listItem={item} />
+  ),
 };

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -311,40 +311,22 @@ const productsList: ProductListItemProps[] = [
   },
 ];
 
-const sectionedCSS = `
-  .product-list-item {
-    display: flex;
-    justify-content: flex-start;
-    text-align: left;
-    padding: var(--space-small);
-  }
-
-  .product-list-item > * {
-    padding: var(--space-small);
-  }
-
-  li > ul > li:not(:last-child) .product-list-item {
-    border-bottom: var(--border-base) solid var(--color-border);
-  }
-`;
-
 function RenderProductList({
   listItem,
 }: {
   readonly listItem: ProductListItemProps;
 }) {
   return (
-    <div className="product-list-item">
-      <style>{sectionedCSS}</style>
+    <Flex template={["shrink", "grow"]} align="center">
       <FormatFile file={listItem.image} display="compact" displaySize="base" />
-      <Flex template={["grow"]}>
+      <div style={{ marginBottom: "8px" }}>
         <Heading level={4}>{listItem.name}</Heading>
         <Flex template={["grow", "shrink"]} align="start">
           <Text>{listItem.description}</Text>
           <Text>{listItem.price}</Text>
         </Flex>
-      </Flex>
-    </div>
+      </div>
+    </Flex>
   );
 }
 

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -134,6 +134,7 @@ SimpleListWithCustomRenderer.args = {
   customRenderItem: (item: SimpleListItemProps) => (
     <RenderSimpleItem listItem={item} />
   ),
+  customItemStyles: true,
 };
 
 function RenderSimpleItem({

--- a/docs/components/List/Web.stories.tsx
+++ b/docs/components/List/Web.stories.tsx
@@ -233,7 +233,7 @@ function RenderProductList({
       style={{
         padding: "16px",
         // If this was outside of Storybook :not(:last-child) would be used
-        borderBottom: listItem.id !== 5 ? "1px solid 	#dadfe2" : "none",
+        borderBottom: listItem.id !== 6 ? "1px solid 	#dadfe2" : "none",
       }}
     >
       <Flex template={["shrink", "grow"]} align="center">

--- a/packages/components/src/List/List.test.tsx
+++ b/packages/components/src/List/List.test.tsx
@@ -144,7 +144,7 @@ describe("When a list item is clicked", () => {
 });
 
 describe("When a list is provided a custom render function", () => {
-  test("it should use the custom render function instead of ListItem", () => {
+  test("it should use the custom render instead of default ListItem behaviour", () => {
     interface CustomListItemProps extends BaseListItemProps {
       readonly name: string;
       readonly address: string;
@@ -174,6 +174,59 @@ describe("When a list is provided a custom render function", () => {
             id: 2,
             name: "Joe Doe",
             address: "456 Main St",
+          },
+        ]}
+        customRenderItem={item => <CustomRenderer listItem={item} />}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test("it should handle a sectioned list with a custom render function", () => {
+    interface CustomListItemProps extends BaseListItemProps {
+      readonly name: string;
+      readonly address: string;
+      readonly section: string;
+    }
+
+    function CustomRenderer({
+      listItem,
+    }: {
+      readonly listItem: CustomListItemProps;
+    }) {
+      return (
+        <div>
+          <Text>{listItem.name}</Text>
+          <Text>{listItem.address}</Text>
+        </div>
+      );
+    }
+    const { container } = render(
+      <List
+        items={[
+          {
+            id: 1,
+            name: "Jane Doe",
+            address: "123 Main St",
+            section: "Employees",
+          },
+          {
+            id: 2,
+            name: "Joe Doe",
+            address: "456 Main St",
+            section: "Employees",
+          },
+          {
+            id: 3,
+            name: "Milton Bradley",
+            address: "123 Fake St",
+            section: "Customers",
+          },
+          {
+            id: 4,
+            name: "Tony Redman",
+            address: "456 Fake St",
+            section: "Customers",
           },
         ]}
         customRenderItem={item => <CustomRenderer listItem={item} />}

--- a/packages/components/src/List/List.test.tsx
+++ b/packages/components/src/List/List.test.tsx
@@ -234,4 +234,43 @@ describe("When a list is provided a custom render function", () => {
     );
     expect(container).toMatchSnapshot();
   });
+
+  test("it should allow for custom styles", () => {
+    interface CustomListItemProps extends BaseListItemProps {
+      readonly name: string;
+      readonly address: string;
+    }
+
+    function CustomRenderer({
+      listItem,
+    }: {
+      readonly listItem: CustomListItemProps;
+    }) {
+      return (
+        <div style={{ padding: "10px" }}>
+          <Text>{listItem.name}</Text>
+          <Text>{listItem.address}</Text>
+        </div>
+      );
+    }
+    const { container } = render(
+      <List
+        items={[
+          {
+            id: 1,
+            name: "Jane Doe",
+            address: "123 Main St",
+          },
+          {
+            id: 2,
+            name: "Joe Doe",
+            address: "456 Main St",
+          },
+        ]}
+        customRenderItem={item => <CustomRenderer listItem={item} />}
+        customItemStyles={true}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/packages/components/src/List/List.test.tsx
+++ b/packages/components/src/List/List.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
-import { List } from ".";
+import { BaseListItemProps, List } from ".";
+import { Text } from "../Text";
 
 it("renders 1 List item with all the props", () => {
   const { container } = render(
@@ -17,6 +18,46 @@ it("renders 1 List item with all the props", () => {
           isActive: true,
           section: "Notification",
           title: "Jordan Yeo completed a visit",
+          onClick: () => {
+            /* do stuff */
+          },
+        },
+      ]}
+    />,
+  );
+  expect(container).toMatchSnapshot();
+});
+
+it("renders a list with multiple sections", () => {
+  const { container } = render(
+    <List
+      items={[
+        {
+          value: "$30.00",
+          content: ["Build a deck", "Fa la la la la"],
+          caption: "Sep 24, 2019",
+          url: "#",
+          icon: "checkmark",
+          iconColor: "green",
+          id: 1,
+          isActive: true,
+          section: "Notifications",
+          title: "Jordan Yeo completed a visit",
+          onClick: () => {
+            /* do stuff */
+          },
+        },
+        {
+          value: "$40.00",
+          content: ["Foo bar", "Baz"],
+          caption: "Sep 25, 2019",
+          url: "#",
+          icon: "checkmark",
+          iconColor: "green",
+          id: 1,
+          isActive: true,
+          section: "Urgent Notifications",
+          title: "Jordan Yeo requires assistance",
           onClick: () => {
             /* do stuff */
           },
@@ -99,5 +140,45 @@ describe("When a list item is clicked", () => {
 
     fireEvent.click(getByRole("button"));
     expect(handleClick).toHaveBeenCalled();
+  });
+});
+
+describe("When a list is provided a custom render function", () => {
+  test("it should use the custom render function instead of ListItem", () => {
+    interface CustomListItemProps extends BaseListItemProps {
+      readonly name: string;
+      readonly address: string;
+    }
+
+    function CustomRenderer({
+      listItem,
+    }: {
+      readonly listItem: CustomListItemProps;
+    }) {
+      return (
+        <div>
+          <Text>{listItem.name}</Text>
+          <Text>{listItem.address}</Text>
+        </div>
+      );
+    }
+    const { container } = render(
+      <List
+        items={[
+          {
+            id: 1,
+            name: "Jane Doe",
+            address: "123 Main St",
+          },
+          {
+            id: 2,
+            name: "Joe Doe",
+            address: "456 Main St",
+          },
+        ]}
+        customRenderItem={item => <CustomRenderer listItem={item} />}
+      />,
+    );
+    expect(container).toMatchSnapshot();
   });
 });

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -22,7 +22,8 @@ interface ListProps<T extends BaseListItemProps = ListItemProps> {
    */
   readonly customRenderItem?: (item: T) => React.ReactNode;
   /**
-   * Set to true for more control over the item styles
+   * Set to true for more control over the item styles. Only modifies styles
+   * when used with customRenderItem.
    */
   readonly customItemStyles?: boolean;
 }

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -2,20 +2,40 @@ import React from "react";
 import classnames from "classnames";
 import get from "lodash/get";
 import groupBy from "lodash/groupBy";
-import styles from "./List.module.css";
+import { Typography } from "@jobber/components/Typography";
+import {
+  BaseListItemProps,
+  ListItem,
+  ListItemProps,
+} from "@jobber/components/List/ListItem";
 import sectionStyles from "./SectionHeader.module.css";
-import { ListItem, ListItemProps } from "./ListItem";
-import { Typography } from "../Typography";
+import styles from "./List.module.css";
 
-interface ListProps {
+interface ListProps<T extends BaseListItemProps = ListItemProps> {
   /**
    * Array of the list items.
    */
-  readonly items: ListItemProps[];
+  readonly items: T[];
+  /**
+   * A custom render function
+   */
+  readonly customRenderItem?: (item: T) => React.ReactNode;
 }
 
-export function List({ items }: ListProps) {
-  const isSectioned = items.some(item => item.section);
+export function List<T extends BaseListItemProps = ListItemProps>({
+  items,
+  customRenderItem,
+}: ListProps<T>) {
+  if (customRenderItem) {
+    return (
+      <ul className={styles.list}>
+        {items.map(item => (
+          <li key={item.id}>{customRenderItem(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+  const isSectioned = items.some(item => "section" in item && item.section);
 
   if (isSectioned) {
     return <SectionedList items={items} />;

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -27,37 +27,34 @@ export function List<T extends BaseListItemProps = ListItemProps>({
   items,
   customRenderItem,
 }: ListProps<T>) {
-  if (customRenderItem) {
-    return (
-      <ul className={styles.list}>
-        {items.map(item => (
-          <li key={item.id}>{customRenderItem(item)}</li>
-        ))}
-      </ul>
-    );
-  }
   const isSectioned = items.some(item => "section" in item && item.section);
 
   if (isSectioned) {
-    return <SectionedList items={items} />;
+    return <SectionedList items={items} customRenderItem={customRenderItem} />;
   } else {
-    return <DisplayList items={items} />;
+    return <DisplayList items={items} customRenderItem={customRenderItem} />;
   }
 }
 
-function DisplayList({ items }: ListProps) {
+function DisplayList<T extends BaseListItemProps = ListItemProps>({
+  items,
+  customRenderItem,
+}: ListProps<T>) {
   return (
     <ul className={styles.list}>
       {items.map(item => (
         <li key={item.id} className={styles.item}>
-          <ListItem {...item} />
+          <ListItem {...item} customRenderItem={customRenderItem} />
         </li>
       ))}
     </ul>
   );
 }
 
-function SectionedList({ items }: ListProps) {
+function SectionedList<T extends BaseListItemProps = ListItemProps>({
+  items,
+  customRenderItem,
+}: ListProps<T>) {
   const sectionedItems = groupBy(items, item => get(item, "section", "Other"));
   const sectionHeaderClassNames = classnames(sectionStyles.sectionHeader);
 
@@ -74,7 +71,7 @@ function SectionedList({ items }: ListProps) {
           <ul className={styles.list}>
             {sectionedItems[sectionName].map(item => (
               <li key={item.id} className={styles.item}>
-                <ListItem {...item} />
+                <ListItem {...item} customRenderItem={customRenderItem} />
               </li>
             ))}
           </ul>

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -21,32 +21,55 @@ interface ListProps<T extends BaseListItemProps = ListItemProps> {
    * rendering
    */
   readonly customRenderItem?: (item: T) => React.ReactNode;
+  /**
+   * Set to true for more control over the item styles
+   */
+  readonly customItemStyles?: boolean;
 }
 
 export function List<T extends BaseListItemProps = ListItemProps>({
   items,
   customRenderItem,
+  customItemStyles,
 }: ListProps<T>) {
   const isSectioned = items.some(item => "section" in item && item.section);
 
   if (isSectioned) {
-    return <SectionedList items={items} customRenderItem={customRenderItem} />;
+    return (
+      <SectionedList
+        items={items}
+        customRenderItem={customRenderItem}
+        customItemStyles={customItemStyles}
+      />
+    );
   } else {
-    return <DisplayList items={items} customRenderItem={customRenderItem} />;
+    return (
+      <DisplayList
+        items={items}
+        customRenderItem={customRenderItem}
+        customItemStyles={customItemStyles}
+      />
+    );
   }
 }
 
 function DisplayList<T extends BaseListItemProps = ListItemProps>({
   items,
   customRenderItem,
+  customItemStyles,
 }: ListProps<T>) {
-  const itemClassNames = classnames(!customRenderItem && styles.item);
+  const omitDefaultStyles = customRenderItem && customItemStyles;
+  const itemClassNames = classnames(!omitDefaultStyles && styles.item);
 
   return (
     <ul className={styles.list}>
       {items.map(item => (
         <li key={item.id} className={itemClassNames}>
-          <ListItem {...item} customRenderItem={customRenderItem} />
+          <ListItem
+            {...item}
+            customRenderItem={customRenderItem}
+            customItemStyles={customItemStyles}
+          />
         </li>
       ))}
     </ul>
@@ -56,10 +79,13 @@ function DisplayList<T extends BaseListItemProps = ListItemProps>({
 function SectionedList<T extends BaseListItemProps = ListItemProps>({
   items,
   customRenderItem,
+  customItemStyles,
 }: ListProps<T>) {
   const sectionedItems = groupBy(items, item => get(item, "section", "Other"));
   const sectionHeaderClassNames = classnames(sectionStyles.sectionHeader);
-  const itemClassNames = classnames(!customRenderItem && styles.item);
+
+  const omitDefaultStyles = customRenderItem && customItemStyles;
+  const itemClassNames = classnames(!omitDefaultStyles && styles.item);
 
   return (
     <ul className={styles.list}>
@@ -74,7 +100,11 @@ function SectionedList<T extends BaseListItemProps = ListItemProps>({
           <ul className={styles.list}>
             {sectionedItems[sectionName].map(item => (
               <li key={item.id} className={itemClassNames}>
-                <ListItem {...item} customRenderItem={customRenderItem} />
+                <ListItem
+                  {...item}
+                  customRenderItem={customRenderItem}
+                  customItemStyles={customItemStyles}
+                />
               </li>
             ))}
           </ul>

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -17,7 +17,8 @@ interface ListProps<T extends BaseListItemProps = ListItemProps> {
    */
   readonly items: T[];
   /**
-   * A custom render function
+   * A function that will be called for each item instead of the default
+   * rendering
    */
   readonly customRenderItem?: (item: T) => React.ReactNode;
 }

--- a/packages/components/src/List/List.tsx
+++ b/packages/components/src/List/List.tsx
@@ -40,10 +40,12 @@ function DisplayList<T extends BaseListItemProps = ListItemProps>({
   items,
   customRenderItem,
 }: ListProps<T>) {
+  const itemClassNames = classnames(!customRenderItem && styles.item);
+
   return (
     <ul className={styles.list}>
       {items.map(item => (
-        <li key={item.id} className={styles.item}>
+        <li key={item.id} className={itemClassNames}>
           <ListItem {...item} customRenderItem={customRenderItem} />
         </li>
       ))}
@@ -57,6 +59,7 @@ function SectionedList<T extends BaseListItemProps = ListItemProps>({
 }: ListProps<T>) {
   const sectionedItems = groupBy(items, item => get(item, "section", "Other"));
   const sectionHeaderClassNames = classnames(sectionStyles.sectionHeader);
+  const itemClassNames = classnames(!customRenderItem && styles.item);
 
   return (
     <ul className={styles.list}>
@@ -70,7 +73,7 @@ function SectionedList<T extends BaseListItemProps = ListItemProps>({
 
           <ul className={styles.list}>
             {sectionedItems[sectionName].map(item => (
-              <li key={item.id} className={styles.item}>
+              <li key={item.id} className={itemClassNames}>
                 <ListItem {...item} customRenderItem={customRenderItem} />
               </li>
             ))}

--- a/packages/components/src/List/ListItem.module.css
+++ b/packages/components/src/List/ListItem.module.css
@@ -26,14 +26,6 @@
 .hoverable:hover,
 .hoverable:focus {
   outline: none;
-}
-
-.isActive > * {
-  background-color: var(--color-surface--background);
-}
-
-.hoverable:hover > *,
-.hoverable:focus > * {
   background-color: var(--color-surface--hover);
 }
 
@@ -56,8 +48,12 @@
   text-align: right;
 }
 
-.isActive:hover > *,
-.isActive:focus > * {
+.isActive {
+  background-color: var(--color-surface--background);
+}
+
+.isActive:hover,
+.isActive:focus {
   background-color: var(--color-surface--background--hover);
 }
 

--- a/packages/components/src/List/ListItem.module.css
+++ b/packages/components/src/List/ListItem.module.css
@@ -6,23 +6,27 @@
   appearance: none;
 }
 
+.action > * {
+  transition: background-color var(--timing-base);
+}
+
 .defaultContainer > * {
   display: flex;
   box-sizing: border-box;
   text-align: left;
   flex: 1;
-  align-items: flex-start;
 }
 
 .customItem > * {
   padding: var(--space-base);
 }
 
-.paddedChild {
+.defaultContent {
+  align-items: flex-start;
   padding: var(--space-small);
 }
 
-.paddedChild > * {
+.defaultContent > * {
   padding: var(--space-small);
 }
 

--- a/packages/components/src/List/ListItem.module.css
+++ b/packages/components/src/List/ListItem.module.css
@@ -6,16 +6,23 @@
   appearance: none;
 }
 
-.defaultContainer {
+.defaultContainer > * {
   display: flex;
   box-sizing: border-box;
-  padding: var(--space-small);
   text-align: left;
   flex: 1;
   align-items: flex-start;
 }
 
-.defaultContainer > * {
+.customItem > * {
+  padding: var(--space-base);
+}
+
+.paddedChild {
+  padding: var(--space-small);
+}
+
+.paddedChild > * {
   padding: var(--space-small);
 }
 
@@ -26,6 +33,14 @@
 .hoverable:hover,
 .hoverable:focus {
   outline: none;
+}
+
+.isActive > * {
+  background-color: var(--color-surface--background);
+}
+
+.hoverable:hover > *,
+.hoverable:focus > * {
   background-color: var(--color-surface--hover);
 }
 
@@ -36,24 +51,18 @@
   height: var(--space-large);
   box-sizing: content-box;
 }
-
 .info {
   flex: 1 1 auto;
   min-width: 0;
   align-self: center;
 }
-
 .amount {
   flex: 0 0 auto;
   text-align: right;
 }
 
-.isActive {
-  background-color: var(--color-surface--background);
-}
-
-.isActive:hover,
-.isActive:focus {
+.isActive:hover > *,
+.isActive:focus > * {
   background-color: var(--color-surface--background--hover);
 }
 

--- a/packages/components/src/List/ListItem.module.css
+++ b/packages/components/src/List/ListItem.module.css
@@ -2,6 +2,7 @@
   width: 100%;
   padding: 0;
   border: none;
+  text-align: left;
   background-color: transparent;
   appearance: none;
 }
@@ -10,18 +11,14 @@
   transition: background-color var(--timing-base);
 }
 
-.defaultContainer > * {
-  display: flex;
-  box-sizing: border-box;
-  text-align: left;
-  flex: 1;
-}
-
 .customItem > * {
   padding: var(--space-base);
 }
 
 .defaultContent {
+  display: flex;
+  box-sizing: border-box;
+  flex: 1;
   align-items: flex-start;
   padding: var(--space-small);
 }

--- a/packages/components/src/List/ListItem.module.css
+++ b/packages/components/src/List/ListItem.module.css
@@ -1,18 +1,21 @@
 .action {
-  display: flex;
   width: 100%;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  appearance: none;
+}
+
+.defaultContainer {
+  display: flex;
   box-sizing: border-box;
   padding: var(--space-small);
-  border: none;
   text-align: left;
-  text-decoration: none;
-  background-color: transparent;
-  transition: background-color var(--timing-base);
-  appearance: none;
+  flex: 1;
   align-items: flex-start;
 }
 
-.action > * {
+.defaultContainer > * {
   padding: var(--space-small);
 }
 
@@ -23,6 +26,14 @@
 .hoverable:hover,
 .hoverable:focus {
   outline: none;
+}
+
+.isActive > * {
+  background-color: var(--color-surface--background);
+}
+
+.hoverable:hover > *,
+.hoverable:focus > * {
   background-color: var(--color-surface--hover);
 }
 
@@ -45,14 +56,8 @@
   text-align: right;
 }
 
-/* States */
-
-.isActive {
-  background-color: var(--color-surface--background);
-}
-
-.isActive:hover,
-.isActive:focus {
+.isActive:hover > *,
+.isActive:focus > * {
   background-color: var(--color-surface--background--hover);
 }
 

--- a/packages/components/src/List/ListItem.module.css.d.ts
+++ b/packages/components/src/List/ListItem.module.css.d.ts
@@ -1,10 +1,11 @@
 declare const styles: {
   readonly "action": string;
+  readonly "defaultContainer": string;
   readonly "hoverable": string;
+  readonly "isActive": string;
   readonly "icon": string;
   readonly "info": string;
   readonly "amount": string;
-  readonly "isActive": string;
   readonly "truncate": string;
 };
 export = styles;

--- a/packages/components/src/List/ListItem.module.css.d.ts
+++ b/packages/components/src/List/ListItem.module.css.d.ts
@@ -2,7 +2,7 @@ declare const styles: {
   readonly "action": string;
   readonly "defaultContainer": string;
   readonly "customItem": string;
-  readonly "paddedChild": string;
+  readonly "defaultContent": string;
   readonly "hoverable": string;
   readonly "isActive": string;
   readonly "icon": string;

--- a/packages/components/src/List/ListItem.module.css.d.ts
+++ b/packages/components/src/List/ListItem.module.css.d.ts
@@ -2,10 +2,10 @@ declare const styles: {
   readonly "action": string;
   readonly "defaultContainer": string;
   readonly "hoverable": string;
-  readonly "isActive": string;
   readonly "icon": string;
   readonly "info": string;
   readonly "amount": string;
+  readonly "isActive": string;
   readonly "truncate": string;
 };
 export = styles;

--- a/packages/components/src/List/ListItem.module.css.d.ts
+++ b/packages/components/src/List/ListItem.module.css.d.ts
@@ -1,11 +1,13 @@
 declare const styles: {
   readonly "action": string;
   readonly "defaultContainer": string;
+  readonly "customItem": string;
+  readonly "paddedChild": string;
   readonly "hoverable": string;
+  readonly "isActive": string;
   readonly "icon": string;
   readonly "info": string;
   readonly "amount": string;
-  readonly "isActive": string;
   readonly "truncate": string;
 };
 export = styles;

--- a/packages/components/src/List/ListItem.module.css.d.ts
+++ b/packages/components/src/List/ListItem.module.css.d.ts
@@ -1,6 +1,5 @@
 declare const styles: {
   readonly "action": string;
-  readonly "defaultContainer": string;
   readonly "customItem": string;
   readonly "defaultContent": string;
   readonly "hoverable": string;

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -79,12 +79,15 @@ export function ListItem<T extends BaseListItemProps = ListItemProps>(
   props: T &
     ListItemProps & {
       readonly customRenderItem?: (item: T) => React.ReactNode;
+      readonly customItemStyles?: boolean;
     },
 ) {
+  const omitDefaultStyles = props.customRenderItem && props.customItemStyles;
   const actionClasses = classnames(
     styles.action,
     props.isActive && styles.isActive,
     (props.onClick || props.url) && styles.hoverable,
+    !omitDefaultStyles && styles.defaultContainer,
   );
   const Wrapper = props.url ? "a" : "button";
 
@@ -111,7 +114,7 @@ export function ListItem<T extends BaseListItemProps = ListItemProps>(
 
 function DefaultRenderItem(props: ListItemProps) {
   return (
-    <div className={styles.defaultContainer}>
+    <>
       {props.icon && (
         <div className={styles.icon}>
           <Icon name={props.icon} color={props.iconColor} />
@@ -138,7 +141,7 @@ function DefaultRenderItem(props: ListItemProps) {
           </Text>
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -9,7 +9,15 @@ import { Typography } from "../Typography";
 import { Markdown } from "../Markdown";
 import { Emphasis } from "../Emphasis";
 
-export interface ListItemProps {
+export interface BaseListItemProps {
+  /**
+   * The ID of the list item. This will be helpful to know the selected list
+   * items when a batch action is implemented.
+   */
+  readonly id: number | string;
+}
+
+export interface ListItemProps extends BaseListItemProps {
   /**
    * Subdued text under the `content` prop.
    */
@@ -20,7 +28,7 @@ export interface ListItemProps {
    * for a multi line content.
    * This supports basic markdown node types such as `_italic_` and `**bold**`.
    */
-  readonly content: string | string[];
+  readonly content?: string | string[];
 
   /**
    * Shows an icon on the left side of the contents.
@@ -31,12 +39,6 @@ export interface ListItemProps {
    * Changes the color of the icons.
    */
   readonly iconColor?: IconColorNames;
-
-  /**
-   * The ID of the list item. This will be helpful to know the selected list
-   * items when a batch action is implemented.
-   */
-  readonly id: number | string;
 
   /**
    * Highlights the list item with the lightest green icon. This communicates
@@ -112,7 +114,7 @@ export function ListItem({
 
       <div className={styles.info}>
         {title && <Heading level={5}>{title}</Heading>}
-        <Description content={content} />
+        {content && <Description content={content} />}
 
         {caption && (
           <Text variation="subdued">
@@ -134,7 +136,7 @@ export function ListItem({
   );
 }
 
-function Description({ content }: Pick<ListItemProps, "content">) {
+function Description({ content }: Pick<Required<ListItemProps>, "content">) {
   if (content instanceof Array) {
     return (
       <>

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -115,7 +115,7 @@ export function ListItem<T extends BaseListItemProps = ListItemProps>(
 
 function DefaultRenderItem(props: ListItemProps) {
   return (
-    <>
+    <div className={styles.defaultContainer}>
       {props.icon && (
         <div className={styles.icon}>
           <Icon name={props.icon} color={props.iconColor} />
@@ -142,7 +142,7 @@ function DefaultRenderItem(props: ListItemProps) {
           </Text>
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -15,6 +15,7 @@ export interface BaseListItemProps {
    * items when a batch action is implemented.
    */
   readonly id: number | string;
+  [key: string]: unknown;
 }
 
 export interface ListItemProps extends BaseListItemProps {
@@ -75,24 +76,21 @@ export interface ListItemProps extends BaseListItemProps {
   ): void;
 }
 
-export function ListItem({
-  caption,
-  content,
-  icon,
-  iconColor,
-  id,
-  isActive,
-  onClick,
-  title,
-  url,
-  value,
-}: ListItemProps) {
+// function isCustomRender<T extends BaseListItemProps = ListItemProps>(item: unknown): item is T {
+//   return "customRender" in item;
+//   }
+
+export function ListItem<T extends BaseListItemProps = ListItemProps>(
+  props: ListItemProps & {
+    readonly customRenderItem?: (item: T) => React.ReactNode;
+  },
+) {
   const actionClasses = classnames(
     styles.action,
-    isActive && styles.isActive,
-    (onClick || url) && styles.hoverable,
+    props.isActive && styles.isActive,
+    (props.onClick || props.url) && styles.hoverable,
   );
-  const Wrapper = url ? "a" : "button";
+  const Wrapper = props.url ? "a" : "button";
 
   const buttonProps = {
     ...(Wrapper === "button" && { role: "button", type: "button" as const }),
@@ -100,39 +98,51 @@ export function ListItem({
 
   return (
     <Wrapper
-      id={id.toString()}
+      id={props.id.toString()}
       className={actionClasses}
-      href={url}
-      onClick={onClick}
+      href={props.url}
+      onClick={props.onClick}
       {...buttonProps}
     >
-      {icon && (
+      {props.customRenderItem ? (
+        props.customRenderItem(props as T)
+      ) : (
+        <DefaultRenderItem {...props} />
+      )}
+    </Wrapper>
+  );
+}
+
+function DefaultRenderItem(props: ListItemProps) {
+  return (
+    <>
+      {props.icon && (
         <div className={styles.icon}>
-          <Icon name={icon} color={iconColor} />
+          <Icon name={props.icon} color={props.iconColor} />
         </div>
       )}
 
       <div className={styles.info}>
-        {title && <Heading level={5}>{title}</Heading>}
-        {content && <Description content={content} />}
+        {props.title && <Heading level={5}>{props.title}</Heading>}
+        {props.content && <Description content={props.content} />}
 
-        {caption && (
+        {props.caption && (
           <Text variation="subdued">
             <Typography element="span" size="small" emphasisType="italic">
-              {caption}
+              {props.caption}
             </Typography>
           </Text>
         )}
       </div>
 
-      {value && (
+      {props.value && (
         <div className={styles.amount}>
           <Text>
-            <Emphasis variation="bold">{value}</Emphasis>
+            <Emphasis variation="bold">{props.value}</Emphasis>
           </Text>
         </div>
       )}
-    </Wrapper>
+    </>
   );
 }
 

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -15,7 +15,6 @@ export interface BaseListItemProps {
    * items when a batch action is implemented.
    */
   readonly id: number | string;
-  [key: string]: unknown;
 }
 
 export interface ListItemProps extends BaseListItemProps {
@@ -76,14 +75,11 @@ export interface ListItemProps extends BaseListItemProps {
   ): void;
 }
 
-// function isCustomRender<T extends BaseListItemProps = ListItemProps>(item: unknown): item is T {
-//   return "customRender" in item;
-//   }
-
 export function ListItem<T extends BaseListItemProps = ListItemProps>(
-  props: ListItemProps & {
-    readonly customRenderItem?: (item: T) => React.ReactNode;
-  },
+  props: T &
+    ListItemProps & {
+      readonly customRenderItem?: (item: T) => React.ReactNode;
+    },
 ) {
   const actionClasses = classnames(
     styles.action,
@@ -105,7 +101,7 @@ export function ListItem<T extends BaseListItemProps = ListItemProps>(
       {...buttonProps}
     >
       {props.customRenderItem ? (
-        props.customRenderItem(props as T)
+        props.customRenderItem(props)
       ) : (
         <DefaultRenderItem {...props} />
       )}

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -11,8 +11,8 @@ import { Emphasis } from "../Emphasis";
 
 export interface BaseListItemProps {
   /**
-   * The ID of the list item. This will be helpful to know the selected list
-   * items when a batch action is implemented.
+   * The ID of the list item. This is important for React to handle efficient
+   * re-rendering of list items.
    */
   readonly id: number | string;
 }
@@ -115,7 +115,7 @@ export function ListItem<T extends BaseListItemProps = ListItemProps>(
 
 function DefaultRenderItem(props: ListItemProps) {
   return (
-    <div className={styles.paddedChild}>
+    <div className={styles.defaultContent}>
       {props.icon && (
         <div className={styles.icon}>
           <Icon name={props.icon} color={props.iconColor} />

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -82,12 +82,10 @@ export function ListItem<T extends BaseListItemProps = ListItemProps>(
       readonly customItemStyles?: boolean;
     },
 ) {
-  const omitDefaultStyles = props.customRenderItem && props.customItemStyles;
   const actionClasses = classnames(
     styles.action,
     props.isActive && styles.isActive,
     (props.onClick || props.url) && styles.hoverable,
-    !omitDefaultStyles && styles.defaultContainer,
     props.customRenderItem && !props.customItemStyles && styles.customItem,
   );
   const Wrapper = props.url ? "a" : "button";

--- a/packages/components/src/List/ListItem.tsx
+++ b/packages/components/src/List/ListItem.tsx
@@ -88,6 +88,7 @@ export function ListItem<T extends BaseListItemProps = ListItemProps>(
     props.isActive && styles.isActive,
     (props.onClick || props.url) && styles.hoverable,
     !omitDefaultStyles && styles.defaultContainer,
+    props.customRenderItem && !props.customItemStyles && styles.customItem,
   );
   const Wrapper = props.url ? "a" : "button";
 
@@ -114,7 +115,7 @@ export function ListItem<T extends BaseListItemProps = ListItemProps>(
 
 function DefaultRenderItem(props: ListItemProps) {
   return (
-    <>
+    <div className={styles.paddedChild}>
       {props.icon && (
         <div className={styles.icon}>
           <Icon name={props.icon} color={props.iconColor} />
@@ -141,7 +142,7 @@ function DefaultRenderItem(props: ListItemProps) {
           </Text>
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -21,10 +21,10 @@ exports[`When a list is provided a custom render function it should handle a sec
         class="list"
       >
         <li
-          class=""
+          class="item"
         >
           <button
-            class="action"
+            class="action defaultContainer"
             id="1"
             role="button"
             type="button"
@@ -44,10 +44,10 @@ exports[`When a list is provided a custom render function it should handle a sec
           </button>
         </li>
         <li
-          class=""
+          class="item"
         >
           <button
-            class="action"
+            class="action defaultContainer"
             id="2"
             role="button"
             type="button"
@@ -84,10 +84,10 @@ exports[`When a list is provided a custom render function it should handle a sec
         class="list"
       >
         <li
-          class=""
+          class="item"
         >
           <button
-            class="action"
+            class="action defaultContainer"
             id="3"
             role="button"
             type="button"
@@ -107,10 +107,10 @@ exports[`When a list is provided a custom render function it should handle a sec
           </button>
         </li>
         <li
-          class=""
+          class="item"
         >
           <button
-            class="action"
+            class="action defaultContainer"
             id="4"
             role="button"
             type="button"
@@ -141,10 +141,10 @@ exports[`When a list is provided a custom render function it should use the cust
     class="list"
   >
     <li
-      class=""
+      class="item"
     >
       <button
-        class="action"
+        class="action defaultContainer"
         id="1"
         role="button"
         type="button"
@@ -164,10 +164,10 @@ exports[`When a list is provided a custom render function it should use the cust
       </button>
     </li>
     <li
-      class=""
+      class="item"
     >
       <button
-        class="action"
+        class="action defaultContainer"
         id="2"
         role="button"
         type="button"
@@ -214,77 +214,73 @@ exports[`renders 1 List item with all the props 1`] = `
           class="item"
         >
           <a
-            class="action isActive hoverable"
+            class="action isActive hoverable defaultContainer"
             href="#"
             id="1"
           >
             <div
-              class="defaultContainer"
+              class="icon"
             >
-              <div
-                class="icon"
+              <svg
+                data-testid="checkmark"
+                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  data-testid="checkmark"
-                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                    style="fill: var(--color-green);"
-                  />
-                </svg>
-              </div>
-              <div
-                class="info"
+                <path
+                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                  style="fill: var(--color-green);"
+                />
+              </svg>
+            </div>
+            <div
+              class="info"
+            >
+              <h5
+                class="base bold base heading"
               >
-                <h5
-                  class="base bold base heading"
-                >
-                  Jordan Yeo completed a visit
-                </h5>
-                <p
-                  class="base regular base text"
-                >
-                  <span
-                    class="truncate"
-                  >
-                    Build a deck
-                  </span>
-                </p>
-                <p
-                  class="base regular base text"
-                >
-                  <span
-                    class="truncate"
-                  >
-                    Fa la la la la
-                  </span>
-                </p>
-                <p
-                  class="base regular base textSecondary"
-                >
-                  <span
-                    class="base regular small italic"
-                  >
-                    Sep 24, 2019
-                  </span>
-                </p>
-              </div>
-              <div
-                class="amount"
+                Jordan Yeo completed a visit
+              </h5>
+              <p
+                class="base regular base text"
               >
-                <p
-                  class="base regular base text"
+                <span
+                  class="truncate"
                 >
-                  <b
-                    class="base bold"
-                  >
-                    $30.00
-                  </b>
-                </p>
-              </div>
+                  Build a deck
+                </span>
+              </p>
+              <p
+                class="base regular base text"
+              >
+                <span
+                  class="truncate"
+                >
+                  Fa la la la la
+                </span>
+              </p>
+              <p
+                class="base regular base textSecondary"
+              >
+                <span
+                  class="base regular small italic"
+                >
+                  Sep 24, 2019
+                </span>
+              </p>
+            </div>
+            <div
+              class="amount"
+            >
+              <p
+                class="base regular base text"
+              >
+                <b
+                  class="base bold"
+                >
+                  $30.00
+                </b>
+              </p>
             </div>
           </a>
         </li>
@@ -318,77 +314,73 @@ exports[`renders a list with multiple sections 1`] = `
           class="item"
         >
           <a
-            class="action isActive hoverable"
+            class="action isActive hoverable defaultContainer"
             href="#"
             id="1"
           >
             <div
-              class="defaultContainer"
+              class="icon"
             >
-              <div
-                class="icon"
+              <svg
+                data-testid="checkmark"
+                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  data-testid="checkmark"
-                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                    style="fill: var(--color-green);"
-                  />
-                </svg>
-              </div>
-              <div
-                class="info"
+                <path
+                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                  style="fill: var(--color-green);"
+                />
+              </svg>
+            </div>
+            <div
+              class="info"
+            >
+              <h5
+                class="base bold base heading"
               >
-                <h5
-                  class="base bold base heading"
-                >
-                  Jordan Yeo completed a visit
-                </h5>
-                <p
-                  class="base regular base text"
-                >
-                  <span
-                    class="truncate"
-                  >
-                    Build a deck
-                  </span>
-                </p>
-                <p
-                  class="base regular base text"
-                >
-                  <span
-                    class="truncate"
-                  >
-                    Fa la la la la
-                  </span>
-                </p>
-                <p
-                  class="base regular base textSecondary"
-                >
-                  <span
-                    class="base regular small italic"
-                  >
-                    Sep 24, 2019
-                  </span>
-                </p>
-              </div>
-              <div
-                class="amount"
+                Jordan Yeo completed a visit
+              </h5>
+              <p
+                class="base regular base text"
               >
-                <p
-                  class="base regular base text"
+                <span
+                  class="truncate"
                 >
-                  <b
-                    class="base bold"
-                  >
-                    $30.00
-                  </b>
-                </p>
-              </div>
+                  Build a deck
+                </span>
+              </p>
+              <p
+                class="base regular base text"
+              >
+                <span
+                  class="truncate"
+                >
+                  Fa la la la la
+                </span>
+              </p>
+              <p
+                class="base regular base textSecondary"
+              >
+                <span
+                  class="base regular small italic"
+                >
+                  Sep 24, 2019
+                </span>
+              </p>
+            </div>
+            <div
+              class="amount"
+            >
+              <p
+                class="base regular base text"
+              >
+                <b
+                  class="base bold"
+                >
+                  $30.00
+                </b>
+              </p>
             </div>
           </a>
         </li>
@@ -413,77 +405,73 @@ exports[`renders a list with multiple sections 1`] = `
           class="item"
         >
           <a
-            class="action isActive hoverable"
+            class="action isActive hoverable defaultContainer"
             href="#"
             id="1"
           >
             <div
-              class="defaultContainer"
+              class="icon"
             >
-              <div
-                class="icon"
+              <svg
+                data-testid="checkmark"
+                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  data-testid="checkmark"
-                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                    style="fill: var(--color-green);"
-                  />
-                </svg>
-              </div>
-              <div
-                class="info"
+                <path
+                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                  style="fill: var(--color-green);"
+                />
+              </svg>
+            </div>
+            <div
+              class="info"
+            >
+              <h5
+                class="base bold base heading"
               >
-                <h5
-                  class="base bold base heading"
-                >
-                  Jordan Yeo requires assistance
-                </h5>
-                <p
-                  class="base regular base text"
-                >
-                  <span
-                    class="truncate"
-                  >
-                    Foo bar
-                  </span>
-                </p>
-                <p
-                  class="base regular base text"
-                >
-                  <span
-                    class="truncate"
-                  >
-                    Baz
-                  </span>
-                </p>
-                <p
-                  class="base regular base textSecondary"
-                >
-                  <span
-                    class="base regular small italic"
-                  >
-                    Sep 25, 2019
-                  </span>
-                </p>
-              </div>
-              <div
-                class="amount"
+                Jordan Yeo requires assistance
+              </h5>
+              <p
+                class="base regular base text"
               >
-                <p
-                  class="base regular base text"
+                <span
+                  class="truncate"
                 >
-                  <b
-                    class="base bold"
-                  >
-                    $40.00
-                  </b>
-                </p>
-              </div>
+                  Foo bar
+                </span>
+              </p>
+              <p
+                class="base regular base text"
+              >
+                <span
+                  class="truncate"
+                >
+                  Baz
+                </span>
+              </p>
+              <p
+                class="base regular base textSecondary"
+              >
+                <span
+                  class="base regular small italic"
+                >
+                  Sep 25, 2019
+                </span>
+              </p>
+            </div>
+            <div
+              class="amount"
+            >
+              <p
+                class="base regular base text"
+              >
+                <b
+                  class="base bold"
+                >
+                  $40.00
+                </b>
+              </p>
             </div>
           </a>
         </li>
@@ -502,27 +490,23 @@ exports[`should render a button list item 1`] = `
       class="item"
     >
       <button
-        class="action hoverable"
+        class="action hoverable defaultContainer"
         id="1"
         role="button"
         type="button"
       >
         <div
-          class="defaultContainer"
+          class="info"
         >
-          <div
-            class="info"
+          <p
+            class="base regular base text"
           >
-            <p
-              class="base regular base text"
+            <span
+              class="truncate"
             >
-              <span
-                class="truncate"
-              >
-                Click me
-              </span>
-            </p>
-          </div>
+              Click me
+            </span>
+          </p>
         </div>
       </button>
     </li>
@@ -539,26 +523,22 @@ exports[`should render a link with url list item 1`] = `
       class="item"
     >
       <a
-        class="action hoverable"
+        class="action hoverable defaultContainer"
         href="/path/to/stuff"
         id="1"
       >
         <div
-          class="defaultContainer"
+          class="info"
         >
-          <div
-            class="info"
+          <p
+            class="base regular base text"
           >
-            <p
-              class="base regular base text"
+            <span
+              class="truncate"
             >
-              <span
-                class="truncate"
-              >
-                Learn more
-              </span>
-            </p>
-          </div>
+              Learn more
+            </span>
+          </p>
         </div>
       </a>
     </li>
@@ -575,26 +555,22 @@ exports[`should render an a tag with url and on click list item 1`] = `
       class="item"
     >
       <a
-        class="action hoverable"
+        class="action hoverable defaultContainer"
         href="/path/to/stuff"
         id="1"
       >
         <div
-          class="defaultContainer"
+          class="info"
         >
-          <div
-            class="info"
+          <p
+            class="base regular base text"
           >
-            <p
-              class="base regular base text"
+            <span
+              class="truncate"
             >
-              <span
-                class="truncate"
-              >
-                Learn more
-              </span>
-            </p>
-          </div>
+              Learn more
+            </span>
+          </p>
         </div>
       </a>
     </li>

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           class="item"
         >
           <button
-            class="action defaultContainer customItem"
+            class="action customItem"
             id="1"
             role="button"
             type="button"
@@ -106,7 +106,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           class="item"
         >
           <button
-            class="action defaultContainer customItem"
+            class="action customItem"
             id="2"
             role="button"
             type="button"
@@ -146,7 +146,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           class="item"
         >
           <button
-            class="action defaultContainer customItem"
+            class="action customItem"
             id="3"
             role="button"
             type="button"
@@ -169,7 +169,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           class="item"
         >
           <button
-            class="action defaultContainer customItem"
+            class="action customItem"
             id="4"
             role="button"
             type="button"
@@ -203,7 +203,7 @@ exports[`When a list is provided a custom render function it should use the cust
       class="item"
     >
       <button
-        class="action defaultContainer customItem"
+        class="action customItem"
         id="1"
         role="button"
         type="button"
@@ -226,7 +226,7 @@ exports[`When a list is provided a custom render function it should use the cust
       class="item"
     >
       <button
-        class="action defaultContainer customItem"
+        class="action customItem"
         id="2"
         role="button"
         type="button"
@@ -273,7 +273,7 @@ exports[`renders 1 List item with all the props 1`] = `
           class="item"
         >
           <a
-            class="action isActive hoverable defaultContainer"
+            class="action isActive hoverable"
             href="#"
             id="1"
           >
@@ -377,7 +377,7 @@ exports[`renders a list with multiple sections 1`] = `
           class="item"
         >
           <a
-            class="action isActive hoverable defaultContainer"
+            class="action isActive hoverable"
             href="#"
             id="1"
           >
@@ -472,7 +472,7 @@ exports[`renders a list with multiple sections 1`] = `
           class="item"
         >
           <a
-            class="action isActive hoverable defaultContainer"
+            class="action isActive hoverable"
             href="#"
             id="1"
           >
@@ -561,7 +561,7 @@ exports[`should render a button list item 1`] = `
       class="item"
     >
       <button
-        class="action hoverable defaultContainer"
+        class="action hoverable"
         id="1"
         role="button"
         type="button"
@@ -598,7 +598,7 @@ exports[`should render a link with url list item 1`] = `
       class="item"
     >
       <a
-        class="action hoverable defaultContainer"
+        class="action hoverable"
         href="/path/to/stuff"
         id="1"
       >
@@ -634,7 +634,7 @@ exports[`should render an a tag with url and on click list item 1`] = `
       class="item"
     >
       <a
-        class="action hoverable defaultContainer"
+        class="action hoverable"
         href="/path/to/stuff"
         id="1"
       >

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -278,7 +278,7 @@ exports[`renders 1 List item with all the props 1`] = `
             id="1"
           >
             <div
-              class="paddedChild"
+              class="defaultContent"
             >
               <div
                 class="icon"
@@ -382,7 +382,7 @@ exports[`renders a list with multiple sections 1`] = `
             id="1"
           >
             <div
-              class="paddedChild"
+              class="defaultContent"
             >
               <div
                 class="icon"
@@ -477,7 +477,7 @@ exports[`renders a list with multiple sections 1`] = `
             id="1"
           >
             <div
-              class="paddedChild"
+              class="defaultContent"
             >
               <div
                 class="icon"
@@ -567,7 +567,7 @@ exports[`should render a button list item 1`] = `
         type="button"
       >
         <div
-          class="paddedChild"
+          class="defaultContent"
         >
           <div
             class="info"
@@ -603,7 +603,7 @@ exports[`should render a link with url list item 1`] = `
         id="1"
       >
         <div
-          class="paddedChild"
+          class="defaultContent"
         >
           <div
             class="info"
@@ -639,7 +639,7 @@ exports[`should render an a tag with url and on click list item 1`] = `
         id="1"
       >
         <div
-          class="paddedChild"
+          class="defaultContent"
         >
           <div
             class="info"

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -1,37 +1,190 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`When a list is provided a custom render function it should use the custom render function instead of ListItem 1`] = `
+exports[`When a list is provided a custom render function it should handle a sectioned list with a custom render function 1`] = `
 <div>
   <ul
     class="list"
   >
-    <li>
-      <div>
-        <p
-          class="base regular base text"
+    <li
+      class="section"
+    >
+      <div
+        class="sectionHeader"
+      >
+        <h4
+          class="base bold large"
         >
-          Jane Doe
-        </p>
-        <p
-          class="base regular base text"
-        >
-          123 Main St
-        </p>
+          Employees
+        </h4>
       </div>
+      <ul
+        class="list"
+      >
+        <li
+          class="item"
+        >
+          <button
+            class="action"
+            id="1"
+            role="button"
+            type="button"
+          >
+            <div>
+              <p
+                class="base regular base text"
+              >
+                Jane Doe
+              </p>
+              <p
+                class="base regular base text"
+              >
+                123 Main St
+              </p>
+            </div>
+          </button>
+        </li>
+        <li
+          class="item"
+        >
+          <button
+            class="action"
+            id="2"
+            role="button"
+            type="button"
+          >
+            <div>
+              <p
+                class="base regular base text"
+              >
+                Joe Doe
+              </p>
+              <p
+                class="base regular base text"
+              >
+                456 Main St
+              </p>
+            </div>
+          </button>
+        </li>
+      </ul>
     </li>
-    <li>
-      <div>
-        <p
-          class="base regular base text"
+    <li
+      class="section"
+    >
+      <div
+        class="sectionHeader"
+      >
+        <h4
+          class="base bold large"
         >
-          Joe Doe
-        </p>
-        <p
-          class="base regular base text"
-        >
-          456 Main St
-        </p>
+          Customers
+        </h4>
       </div>
+      <ul
+        class="list"
+      >
+        <li
+          class="item"
+        >
+          <button
+            class="action"
+            id="3"
+            role="button"
+            type="button"
+          >
+            <div>
+              <p
+                class="base regular base text"
+              >
+                Milton Bradley
+              </p>
+              <p
+                class="base regular base text"
+              >
+                123 Fake St
+              </p>
+            </div>
+          </button>
+        </li>
+        <li
+          class="item"
+        >
+          <button
+            class="action"
+            id="4"
+            role="button"
+            type="button"
+          >
+            <div>
+              <p
+                class="base regular base text"
+              >
+                Tony Redman
+              </p>
+              <p
+                class="base regular base text"
+              >
+                456 Fake St
+              </p>
+            </div>
+          </button>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`When a list is provided a custom render function it should use the custom render instead of default ListItem behaviour 1`] = `
+<div>
+  <ul
+    class="list"
+  >
+    <li
+      class="item"
+    >
+      <button
+        class="action"
+        id="1"
+        role="button"
+        type="button"
+      >
+        <div>
+          <p
+            class="base regular base text"
+          >
+            Jane Doe
+          </p>
+          <p
+            class="base regular base text"
+          >
+            123 Main St
+          </p>
+        </div>
+      </button>
+    </li>
+    <li
+      class="item"
+    >
+      <button
+        class="action"
+        id="2"
+        role="button"
+        type="button"
+      >
+        <div>
+          <p
+            class="base regular base text"
+          >
+            Joe Doe
+          </p>
+          <p
+            class="base regular base text"
+          >
+            456 Main St
+          </p>
+        </div>
+      </button>
     </li>
   </ul>
 </div>

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`When a list is provided a custom render function it should use the custom render function instead of ListItem 1`] = `
+<div>
+  <ul
+    class="list"
+  >
+    <li>
+      <div>
+        <p
+          class="base regular base text"
+        >
+          Jane Doe
+        </p>
+        <p
+          class="base regular base text"
+        >
+          123 Main St
+        </p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <p
+          class="base regular base text"
+        >
+          Joe Doe
+        </p>
+        <p
+          class="base regular base text"
+        >
+          456 Main St
+        </p>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`renders 1 List item with all the props 1`] = `
 <div>
   <ul
@@ -89,6 +126,197 @@ exports[`renders 1 List item with all the props 1`] = `
                   class="base bold"
                 >
                   $30.00
+                </b>
+              </p>
+            </div>
+          </a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`renders a list with multiple sections 1`] = `
+<div>
+  <ul
+    class="list"
+  >
+    <li
+      class="section"
+    >
+      <div
+        class="sectionHeader"
+      >
+        <h4
+          class="base bold large"
+        >
+          Notifications
+        </h4>
+      </div>
+      <ul
+        class="list"
+      >
+        <li
+          class="item"
+        >
+          <a
+            class="action isActive hoverable"
+            href="#"
+            id="1"
+          >
+            <div
+              class="icon"
+            >
+              <svg
+                data-testid="checkmark"
+                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                  style="fill: var(--color-green);"
+                />
+              </svg>
+            </div>
+            <div
+              class="info"
+            >
+              <h5
+                class="base bold base heading"
+              >
+                Jordan Yeo completed a visit
+              </h5>
+              <p
+                class="base regular base text"
+              >
+                <span
+                  class="truncate"
+                >
+                  Build a deck
+                </span>
+              </p>
+              <p
+                class="base regular base text"
+              >
+                <span
+                  class="truncate"
+                >
+                  Fa la la la la
+                </span>
+              </p>
+              <p
+                class="base regular base textSecondary"
+              >
+                <span
+                  class="base regular small italic"
+                >
+                  Sep 24, 2019
+                </span>
+              </p>
+            </div>
+            <div
+              class="amount"
+            >
+              <p
+                class="base regular base text"
+              >
+                <b
+                  class="base bold"
+                >
+                  $30.00
+                </b>
+              </p>
+            </div>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="section"
+    >
+      <div
+        class="sectionHeader"
+      >
+        <h4
+          class="base bold large"
+        >
+          Urgent Notifications
+        </h4>
+      </div>
+      <ul
+        class="list"
+      >
+        <li
+          class="item"
+        >
+          <a
+            class="action isActive hoverable"
+            href="#"
+            id="1"
+          >
+            <div
+              class="icon"
+            >
+              <svg
+                data-testid="checkmark"
+                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                  style="fill: var(--color-green);"
+                />
+              </svg>
+            </div>
+            <div
+              class="info"
+            >
+              <h5
+                class="base bold base heading"
+              >
+                Jordan Yeo requires assistance
+              </h5>
+              <p
+                class="base regular base text"
+              >
+                <span
+                  class="truncate"
+                >
+                  Foo bar
+                </span>
+              </p>
+              <p
+                class="base regular base text"
+              >
+                <span
+                  class="truncate"
+                >
+                  Baz
+                </span>
+              </p>
+              <p
+                class="base regular base textSecondary"
+              >
+                <span
+                  class="base regular small italic"
+                >
+                  Sep 25, 2019
+                </span>
+              </p>
+            </div>
+            <div
+              class="amount"
+            >
+              <p
+                class="base regular base text"
+              >
+                <b
+                  class="base bold"
+                >
+                  $40.00
                 </b>
               </p>
             </div>

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`When a list is provided a custom render function it should handle a sec
         class="list"
       >
         <li
-          class="item"
+          class=""
         >
           <button
             class="action"
@@ -44,7 +44,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           </button>
         </li>
         <li
-          class="item"
+          class=""
         >
           <button
             class="action"
@@ -84,7 +84,7 @@ exports[`When a list is provided a custom render function it should handle a sec
         class="list"
       >
         <li
-          class="item"
+          class=""
         >
           <button
             class="action"
@@ -107,7 +107,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           </button>
         </li>
         <li
-          class="item"
+          class=""
         >
           <button
             class="action"
@@ -141,7 +141,7 @@ exports[`When a list is provided a custom render function it should use the cust
     class="list"
   >
     <li
-      class="item"
+      class=""
     >
       <button
         class="action"
@@ -164,7 +164,7 @@ exports[`When a list is provided a custom render function it should use the cust
       </button>
     </li>
     <li
-      class="item"
+      class=""
     >
       <button
         class="action"
@@ -219,68 +219,72 @@ exports[`renders 1 List item with all the props 1`] = `
             id="1"
           >
             <div
-              class="icon"
+              class="defaultContainer"
             >
-              <svg
-                data-testid="checkmark"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="icon"
               >
-                <path
-                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                  style="fill: var(--color-green);"
-                />
-              </svg>
-            </div>
-            <div
-              class="info"
-            >
-              <h5
-                class="base bold base heading"
-              >
-                Jordan Yeo completed a visit
-              </h5>
-              <p
-                class="base regular base text"
-              >
-                <span
-                  class="truncate"
+                <svg
+                  data-testid="checkmark"
+                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Build a deck
-                </span>
-              </p>
-              <p
-                class="base regular base text"
+                  <path
+                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                    style="fill: var(--color-green);"
+                  />
+                </svg>
+              </div>
+              <div
+                class="info"
               >
-                <span
-                  class="truncate"
+                <h5
+                  class="base bold base heading"
                 >
-                  Fa la la la la
-                </span>
-              </p>
-              <p
-                class="base regular base textSecondary"
+                  Jordan Yeo completed a visit
+                </h5>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Build a deck
+                  </span>
+                </p>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Fa la la la la
+                  </span>
+                </p>
+                <p
+                  class="base regular base textSecondary"
+                >
+                  <span
+                    class="base regular small italic"
+                  >
+                    Sep 24, 2019
+                  </span>
+                </p>
+              </div>
+              <div
+                class="amount"
               >
-                <span
-                  class="base regular small italic"
+                <p
+                  class="base regular base text"
                 >
-                  Sep 24, 2019
-                </span>
-              </p>
-            </div>
-            <div
-              class="amount"
-            >
-              <p
-                class="base regular base text"
-              >
-                <b
-                  class="base bold"
-                >
-                  $30.00
-                </b>
-              </p>
+                  <b
+                    class="base bold"
+                  >
+                    $30.00
+                  </b>
+                </p>
+              </div>
             </div>
           </a>
         </li>
@@ -319,68 +323,72 @@ exports[`renders a list with multiple sections 1`] = `
             id="1"
           >
             <div
-              class="icon"
+              class="defaultContainer"
             >
-              <svg
-                data-testid="checkmark"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="icon"
               >
-                <path
-                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                  style="fill: var(--color-green);"
-                />
-              </svg>
-            </div>
-            <div
-              class="info"
-            >
-              <h5
-                class="base bold base heading"
-              >
-                Jordan Yeo completed a visit
-              </h5>
-              <p
-                class="base regular base text"
-              >
-                <span
-                  class="truncate"
+                <svg
+                  data-testid="checkmark"
+                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Build a deck
-                </span>
-              </p>
-              <p
-                class="base regular base text"
+                  <path
+                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                    style="fill: var(--color-green);"
+                  />
+                </svg>
+              </div>
+              <div
+                class="info"
               >
-                <span
-                  class="truncate"
+                <h5
+                  class="base bold base heading"
                 >
-                  Fa la la la la
-                </span>
-              </p>
-              <p
-                class="base regular base textSecondary"
+                  Jordan Yeo completed a visit
+                </h5>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Build a deck
+                  </span>
+                </p>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Fa la la la la
+                  </span>
+                </p>
+                <p
+                  class="base regular base textSecondary"
+                >
+                  <span
+                    class="base regular small italic"
+                  >
+                    Sep 24, 2019
+                  </span>
+                </p>
+              </div>
+              <div
+                class="amount"
               >
-                <span
-                  class="base regular small italic"
+                <p
+                  class="base regular base text"
                 >
-                  Sep 24, 2019
-                </span>
-              </p>
-            </div>
-            <div
-              class="amount"
-            >
-              <p
-                class="base regular base text"
-              >
-                <b
-                  class="base bold"
-                >
-                  $30.00
-                </b>
-              </p>
+                  <b
+                    class="base bold"
+                  >
+                    $30.00
+                  </b>
+                </p>
+              </div>
             </div>
           </a>
         </li>
@@ -410,68 +418,72 @@ exports[`renders a list with multiple sections 1`] = `
             id="1"
           >
             <div
-              class="icon"
+              class="defaultContainer"
             >
-              <svg
-                data-testid="checkmark"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="icon"
               >
-                <path
-                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                  style="fill: var(--color-green);"
-                />
-              </svg>
-            </div>
-            <div
-              class="info"
-            >
-              <h5
-                class="base bold base heading"
-              >
-                Jordan Yeo requires assistance
-              </h5>
-              <p
-                class="base regular base text"
-              >
-                <span
-                  class="truncate"
+                <svg
+                  data-testid="checkmark"
+                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Foo bar
-                </span>
-              </p>
-              <p
-                class="base regular base text"
+                  <path
+                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                    style="fill: var(--color-green);"
+                  />
+                </svg>
+              </div>
+              <div
+                class="info"
               >
-                <span
-                  class="truncate"
+                <h5
+                  class="base bold base heading"
                 >
-                  Baz
-                </span>
-              </p>
-              <p
-                class="base regular base textSecondary"
+                  Jordan Yeo requires assistance
+                </h5>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Foo bar
+                  </span>
+                </p>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Baz
+                  </span>
+                </p>
+                <p
+                  class="base regular base textSecondary"
+                >
+                  <span
+                    class="base regular small italic"
+                  >
+                    Sep 25, 2019
+                  </span>
+                </p>
+              </div>
+              <div
+                class="amount"
               >
-                <span
-                  class="base regular small italic"
+                <p
+                  class="base regular base text"
                 >
-                  Sep 25, 2019
-                </span>
-              </p>
-            </div>
-            <div
-              class="amount"
-            >
-              <p
-                class="base regular base text"
-              >
-                <b
-                  class="base bold"
-                >
-                  $40.00
-                </b>
-              </p>
+                  <b
+                    class="base bold"
+                  >
+                    $40.00
+                  </b>
+                </p>
+              </div>
             </div>
           </a>
         </li>
@@ -496,17 +508,21 @@ exports[`should render a button list item 1`] = `
         type="button"
       >
         <div
-          class="info"
+          class="defaultContainer"
         >
-          <p
-            class="base regular base text"
+          <div
+            class="info"
           >
-            <span
-              class="truncate"
+            <p
+              class="base regular base text"
             >
-              Click me
-            </span>
-          </p>
+              <span
+                class="truncate"
+              >
+                Click me
+              </span>
+            </p>
+          </div>
         </div>
       </button>
     </li>
@@ -528,17 +544,21 @@ exports[`should render a link with url list item 1`] = `
         id="1"
       >
         <div
-          class="info"
+          class="defaultContainer"
         >
-          <p
-            class="base regular base text"
+          <div
+            class="info"
           >
-            <span
-              class="truncate"
+            <p
+              class="base regular base text"
             >
-              Learn more
-            </span>
-          </p>
+              <span
+                class="truncate"
+              >
+                Learn more
+              </span>
+            </p>
+          </div>
         </div>
       </a>
     </li>
@@ -560,17 +580,21 @@ exports[`should render an a tag with url and on click list item 1`] = `
         id="1"
       >
         <div
-          class="info"
+          class="defaultContainer"
         >
-          <p
-            class="base regular base text"
+          <div
+            class="info"
           >
-            <span
-              class="truncate"
+            <p
+              class="base regular base text"
             >
-              Learn more
-            </span>
-          </p>
+              <span
+                class="truncate"
+              >
+                Learn more
+              </span>
+            </p>
+          </div>
         </div>
       </a>
     </li>

--- a/packages/components/src/List/__snapshots__/List.test.tsx.snap
+++ b/packages/components/src/List/__snapshots__/List.test.tsx.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`When a list is provided a custom render function it should allow for custom styles 1`] = `
+<div>
+  <ul
+    class="list"
+  >
+    <li
+      class=""
+    >
+      <button
+        class="action"
+        id="1"
+        role="button"
+        type="button"
+      >
+        <div
+          style="padding: 10px;"
+        >
+          <p
+            class="base regular base text"
+          >
+            Jane Doe
+          </p>
+          <p
+            class="base regular base text"
+          >
+            123 Main St
+          </p>
+        </div>
+      </button>
+    </li>
+    <li
+      class=""
+    >
+      <button
+        class="action"
+        id="2"
+        role="button"
+        type="button"
+      >
+        <div
+          style="padding: 10px;"
+        >
+          <p
+            class="base regular base text"
+          >
+            Joe Doe
+          </p>
+          <p
+            class="base regular base text"
+          >
+            456 Main St
+          </p>
+        </div>
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`When a list is provided a custom render function it should handle a sectioned list with a custom render function 1`] = `
 <div>
   <ul
@@ -24,7 +83,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           class="item"
         >
           <button
-            class="action defaultContainer"
+            class="action defaultContainer customItem"
             id="1"
             role="button"
             type="button"
@@ -47,7 +106,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           class="item"
         >
           <button
-            class="action defaultContainer"
+            class="action defaultContainer customItem"
             id="2"
             role="button"
             type="button"
@@ -87,7 +146,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           class="item"
         >
           <button
-            class="action defaultContainer"
+            class="action defaultContainer customItem"
             id="3"
             role="button"
             type="button"
@@ -110,7 +169,7 @@ exports[`When a list is provided a custom render function it should handle a sec
           class="item"
         >
           <button
-            class="action defaultContainer"
+            class="action defaultContainer customItem"
             id="4"
             role="button"
             type="button"
@@ -144,7 +203,7 @@ exports[`When a list is provided a custom render function it should use the cust
       class="item"
     >
       <button
-        class="action defaultContainer"
+        class="action defaultContainer customItem"
         id="1"
         role="button"
         type="button"
@@ -167,7 +226,7 @@ exports[`When a list is provided a custom render function it should use the cust
       class="item"
     >
       <button
-        class="action defaultContainer"
+        class="action defaultContainer customItem"
         id="2"
         role="button"
         type="button"
@@ -219,68 +278,72 @@ exports[`renders 1 List item with all the props 1`] = `
             id="1"
           >
             <div
-              class="icon"
+              class="paddedChild"
             >
-              <svg
-                data-testid="checkmark"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="icon"
               >
-                <path
-                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                  style="fill: var(--color-green);"
-                />
-              </svg>
-            </div>
-            <div
-              class="info"
-            >
-              <h5
-                class="base bold base heading"
-              >
-                Jordan Yeo completed a visit
-              </h5>
-              <p
-                class="base regular base text"
-              >
-                <span
-                  class="truncate"
+                <svg
+                  data-testid="checkmark"
+                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Build a deck
-                </span>
-              </p>
-              <p
-                class="base regular base text"
+                  <path
+                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                    style="fill: var(--color-green);"
+                  />
+                </svg>
+              </div>
+              <div
+                class="info"
               >
-                <span
-                  class="truncate"
+                <h5
+                  class="base bold base heading"
                 >
-                  Fa la la la la
-                </span>
-              </p>
-              <p
-                class="base regular base textSecondary"
+                  Jordan Yeo completed a visit
+                </h5>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Build a deck
+                  </span>
+                </p>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Fa la la la la
+                  </span>
+                </p>
+                <p
+                  class="base regular base textSecondary"
+                >
+                  <span
+                    class="base regular small italic"
+                  >
+                    Sep 24, 2019
+                  </span>
+                </p>
+              </div>
+              <div
+                class="amount"
               >
-                <span
-                  class="base regular small italic"
+                <p
+                  class="base regular base text"
                 >
-                  Sep 24, 2019
-                </span>
-              </p>
-            </div>
-            <div
-              class="amount"
-            >
-              <p
-                class="base regular base text"
-              >
-                <b
-                  class="base bold"
-                >
-                  $30.00
-                </b>
-              </p>
+                  <b
+                    class="base bold"
+                  >
+                    $30.00
+                  </b>
+                </p>
+              </div>
             </div>
           </a>
         </li>
@@ -319,68 +382,72 @@ exports[`renders a list with multiple sections 1`] = `
             id="1"
           >
             <div
-              class="icon"
+              class="paddedChild"
             >
-              <svg
-                data-testid="checkmark"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="icon"
               >
-                <path
-                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                  style="fill: var(--color-green);"
-                />
-              </svg>
-            </div>
-            <div
-              class="info"
-            >
-              <h5
-                class="base bold base heading"
-              >
-                Jordan Yeo completed a visit
-              </h5>
-              <p
-                class="base regular base text"
-              >
-                <span
-                  class="truncate"
+                <svg
+                  data-testid="checkmark"
+                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Build a deck
-                </span>
-              </p>
-              <p
-                class="base regular base text"
+                  <path
+                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                    style="fill: var(--color-green);"
+                  />
+                </svg>
+              </div>
+              <div
+                class="info"
               >
-                <span
-                  class="truncate"
+                <h5
+                  class="base bold base heading"
                 >
-                  Fa la la la la
-                </span>
-              </p>
-              <p
-                class="base regular base textSecondary"
+                  Jordan Yeo completed a visit
+                </h5>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Build a deck
+                  </span>
+                </p>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Fa la la la la
+                  </span>
+                </p>
+                <p
+                  class="base regular base textSecondary"
+                >
+                  <span
+                    class="base regular small italic"
+                  >
+                    Sep 24, 2019
+                  </span>
+                </p>
+              </div>
+              <div
+                class="amount"
               >
-                <span
-                  class="base regular small italic"
+                <p
+                  class="base regular base text"
                 >
-                  Sep 24, 2019
-                </span>
-              </p>
-            </div>
-            <div
-              class="amount"
-            >
-              <p
-                class="base regular base text"
-              >
-                <b
-                  class="base bold"
-                >
-                  $30.00
-                </b>
-              </p>
+                  <b
+                    class="base bold"
+                  >
+                    $30.00
+                  </b>
+                </p>
+              </div>
             </div>
           </a>
         </li>
@@ -410,68 +477,72 @@ exports[`renders a list with multiple sections 1`] = `
             id="1"
           >
             <div
-              class="icon"
+              class="paddedChild"
             >
-              <svg
-                data-testid="checkmark"
-                style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="icon"
               >
-                <path
-                  d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
-                  style="fill: var(--color-green);"
-                />
-              </svg>
-            </div>
-            <div
-              class="info"
-            >
-              <h5
-                class="base bold base heading"
-              >
-                Jordan Yeo requires assistance
-              </h5>
-              <p
-                class="base regular base text"
-              >
-                <span
-                  class="truncate"
+                <svg
+                  data-testid="checkmark"
+                  style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Foo bar
-                </span>
-              </p>
-              <p
-                class="base regular base text"
+                  <path
+                    d="M4.703 12.029a1 1 0 1 0-1.414 1.414l4.699 5.293a1 1 0 0 0 1.414 0L20.695 7.443a1 1 0 1 0-1.414-1.414L8.695 16.615l-3.992-4.586Z"
+                    style="fill: var(--color-green);"
+                  />
+                </svg>
+              </div>
+              <div
+                class="info"
               >
-                <span
-                  class="truncate"
+                <h5
+                  class="base bold base heading"
                 >
-                  Baz
-                </span>
-              </p>
-              <p
-                class="base regular base textSecondary"
+                  Jordan Yeo requires assistance
+                </h5>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Foo bar
+                  </span>
+                </p>
+                <p
+                  class="base regular base text"
+                >
+                  <span
+                    class="truncate"
+                  >
+                    Baz
+                  </span>
+                </p>
+                <p
+                  class="base regular base textSecondary"
+                >
+                  <span
+                    class="base regular small italic"
+                  >
+                    Sep 25, 2019
+                  </span>
+                </p>
+              </div>
+              <div
+                class="amount"
               >
-                <span
-                  class="base regular small italic"
+                <p
+                  class="base regular base text"
                 >
-                  Sep 25, 2019
-                </span>
-              </p>
-            </div>
-            <div
-              class="amount"
-            >
-              <p
-                class="base regular base text"
-              >
-                <b
-                  class="base bold"
-                >
-                  $40.00
-                </b>
-              </p>
+                  <b
+                    class="base bold"
+                  >
+                    $40.00
+                  </b>
+                </p>
+              </div>
             </div>
           </a>
         </li>
@@ -496,17 +567,21 @@ exports[`should render a button list item 1`] = `
         type="button"
       >
         <div
-          class="info"
+          class="paddedChild"
         >
-          <p
-            class="base regular base text"
+          <div
+            class="info"
           >
-            <span
-              class="truncate"
+            <p
+              class="base regular base text"
             >
-              Click me
-            </span>
-          </p>
+              <span
+                class="truncate"
+              >
+                Click me
+              </span>
+            </p>
+          </div>
         </div>
       </button>
     </li>
@@ -528,17 +603,21 @@ exports[`should render a link with url list item 1`] = `
         id="1"
       >
         <div
-          class="info"
+          class="paddedChild"
         >
-          <p
-            class="base regular base text"
+          <div
+            class="info"
           >
-            <span
-              class="truncate"
+            <p
+              class="base regular base text"
             >
-              Learn more
-            </span>
-          </p>
+              <span
+                class="truncate"
+              >
+                Learn more
+              </span>
+            </p>
+          </div>
         </div>
       </a>
     </li>
@@ -560,17 +639,21 @@ exports[`should render an a tag with url and on click list item 1`] = `
         id="1"
       >
         <div
-          class="info"
+          class="paddedChild"
         >
-          <p
-            class="base regular base text"
+          <div
+            class="info"
           >
-            <span
-              class="truncate"
+            <p
+              class="base regular base text"
             >
-              Learn more
-            </span>
-          </p>
+              <span
+                class="truncate"
+              >
+                Learn more
+              </span>
+            </p>
+          </div>
         </div>
       </a>
     </li>

--- a/packages/components/src/List/index.ts
+++ b/packages/components/src/List/index.ts
@@ -1,2 +1,2 @@
 export { List } from "./List";
-export { ListItem, ListItemProps } from "./ListItem";
+export { BaseListItemProps, ListItem, ListItemProps } from "./ListItem";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The List component is rarely used because it can currently only be used to render list items in a very particular format. If consumers were able to specify how the items are rendered it could be used in many more places. This PR adds that flexibility.

## Changes

The `content` prop in `ListItemProps` is now optional

### Added

Before these changes `ListItem` was used to render the items passed into `List`. This PR adds a `customRenderItem` prop to `List` that will take precedence over `ListItem`. If no `customRenderItem` is provided the behaviour with using `ListItem` should be unchanged.

### Changed

For existing `List` implementations there should be no change to functionality

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Some before and after photos from testing things using the pre-release:

### Selecting item type when adding a new item on the Schedule Alpha page
Before:
![Screenshot 2024-10-22 at 11 32 24 AM](https://github.com/user-attachments/assets/1a9398f6-150b-484e-bcae-851cbe79b72c)

After:
![Screenshot 2024-10-22 at 11 08 56 AM](https://github.com/user-attachments/assets/5ebd6602-1909-469b-9fe4-6c74b3a5c76e)


### Selecting a line item on the same page
Before:
![Screenshot 2024-10-22 at 11 32 35 AM](https://github.com/user-attachments/assets/a9402e09-6bcc-48a8-b312-6dcac8ddf4b9)

After:
![Screenshot 2024-10-22 at 11 09 11 AM](https://github.com/user-attachments/assets/47bca645-9fb0-458b-ae69-4081932c2482)

### Promo stats [here](http://anchor.localhost.test:3000/administration/promotions)
Before:
![Screenshot 2024-10-22 at 11 33 12 AM](https://github.com/user-attachments/assets/c3fb6ef4-d3f0-4caa-8383-2de47a84c20f)


After:
![Screenshot 2024-10-22 at 11 05 26 AM](https://github.com/user-attachments/assets/f832c944-bf1f-4403-9ecb-eea5547a6287)

Christain Ellinger was kind enough to offer to test out the 5 instances in disputes as well, Also be sure to play around with my new stories in Storybook.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
