### PR TITLE
fix(components): JOB-104988 Add accessibility attributes (also helps with testing)

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -60,6 +60,7 @@ export function DataListHeaderTile<T extends DataListObject>({
       {isSortable && (
         <DataListSortingArrows
           order={sortingState?.key === headerKey ? sortingState.order : "none"}
+          columnKey={headerKey}
         />
       )}
     </Tag>

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -60,7 +60,7 @@ export function DataListHeaderTile<T extends DataListObject>({
       {isSortable && (
         <DataListSortingArrows
           order={sortingState?.key === headerKey ? sortingState.order : "none"}
-          columnKey={headerKey}
+          headerKey={headerKey}
         />
       )}
     </Tag>

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
@@ -3,6 +3,7 @@ import styles from "./DataListSortingArrows.module.css";
 
 interface DataListSortingArrowsProps {
   readonly order?: "asc" | "desc" | "none";
+  readonly columnKey?: string;
 }
 
 export const SORTING_ICON_TEST_ID = "ATL-DataList-Sorting-Icon";
@@ -13,12 +14,15 @@ const SORT_ORDER_MAP = {
   none: "none",
 } as const;
 
-export function DataListSortingArrows({ order }: DataListSortingArrowsProps) {
+export function DataListSortingArrows({
+  columnKey,
+  order,
+}: DataListSortingArrowsProps) {
   return (
     <div
       className={styles.sortIcon}
       data-testid={SORTING_ICON_TEST_ID}
-      aria-label="Sort Icon"
+      aria-label={`${columnKey} sort icon`}
       aria-sort={order ? SORT_ORDER_MAP[order] : undefined}
     >
       <svg

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
@@ -7,13 +7,19 @@ interface DataListSortingArrowsProps {
 
 export const SORTING_ICON_TEST_ID = "ATL-DataList-Sorting-Icon";
 
+const SORT_ORDER_MAP = {
+  asc: "ascending",
+  desc: "descending",
+  none: "none",
+} as const;
+
 export function DataListSortingArrows({ order }: DataListSortingArrowsProps) {
   return (
     <div
       className={styles.sortIcon}
       data-testid={SORTING_ICON_TEST_ID}
       aria-label="Sort Icon"
-      aria-sort={order == "asc" ? "ascending" : "descending"}
+      aria-sort={order ? SORT_ORDER_MAP[order] : undefined}
     >
       <svg
         width="24"

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
@@ -3,7 +3,7 @@ import styles from "./DataListSortingArrows.module.css";
 
 interface DataListSortingArrowsProps {
   readonly order?: "asc" | "desc" | "none";
-  readonly columnKey?: string;
+  readonly headerKey?: string;
 }
 
 export const SORTING_ICON_TEST_ID = "ATL-DataList-Sorting-Icon";
@@ -15,14 +15,14 @@ const SORT_ORDER_MAP = {
 } as const;
 
 export function DataListSortingArrows({
-  columnKey,
+  headerKey,
   order,
 }: DataListSortingArrowsProps) {
   return (
     <div
       className={styles.sortIcon}
       data-testid={SORTING_ICON_TEST_ID}
-      aria-label={`${columnKey} sort icon`}
+      aria-label={`${headerKey} sort icon`}
       aria-sort={order ? SORT_ORDER_MAP[order] : undefined}
     >
       <svg

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListSortingArrows.tsx
@@ -9,7 +9,12 @@ export const SORTING_ICON_TEST_ID = "ATL-DataList-Sorting-Icon";
 
 export function DataListSortingArrows({ order }: DataListSortingArrowsProps) {
   return (
-    <div className={styles.sortIcon} data-testid={SORTING_ICON_TEST_ID}>
+    <div
+      className={styles.sortIcon}
+      data-testid={SORTING_ICON_TEST_ID}
+      aria-label="Sort Icon"
+      aria-sort={order == "asc" ? "ascending" : "descending"}
+    >
       <svg
         width="24"
         height="24"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Sorting icon in `DataList` was missing some accessibility tags, which would be helpful for screen reading devices.
Moreover, having those properties would allow us to select those elements in UI tests.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `aria-label`
- `aria-sort`
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/e22f8f4e-349a-4c99-a309-2ed36d532fc6">
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/b9af92b2-7546-4a0b-843d-79f322b51c8a">


### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- DataList sorting not receiving aria attributes. 

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
