### PR TITLE
feat(components): standardize StatusLabel + StatusIndicator across platforms [JOB-107688]

### DIFF
--- a/docs/components/Flex/Mobile.stories.tsx
+++ b/docs/components/Flex/Mobile.stories.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { View } from "react-native";
-import { Card, Content, Flex, Icon, Text } from "@jobber/components-native";
-import { StatusLabel } from "@jobber/components/StatusLabel";
+import {
+  Card,
+  Content,
+  Flex,
+  Icon,
+  StatusLabel,
+  Text,
+} from "@jobber/components-native";
 
 export default {
   title: "Components/Layouts and Structure/Flex/Mobile",
@@ -24,7 +30,7 @@ const NestedTemplate: ComponentStory<typeof Flex> = args => (
       <View>
         <Flex template={["grow", "shrink"]}>
           <Text emphasis="strong">Dylan Tec</Text>
-          <StatusLabel label="Success" status="success" />
+          <StatusLabel text="Success" status="success" />
         </Flex>
         <Text>Sep 03 | $100 | Quote #93</Text>
       </View>

--- a/packages/components-native/src/StatusIndicator/StatusIndicator.style.ts
+++ b/packages/components-native/src/StatusIndicator/StatusIndicator.style.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from "react-native";
+import { tokens } from "../utils/design";
+
+const statusIndicatorDiameter = tokens["space-small"];
+
+export const styles = StyleSheet.create({
+  statusIndicator: {
+    borderRadius: tokens["radius-circle"],
+    backgroundColor: tokens["color-success"],
+    width: statusIndicatorDiameter,
+    height: statusIndicatorDiameter,
+  },
+});

--- a/packages/components-native/src/StatusIndicator/StatusIndicator.test.tsx
+++ b/packages/components-native/src/StatusIndicator/StatusIndicator.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { StatusIndicator } from "./StatusIndicator";
+
+describe("StatusIndicator", () => {
+  describe("status", () => {
+    describe('when status prop set to default ("success")', () => {
+      it("should match snapshot", () => {
+        const view = render(<StatusIndicator status="success" />).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when status prop set to "warning"', () => {
+      it("should match snapshot", () => {
+        const view = render(<StatusIndicator status="warning" />).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when status prop set to "critical"', () => {
+      it("should match snapshot", () => {
+        const view = render(<StatusIndicator status="critical" />).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when status prop set to "inactive"', () => {
+      it("should match snapshot", () => {
+        const view = render(<StatusIndicator status="inactive" />).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+
+    describe('when status prop set to "informative"', () => {
+      it("should match snapshot", () => {
+        const view = render(<StatusIndicator status="informative" />).toJSON();
+        expect(view).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/packages/components-native/src/StatusIndicator/StatusIndicator.tsx
+++ b/packages/components-native/src/StatusIndicator/StatusIndicator.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { View } from "react-native";
+import { styles } from "./StatusIndicator.style";
+import { tokens } from "../utils/design";
+
+export type StatusType =
+  | "success"
+  | "warning"
+  | "critical"
+  | "inactive"
+  | "informative";
+
+interface StatusIndicatorProps {
+  readonly status: StatusType;
+}
+
+export function StatusIndicator({ status }: StatusIndicatorProps) {
+  return (
+    <View
+      testID={`${status}Indicator`}
+      style={[
+        styles.statusIndicator,
+        { backgroundColor: tokens[`color-${status}`] },
+      ]}
+    />
+  );
+}

--- a/packages/components-native/src/StatusIndicator/__snapshots__/StatusIndicator.test.tsx.snap
+++ b/packages/components-native/src/StatusIndicator/__snapshots__/StatusIndicator.test.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StatusIndicator status when status prop set to "critical" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "hsl(107, 58%, 33%)",
+        "borderRadius": 100,
+        "height": 8,
+        "width": 8,
+      },
+      {
+        "backgroundColor": "hsl(6, 64%, 51%)",
+      },
+    ]
+  }
+  testID="criticalIndicator"
+/>
+`;
+
+exports[`StatusIndicator status when status prop set to "inactive" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "hsl(107, 58%, 33%)",
+        "borderRadius": 100,
+        "height": 8,
+        "width": 8,
+      },
+      {
+        "backgroundColor": "hsl(198, 25%, 33%)",
+      },
+    ]
+  }
+  testID="inactiveIndicator"
+/>
+`;
+
+exports[`StatusIndicator status when status prop set to "informative" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "hsl(107, 58%, 33%)",
+        "borderRadius": 100,
+        "height": 8,
+        "width": 8,
+      },
+      {
+        "backgroundColor": "hsl(207, 79%, 57%)",
+      },
+    ]
+  }
+  testID="informativeIndicator"
+/>
+`;
+
+exports[`StatusIndicator status when status prop set to "warning" should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "hsl(107, 58%, 33%)",
+        "borderRadius": 100,
+        "height": 8,
+        "width": 8,
+      },
+      {
+        "backgroundColor": "hsl(51, 64%, 49%)",
+      },
+    ]
+  }
+  testID="warningIndicator"
+/>
+`;
+
+exports[`StatusIndicator status when status prop set to default ("success") should match snapshot 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "hsl(107, 58%, 33%)",
+        "borderRadius": 100,
+        "height": 8,
+        "width": 8,
+      },
+      {
+        "backgroundColor": "hsl(107, 58%, 33%)",
+      },
+    ]
+  }
+  testID="successIndicator"
+/>
+`;

--- a/packages/components-native/src/StatusIndicator/index.ts
+++ b/packages/components-native/src/StatusIndicator/index.ts
@@ -1,0 +1,2 @@
+export { StatusIndicator } from "./StatusIndicator";
+export type { StatusType } from "./StatusIndicator";

--- a/packages/components-native/src/StatusLabel/StatusLabel.style.ts
+++ b/packages/components-native/src/StatusLabel/StatusLabel.style.ts
@@ -1,33 +1,24 @@
 import { StyleSheet } from "react-native";
 import { tokens } from "../utils/design";
 
-const statusLabelIconDiameter = tokens["space-base"] - tokens["space-smaller"]; //12px
-
-const indicatorOffset = tokens["space-smallest"] + tokens["space-minuscule"];
-
-// Needs to be hardcoded to 3 as this shouldn't change with the tokens
-const statusLabelRadius = 3;
-
 export const styles = StyleSheet.create({
   statusLabelRow: {
     flexDirection: "row",
     justifyContent: "flex-end",
+    alignItems: "center",
     flexWrap: "nowrap",
+    flexGrow: 0,
+    flexShrink: 1,
+    gap: tokens["space-smaller"],
+    backgroundColor: tokens["color-success--surface"],
+    borderRadius: tokens["radius-large"],
+    paddingVertical: tokens["space-smaller"],
+    paddingHorizontal: tokens["space-small"],
   },
   statusLabelText: {
     flexShrink: 1,
   },
-  statusLabelIcon: {
-    borderRadius: statusLabelRadius,
-    backgroundColor: tokens["color-success"],
-    width: statusLabelIconDiameter,
-    height: statusLabelIconDiameter,
-    marginTop: indicatorOffset,
-  },
   labelTextStartAligned: {
     flexDirection: "row-reverse",
-  },
-  innerPad: {
-    width: tokens["space-small"],
   },
 });

--- a/packages/components-native/src/StatusLabel/StatusLabel.tsx
+++ b/packages/components-native/src/StatusLabel/StatusLabel.tsx
@@ -29,7 +29,7 @@ interface StatusLabelProps {
   readonly alignment?: "start" | "end";
 
   /**
-   * Status color of the indicator beside text
+   * Sets the status colors for the container, label and StatusIndicator
    */
   readonly status?: StatusType;
 }

--- a/packages/components-native/src/StatusLabel/StatusLabel.tsx
+++ b/packages/components-native/src/StatusLabel/StatusLabel.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { View } from "react-native";
 import { styles } from "./StatusLabel.style";
+import { StatusIndicator } from "../StatusIndicator";
 import { tokens } from "../utils/design";
-import { Text } from "../Text";
+import { Typography } from "../Typography";
 
 export type StatusType =
   | "success"
@@ -28,7 +29,7 @@ interface StatusLabelProps {
   readonly alignment?: "start" | "end";
 
   /**
-   * Status color of the square beside text
+   * Status color of the indicator beside text
    */
   readonly status?: StatusType;
 }
@@ -42,32 +43,20 @@ export function StatusLabel({
     <View
       style={[
         styles.statusLabelRow,
+        { backgroundColor: tokens[`color-${status}--surface`] },
         alignment === "start" && styles.labelTextStartAligned,
       ]}
     >
       <View style={styles.statusLabelText}>
-        <Text align={alignment} level="textSupporting" variation="subdued">
+        <Typography
+          align={alignment}
+          size="smaller"
+          color={`${status}OnSurface`}
+        >
           {text}
-        </Text>
+        </Typography>
       </View>
-      <View style={styles.innerPad} />
-      <StatusLabelIcon status={status} />
+      <StatusIndicator status={status} />
     </View>
-  );
-}
-
-interface StatusLabelIconProps {
-  readonly status: StatusType;
-}
-
-function StatusLabelIcon({ status }: StatusLabelIconProps) {
-  return (
-    <View
-      testID={`${status}LabelIcon`}
-      style={[
-        styles.statusLabelIcon,
-        { backgroundColor: tokens[`color-${status}`] },
-      ]}
-    />
   );
 }

--- a/packages/components-native/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/packages/components-native/src/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -5,9 +5,20 @@ exports[`StatusLabel alignment when alignment prop set to "end" should match sna
   style={
     [
       {
+        "alignItems": "center",
+        "backgroundColor": "hsl(109, 28%, 92%)",
+        "borderRadius": 16,
         "flexDirection": "row",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "flexWrap": "nowrap",
+        "gap": 4,
         "justifyContent": "flex-end",
+        "paddingHorizontal": 8,
+        "paddingVertical": 4,
+      },
+      {
+        "backgroundColor": "hsl(109, 28%, 92%)",
       },
       false,
     ]
@@ -25,22 +36,21 @@ exports[`StatusLabel alignment when alignment prop set to "end" should match sna
       adjustsFontSizeToFit={false}
       allowFontScaling={true}
       collapsable={false}
-      maxFontSizeMultiplier={1.1428571428571428}
       selectable={true}
       selectionColor="hsl(86, 100%, 46%)"
       style={
         [
           {
-            "fontFamily": "inter-medium",
+            "fontFamily": "inter-regular",
           },
           {
-            "color": "hsl(197, 15%, 45%)",
+            "color": "hsl(107, 64%, 16%)",
           },
           {
             "textAlign": "right",
           },
           {
-            "fontSize": 14,
+            "fontSize": 12,
             "lineHeight": 18,
           },
           {
@@ -54,27 +64,19 @@ exports[`StatusLabel alignment when alignment prop set to "end" should match sna
   </View>
   <View
     style={
-      {
-        "width": 8,
-      }
-    }
-  />
-  <View
-    style={
       [
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
-          "borderRadius": 3,
-          "height": 12,
-          "marginTop": 3,
-          "width": 12,
+          "borderRadius": 100,
+          "height": 8,
+          "width": 8,
         },
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
         },
       ]
     }
-    testID="successLabelIcon"
+    testID="successIndicator"
   />
 </View>
 `;
@@ -84,9 +86,20 @@ exports[`StatusLabel alignment when alignment prop set to default ("start") shou
   style={
     [
       {
+        "alignItems": "center",
+        "backgroundColor": "hsl(109, 28%, 92%)",
+        "borderRadius": 16,
         "flexDirection": "row",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "flexWrap": "nowrap",
+        "gap": 4,
         "justifyContent": "flex-end",
+        "paddingHorizontal": 8,
+        "paddingVertical": 4,
+      },
+      {
+        "backgroundColor": "hsl(109, 28%, 92%)",
       },
       false,
     ]
@@ -104,22 +117,21 @@ exports[`StatusLabel alignment when alignment prop set to default ("start") shou
       adjustsFontSizeToFit={false}
       allowFontScaling={true}
       collapsable={false}
-      maxFontSizeMultiplier={1.1428571428571428}
       selectable={true}
       selectionColor="hsl(86, 100%, 46%)"
       style={
         [
           {
-            "fontFamily": "inter-medium",
+            "fontFamily": "inter-regular",
           },
           {
-            "color": "hsl(197, 15%, 45%)",
+            "color": "hsl(107, 64%, 16%)",
           },
           {
             "textAlign": "right",
           },
           {
-            "fontSize": 14,
+            "fontSize": 12,
             "lineHeight": 18,
           },
           {
@@ -133,27 +145,19 @@ exports[`StatusLabel alignment when alignment prop set to default ("start") shou
   </View>
   <View
     style={
-      {
-        "width": 8,
-      }
-    }
-  />
-  <View
-    style={
       [
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
-          "borderRadius": 3,
-          "height": 12,
-          "marginTop": 3,
-          "width": 12,
+          "borderRadius": 100,
+          "height": 8,
+          "width": 8,
         },
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
         },
       ]
     }
-    testID="successLabelIcon"
+    testID="successIndicator"
   />
 </View>
 `;
@@ -163,9 +167,20 @@ exports[`StatusLabel status when status prop set to "critical" should match snap
   style={
     [
       {
+        "alignItems": "center",
+        "backgroundColor": "hsl(109, 28%, 92%)",
+        "borderRadius": 16,
         "flexDirection": "row",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "flexWrap": "nowrap",
+        "gap": 4,
         "justifyContent": "flex-end",
+        "paddingHorizontal": 8,
+        "paddingVertical": 4,
+      },
+      {
+        "backgroundColor": "hsl(7, 63%, 95%)",
       },
       false,
     ]
@@ -183,22 +198,21 @@ exports[`StatusLabel status when status prop set to "critical" should match snap
       adjustsFontSizeToFit={false}
       allowFontScaling={true}
       collapsable={false}
-      maxFontSizeMultiplier={1.1428571428571428}
       selectable={true}
       selectionColor="hsl(86, 100%, 46%)"
       style={
         [
           {
-            "fontFamily": "inter-medium",
+            "fontFamily": "inter-regular",
           },
           {
-            "color": "hsl(197, 15%, 45%)",
+            "color": "hsl(6, 100%, 24%)",
           },
           {
             "textAlign": "right",
           },
           {
-            "fontSize": 14,
+            "fontSize": 12,
             "lineHeight": 18,
           },
           {
@@ -212,27 +226,19 @@ exports[`StatusLabel status when status prop set to "critical" should match snap
   </View>
   <View
     style={
-      {
-        "width": 8,
-      }
-    }
-  />
-  <View
-    style={
       [
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
-          "borderRadius": 3,
-          "height": 12,
-          "marginTop": 3,
-          "width": 12,
+          "borderRadius": 100,
+          "height": 8,
+          "width": 8,
         },
         {
           "backgroundColor": "hsl(6, 64%, 51%)",
         },
       ]
     }
-    testID="criticalLabelIcon"
+    testID="criticalIndicator"
   />
 </View>
 `;
@@ -242,9 +248,20 @@ exports[`StatusLabel status when status prop set to "inactive" should match snap
   style={
     [
       {
+        "alignItems": "center",
+        "backgroundColor": "hsl(109, 28%, 92%)",
+        "borderRadius": 16,
         "flexDirection": "row",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "flexWrap": "nowrap",
+        "gap": 4,
         "justifyContent": "flex-end",
+        "paddingHorizontal": 8,
+        "paddingVertical": 4,
+      },
+      {
+        "backgroundColor": "hsl(195, 12%, 94%)",
       },
       false,
     ]
@@ -262,22 +279,21 @@ exports[`StatusLabel status when status prop set to "inactive" should match snap
       adjustsFontSizeToFit={false}
       allowFontScaling={true}
       collapsable={false}
-      maxFontSizeMultiplier={1.1428571428571428}
       selectable={true}
       selectionColor="hsl(86, 100%, 46%)"
       style={
         [
           {
-            "fontFamily": "inter-medium",
+            "fontFamily": "inter-regular",
           },
           {
-            "color": "hsl(197, 15%, 45%)",
+            "color": "hsl(197, 90%, 12%)",
           },
           {
             "textAlign": "right",
           },
           {
-            "fontSize": 14,
+            "fontSize": 12,
             "lineHeight": 18,
           },
           {
@@ -291,27 +307,19 @@ exports[`StatusLabel status when status prop set to "inactive" should match snap
   </View>
   <View
     style={
-      {
-        "width": 8,
-      }
-    }
-  />
-  <View
-    style={
       [
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
-          "borderRadius": 3,
-          "height": 12,
-          "marginTop": 3,
-          "width": 12,
+          "borderRadius": 100,
+          "height": 8,
+          "width": 8,
         },
         {
           "backgroundColor": "hsl(198, 25%, 33%)",
         },
       ]
     }
-    testID="inactiveLabelIcon"
+    testID="inactiveIndicator"
   />
 </View>
 `;
@@ -321,9 +329,20 @@ exports[`StatusLabel status when status prop set to "informative" should match s
   style={
     [
       {
+        "alignItems": "center",
+        "backgroundColor": "hsl(109, 28%, 92%)",
+        "borderRadius": 16,
         "flexDirection": "row",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "flexWrap": "nowrap",
+        "gap": 4,
         "justifyContent": "flex-end",
+        "paddingHorizontal": 8,
+        "paddingVertical": 4,
+      },
+      {
+        "backgroundColor": "hsl(207, 87%, 94%)",
       },
       false,
     ]
@@ -341,22 +360,21 @@ exports[`StatusLabel status when status prop set to "informative" should match s
       adjustsFontSizeToFit={false}
       allowFontScaling={true}
       collapsable={false}
-      maxFontSizeMultiplier={1.1428571428571428}
       selectable={true}
       selectionColor="hsl(86, 100%, 46%)"
       style={
         [
           {
-            "fontFamily": "inter-medium",
+            "fontFamily": "inter-regular",
           },
           {
-            "color": "hsl(197, 15%, 45%)",
+            "color": "hsl(207, 61%, 34%)",
           },
           {
             "textAlign": "right",
           },
           {
-            "fontSize": 14,
+            "fontSize": 12,
             "lineHeight": 18,
           },
           {
@@ -370,27 +388,19 @@ exports[`StatusLabel status when status prop set to "informative" should match s
   </View>
   <View
     style={
-      {
-        "width": 8,
-      }
-    }
-  />
-  <View
-    style={
       [
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
-          "borderRadius": 3,
-          "height": 12,
-          "marginTop": 3,
-          "width": 12,
+          "borderRadius": 100,
+          "height": 8,
+          "width": 8,
         },
         {
           "backgroundColor": "hsl(207, 79%, 57%)",
         },
       ]
     }
-    testID="informativeLabelIcon"
+    testID="informativeIndicator"
   />
 </View>
 `;
@@ -400,9 +410,20 @@ exports[`StatusLabel status when status prop set to "warning" should match snaps
   style={
     [
       {
+        "alignItems": "center",
+        "backgroundColor": "hsl(109, 28%, 92%)",
+        "borderRadius": 16,
         "flexDirection": "row",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "flexWrap": "nowrap",
+        "gap": 4,
         "justifyContent": "flex-end",
+        "paddingHorizontal": 8,
+        "paddingVertical": 4,
+      },
+      {
+        "backgroundColor": "hsl(52, 64%, 89%)",
       },
       false,
     ]
@@ -420,22 +441,21 @@ exports[`StatusLabel status when status prop set to "warning" should match snaps
       adjustsFontSizeToFit={false}
       allowFontScaling={true}
       collapsable={false}
-      maxFontSizeMultiplier={1.1428571428571428}
       selectable={true}
       selectionColor="hsl(86, 100%, 46%)"
       style={
         [
           {
-            "fontFamily": "inter-medium",
+            "fontFamily": "inter-regular",
           },
           {
-            "color": "hsl(197, 15%, 45%)",
+            "color": "hsl(51, 64%, 24%)",
           },
           {
             "textAlign": "right",
           },
           {
-            "fontSize": 14,
+            "fontSize": 12,
             "lineHeight": 18,
           },
           {
@@ -449,27 +469,19 @@ exports[`StatusLabel status when status prop set to "warning" should match snaps
   </View>
   <View
     style={
-      {
-        "width": 8,
-      }
-    }
-  />
-  <View
-    style={
       [
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
-          "borderRadius": 3,
-          "height": 12,
-          "marginTop": 3,
-          "width": 12,
+          "borderRadius": 100,
+          "height": 8,
+          "width": 8,
         },
         {
           "backgroundColor": "hsl(51, 64%, 49%)",
         },
       ]
     }
-    testID="warningLabelIcon"
+    testID="warningIndicator"
   />
 </View>
 `;
@@ -479,9 +491,20 @@ exports[`StatusLabel status when status prop set to default ("success") should m
   style={
     [
       {
+        "alignItems": "center",
+        "backgroundColor": "hsl(109, 28%, 92%)",
+        "borderRadius": 16,
         "flexDirection": "row",
+        "flexGrow": 0,
+        "flexShrink": 1,
         "flexWrap": "nowrap",
+        "gap": 4,
         "justifyContent": "flex-end",
+        "paddingHorizontal": 8,
+        "paddingVertical": 4,
+      },
+      {
+        "backgroundColor": "hsl(109, 28%, 92%)",
       },
       false,
     ]
@@ -499,22 +522,21 @@ exports[`StatusLabel status when status prop set to default ("success") should m
       adjustsFontSizeToFit={false}
       allowFontScaling={true}
       collapsable={false}
-      maxFontSizeMultiplier={1.1428571428571428}
       selectable={true}
       selectionColor="hsl(86, 100%, 46%)"
       style={
         [
           {
-            "fontFamily": "inter-medium",
+            "fontFamily": "inter-regular",
           },
           {
-            "color": "hsl(197, 15%, 45%)",
+            "color": "hsl(107, 64%, 16%)",
           },
           {
             "textAlign": "right",
           },
           {
-            "fontSize": 14,
+            "fontSize": 12,
             "lineHeight": 18,
           },
           {
@@ -528,27 +550,19 @@ exports[`StatusLabel status when status prop set to default ("success") should m
   </View>
   <View
     style={
-      {
-        "width": 8,
-      }
-    }
-  />
-  <View
-    style={
       [
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
-          "borderRadius": 3,
-          "height": 12,
-          "marginTop": 3,
-          "width": 12,
+          "borderRadius": 100,
+          "height": 8,
+          "width": 8,
         },
         {
           "backgroundColor": "hsl(107, 58%, 33%)",
         },
       ]
     }
-    testID="successLabelIcon"
+    testID="successIndicator"
   />
 </View>
 `;

--- a/packages/components/src/StatusLabel/StatusLabel.module.css
+++ b/packages/components/src/StatusLabel/StatusLabel.module.css
@@ -5,7 +5,7 @@
   display: flex;
   width: fit-content;
   padding: 0.375rem 0.625rem 0.375rem 0.5rem;
-  border-radius: 0.75rem;
+  border-radius: var(--radius-large);
   flex-direction: row;
   flex-wrap: nowrap;
   gap: 0.375rem;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We have a disjointed visual treatment of StatusLabel in web and mobile. Also, when the StatusIndicator was extracted for easier re-use in web, there was no followup to allow the same in mobile.

Styling of web StatusLabel:
![image](https://github.com/user-attachments/assets/3f30d370-e89f-4eaf-97d8-f1efd8f082e3)

Old styling of mobile StatusLabel:
![image](https://github.com/user-attachments/assets/821b5756-7e69-404c-b76b-5ef96b5e78dd)

New styling for mobile StatusLabel:
![image](https://github.com/user-attachments/assets/eaf64736-e3bd-44f7-a388-81e28287b98c)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- new StatusIndicator component for `components-native`

### Changed

- Styling of mobile StatusLabel
- StatusLabel now consumes StatusIndicator

### Fixed

- Mobile StatusLabel now looks like the web StatusLabel

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
