### PR TITLE
refactor(components): Replace ToggleOpen with HandleOpen

### DIFF
--- a/docs/components/Combobox/Combobox.stories.mdx
+++ b/docs/components/Combobox/Combobox.stories.mdx
@@ -64,8 +64,8 @@ story.
 **Child Render Function:** If neither a Chip nor a Button is sufficient for your
 needs, you may instead provide a function as the child to `Combobox.Activator`.
 
-As arguments, the function will receive the toggle method to swap between open
-and closed states, as well as accessibility attributes required for a Combobox.
+As arguments, the function will receive a method to open the Combobox (closing
+is handled internally), and accessibility attributes required for a Combobox.
 **You must implement these yourself**. See the
 [render function example](../?path=/story/components-selections-combobox-web--custom-activator)
 for reference.

--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -190,10 +190,10 @@ const ComboboxCustomActivator: ComponentStory<typeof Combobox> = args => {
               tabIndex={0}
               aria-controls={activatorAPI.ariaControls}
               aria-expanded={activatorAPI.ariaExpanded}
-              onClick={activatorAPI.toggleOpen}
+              onClick={activatorAPI.open}
               onKeyDown={e => {
                 if (e.key === "Enter" || e.key === " ") {
-                  activatorAPI.toggleOpen();
+                  activatorAPI.open();
                 }
               }}
               style={{

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -52,11 +52,6 @@ describe("Combobox", () => {
       expect(screen.getByText("Add Teammate")).toBeInTheDocument();
     });
 
-    it("should close the menu when clicking the activator", async () => {
-      await userEvent.click(screen.getByRole("combobox"));
-      expect(screen.getByTestId(MENU_TEST_ID)).toHaveClass("hidden");
-    });
-
     it("should close the menu when clicking outside the menu (which clicks the overlay)", async () => {
       await userEvent.click(screen.getByTestId(OVERLAY_TEST_ID));
       expect(screen.getByTestId(MENU_TEST_ID)).toHaveClass("hidden");

--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -34,7 +34,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
     open,
     handleClose,
     handleSelection,
-    toggleOpen,
+    handleOpen,
     internalFilteredOptions,
     handleSearchChange,
   } = useCombobox(
@@ -52,7 +52,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
       selected={selectedOptions}
       selectionHandler={handleSelection}
       open={open}
-      toggleOpen={toggleOpen}
+      handleOpen={handleOpen}
       handleClose={handleClose}
       shouldScroll={shouldScroll}
       searchValue={searchValue}

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -83,15 +83,14 @@ export interface ComboboxCustomActivatorProps {
   role: "combobox";
 
   /**
-   * Method to toggle the open state of the Combobox.
-   * All callbacks and cleanup will be handled when toggled to closed.
+   * Method to open the Combobox. Closing is handled by the Combobox itself.
    */
-  toggleOpen: () => void;
+  open: () => void;
 }
 
 export type ComboboxActivatorAccessibility = Omit<
   ComboboxCustomActivatorProps,
-  "toggleOpen"
+  "open"
 >;
 
 export interface ComboboxActivatorProps {

--- a/packages/components/src/Combobox/ComboboxProvider.tsx
+++ b/packages/components/src/Combobox/ComboboxProvider.tsx
@@ -7,7 +7,7 @@ export interface ComboboxProviderProps {
   readonly selectionHandler: (option: ComboboxOption) => void;
   readonly open: boolean;
   readonly handleClose: () => void;
-  readonly toggleOpen: () => void;
+  readonly handleOpen: () => void;
   readonly shouldScroll: MutableRefObject<boolean>;
   readonly searchValue: string;
   readonly label?: string;

--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.pom.tsx
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.pom.tsx
@@ -15,7 +15,7 @@ export function renderComboboxAction(
 ) {
   return render(
     <ComboboxContextProvider
-      toggleOpen={jest.fn()}
+      handleOpen={jest.fn()}
       handleClose={handleClose}
       selected={[]}
       open={true}

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.test.tsx
@@ -1,43 +1,30 @@
 import React, { ReactElement } from "react";
 import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Button } from "@jobber/components/Button";
 import { Chip } from "@jobber/components/Chip";
 import { ComboboxActivator } from "./ComboboxActivator";
 import { ComboboxContextProvider } from "../../ComboboxProvider";
 import { ComboboxCustomActivatorProps } from "../../Combobox.types";
 
-const toggleOpen = jest.fn();
+const handleOpen = jest.fn();
 
 afterEach(() => {
-  toggleOpen.mockClear();
+  handleOpen.mockClear();
 });
 
 describe("ComboboxActivator", () => {
-  describe("when open is true", () => {
-    it("should call toggleOpen when the activator is clicked", () => {
-      const { getByRole } = renderComboboxActivator(
-        <Button label="Teammates" />,
-        true,
-      );
-      const activator = getByRole("combobox");
-
-      activator.click();
-
-      expect(toggleOpen).toHaveBeenCalled();
-    });
-  });
-
   describe("when open is false", () => {
-    it("should call toggleOpen when the activator is clicked", () => {
+    it("should call handleOpen when the activator is clicked", async () => {
       const { getByRole } = renderComboboxActivator(
         <Button label="Teammates" />,
         false,
       );
       const activator = getByRole("combobox");
 
-      activator.click();
+      await userEvent.click(activator);
 
-      expect(toggleOpen).toHaveBeenCalled();
+      expect(handleOpen).toHaveBeenCalled();
     });
   });
   it("can render a Button with role 'combobox' and onClick handler", () => {
@@ -70,6 +57,18 @@ describe("ComboboxActivator", () => {
     expect(getByText("Teammates")).toBeInTheDocument();
     expect(queryByRole("combobox")).toBeInTheDocument();
   });
+  it("opens the combobox when custom element is clicked", async () => {
+    const { getByRole } = renderComboboxActivator(
+      (api: ComboboxCustomActivatorProps) => (
+        <div role={api.role} onClick={api.open}>
+          Teammates
+        </div>
+      ),
+      true,
+    );
+    await userEvent.click(getByRole("combobox"));
+    expect(handleOpen).toHaveBeenCalled();
+  });
 });
 
 function renderComboboxActivator(
@@ -78,7 +77,7 @@ function renderComboboxActivator(
 ) {
   return render(
     <ComboboxContextProvider
-      toggleOpen={toggleOpen}
+      handleOpen={handleOpen}
       handleClose={jest.fn()}
       selectionHandler={jest.fn()}
       shouldScroll={{ current: false }}

--- a/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
+++ b/packages/components/src/Combobox/components/ComboboxActivator/ComboboxActivator.tsx
@@ -6,7 +6,7 @@ import { ComboboxActivatorProps } from "../../Combobox.types";
 import { useComboboxActivatorAccessibility } from "../../hooks/useComboboxActivatorAccessibility";
 
 export function ComboboxActivator(props: ComboboxActivatorProps) {
-  const { toggleOpen } = React.useContext(ComboboxContext);
+  const { handleOpen } = React.useContext(ComboboxContext);
   const accessibilityAttributes = useComboboxActivatorAccessibility();
 
   if (
@@ -15,10 +15,10 @@ export function ComboboxActivator(props: ComboboxActivatorProps) {
   ) {
     return React.cloneElement(props.children, {
       role: accessibilityAttributes.role,
-      onClick: toggleOpen,
+      onClick: handleOpen,
     });
   } else if (typeof props.children === "function") {
-    return props.children({ ...accessibilityAttributes, toggleOpen });
+    return props.children({ ...accessibilityAttributes, open: handleOpen });
   }
 
   return null;

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.test.tsx
@@ -4,14 +4,14 @@ import { ComboboxContent } from "./ComboboxContent";
 import { ComboboxContextProvider } from "../../ComboboxProvider";
 import { ComboboxOption } from "../../Combobox.types";
 
-const toggleOpen = jest.fn();
+const handleOpen = jest.fn();
 const setSelected = jest.fn();
 const handleSelect = jest.fn();
 const setSearchValue = jest.fn();
 const handleClose = jest.fn();
 
 afterEach(() => {
-  toggleOpen.mockClear();
+  handleOpen.mockClear();
   setSelected.mockClear();
   setSearchValue.mockClear();
   handleSelect.mockClear();
@@ -78,7 +78,7 @@ function renderComboboxContent(
 ) {
   return render(
     <ComboboxContextProvider
-      toggleOpen={toggleOpen}
+      handleOpen={handleOpen}
       handleClose={handleClose}
       selectionHandler={handleSelect}
       shouldScroll={{ current: false }}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContentList/ComboboxContentList.test.tsx
@@ -53,7 +53,7 @@ function renderComboboxContentList(
 ) {
   return render(
     <ComboboxContextProvider
-      toggleOpen={jest.fn()}
+      handleOpen={jest.fn()}
       handleClose={jest.fn()}
       selectionHandler={jest.fn()}
       shouldScroll={{ current: false }}

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.test.tsx
@@ -5,30 +5,20 @@ import { ComboboxTrigger } from "./ComboboxTrigger";
 import { ComboboxContextProvider } from "../../ComboboxProvider";
 import { ComboboxOption } from "../../Combobox.types";
 
-const toggleOpen = jest.fn();
+const handleOpen = jest.fn();
 
 afterEach(() => {
-  toggleOpen.mockClear();
+  handleOpen.mockClear();
 });
 
 describe("ComboboxTrigger", () => {
   describe("when open is false", () => {
-    it("calls toggleOpen", async () => {
+    it("calls handleOpen", async () => {
       renderTrigger();
       const trigger = screen.getByRole("combobox");
 
       await userEvent.click(trigger);
-      expect(toggleOpen).toHaveBeenCalled();
-    });
-  });
-
-  describe("when open is true", () => {
-    it("calls toggleOpen", async () => {
-      renderTrigger(true);
-      const trigger = screen.getByRole("combobox");
-
-      await userEvent.click(trigger);
-      expect(toggleOpen).toHaveBeenCalled();
+      expect(handleOpen).toHaveBeenCalled();
     });
   });
 
@@ -124,7 +114,7 @@ function renderTrigger(
 ) {
   return render(
     <ComboboxContextProvider
-      toggleOpen={toggleOpen}
+      handleOpen={handleOpen}
       handleClose={jest.fn()}
       selected={[]}
       open={open}

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
@@ -8,7 +8,7 @@ export function ComboboxTrigger({
   label = "Select",
   selected,
 }: ComboboxTriggerProps) {
-  const { toggleOpen } = React.useContext(ComboboxContext);
+  const { handleOpen } = React.useContext(ComboboxContext);
 
   const hasSelection = selected.length;
   const selectedLabel = selected.map(option => option.label).join(", ");
@@ -19,7 +19,7 @@ export function ComboboxTrigger({
       label={hasSelection ? selectedLabel : ""}
       ariaLabel={label}
       heading={label}
-      onClick={toggleOpen}
+      onClick={handleOpen}
       role="combobox"
     >
       {!hasSelection && (

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -44,7 +44,7 @@ export function useCombobox(
     [onSearch, debounceTime],
   );
 
-  const { handleClose, handleSelection, toggleOpen } = useMakeComboboxHandlers(
+  const { handleClose, handleSelection, handleOpen } = useMakeComboboxHandlers(
     setOpen,
     open,
     setSearchValue,
@@ -70,7 +70,7 @@ export function useCombobox(
     shouldScroll,
     handleClose,
     handleSelection,
-    toggleOpen,
+    handleOpen,
     internalFilteredOptions,
     handleSearchChange: onSearch ? searchCallback : noop,
   };

--- a/packages/components/src/Combobox/hooks/useMakeComboboxHandlers.ts
+++ b/packages/components/src/Combobox/hooks/useMakeComboboxHandlers.ts
@@ -4,7 +4,7 @@ import { ComboboxOption } from "../Combobox.types";
 export interface UseMakeComboboxHandlersReturn {
   handleClose: () => void;
   handleSelection: (selection: ComboboxOption) => void;
-  toggleOpen: () => void;
+  handleOpen: () => void;
 }
 
 export function useMakeComboboxHandlers(
@@ -34,14 +34,6 @@ export function useMakeComboboxHandlers(
     setOpen(true);
   }, [setOpen]);
 
-  const toggleOpen = useCallback(() => {
-    if (open) {
-      handleClose();
-    } else {
-      handleOpen();
-    }
-  }, [open, handleClose, handleOpen]);
-
   const handleSelection = useCallback(
     (selection: ComboboxOption) => {
       if (multiSelect) {
@@ -67,7 +59,7 @@ export function useMakeComboboxHandlers(
   return {
     handleClose,
     handleSelection,
-    toggleOpen,
+    handleOpen,
   };
 }
 

--- a/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
+++ b/packages/components/src/DataList/components/DataListFilters/components/DataListSort/DataListSort.test.tsx
@@ -81,7 +81,7 @@ describe("DataListSort", () => {
     });
 
     it("should close the popover when the button is clicked again", async () => {
-      await userEvent.click(screen.getByRole("combobox"));
+      await userEvent.click(screen.getByTestId("ATL-Combobox-Overlay"));
       expect(screen.getByTestId(MENU_TEST_ID)).toHaveClass("hidden");
     });
   });


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Combobox doesn't allow you to actually interact with the Activator again once the combobox is open. Maybe some day it will, but that day is not today.

With that, the `toggleOpen` method is a bit misleading. in practice it is a one way toggle that can only ever toggle from closed -> open.

the `toggleOpen` method has a dead code path that only exists in theory. functionally, you have no way to interact with the activator while the combobox is open. we will close it when you click outside the combobox, when you press ESC, when you interact with an Action that has the default close on click, or when you make a selection in single select mode.

the only way you can interact with it would be through DOM manipulation which is not realistic.

it's similar to how we handle the overlay

```
        {open && (
          <div
            className={styles.overlay}
            onClick={() => handleClose()}
            data-testid="ATL-Combobox-Overlay"
          />
        )}
```

this one is more explicit since the condition ensures we'd never even have this element rendered if it was closed, but there conceptually it's the same. we know that in practice, you can't interact with the activator once the combobox is open.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

the exposed method from the API is now named `open`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

remvoed some tests that were checking cases that aren't real, or doing interactions no user could do

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

play around with some normal comboboxes, custom Chip/Button activator comboboxes and finally the fully customized activator combobox.

all of them should still open when the activator is interacted with, and close as expected when clicking outside, pressing ESC, making selections in single select mode etc.

it will even look like it closes when you click the activator while it's open, just know that's the `handleClose` on the overlay doing it in reality.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
