### PR TITLE
feat(components): re-position search to be primary element

### DIFF
--- a/packages/components/src/DataList/DataList.module.css
+++ b/packages/components/src/DataList/DataList.module.css
@@ -26,10 +26,9 @@
 }
 
 .headerFilters {
-  display: grid;
+  display: flex;
   padding: calc(var(--space-small) + var(--space-smaller)) 0;
   gap: var(--space-small);
-  grid-template-columns: auto fit-content(calc(var(--base-unit) * 14));
 }
 
 .headerFilters:empty {

--- a/packages/components/src/DataList/DataList.tsx
+++ b/packages/components/src/DataList/DataList.tsx
@@ -160,8 +160,8 @@ function InternalDataList({
       {shouldRenderStickyHeader && (
         <DataListStickyHeader>
           <div className={styles.headerFilters}>
-            <InternalDataListFilters />
             <InternalDataListSearch />
+            <InternalDataListFilters />
           </div>
 
           <InternalDataListStatusBar />

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.module.css
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.module.css
@@ -9,7 +9,7 @@
 
   position: absolute;
   top: 50%;
-  right: var(--button-offset);
+  left: var(--button-offset);
   visibility: hidden;
   width: 0;
   padding: var(--space-smaller) 0;
@@ -24,6 +24,7 @@
 
 .searchInputVisible {
   visibility: visible;
+  z-index: 1;
   width: calc(100% - var(--button-offset));
   opacity: 1;
 }

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.tsx
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.tsx
@@ -69,6 +69,7 @@ export function InternalDataListSearch() {
           initialChild={
             <Button
               variation="subtle"
+              type="secondary"
               icon="search"
               ariaLabel="Search"
               onClick={toggleSearch}
@@ -77,6 +78,7 @@ export function InternalDataListSearch() {
           switchTo={
             <Button
               variation="subtle"
+              type="secondary"
               icon="remove"
               ariaLabel="Close search bar"
               onClick={toggleSearch}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Roughly ~1 year of usage data on interaction patterns with the new DataList has given us some clear indicators that Search is a much more primary interaction than was anticipated.

## Changes

### Changed

- Updates the order of elements in the `DataListStickyHeader` so that Search is the leading UI element, now followed by the filter Chips if present

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
