### PR TITLE
docs(components): better disambiguate InlineLabel and StatusLabel [JOB-108048]

### DIFF
--- a/docs/components/InlineLabel/InlineLabel.stories.mdx
+++ b/docs/components/InlineLabel/InlineLabel.stories.mdx
@@ -9,7 +9,7 @@ import { InlineLabel } from "@jobber/components/InlineLabel";
 # Inline Label
 
 InlineLabel is a generic badging element that can be used to distinguish a
-labeling Boxelement from other typographic content.
+labeling element from other typographic content.
 
 ## Design & usage guidelines
 

--- a/docs/components/InlineLabel/InlineLabel.stories.mdx
+++ b/docs/components/InlineLabel/InlineLabel.stories.mdx
@@ -1,32 +1,56 @@
 import { Canvas, Meta } from "@storybook/addon-docs";
+import { Heading } from "@jobber/components/Heading";
+import { Text } from "@jobber/components/Text";
 import { InlineLabel } from "@jobber/components/InlineLabel";
 
 <Meta title="Components/Status and Feedback/InlineLabel" />
 
 # Inline Label
 
-Inline labels are typically used to indicate state/status on objects within the
-application.
+InlineLabel is a generic badging element that can be used to distinguish a
+labeling text element from other typographic content.
 
 ## Design & usage guidelines
 
 Inline labels can be used fairly broadly, but the application of
 [color](../?path=/docs/design-colors--docs) should be handled with intent. Use
 of colour along with a descriptive label can help the user understand the
-meaning of an item's status.
+meaning of an item.
 
-| Color                                                                                                             | Meaning     |
-| :---------------------------------------------------------------------------------------------------------------- | :---------- |
-| <InlineLabel color="red">Past due</InlineLabel> <InlineLabel color="red">Changes requested</InlineLabel>          | Critical    |
-| <InlineLabel color="yellow">Unscheduled</InlineLabel> <InlineLabel color="yellow">Awaiting response</InlineLabel> | Warning     |
-| <InlineLabel color="green">Approved</InlineLabel> <InlineLabel color="green">Paid</InlineLabel>                   | Success     |
-| <InlineLabel color="greyBlue">Draft</InlineLabel> <InlineLabel color="greyBlue">Archived</InlineLabel>            | Inactive    |
-| <InlineLabel color="lightBlue">Sent</InlineLabel> <InlineLabel color="lightBlue">Converted</InlineLabel>          | Informative |
+### Counts
 
-### Related components
+<Canvas>
+  <Text>Unread</Text>
+  <InlineLabel color="red">+99</InlineLabel>
+</Canvas>
 
-For simpler mapping of statuses to their semantic colours, use
-[StatusLabel.](../?path=/docs/components-status-and-feedback-statuslabel--docs)
+### Trends
+
+<Canvas>
+  <InlineLabel color="red">↓ 15%</InlineLabel>
+  <InlineLabel color="green">↑ 25%</InlineLabel>
+</Canvas>
+
+### Tags
+
+<Canvas>
+  <InlineLabel>Do not contact</InlineLabel>
+  <InlineLabel>Northeast</InlineLabel>
+  <InlineLabel>Residential</InlineLabel>
+  <InlineLabel>Electrical</InlineLabel>
+</Canvas>
+
+### Labels that need to be distinguished from other typographic element
+
+<Canvas>
+  <Heading level={2}>Do not contact</Heading>
+  <InlineLabel size="large">Beta</InlineLabel>
+</Canvas>
+
+## Related components
+
+[StatusLabel](../?path=/docs/components-status-and-feedback-statuslabel--docs)
+should be used when you're conveying the "status" of something.
 
 ## Sizes
 

--- a/docs/components/InlineLabel/InlineLabel.stories.mdx
+++ b/docs/components/InlineLabel/InlineLabel.stories.mdx
@@ -60,9 +60,11 @@ of an item.
 [StatusLabel](../?path=/docs/components-status-and-feedback-statuslabel--docs)
 should be used when you're conveying the "status" of something.
 
-## Sizes
+## Variants
 
-### Large
+### Sizes
+
+#### Large
 
 <Canvas>
   <InlineLabel size="large" color="blue">
@@ -70,7 +72,7 @@ should be used when you're conveying the "status" of something.
   </InlineLabel>
 </Canvas>
 
-### Larger
+#### Larger
 
 <Canvas>
   <InlineLabel size="larger" color="green">
@@ -78,7 +80,7 @@ should be used when you're conveying the "status" of something.
   </InlineLabel>
 </Canvas>
 
-## Colors
+### Colors
 
 | Inline Label                                               | Color         |
 | :--------------------------------------------------------- | :------------ |

--- a/docs/components/InlineLabel/InlineLabel.stories.mdx
+++ b/docs/components/InlineLabel/InlineLabel.stories.mdx
@@ -14,8 +14,8 @@ labeling text element from other typographic content.
 
 Inline labels can be used fairly broadly, but the application of
 [color](../?path=/docs/design-colors--docs) should be handled with intent. Use
-of colour along with a descriptive label can help the user understand the
-meaning of an item.
+of color along with a descriptive label can help the user understand the meaning
+of an item.
 
 ### Counts
 

--- a/docs/components/InlineLabel/InlineLabel.stories.mdx
+++ b/docs/components/InlineLabel/InlineLabel.stories.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta } from "@storybook/addon-docs";
 import { Heading } from "@jobber/components/Heading";
 import { Text } from "@jobber/components/Text";
+import { Box } from "@jobber/components/Box";
 import { InlineLabel } from "@jobber/components/InlineLabel";
 
 <Meta title="Components/Status and Feedback/InlineLabel" />
@@ -8,7 +9,7 @@ import { InlineLabel } from "@jobber/components/InlineLabel";
 # Inline Label
 
 InlineLabel is a generic badging element that can be used to distinguish a
-labeling text element from other typographic content.
+labeling Boxelement from other typographic content.
 
 ## Design & usage guidelines
 
@@ -20,31 +21,38 @@ of an item.
 ### Counts
 
 <Canvas>
-  <Text>Unread</Text>
-  <InlineLabel color="red">+99</InlineLabel>
+  <Box direction="row" alignItems="baseline" gap="small">
+    <Text>Unread</Text>
+    <InlineLabel color="red">+99</InlineLabel>
+  </Box>
 </Canvas>
 
 ### Trends
 
 <Canvas>
-  <InlineLabel color="red">↓ 15%</InlineLabel>
-  <InlineLabel color="green">↑ 25%</InlineLabel>
+  <InlineLabel color="red">↓ 15</InlineLabel>
+  <InlineLabel color="green">↑ 25</InlineLabel>
 </Canvas>
 
 ### Tags
 
 <Canvas>
-  <InlineLabel>Do not contact</InlineLabel>
-  <InlineLabel>Northeast</InlineLabel>
-  <InlineLabel>Residential</InlineLabel>
-  <InlineLabel>Electrical</InlineLabel>
+  <Box direction="row" alignItems="center" gap="smaller">
+    <InlineLabel>Preferred customer</InlineLabel>
+    <InlineLabel>Northeast</InlineLabel>
+    <InlineLabel>Residential</InlineLabel>
+    <InlineLabel>Electrical</InlineLabel>
+    <InlineLabel>10OFF promo</InlineLabel>
+  </Box>
 </Canvas>
 
 ### Labels that need to be distinguished from other typographic element
 
 <Canvas>
-  <Heading level={2}>Do not contact</Heading>
-  <InlineLabel size="large">Beta</InlineLabel>
+  <Box direction="row" alignItems="center" gap="small">
+    <Heading level={2}>New feature</Heading>
+    <InlineLabel size="large">Beta</InlineLabel>
+  </Box>
 </Canvas>
 
 ## Related components

--- a/docs/components/StatusLabel/StatusLabel.stories.mdx
+++ b/docs/components/StatusLabel/StatusLabel.stories.mdx
@@ -65,9 +65,13 @@ where the StatusLabel is on the right, use the `end` alignment.
 
 ## Related components
 
-- [InlineLabel](../?path=/docs/components-status-and-feedback-inlinelabel--docs)
-  should be replaced with StatusLabel where possible to provide a more
-  intentional communication of status to users
+[InlineLabel](../?path=/docs/components-status-and-feedback-inlinelabel--docs)
+is a more generic badging element that can be used in non-"status"-y ways
+
+- counts
+- trends
+- tags
+- labels that need to be distinguished from other typographic content
 
 ## Content guidelines
 

--- a/docs/components/StatusLabel/StatusLabel.stories.mdx
+++ b/docs/components/StatusLabel/StatusLabel.stories.mdx
@@ -94,11 +94,6 @@ only method of communicating status.
 
 ## Responsiveness
 
-StatusLabel should take up as much space as is available. If StatusLabel's label
-is longer than the space available, the label should wrap.
-
-## Notes
-
-- StatusLabel should replace
-  [InlineLabel](../?path=/docs/components-status-and-feedback-inlinelabel--docs)
-  where possible.
+StatusLabel should "hug" it's contents, but otherwise grow as long as needed in
+the available space. If StatusLabel's label is longer than the space available,
+the label should wrap.


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When we did Summit the design team landed on a path where there would be no more InlineLabel, only the re-designed StatusLabel. Accordingly, we deprecated the component in the design system.

Over time, though, designers kept using InlineLabel and had some pretty legitimate use cases for not using StatusLabel. We’ve even aligned internally on usage guidance/disambiguation, so this adds that guidance to help designers choose the "right" *Label and removes references that suggest the InlineLabel should go away.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Better disambiguation comments to both Inline- and StatusLabel "Related components" sections

### Removed

- Scrapped references that InlineLabel should not be used

## Testing

Read the docs! 

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
