### PR TITLE
fix(design): Updating the task icon to use task-color [JOB-98804]

### DIFF
--- a/packages/design/src/iconStyles/iconColors.ts
+++ b/packages/design/src/iconStyles/iconColors.ts
@@ -144,5 +144,8 @@ export const iconColors = {
     brandHighlight: {
       value: "{color.brand-.highlight}",
     },
+    task: {
+      value: "{color.task}",
+    },
   },
 };

--- a/packages/design/src/iconStyles/iconStyles.web.ts
+++ b/packages/design/src/iconStyles/iconStyles.web.ts
@@ -53,7 +53,7 @@ export const webIconStyles: Record<string, React.CSSProperties> = {
     fill: "{color.request}",
   },
   task: {
-    fill: "{color.navy}",
+    fill: "{color.task}",
   },
   userUnassigned: {
     fill: "{color.destructive}",


### PR DESCRIPTION

## Motivations

The task icon was defaulting to color-navy which caused it to not look good in dark mode. This updates the task icon to use color-task to accommodate for both light and dark modes.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `task` icon now defaults to `color-task`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
