### PR TITLE
feat(docx): Improve search experience in new docs site

### DIFF
--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -31,17 +31,12 @@ export const NavMenu = () => {
         </Box>
       </Box>
       <Box padding="base">
-        <button
-          onClick={() => setOpen(true)}
-          type="button"
-          style={{ background: "transparent", border: 0 }}
-        >
-          <InputText
-            size="small"
-            prefix={{ icon: "search" }}
-            placeholder="Search"
-          />
-        </button>
+        <InputText
+          size="small"
+          prefix={{ icon: "search" }}
+          placeholder="Search"
+          onFocus={() => setOpen(true)}
+        />
       </Box>
       <SearchBox open={open} setOpen={setOpen} />
       <MenuList>

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -31,12 +31,17 @@ export const NavMenu = () => {
         </Box>
       </Box>
       <Box padding="base">
-        <InputText
-          size="small"
-          prefix={{ icon: "search" }}
-          placeholder="Search"
-          onFocus={() => setOpen(true)}
-        />
+        <button
+          onClick={() => setOpen(true)}
+          type="button"
+          style={{ background: "transparent", border: 0 }}
+        >
+          <InputText
+            size="small"
+            prefix={{ icon: "search" }}
+            placeholder="Search"
+          />
+        </button>
       </Box>
       <SearchBox open={open} setOpen={setOpen} />
       <MenuList>

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -1,4 +1,4 @@
-import { Box, InputText } from "@jobber/components";
+import { Box, Button } from "@jobber/components";
 import { Link } from "react-router-dom";
 import { PropsWithChildren, useState } from "react";
 import { SearchBox } from "./SearchBox";
@@ -31,17 +31,12 @@ export const NavMenu = () => {
         </Box>
       </Box>
       <Box padding="base">
-        <button
+        <Button
           onClick={() => setOpen(true)}
-          type="button"
-          style={{ background: "transparent", border: 0 }}
-        >
-          <InputText
-            size="small"
-            prefix={{ icon: "search" }}
-            placeholder="Search"
-          />
-        </button>
+          label="Search"
+          icon="search"
+          variation="subtle"
+        />
       </Box>
       <SearchBox open={open} setOpen={setOpen} />
       <MenuList>

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -36,7 +36,11 @@ export const NavMenu = () => {
           type="button"
           style={{ background: "transparent", border: 0 }}
         >
-          <InputText placeholder="Search" />
+          <InputText
+            size="small"
+            prefix={{ icon: "search" }}
+            placeholder="Search"
+          />
         </button>
       </Box>
       <SearchBox open={open} setOpen={setOpen} />

--- a/packages/site/src/layout/SearchBox.module.css
+++ b/packages/site/src/layout/SearchBox.module.css
@@ -1,0 +1,7 @@
+.searchBoxResults {
+    width: 100%;
+    max-height: calc(100vh - 240px);
+    overflow-y: scroll;
+    padding: var(--space-smallest);
+    box-sizing: border-box;
+}

--- a/packages/site/src/layout/SearchBox.tsx
+++ b/packages/site/src/layout/SearchBox.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
 } from "@jobber/components";
 import { useEffect, useMemo, useRef, useState } from "react";
+import styles from "./SearchBox.module.css";
 import { ContentCardWrapper } from "../components/ContentCardWrapper";
 import { ContentCard } from "../components/ContentCard";
 import { componentList } from "../componentList";
@@ -56,15 +57,17 @@ export const SearchBox = ({
   };
 
   return (
-    <Modal open={open} onRequestClose={closeModal} title="Search">
+    <Modal size="large" open={open} onRequestClose={closeModal} title="Search">
       <Content>
         <InputText
           ref={ref}
           value={search}
           placeholder="Search"
+          prefix={{ icon: "search" }}
+          clearable="always"
           onChange={d => setSearch(d as string)}
         />
-        <Box width="100%">
+        <div className={styles.searchBoxResults}>
           {filteredComponentList.length > 0 && (
             <Content>
               <Typography size="larger" fontWeight="bold">
@@ -107,7 +110,7 @@ export const SearchBox = ({
               </Content>
             </Box>
           )}
-        </Box>
+        </div>
       </Content>
     </Modal>
   );

--- a/packages/site/src/layout/SearchBox.tsx
+++ b/packages/site/src/layout/SearchBox.tsx
@@ -58,7 +58,7 @@ export const SearchBox = ({
 
   return (
     <Modal size="large" open={open} onRequestClose={closeModal} title="Search">
-      <Content>
+      <Content spacing={"larger"}>
         <InputText
           ref={ref}
           value={search}
@@ -70,7 +70,13 @@ export const SearchBox = ({
         <div className={styles.searchBoxResults}>
           {filteredComponentList.length > 0 && (
             <Content>
-              <Typography size="larger" fontWeight="bold">
+              <Typography
+                size={"base"}
+                fontWeight={"bold"}
+                textCase={"uppercase"}
+                textColor={"textSecondary"}
+                element="h3"
+              >
                 Components
               </Typography>
               <ContentCardWrapper>
@@ -91,7 +97,13 @@ export const SearchBox = ({
           {filteredDesignList.length > 0 && (
             <Box padding={{ top: "largest" }}>
               <Content>
-                <Typography size="larger" fontWeight="bold">
+                <Typography
+                  size={"base"}
+                  fontWeight={"bold"}
+                  textCase={"uppercase"}
+                  textColor={"textSecondary"}
+                  element="h3"
+                >
                   Design
                 </Typography>
                 <ContentCardWrapper>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Searching the new docs site should be smooth and consumer grade! This cleans up some UI cruft and makes the search feel more intuitive.

### Before

- No search icon or clearable on the search input
- Modal would overflow the screen, forcing scroll - also limited results per viewport with a "base" width modal
- Results headings too similar in weight to section headings (Design + Components)
- Could not predictably fire the Search modal via keyboard

https://github.com/user-attachments/assets/cf322dd0-9bfc-40ce-87e7-ad9abe3ebca3

### After

- Search icon on the search input, and it's clearable
- Modal cannot overflow the screen
- Modal is wider, allowing for more results per query
- Better hierarchy within search results (more spacing, emphasis on content over headings)
- Can predictably fire the search modal using keyboard

https://github.com/user-attachments/assets/80b596e6-b0d0-42ac-bf72-2a04574db442


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- add clear and icon to input
- use large modal
- style results box
- Nav search item is a Button now

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
