### PR TITLE
chore: Undo previous lerna publish which failed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44625,7 +44625,7 @@
     },
     "packages/components": {
       "name": "@jobber/components",
-      "version": "5.46.1",
+      "version": "5.46.0",
       "license": "MIT",
       "dependencies": {
         "@jobber/formatters": "^0.3.0",
@@ -44699,7 +44699,7 @@
     },
     "packages/components-native": {
       "name": "@jobber/components-native",
-      "version": "0.73.4",
+      "version": "0.73.3",
       "license": "MIT",
       "dependencies": {
         "@react-native-clipboard/clipboard": "^1.11.2",
@@ -46378,7 +46378,7 @@
     },
     "packages/generators": {
       "name": "@jobber/generators",
-      "version": "0.11.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "inquirer-path": "^1.0.0-beta5"
@@ -46386,7 +46386,7 @@
     },
     "packages/hooks": {
       "name": "@jobber/hooks",
-      "version": "2.11.2",
+      "version": "2.11.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.20",
@@ -46426,10 +46426,10 @@
     },
     "packages/site": {
       "name": "@jobber/atlantis-site",
-      "version": "0.1.1",
+      "version": "0.1.0",
       "dependencies": {
-        "@jobber/components": "^5.46.1",
-        "@jobber/hooks": "^2.11.2",
+        "@jobber/components": "*",
+        "@jobber/hooks": "*",
         "prismjs": "^1.29.0",
         "react": "18.2.0",
         "react-element-to-jsx-string": "^15.0.0",

--- a/packages/components-native/CHANGELOG.md
+++ b/packages/components-native/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.73.4](https://github.com/GetJobber/atlantis/compare/@jobber/components-native@0.73.3...@jobber/components-native@0.73.4) (2024-11-04)
-
-**Note:** Version bump only for package @jobber/components-native
-
-
-
-
-
 ## [0.73.3](https://github.com/GetJobber/atlantis/compare/@jobber/components-native@0.73.2...@jobber/components-native@0.73.3) (2024-10-24)
 
 

--- a/packages/components-native/package.json
+++ b/packages/components-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/components-native",
-  "version": "0.73.4",
+  "version": "0.73.3",
   "license": "MIT",
   "description": "React Native implementation of Atlantis",
   "repository": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.46.1](https://github.com/GetJobber/atlantis/compare/@jobber/components@5.46.0...@jobber/components@5.46.1) (2024-11-04)
-
-**Note:** Version bump only for package @jobber/components
-
-
-
-
-
 # [5.46.0](https://github.com/GetJobber/atlantis/compare/@jobber/components@5.45.0...@jobber/components@5.46.0) (2024-10-29)
 
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/components",
-  "version": "5.46.1",
+  "version": "5.46.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/generators/CHANGELOG.md
+++ b/packages/generators/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.11.1](https://github.com/GetJobber/atlantis/compare/@jobber/generators@0.11.0...@jobber/generators@0.11.1) (2024-11-04)
-
-**Note:** Version bump only for package @jobber/generators
-
-
-
-
-
 # [0.11.0](https://github.com/GetJobber/atlantis/compare/@jobber/generators@0.10.3...@jobber/generators@0.11.0) (2024-10-29)
 
 

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/generators",
-  "version": "0.11.1",
+  "version": "0.11.0",
   "license": "MIT",
   "main": "index.js",
   "scripts": {},

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.11.2](https://github.com/GetJobber/atlantis/compare/@jobber/hooks@2.11.1...@jobber/hooks@2.11.2) (2024-11-04)
-
-**Note:** Version bump only for package @jobber/hooks
-
-
-
-
-
 ## [2.11.1](https://github.com/GetJobber/atlantis/compare/@jobber/hooks@2.11.0...@jobber/hooks@2.11.1) (2024-10-01)
 
 **Note:** Version bump only for package @jobber/hooks

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/hooks",
-  "version": "2.11.2",
+  "version": "2.11.1",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.js",

--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.1](https://github.com/GetJobber/atlantis/compare/@jobber/atlantis-site@0.1.0...@jobber/atlantis-site@0.1.1) (2024-11-04)
-
-**Note:** Version bump only for package @jobber/atlantis-site
-
-
-
-
-
 # 0.1.0 (2024-10-29)
 
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jobber/atlantis-site",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -11,8 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@jobber/components": "^5.46.1",
-    "@jobber/hooks": "^2.11.2",
+    "@jobber/components": "*",
+    "@jobber/hooks": "*",
     "prismjs": "^1.29.0",
     "react": "18.2.0",
     "react-element-to-jsx-string": "^15.0.0",


### PR DESCRIPTION


<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This reverts commit 9e81dbe0dc0e5fc1b96e5cf85be2c335734b8364.

Lerna is confused about the state of the world because it pushed a commit with new version numbers, but it failed to actually publish because it didn't have npm authentication setup, which I restored in my last PR.


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Fix lerna's confusion


## Testing

<!-- How to test your changes. -->

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)
