### PR TITLE
DRAFT + Exploration : Forms without React Hook Form + Component Shim Pattern

### DIFF
--- a/packages/components/src/FormField/FormFieldAffix.tsx
+++ b/packages/components/src/FormField/FormFieldAffix.tsx
@@ -19,6 +19,7 @@ export function AffixLabel({
   const affixLabelClass = classnames(styles.affixLabel, {
     [styles.suffix]: variation === "suffix",
   });
+  if (!label) return null;
 
   return (
     <div ref={labelRef} className={affixLabelClass}>
@@ -44,7 +45,7 @@ export function AffixIcon({
 
   const iconSize = size === "small" ? "small" : "base";
 
-  if (!icon) return <></>;
+  if (!icon) return null;
 
   return (
     <div className={affixIconClass}>

--- a/packages/components/src/FormField/FormFieldDescription.tsx
+++ b/packages/components/src/FormField/FormFieldDescription.tsx
@@ -4,13 +4,17 @@ import { Text } from "../Text";
 
 interface FormFieldDescriptionProps {
   readonly id: string;
-  readonly description: string;
+  readonly description?: string;
+  readonly visible?: boolean;
 }
 
 export function FormFieldDescription({
   id,
   description,
+  visible = true,
 }: FormFieldDescriptionProps) {
+  if (!visible) return null;
+
   return (
     <div id={id} className={styles.description}>
       <Text size="small" variation="subdued">

--- a/packages/components/src/FormField/FormFieldPostFix.tsx
+++ b/packages/components/src/FormField/FormFieldPostFix.tsx
@@ -5,9 +5,15 @@ import { Spinner } from "../Spinner";
 
 interface FormFieldPostFixProps {
   readonly variation: "select" | "spinner";
+  readonly visible?: boolean;
 }
 
-export function FormFieldPostFix({ variation }: FormFieldPostFixProps) {
+export function FormFieldPostFix({
+  variation,
+  visible = true,
+}: FormFieldPostFixProps) {
+  if (!visible) return null;
+
   return (
     <span className={styles.postfix}>
       {variation === "select" ? (

--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -123,6 +123,11 @@ export interface CommonFormFieldProps {
    * set it to `always`.
    */
   readonly clearable?: Clearable;
+
+  /**
+   * Which version of the Field to use
+   */
+  version?: 1;
 }
 
 export interface FormFieldProps extends CommonFormFieldProps {

--- a/packages/components/src/FormField/components/ClearAction.tsx
+++ b/packages/components/src/FormField/components/ClearAction.tsx
@@ -7,9 +7,15 @@ interface ClearActionProps {
    * Click handler
    */
   readonly onClick: () => void;
+  readonly visible?: boolean;
 }
 
-export function ClearAction({ onClick }: ClearActionProps): JSX.Element {
+export function ClearAction({
+  onClick,
+  visible,
+}: ClearActionProps): React.ReactElement | null {
+  if (!visible) return null;
+
   return (
     <button
       className={styles.clearInput}

--- a/packages/components/src/InputText/InputText.rebuilt.tsx
+++ b/packages/components/src/InputText/InputText.rebuilt.tsx
@@ -1,0 +1,126 @@
+import React, { forwardRef, useEffect, useId } from "react";
+import { Clearable } from "@jobber/hooks";
+import {
+  FormFieldWrapper,
+  FormFieldWrapperHookProps,
+  useFormFieldWrapperStyles,
+} from "../FormField/FormFieldWrapper";
+import { FormFieldPostFix } from "../FormField/FormFieldPostFix";
+import {
+  AutocompleteTypes,
+  FormFieldTypes,
+  useAtlantisFormField,
+  useAtlantisFormFieldActions,
+  useAtlantisFormFieldName,
+} from "../FormField";
+
+export const InputTextSPAR = forwardRef(function InputTextInternal(
+  props: InputTextRebuiltProps,
+  inputRefs: React.Ref<HTMLInputElement>,
+) {
+  const legacyPropHelper = {
+    prefixWidth: 0,
+    suffixWidth: 0,
+    ...props,
+    version: 1,
+  };
+  const id = useId();
+
+  const [value, setValue] = React.useState(props.value || "");
+
+  useEffect(() => {
+    setValue(props.value || "");
+  }, [props.value]);
+
+  const { inputStyle } = useFormFieldWrapperStyles({
+    ...(legacyPropHelper as FormFieldWrapperHookProps),
+  });
+
+  const { name } = useAtlantisFormFieldName({
+    nameProp: props.name,
+    id: props.id || id,
+  });
+
+  const {
+    handleChange,
+    handleBlur,
+    handleFocus,
+    handleKeyDown,
+    handleValidation,
+  } = useAtlantisFormFieldActions({
+    name,
+    onChange: props.onChange as
+      | ((
+          newValue: string | number | boolean | Date,
+          event?:
+            | React.ChangeEvent<
+                HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+              >
+            | undefined,
+        ) => void)
+      | undefined,
+    onBlur: props.onBlur as (() => void) | undefined,
+    onFocus: props.onFocus as () => void,
+    onControllerBlur: () => ({}),
+    onControllerChange: () => ({}),
+    type: "text",
+    setValue,
+  });
+
+  const { fieldProps } = useAtlantisFormField({
+    id,
+    name,
+    rest: {},
+    validations: false,
+    handleChange,
+    handleBlur,
+    handleFocus,
+    handleKeyDown,
+    handleValidation,
+    errorMessage: "",
+  });
+
+  return (
+    <FormFieldWrapper
+      name={name}
+      error={props.error ?? ""}
+      identifier={id}
+      descriptionIdentifier={props["aria-describedby"] ?? ""}
+      clearable={props.clearable ?? "never"}
+      onClear={props.onClear ?? (() => ({}))}
+      type={props.type}
+      placeholder={props.placeholder}
+      value={value as string}
+    >
+      <>
+        <input
+          {...fieldProps}
+          name={name}
+          ref={inputRefs}
+          className={inputStyle}
+          value={value}
+          onChange={e => setValue(e.target.value)}
+        />
+        <FormFieldPostFix
+          variation="spinner"
+          visible={props.loading ?? false}
+        />
+        {props.children}
+      </>
+    </FormFieldWrapper>
+  );
+});
+
+export interface InputTextRebuiltProps
+  extends React.InputHTMLAttributes<never> {
+  readonly error?: string;
+  readonly identifier?: string;
+  readonly autocomplete?: boolean | AutocompleteTypes;
+  readonly loading?: boolean;
+  readonly onKeyUp?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  readonly children?: React.ReactNode;
+  readonly clearable?: Clearable;
+  readonly onClear?: () => void;
+  readonly type?: FormFieldTypes;
+  readonly version: 2;
+}

--- a/packages/components/src/InputText/InputText.tsx
+++ b/packages/components/src/InputText/InputText.tsx
@@ -59,7 +59,7 @@ interface MultilineProps extends BaseProps {
   readonly rows?: number | RowRange;
 }
 
-type InputTextPropOptions = XOR<BaseProps, MultilineProps>;
+export type InputTextPropOptions = XOR<BaseProps, MultilineProps>;
 
 function InputTextInternal(
   props: InputTextPropOptions,

--- a/packages/components/src/InputText/index.ts
+++ b/packages/components/src/InputText/index.ts
@@ -1,1 +1,0 @@
-export { InputText, InputTextRef } from "./InputText";

--- a/packages/components/src/InputText/index.tsx
+++ b/packages/components/src/InputText/index.tsx
@@ -1,0 +1,31 @@
+import React, { ForwardedRef } from "react";
+import {
+  InputText as InputTextLegacy,
+  InputTextPropOptions,
+  InputTextRef,
+} from "./InputText";
+import { InputTextRebuiltProps, InputTextSPAR } from "./InputText.rebuilt";
+
+type CombinedProps = InputTextPropOptions | InputTextRebuiltProps;
+
+export const InputText = React.forwardRef(function InputText(
+  props: CombinedProps,
+  ref,
+) {
+  if (props.version === 2) {
+    return (
+      <InputTextSPAR
+        {...(props as InputTextRebuiltProps)}
+        ref={ref as ForwardedRef<HTMLInputElement>}
+      />
+    );
+  }
+
+  return (
+    <InputTextLegacy
+      {...(props as InputTextPropOptions)}
+      ref={ref as ForwardedRef<InputTextRef>}
+    />
+  );
+});
+export { InputTextRef };

--- a/packages/components/src/InputValidation/InputValidation.tsx
+++ b/packages/components/src/InputValidation/InputValidation.tsx
@@ -9,14 +9,20 @@ interface InputValidationProps {
    * Validation message to be displayed
    */
   readonly message: string;
+  readonly visible?: boolean;
 }
 
-export function InputValidation({ message }: InputValidationProps) {
+export function InputValidation({
+  message,
+  visible = true,
+}: InputValidationProps) {
   const messages = [message];
   const variants = {
     slideOut: { y: "5%", opacity: 0 },
     slideIn: { y: 0, opacity: 1 },
   };
+
+  if (!visible) return null;
 
   return (
     <>


### PR DESCRIPTION

## Motivations

We have an upcoming need to decouple from `react-hook-form`. We still want to leverage the library, but we no longer want our form components to be directly coupled, instead we want them to support being used in that environment but not use the library directly.

This PR is the first step towards that future.

In this PR, we've broken down all the requisite parts of FormField and FormFieldWrapper into either smaller bite-sized components, or hooks.

This allows FormFieldWrapper to now just be collating a variety of smaller pieces into a cohesive whole. The purpose of the first part of this refactor was to ensure that *nothing* changed for the main control flow, which can be verified by our passing test suite (with no changes to tests in this PR. I want to verify passing tests still in our downstream applications).

With FormFieldWrapper/FormField broken down into chunks, we could now leverage those chunks directly in a new version of `InputText` that bypasses the Form and react-hook-form specific FormField components by leveraging FormFieldWrapper directly, and providing the `input` html element directly.

You can verify this new component is working through the third part of this refactor, the potential pattern for an Atlantis Shim. Currently if you use `InputText` directly, you'll get the OG version of the component. If you pass a prop called 'version' set to `2` you'll get the new component. You can see how we handle this swap in `index.tsx` under InputText.

## Testing

To test, open a storybook story (InputText/Web.stories) and add `version:2` to any of the prop lists. It'll turn that InputText into a Version 2.0 InputText. It should still be functional in that test.

Efforts were taken to gets tests as good as possible for the new version of the component. If you forcibly swap to the new version (in the shim, force flow to the new component versus the old), you should only have failing tests in Form (which makes sense, react-hook-form is not part of the flow), AutoComplete (some tests rely on react-hook-form functionality) and InputText (some tests rely on react-hook-form functionality). The rest of the tests in the system (which only use InputText downstream with basic examples) pass fine in this scenario.

## Changes

- Refactored FormFieldWrapper and FormField to be broken down into smaller chunks, but no actual code changes.
- Added InputTextSPAR (naming TBD) as a potential 'new' implementation of InputText that bypasses react-hook-form.
- Added a potential pattern for an Atlantis Shim to allow existing users of a component to get the legacy version of the component, and consumers wishing to use the new pattern can apply an additional prop `version:2` to the prop list.


Mainly looking for discussion on the possible approaches from the team! :)



---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
