### PR TITLE
fix(design): Updated CSS selectors for dark scrollbar colour [JOB-108461]

### DIFF
--- a/packages/design/src/styles/dark.mode.suffixStyles.css
+++ b/packages/design/src/styles/dark.mode.suffixStyles.css
@@ -1,5 +1,13 @@
-/* autoprefixer: off */
-@supports selector(::-webkit-scrollbar) {
+@supports (scrollbar-color: #000 #000) {
+  /* stylelint-disable-next-line selector-max-type */
+  html {
+    scrollbar-color: var(--color-surface--background--subtle)
+      var(--color-surface--background);
+  }
+}
+
+/* Safari doesn't support scrollbar-color yet, so we're using the non-standard selector for now. */
+@supports not (scrollbar-color: #000 #000) {
   [data-theme="dark"]:root html ::-webkit-scrollbar,
   [data-theme="dark"]:root body ::-webkit-scrollbar {
     background-color: var(--color-surface--background);

--- a/packages/design/src/styles/dark.mode.suffixStyles.css
+++ b/packages/design/src/styles/dark.mode.suffixStyles.css
@@ -1,13 +1,13 @@
 /* autoprefixer: off */
 @supports (scrollbar-color: #000 #000) {
-  /* stylelint-disable-next-line selector-max-type */
-  [data-theme="dark"]:root html {
+  html[data-theme="dark"] {
     scrollbar-color: var(--color-surface--background--subtle)
       var(--color-surface--background);
   }
 }
 
 /* Safari doesn't support scrollbar-color yet, so we're using the non-standard selector for now. */
+/* autoprefixer: off */
 @supports not (scrollbar-color: #000 #000) {
   [data-theme="dark"]:root html ::-webkit-scrollbar,
   [data-theme="dark"]:root body ::-webkit-scrollbar {

--- a/packages/design/src/styles/dark.mode.suffixStyles.css
+++ b/packages/design/src/styles/dark.mode.suffixStyles.css
@@ -1,3 +1,4 @@
+/* autoprefixer: off */
 @supports (scrollbar-color: #000 #000) {
   /* stylelint-disable-next-line selector-max-type */
   [data-theme="dark"]:root html {

--- a/packages/design/src/styles/dark.mode.suffixStyles.css
+++ b/packages/design/src/styles/dark.mode.suffixStyles.css
@@ -1,6 +1,6 @@
 @supports (scrollbar-color: #000 #000) {
   /* stylelint-disable-next-line selector-max-type */
-  html {
+  [data-theme="dark"]:root html {
     scrollbar-color: var(--color-surface--background--subtle)
       var(--color-surface--background);
   }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We wanted to move away from using `::-webkit-scrollbar` as a CSS selector as it is considered non-standard (https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar).

Unfortunately the change does not work on Safari, so the previous code remains for that case only. Safari's current behaviour seems to be on initial page load, the scrollbar is light but turns dark on subsequent page loads and this behaviour is unaffected by this change.


### Fixed

- Updated the CSS selector for the dark mode of the scrollbar for supported browsers


## Testing
Turn on dark mode and check out the scrollbar 👀 

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)


## Screenshots
Removed -- don't believe their lies

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
