### PR TITLE
POC Update useRefocusOnActivator for SPAR testing

### DIFF
--- a/packages/hooks/src/useRefocusOnActivator/useRefocusOnActivator.ts
+++ b/packages/hooks/src/useRefocusOnActivator/useRefocusOnActivator.ts
@@ -15,8 +15,8 @@ export function useRefocusOnActivator(active: boolean) {
     }
 
     return () => {
-      if (active) {
-        if (activator instanceof HTMLElement) {
+      if (active && activator instanceof HTMLElement) {
+        if (document.contains(activator)) {
           activator.focus();
         }
         activator = undefined;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`useRefocusOnActivator` is designed to refocus the element that was active before an overlay element was opened, once the overlay is dismissed. 

Without this change, the issue discussed offline might be that the hook is trying to refocus an element that no longer exists or is not appropriate to refocus when the component unmounts.

This PR is to test if checking that the document contains the activator will fix the issue, as to not attempt to focus an element that has been removed from the DOM.

**Disclaimer**: I haven't dug too much into the issue, so this PR is really just an initial test to see if behaviour changes at all in product. I have also not tested this in Atlantis itself or any other places in product to see if there are any side effects.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
