### PR TITLE
feat(docx): add disambiguation to a few components' Search

### DIFF
--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -3,12 +3,13 @@ export const componentList = [
     title: "AnimatedPresence",
     to: "/components/AnimatedPresence",
     imageURL: "/Animation.png",
-    additionalMatches: ["Motion"],
+    additionalMatches: ["Motion", "Animation"],
   },
   {
     title: "AnimatedSwitcher",
     to: "/components/AnimatedSwitcher",
     imageURL: "/Animation.png",
+    additionalMatches: ["Motion", "Animation"],
   },
   {
     title: "Autocomplete",
@@ -29,20 +30,24 @@ export const componentList = [
     title: "Chip",
     to: "/components/Chip",
     imageURL: "/Chip.png",
+    additionalMatches: ["Pill"],
   },
   {
     title: "Disclosure",
     to: "/components/Disclosure",
     imageURL: "/Disclosure.png",
+    additionalMatches: ["Accordion", "Collapsable"],
   },
   {
     title: "StatusLabel",
     to: "/components/StatusLabel",
     imageURL: "/StatusLabel.png",
+    additionalMatches: ["Badge", "Pill", "InlineLabel"],
   },
   {
     title: "Switch",
     to: "/components/Switch",
     imageURL: "/Switch.png",
+    additionalMatches: ["Toggle"],
   },
 ];

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -30,19 +30,19 @@ export const componentList = [
     title: "Chip",
     to: "/components/Chip",
     imageURL: "/Chip.png",
-    additionalMatches: ["Pill"],
+    additionalMatches: ["Pill", "Badge", "Tag"],
   },
   {
     title: "Disclosure",
     to: "/components/Disclosure",
     imageURL: "/Disclosure.png",
-    additionalMatches: ["Accordion", "Collapsable"],
+    additionalMatches: ["Accordion", "Collapsable", "Expandable", "Toggle"],
   },
   {
     title: "StatusLabel",
     to: "/components/StatusLabel",
     imageURL: "/StatusLabel.png",
-    additionalMatches: ["Badge", "Pill", "InlineLabel"],
+    additionalMatches: ["Badge", "Pill", "Tag", "InlineLabel"],
   },
   {
     title: "Switch",

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -3,7 +3,7 @@ export const componentList = [
     title: "AnimatedPresence",
     to: "/components/AnimatedPresence",
     imageURL: "/Animation.png",
-    additionalMatches: ["Motion", "Animation"],
+    additionalMatches: ["Motion", "Animation", "Reveal"],
   },
   {
     title: "AnimatedSwitcher",
@@ -36,13 +36,19 @@ export const componentList = [
     title: "Disclosure",
     to: "/components/Disclosure",
     imageURL: "/Disclosure.png",
-    additionalMatches: ["Accordion", "Collapsable", "Expandable", "Toggle"],
+    additionalMatches: [
+      "Accordion",
+      "Collapsable",
+      "Expandable",
+      "Toggle",
+      "Reveal",
+    ],
   },
   {
     title: "StatusLabel",
     to: "/components/StatusLabel",
     imageURL: "/StatusLabel.png",
-    additionalMatches: ["Badge", "Pill", "Tag", "InlineLabel"],
+    additionalMatches: ["Badge", "Pill", "Tag", "InlineLabel", "Inline Label"],
   },
   {
     title: "Switch",

--- a/packages/site/src/layout/SearchBox.tsx
+++ b/packages/site/src/layout/SearchBox.tsx
@@ -41,7 +41,7 @@ export const SearchBox = ({
   const filteredComponentList = useMemo(() => {
     return componentList.filter(
       d =>
-        d.title.includes(search) ||
+        d.title.toLowerCase().includes(search.toLowerCase()) ||
         d.additionalMatches?.find(e => e.includes(search)),
     );
   }, [search]);

--- a/packages/site/src/layout/SearchBox.tsx
+++ b/packages/site/src/layout/SearchBox.tsx
@@ -42,7 +42,9 @@ export const SearchBox = ({
     return componentList.filter(
       d =>
         d.title.toLowerCase().includes(search.toLowerCase()) ||
-        d.additionalMatches?.find(e => e.includes(search)),
+        d.additionalMatches?.find(e =>
+          e.toLowerCase().includes(search.toLowerCase()),
+        ),
     );
   }, [search]);
   useEffect(() => {

--- a/packages/site/src/pages/HomePage.tsx
+++ b/packages/site/src/pages/HomePage.tsx
@@ -6,7 +6,7 @@ export const HomePage = () => {
       structure={{
         header: {
           title: "Atlantis",
-          body: "Design and build consumer-grade products with this world-class design system",
+          body: "Design and build consumer-grade experiences with Jobber's design system",
           ctaLabel: "Get Started",
           to: "/content/design/welcome-guide",
         },


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

It's common for less-universal components (ie not Button) to be known by different names. This makes it easier to find some of those components in our system, which is especially useful for newer consumers and contributors to adopt our nomenclature.

Inspiration from [component.gallery](https://component.gallery/)
![image](https://github.com/user-attachments/assets/0b809c96-8dee-46f2-9348-9280d247e3f3)

**Before**
"Looks like Atlantis doesn't have a `pill` component, guess I have to design one myself!"
![image](https://github.com/user-attachments/assets/5e0aa719-f366-4cfc-981e-a5488b648871)

**After**
"Ah I see one of these might be what I'm looking for"
![image](https://github.com/user-attachments/assets/630fa22a-5ecb-4d4f-9cc9-90187786723e)

Additionally, search should be case-insensitive, so you can search "button" and see Button.

**Before**
![image](https://github.com/user-attachments/assets/377751be-9187-4cd0-9ff9-c33a0c341925)
![image](https://github.com/user-attachments/assets/08d34107-3066-4eba-b57f-da6287757455)

**After**
![image](https://github.com/user-attachments/assets/64fde22d-1e1b-4dfe-89bc-2a62960ff0f1)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Search for some of the terms in the "Additional Results" fields for each component

Search in upper and lower case

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
