### PR TITLE
fix(components): Remove unnecessary useRefocusOnActivator from DataListHeaderTile

### DIFF
--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -87,7 +87,7 @@ export function generateHeaderElements<T extends DataListObject>(
   const headerElements = Object.keys(headers).reduce(
     (acc, key) => ({
       ...acc,
-      [key]: <DataListHeaderTile headers={headers} headerKey={key} visible />,
+      [key]: <DataListHeaderTile headers={headers} headerKey={key} />,
     }),
     {} as DataListItemTypeFromHeader<T, typeof headers>,
   );

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -2,7 +2,6 @@
 import React, { useRef, useState } from "react";
 import classnames from "classnames";
 import { useFocusTrap } from "@jobber/hooks/useFocusTrap";
-import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
 import styles from "./DataListHeaderTile.module.css";
 import { DataListSortingArrows } from "./DataListSortingArrows";
 import { DataListSortingOptions } from "./components/DataListSortingOptions";
@@ -17,15 +16,12 @@ import {
 interface DataListHeaderTileProps<T extends DataListObject> {
   readonly headers: DataListHeader<T>;
   readonly headerKey: string;
-  readonly visible: boolean;
 }
 
 export function DataListHeaderTile<T extends DataListObject>({
   headers,
   headerKey,
-  visible = false,
 }: DataListHeaderTileProps<T>) {
-  useRefocusOnActivator(visible);
   const { sorting } = useDataListContext();
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
The video of the issue can be found here: https://jobber.atlassian.net/browse/JOB-108034

Basically, navigating to Home from Requests tab (where DataList -> DataListHeaderTile is instantiated) caused Requests nav link item to refocus, making it appear as if this is still an active link.

While investigating the issue, I noticed that the `useRefocusOnActivator` hook was called twice, once in `DataListSortingOptions` (to move focus back onto the column header after the sorting option was selected with an assistive technology/keyboard) and in `DataListHeaderTile` (where I believe it should NOT be called). So this PR removes calling this hook in `DataListHeaderTile`.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->
- `visible` prop from `DataListHeaderTile`
- `useRefocusOnActivator` hook call in `DataListHeaderTile`

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
