### PR TITLE
refactor(design): Decouple border width tokens from spacing

### DIFF
--- a/packages/design/src/tokens/border.tokens.json
+++ b/packages/design/src/tokens/border.tokens.json
@@ -3,16 +3,16 @@
     "$type": "dimension",
     "$description": "Border tokens. These are used to define the border width of elements. Feel free to use these directly.",
     "base": {
-      "$value": "{space.minuscule}"
+      "$value": "1px"
     },
     "thick": {
-      "$value": "{space.smallest}"
+      "$value": "2px"
     },
     "thicker": {
-      "$value": "{space.smaller}"
+      "$value": "4px"
     },
     "thickest": {
-      "$value": "{space.small}"
+      "$value": "8px"
     }
   }
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We don't want to use spacing for things that aren't spacing (ie dimensions like height and width). This should extend to border thickness as well.

(Noted by @Beccaneer in a [related PR for Divider](https://github.com/GetJobber/atlantis/pull/2110#issuecomment-2471155109))

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Border-width tokens now resolve to a pixel value instead of a spacing token which _then_ resolves to a pixel value.
- NOTE: underlying values are not changed
  - `border` = 1px
  - `border-thick` = 2px
  - `border-thicker` = 4px
  - `border-thickest` = 8px 

## Testing

On the Cloudflare build (or locally, once you've run `npm run bootstrap && npm start`), you can go to a component that references the border tokens (ie Card) and inspect the CSS custom prop, then follow the custom prop to its' definition and see that it no longer resolves to the space value.
![image](https://github.com/user-attachments/assets/83112c6d-e725-44c2-9959-243aee3cbb02)
![image](https://github.com/user-attachments/assets/b3a1ae5a-e9a2-43f2-984c-4be4eb270bdf)

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
