### PR TITLE
feat(components): Add size prop to SegmentedControl

### DIFF
--- a/docs/components/SegmentedControl/Web.stories.tsx
+++ b/docs/components/SegmentedControl/Web.stories.tsx
@@ -4,6 +4,7 @@ import { SegmentedControl } from "@jobber/components/SegmentedControl";
 import { Button } from "@jobber/components/Button";
 import { Text } from "@jobber/components/Text";
 import { Typography } from "@jobber/components/Typography";
+import { Heading } from "@jobber/components/Heading";
 
 const meta: Meta = {
   title: "Components/Selections/SegmentedControl/Web",
@@ -64,5 +65,29 @@ export const Uncontrolled: Story = () => {
         </SegmentedControl.Option>
       ))}
     </SegmentedControl>
+  );
+};
+
+export const Sizes: Story = () => {
+  return (
+    <div>
+      <Heading level={4}>Small</Heading>
+      <SegmentedControl defaultValue="day" size="small">
+        {options.map(option => (
+          <SegmentedControl.Option key={option.value} value={option.value}>
+            {option.label}
+          </SegmentedControl.Option>
+        ))}
+      </SegmentedControl>
+      <br />
+      <Heading level={4}>Base</Heading>
+      <SegmentedControl defaultValue="day">
+        {options.map(option => (
+          <SegmentedControl.Option key={option.value} value={option.value}>
+            {option.label}
+          </SegmentedControl.Option>
+        ))}
+      </SegmentedControl>
+    </div>
   );
 };

--- a/docs/components/SegmentedControl/Web.stories.tsx
+++ b/docs/components/SegmentedControl/Web.stories.tsx
@@ -86,6 +86,14 @@ export const Sizes: Story = () => {
           </SegmentedControl.Option>
         ))}
       </SegmentedControl>
+      <Heading level={4}>Large</Heading>
+      <SegmentedControl defaultValue="day" size="large">
+        {options.map(option => (
+          <SegmentedControl.Option key={option.value} value={option.value}>
+            {option.label}
+          </SegmentedControl.Option>
+        ))}
+      </SegmentedControl>
     </Content>
   );
 };

--- a/docs/components/SegmentedControl/Web.stories.tsx
+++ b/docs/components/SegmentedControl/Web.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from "@jobber/components/Button";
 import { Text } from "@jobber/components/Text";
 import { Typography } from "@jobber/components/Typography";
 import { Heading } from "@jobber/components/Heading";
+import { Content } from "@jobber/components/Content";
 
 const meta: Meta = {
   title: "Components/Selections/SegmentedControl/Web",
@@ -33,12 +34,11 @@ export const Controlled: Story = () => {
   const [activeOption, setActiveOption] = useState("week");
 
   return (
-    <div>
+    <Content>
       <Text>
         Control the state without interacting with the SegmentedControl
         directly. Navigate through the options and reset state via the button.
       </Text>
-      <br />
       <Typography>Current activeOption: {activeOption}</Typography>
       <SegmentedControl
         selectedValue={activeOption}
@@ -50,9 +50,8 @@ export const Controlled: Story = () => {
           </SegmentedControl.Option>
         ))}
       </SegmentedControl>
-      <br />
       <Button label="Reset to Week" onClick={() => setActiveOption("week")} />
-    </div>
+    </Content>
   );
 };
 
@@ -70,7 +69,7 @@ export const Uncontrolled: Story = () => {
 
 export const Sizes: Story = () => {
   return (
-    <div>
+    <Content>
       <Heading level={4}>Small</Heading>
       <SegmentedControl defaultValue="day" size="small">
         {options.map(option => (
@@ -79,7 +78,6 @@ export const Sizes: Story = () => {
           </SegmentedControl.Option>
         ))}
       </SegmentedControl>
-      <br />
       <Heading level={4}>Base</Heading>
       <SegmentedControl defaultValue="day">
         {options.map(option => (
@@ -88,6 +86,6 @@ export const Sizes: Story = () => {
           </SegmentedControl.Option>
         ))}
       </SegmentedControl>
-    </div>
+    </Content>
   );
 };

--- a/packages/components/src/SegmentedControl/SegmentedControl.module.css
+++ b/packages/components/src/SegmentedControl/SegmentedControl.module.css
@@ -3,7 +3,7 @@
   grid-template-columns: repeat(var(--segmentedControl--option-count), 1fr);
   align-items: center;
   position: relative;
-  min-height: 32px;
+  min-height: 40px;
   box-sizing: border-box;
   border: var(--border-base) solid var(--color-border--interactive);
   border-radius: var(--radius-base);

--- a/packages/components/src/SegmentedControl/SegmentedControl.module.css
+++ b/packages/components/src/SegmentedControl/SegmentedControl.module.css
@@ -10,6 +10,10 @@
   background-color: var(--color-surface--background);
 }
 
+.small {
+  min-height: 32px;
+}
+
 .container input[type="radio"] {
   position: absolute;
   left: -999vw;

--- a/packages/components/src/SegmentedControl/SegmentedControl.module.css
+++ b/packages/components/src/SegmentedControl/SegmentedControl.module.css
@@ -1,9 +1,11 @@
 .container {
+  --segmentedControl--size: 40px;
+
   display: grid;
   grid-template-columns: repeat(var(--segmentedControl--option-count), 1fr);
   align-items: center;
   position: relative;
-  min-height: 40px;
+  min-height: var(--segmentedControl--size);
   box-sizing: border-box;
   border: var(--border-base) solid var(--color-border--interactive);
   border-radius: var(--radius-base);
@@ -11,11 +13,11 @@
 }
 
 .small {
-  min-height: 32px;
+  --segmentedControl--size: 32px;
 }
 
 .large {
-  min-height: 48px;
+  --segmentedControl--size: 48px;
 }
 
 .container input[type="radio"] {

--- a/packages/components/src/SegmentedControl/SegmentedControl.module.css
+++ b/packages/components/src/SegmentedControl/SegmentedControl.module.css
@@ -14,6 +14,10 @@
   min-height: 32px;
 }
 
+.large {
+  min-height: 48px;
+}
+
 .container input[type="radio"] {
   position: absolute;
   left: -999vw;

--- a/packages/components/src/SegmentedControl/SegmentedControl.module.css.d.ts
+++ b/packages/components/src/SegmentedControl/SegmentedControl.module.css.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "container": string;
+  readonly "small": string;
 };
 export = styles;
 

--- a/packages/components/src/SegmentedControl/SegmentedControl.module.css.d.ts
+++ b/packages/components/src/SegmentedControl/SegmentedControl.module.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles: {
   readonly "container": string;
   readonly "small": string;
+  readonly "large": string;
 };
 export = styles;
 

--- a/packages/components/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControl.tsx
@@ -30,6 +30,13 @@ interface SegmentedControlProps<T> extends PropsWithChildren {
    * @default useId()
    */
   readonly name?: string;
+
+  /**
+   * Adjusts the size of the SegmentedControl. The default size is "base".
+   *
+   * @default base
+   */
+  readonly size?: "small" | "base";
 }
 
 export function SegmentedControl<T>({
@@ -38,6 +45,7 @@ export function SegmentedControl<T>({
   defaultValue,
   children,
   name = useId(),
+  size = "base",
 }: SegmentedControlProps<T>) {
   const container = useRef<HTMLDivElement>(null);
 
@@ -48,7 +56,9 @@ export function SegmentedControl<T>({
       defaultValue={defaultValue}
       name={name}
     >
-      <SegmentedControlBase ref={container}>{children}</SegmentedControlBase>
+      <SegmentedControlBase ref={container} size={size}>
+        {children}
+      </SegmentedControlBase>
     </SegmentedControlProvider>
   );
 }

--- a/packages/components/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControl.tsx
@@ -36,7 +36,7 @@ interface SegmentedControlProps<T> extends PropsWithChildren {
    *
    * @default base
    */
-  readonly size?: "small" | "base";
+  readonly size?: "small" | "base" | "large";
 }
 
 export function SegmentedControl<T>({

--- a/packages/components/src/SegmentedControl/SegmentedControlBase.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControlBase.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React, {
   CSSProperties,
   Children,
@@ -6,26 +7,35 @@ import React, {
 } from "react";
 import styles from "./SegmentedControl.module.css";
 
-const SegmentedControlBase = forwardRef<HTMLDivElement, PropsWithChildren>(
-  function SegmentedControlBase({ children }, ref) {
-    const optionCount = Children.count(children);
+export interface SegmentedControlBaseProps extends PropsWithChildren {
+  readonly size?: "small" | "base";
+}
 
-    return (
-      <div
-        ref={ref}
-        className={styles.container}
-        role="radiogroup"
-        style={
-          {
-            "--segmentedControl--option-count": optionCount,
-          } as CSSProperties
-        }
-      >
-        {children}
-        <span />
-      </div>
-    );
-  },
-);
+const SegmentedControlBase = forwardRef<
+  HTMLDivElement,
+  SegmentedControlBaseProps
+>(function SegmentedControlBase({ children, size = "base" }, ref) {
+  const optionCount = Children.count(children);
+
+  const containerClassNames = classNames(styles.container, {
+    [styles.small]: size === "small",
+  });
+
+  return (
+    <div
+      ref={ref}
+      className={containerClassNames}
+      role="radiogroup"
+      style={
+        {
+          "--segmentedControl--option-count": optionCount,
+        } as CSSProperties
+      }
+    >
+      {children}
+      <span />
+    </div>
+  );
+});
 
 export { SegmentedControlBase };

--- a/packages/components/src/SegmentedControl/SegmentedControlBase.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControlBase.tsx
@@ -8,7 +8,7 @@ import React, {
 import styles from "./SegmentedControl.module.css";
 
 export interface SegmentedControlBaseProps extends PropsWithChildren {
-  readonly size?: "small" | "base";
+  readonly size?: "small" | "base" | "large";
 }
 
 const SegmentedControlBase = forwardRef<
@@ -19,6 +19,7 @@ const SegmentedControlBase = forwardRef<
 
   const containerClassNames = classNames(styles.container, {
     [styles.small]: size === "small",
+    [styles.large]: size === "large",
   });
 
   return (


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Some current implementations of similar components within product have varying heights. We can match our `Button` component and offer 2 sizes, `base` & `small`

<img width="715" alt="Screenshot 2024-11-14 at 11 57 25 PM" src="https://github.com/user-attachments/assets/9e6a3dc0-b6fd-4821-bbf0-4414f1cfda03">


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

<!-- new features -->
- `size` prop that is set on the parent
- added a `Sizes` story to show what `base` and `small` look like

### Changed

<!-- changes in existing functionality -->
- the default `SegmentedControl` is now `40px` in height to match other components like `Button`, where the `base` is also `40px`
- now the `small` variation is `32px` in height

## Testing

<!-- How to test your changes. -->

Check out the Sizes story.

I'll also share video, to show that a long label (although not recommended) will still give the same spacing, etc between `base` & `small`

https://github.com/user-attachments/assets/e611eee1-15f8-4151-86f5-ea8fbea49d4d



---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
