### PR TITLE
fix(components): Fix DataList Sticky Header Scrolling  [JOB-96126]

### DIFF
--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.module.css
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.module.css
@@ -20,11 +20,16 @@
     opacity var(--transition-properties),
     width var(--transition-properties),
     visibility var(--transition-properties);
+
+  @media not (--medium-screens-and-up) {
+    overflow: hidden;
+  }
 }
 
 .searchInputVisible {
   visibility: visible;
   width: calc(100% - var(--button-offset));
+  overflow: visible;
   opacity: 1;
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--page)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - design
    - eslint
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

Credit to Zak as I copied most of this PR description from [his PR](https://github.com/GetJobber/atlantis/pull/1918) but since this is a different solution I decided to put up a separate PR to avoid any confusion based on the comments on the other one

## Motivations
Right now there's an issue on below medium screens where you can scroll horizontally because of some extra unintended width

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Small CSS changes

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

Even though we're setting a `width: 0` on this parent element

<img width="1594" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/2502c19c-65db-40a5-bad3-d22594362cda">
the nested FormField elements still have a width
<img width="1593" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/33fef17e-09f0-48b7-b390-00a551cf9ba8">
<img width="1598" alt="image" src="https://github.com/GetJobber/atlantis/assets/11843215/af1a5f36-a445-4a46-976d-6e596338d1d0">

these are causing the layout to have horizontal scrolling
![Kapture 2024-06-05 at 14 11 41](https://github.com/GetJobber/atlantis/assets/11843215/2f047fc8-0757-4e8e-960e-47b8e5241d40)

with that `width: 0` we're clearly trying to make them take up no space, and have them be functionally invisible. This is achieved in this PR by setting overflow to hidden for small screen sizes unless the search is expanded.

### Security

- <!-- in case of vulnerabilities -->

## Testing
this can all be done in Storybook

head on over to the DataList basic example. swap to a mobile view, see that you can pull it back and forth horizontally  and a bottom scrollbar appears on master. Here is a recording of that:


https://github.com/user-attachments/assets/6d2b714c-1eb8-4a90-bb18-a444348378d2

see that you can no longer do that on this PR

additionally
- on large screens, the search should always be there - no button needed to toggle visibility
- on medium and below screen, the search button should be there and when you press it the search input shows AND it is auto focused then when you press the X to hide the search input, it goes away again
- small/mobile screens same thing as medium and below
- the search input has a smooth animation when it is opened

You can also test this via pre-release anywhere in Jobber that uses Datalist with a StickyHeader. Here are some recordings from my testing via the pre-release:

[Clients Index](http://localhost.test:3000/clients?nav_label=Clients&nav_source=sidebar)
https://github.com/user-attachments/assets/9a350a91-c662-49bc-8656-2f24ee040eab

[Jobs Index](http://localhost.test:3000/work_orders)
https://github.com/user-attachments/assets/ad2f0e0d-9ee2-4d30-9e05-8d6056cbf825

[Invoice Index](http://localhost.test:3000/invoices)
https://github.com/user-attachments/assets/54913bc0-2324-44df-a078-9fcea13acebe



<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
