### PR TITLE
CLEANUP Remove autoprefixer comment for webpack v5

### DIFF
--- a/packages/design/src/styles/dark.mode.suffixStyles.css
+++ b/packages/design/src/styles/dark.mode.suffixStyles.css
@@ -7,7 +7,6 @@
 }
 
 /* Safari doesn't support scrollbar-color yet, so we're using the non-standard selector for now. */
-/* autoprefixer: off */
 @supports not (scrollbar-color: #000 #000) {
   [data-theme="dark"]:root html ::-webkit-scrollbar,
   [data-theme="dark"]:root body ::-webkit-scrollbar {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Upgrading to Webpack v5, we were getting a warning that the second autoprefixer comment was being ignored. This would cause an overlay of the warning on the Jobber application.

## Changes
- Remove the 2nd autoprefixer comment
