### PR TITLE
feat(components): Add testID to Divider and dynamically reference size and direction props

### DIFF
--- a/packages/components/src/Divider/Divider.module.css
+++ b/packages/components/src/Divider/Divider.module.css
@@ -1,12 +1,12 @@
 .divider {
-  --divider-width: var(--border-base);
+  /* --divider-width: var(--border-base); */
   --divider-color: var(--color-border);
   margin: 0;
   padding: 0;
   border: none;
 }
 
-.large {
+/* .large {
   --divider-width: var(--border-thick);
   opacity: 0.875;
 }
@@ -19,7 +19,7 @@
 .largest {
   --divider-width: var(--border-thickest);
   opacity: 0.375;
-}
+} */
 
 .horizontal {
   height: var(--space-minuscule);

--- a/packages/components/src/Divider/Divider.module.css
+++ b/packages/components/src/Divider/Divider.module.css
@@ -1,33 +1,6 @@
 .divider {
-  /* --divider-width: var(--border-base); */
   --divider-color: var(--color-border);
   margin: 0;
   padding: 0;
   border: none;
-}
-
-/* .large {
-  --divider-width: var(--border-thick);
-  opacity: 0.875;
-}
-
-.larger {
-  --divider-width: var(--border-thicker);
-  opacity: 0.625;
-}
-
-.largest {
-  --divider-width: var(--border-thickest);
-  opacity: 0.375;
-} */
-
-.horizontal {
-  height: var(--space-minuscule);
-  border-bottom: var(--divider-width) solid var(--divider-color);
-}
-
-.vertical {
-  width: var(--space-minuscule);
-  height: auto;
-  border-right: var(--divider-width) solid var(--divider-color);
 }

--- a/packages/components/src/Divider/Divider.module.css.d.ts
+++ b/packages/components/src/Divider/Divider.module.css.d.ts
@@ -1,8 +1,5 @@
 declare const styles: {
   readonly "divider": string;
-  readonly "large": string;
-  readonly "larger": string;
-  readonly "largest": string;
   readonly "horizontal": string;
   readonly "vertical": string;
 };

--- a/packages/components/src/Divider/Divider.module.css.d.ts
+++ b/packages/components/src/Divider/Divider.module.css.d.ts
@@ -1,7 +1,5 @@
 declare const styles: {
   readonly "divider": string;
-  readonly "horizontal": string;
-  readonly "vertical": string;
 };
 export = styles;
 

--- a/packages/components/src/Divider/Divider.test.tsx
+++ b/packages/components/src/Divider/Divider.test.tsx
@@ -8,6 +8,11 @@ describe("Divider", () => {
     expect(container).toMatchSnapshot();
   });
 
+  it("applies testID prop to div element", () => {
+    const { getByTestId } = render(<Divider testID="ATL-divider" />);
+    expect(getByTestId("ATL-divider")).toBeInTheDocument();
+  });
+
   describe("when large", () => {
     it("renders", () => {
       const { container } = render(<Divider size="large" />);

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -9,17 +9,24 @@ interface DividerProps {
    * @default "base"
    */
   readonly size?: "base" | "large" | "larger" | "largest";
+
   /**
    * The direction of the divider
    *
    * @default "horizontal"
    */
   readonly direction?: "horizontal" | "vertical";
+
+  /**
+   * A reference to the element in the rendered output
+   */
+  readonly testID?: string;
 }
 
 export function Divider({
   size = "base",
   direction = "horizontal",
+  testID,
 }: DividerProps) {
   const className = classnames(styles.divider, {
     [styles.large]: size === "large",
@@ -29,5 +36,7 @@ export function Divider({
     [styles.vertical]: direction == "vertical",
   });
 
-  return <div className={className} role="none presentation" />;
+  return (
+    <div className={className} data-testid={testID} role="none presentation" />
+  );
 }

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import classnames from "classnames";
 import styles from "./Divider.module.css";
 import sizes from "./DividerSizes.module.css";
+import directions from "./DividerDirections.module.css";
 
 interface DividerProps {
   /**
@@ -16,7 +17,7 @@ interface DividerProps {
    *
    * @default "horizontal"
    */
-  readonly direction?: "horizontal" | "vertical";
+  readonly direction?: keyof typeof directions;
 
   /**
    * A reference to the element in the rendered output
@@ -29,10 +30,11 @@ export function Divider({
   direction = "horizontal",
   testID,
 }: DividerProps) {
-  const className = classnames(styles.divider, sizes[size], {
-    [styles.horizontal]: direction == "horizontal",
-    [styles.vertical]: direction == "vertical",
-  });
+  const className = classnames(
+    styles.divider,
+    sizes[size],
+    directions[direction],
+  );
 
   return (
     <div className={className} data-testid={testID} role="none presentation" />

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import styles from "./Divider.module.css";
+import sizes from "./DividerSizes.module.css";
 
 interface DividerProps {
   /**
@@ -8,7 +9,7 @@ interface DividerProps {
    *
    * @default "base"
    */
-  readonly size?: "base" | "large" | "larger" | "largest";
+  readonly size?: keyof typeof sizes;
 
   /**
    * The direction of the divider
@@ -28,10 +29,7 @@ export function Divider({
   direction = "horizontal",
   testID,
 }: DividerProps) {
-  const className = classnames(styles.divider, {
-    [styles.large]: size === "large",
-    [styles.larger]: size === "larger",
-    [styles.largest]: size === "largest",
+  const className = classnames(styles.divider, sizes[size], {
     [styles.horizontal]: direction == "horizontal",
     [styles.vertical]: direction == "vertical",
   });

--- a/packages/components/src/Divider/DividerDirections.module.css
+++ b/packages/components/src/Divider/DividerDirections.module.css
@@ -1,0 +1,10 @@
+.horizontal {
+  height: var(--space-minuscule);
+  border-bottom: var(--divider-width) solid var(--divider-color);
+}
+
+.vertical {
+  width: var(--space-minuscule);
+  height: auto;
+  border-right: var(--divider-width) solid var(--divider-color);
+}

--- a/packages/components/src/Divider/DividerDirections.module.css.d.ts
+++ b/packages/components/src/Divider/DividerDirections.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "horizontal": string;
+  readonly "vertical": string;
+};
+export = styles;
+

--- a/packages/components/src/Divider/DividerSizes.module.css
+++ b/packages/components/src/Divider/DividerSizes.module.css
@@ -1,0 +1,18 @@
+.base {
+  --divider-width: var(--border-base);
+}
+
+.large {
+  --divider-width: var(--border-thick);
+  opacity: 0.875;
+}
+
+.larger {
+  --divider-width: var(--border-thicker);
+  opacity: 0.625;
+}
+
+.largest {
+  --divider-width: var(--border-thickest);
+  opacity: 0.375;
+}

--- a/packages/components/src/Divider/DividerSizes.module.css.d.ts
+++ b/packages/components/src/Divider/DividerSizes.module.css.d.ts
@@ -1,0 +1,8 @@
+declare const styles: {
+  readonly "base": string;
+  readonly "large": string;
+  readonly "larger": string;
+  readonly "largest": string;
+};
+export = styles;
+

--- a/packages/components/src/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/packages/components/src/Divider/__snapshots__/Divider.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Divider should render 1`] = `
 <div>
   <div
-    class="divider horizontal"
+    class="divider base horizontal"
     role="none presentation"
   />
 </div>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Updating `Divider` in `@jobber/components` as part of our continued effort to increase prop consistency between equivalent web and mobile components.

Now `Divider` props are exactly the same in mobile and web versions

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

<!-- new features -->
A new `testID` prop exists on the `div`.  A test for that prop was also added in `Divider.test.tsx`

### Changed

<!-- changes in existing functionality -->
In following a similar pattern to other components in Atlantis, I decided to dynamically reference the size and direction props to ensure the component is tightly coupled to the available size/direction options.  This means a few new files were created - `DividerSizes.module.css` and `DividerDirections.module.css`. This also DRYs up a bit of the logic in `Divider.tsx`

## Testing

<!-- How to test your changes. -->

Testing the pre-release in product is linked below.
UI/UX wise, everything remains the same as it was before. You can now add a `testID` .

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
