### PR TITLE
fix(docx): hide duplicate h1s in imported `Stories` content

### DIFF
--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -107,3 +107,7 @@ pre.root-pre {
   padding: var(--space-large);
   border-radius: var(--radius-base);
 }
+
+section[role="tabpanel"] > div > h1:first-of-type {
+  display: none;
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We had double h1s: one from the `Page` title, and one imported from the `stories.mdx` file.

![image](https://github.com/user-attachments/assets/8fa73c02-ca9d-4321-bb8c-39cb81f30ac8)

## Changes

### Fixed

- Only one h1 rendered on the page
![image](https://github.com/user-attachments/assets/a984ca77-a44c-43d8-9bd3-0a2a27c00e09)
![image](https://github.com/user-attachments/assets/3f97212c-dcca-456c-b87b-f8493e76c462)
![image](https://github.com/user-attachments/assets/496da3cd-75a3-4add-9667-de3f19ac29f6)

## Testing

View a few tabbed docs pages in the new site

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
