### PR TITLE
docs(components): Adding Countdown to Docs

### DIFF
--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -112,6 +112,7 @@ const components = [
   "Button",
   "Checkbox",
   "Chip",
+  "Countdown",
   "Disclosure",
   "StatusLabel",
   "Switch",

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -33,6 +33,11 @@ export const componentList = [
     additionalMatches: ["Pill", "Badge", "Tag"],
   },
   {
+    title: "Countdown",
+    to: "/components/Countdown",
+    imageURL: "/Countdown.png",
+  },
+  {
     title: "Disclosure",
     to: "/components/Disclosure",
     imageURL: "/Disclosure.png",

--- a/packages/site/src/content/Countdown/Countdown.props.json
+++ b/packages/site/src/content/Countdown/Countdown.props.json
@@ -1,0 +1,65 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/Countdown/Countdown.tsx",
+    "description": "",
+    "displayName": "Countdown",
+    "methods": [],
+    "props": {
+      "date": {
+        "defaultValue": null,
+        "description": "The date that is being counted down to.\nValue for date as a `string` should be in ISO 8601 format.",
+        "name": "date",
+        "parent": {
+          "fileName": "../components/src/Countdown/Countdown.tsx",
+          "name": "CountdownProps"
+        },
+        "required": true,
+        "type": {
+          "name": "string | number | Date"
+        }
+      },
+      "showUnits": {
+        "defaultValue": null,
+        "description": "Whether or not to present the unit of time to the user, or just the raw numbers.",
+        "name": "showUnits",
+        "parent": {
+          "fileName": "../components/src/Countdown/Countdown.tsx",
+          "name": "CountdownProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "granularity": {
+        "defaultValue": {
+          "value": "dhms"
+        },
+        "description": "Defines the time format presented\n(e.g., dhms will show days, hours, minutes, and seconds)",
+        "name": "granularity",
+        "parent": {
+          "fileName": "../components/src/Countdown/Countdown.tsx",
+          "name": "CountdownProps"
+        },
+        "required": false,
+        "type": {
+          "name": "GranularityOptions"
+        }
+      },
+      "onComplete": {
+        "defaultValue": null,
+        "description": "Callback when the countdown is done",
+        "name": "onComplete",
+        "parent": {
+          "fileName": "../components/src/Countdown/Countdown.tsx",
+          "name": "CountdownProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      }
+    }
+  }
+]

--- a/packages/site/src/content/Countdown/index.tsx
+++ b/packages/site/src/content/Countdown/index.tsx
@@ -15,6 +15,7 @@ export default {
     },
   },
   title: "Countdown",
+  description: "",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/Countdown/index.tsx
+++ b/packages/site/src/content/Countdown/index.tsx
@@ -1,0 +1,24 @@
+import { Countdown } from "@jobber/components";
+import CountdownContent from "@atlantis/docs/components/Countdown/Countdown.stories.mdx";
+import Props from "./Countdown.props.json";
+import { ContentExport } from "../../types/content";
+
+export default {
+  content: () => <CountdownContent />,
+  props: Props,
+  component: {
+    element: Countdown,
+    defaultProps: {
+      granularity: "dhms",
+      showUnits: true,
+      date: new Date(new Date().getTime() + 25 * 3600 * 1000).toISOString(),
+    },
+  },
+  title: "Countdown",
+  links: [
+    {
+      label: "Storybook",
+      url: "http://localhost:6006/?path=/docs/components-utilities-Countdown-web--docs",
+    },
+  ],
+} as const satisfies ContentExport;

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -4,6 +4,7 @@ import AutoCompleteContent from "./Autocomplete";
 import ButtonContent from "./Button";
 import ChipContent from "./Chip";
 import CheckboxContent from "./Checkbox";
+import CountdownContent from "./Countdown";
 import StatusLabelContent from "./StatusLabel";
 import SwitchContent from "./Switch";
 import DisclosureContent from "./Disclosure";
@@ -27,6 +28,9 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   Chip: {
     ...ChipContent,
+  },
+  Countdown: {
+    ...CountdownContent,
   },
   StatusLabel: {
     ...StatusLabelContent,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Adding `Countdown` to the new docs site

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

Added the `Countdown` component to the new docs site.

## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see a `Countdown` option after clicking on Components.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
