### PR TITLE
docs(components): Adding Heading to Docs

### DIFF
--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -115,6 +115,7 @@ const components = [
   "Chip",
   "Countdown",
   "Disclosure",
+  "Heading",
   "StatusLabel",
   "Switch",
 ];

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -56,6 +56,12 @@ export const componentList = [
     ],
   },
   {
+    title: "Heading",
+    to: "/components/Heading",
+    imageURL: "/Heading.png",
+    additionalMatches: ["Title", "Subtitle", "Header"],
+  },
+  {
     title: "StatusLabel",
     to: "/components/StatusLabel",
     imageURL: "/StatusLabel.png",

--- a/packages/site/src/content/Heading/Heading.props.json
+++ b/packages/site/src/content/Heading/Heading.props.json
@@ -1,0 +1,39 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/Heading/Heading.tsx",
+    "description": "",
+    "displayName": "Heading",
+    "methods": [],
+    "props": {
+      "level": {
+        "defaultValue": {
+          "value": 5
+        },
+        "description": "",
+        "name": "level",
+        "parent": {
+          "fileName": "../components/src/Heading/Heading.tsx",
+          "name": "HeadingProps"
+        },
+        "required": false,
+        "type": {
+          "name": "HeadingLevel"
+        }
+      },
+      "element": {
+        "defaultValue": null,
+        "description": "Allows overriding of the element rendered. Defaults to the heading specified with level.",
+        "name": "element",
+        "parent": {
+          "fileName": "../components/src/Heading/Heading.tsx",
+          "name": "HeadingProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"span\""
+        }
+      }
+    }
+  }
+]

--- a/packages/site/src/content/Heading/index.tsx
+++ b/packages/site/src/content/Heading/index.tsx
@@ -1,0 +1,25 @@
+import { Heading } from "@jobber/components";
+import HeadingContent from "@atlantis/docs/components/Heading/Heading.stories.mdx";
+import Props from "./Heading.props.json";
+import { ContentExport } from "../../types/content";
+
+export default {
+  content: () => <HeadingContent />,
+  props: Props,
+  component: {
+    element: Heading,
+    defaultProps: {
+      children: "New client",
+      level: "1",
+      element: "h1",
+    },
+  },
+  title: "Heading",
+  description: "",
+  links: [
+    {
+      label: "Storybook",
+      url: "http://localhost:6006/?path=/docs/components-utilities-Heading-web--docs",
+    },
+  ],
+} as const satisfies ContentExport;

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -9,6 +9,7 @@ import CountdownContent from "./Countdown";
 import StatusLabelContent from "./StatusLabel";
 import SwitchContent from "./Switch";
 import DisclosureContent from "./Disclosure";
+import HeadingContent from "./Heading";
 import { ContentExport } from "../types/content";
 
 export const SiteContent: Record<string, ContentExport> = {
@@ -44,5 +45,8 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   Disclosure: {
     ...DisclosureContent,
+  },
+  Heading: {
+    ...HeadingContent,
   },
 };


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Adding `Heading` to the new docs site

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

Added the `Heading` component to the new docs site.

**NOTE** HeadingLevel is a type and doesn't come through on the props table like we'd expect - I see the same thing is happening with `IconNames` in `AnimatedSwitcher` and `Button` so I assume we're ok to move ahead for now. I've noted in the Figma that it would be nice to get more functionality in this area in the future

![Screenshot 2024-11-26 at 6 02 10 PM](https://github.com/user-attachments/assets/7de231b1-e917-4664-ba13-0a07a23a7286)


## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see a `Heading` option after clicking on Components.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
