### PR TITLE
docs(components): Adding Changes to Generated Files [NO TICKET]

### DIFF
--- a/packages/site/src/content/Autocomplete/Autocomplete.props.json
+++ b/packages/site/src/content/Autocomplete/Autocomplete.props.json
@@ -29,7 +29,7 @@
         },
         "required": false,
         "type": {
-          "name": "{ [x: number]: GroupOption; length: number; toString: (() => string) & (() => string); toLocaleString: (() => string) & (() => string); pop: () => GroupOption; push: (...items: GroupOption[]) => number; ... 29 more ...; [Symbol.unscopables]: () => { ...; }; } | { ...; }"
+          "name": "{ [x: number]: GroupOption; length: number; toString: () => string; toLocaleString: { (): string; (locales: string | string[], options?: NumberFormatOptions & DateTimeFormatOptions): string; }; ... 37 more ...; readonly [Symbol.unscopables]: { ...; }; } | { ...; }"
         }
       },
       "value": {
@@ -98,7 +98,7 @@
         },
         "required": true,
         "type": {
-          "name": "(newInputText: string) => { [x: number]: GroupOption; length: number; toString: (() => string) & (() => string); toLocaleString: (() => string) & (() => string); pop: () => GroupOption; ... 30 more ...; [Symbol.unscopables]: () => { ...; }; } | { ...; } | Promise<...>"
+          "name": "(newInputText: string) => { [x: number]: GroupOption; length: number; toString: () => string; toLocaleString: { (): string; (locales: string | string[], options?: NumberFormatOptions & DateTimeFormatOptions): string; }; ... 37 more ...; readonly [Symbol.unscopables]: { ...; }; } | { ...; } | Promise<...>"
         }
       },
       "placeholder": {
@@ -228,7 +228,7 @@
         },
         "required": false,
         "type": {
-          "name": "RegisterOptions<FieldValues, string>"
+          "name": "RegisterOptions"
         }
       },
       "ref": {

--- a/packages/site/src/content/Disclosure/Disclosure.props.json
+++ b/packages/site/src/content/Disclosure/Disclosure.props.json
@@ -46,6 +46,32 @@
         "type": {
           "name": "boolean"
         }
+      },
+      "onToggle": {
+        "defaultValue": null,
+        "description": "Callback that is called when the disclosure is toggled.",
+        "name": "onToggle",
+        "parent": {
+          "fileName": "../components/src/Disclosure/Disclosure.tsx",
+          "name": "DisclosureProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(newOpened: boolean) => void"
+        }
+      },
+      "open": {
+        "defaultValue": null,
+        "description": "Used to make the disclosure a Controlled Component.",
+        "name": "open",
+        "parent": {
+          "fileName": "../components/src/Disclosure/Disclosure.tsx",
+          "name": "DisclosureProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
       }
     }
   }


### PR DESCRIPTION
### Changed
There are a couple of files with generated changes that have not yet been added to the code base, and they keep popping up every time we run the generate script, so I would like to add these in to prevent having to revert these files with every PR :) 


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
