### PR TITLE
docs: Remove description from component indexes and page [JOB-110417]

### DIFF
--- a/packages/site/src/content/AnimatedPresence/index.tsx
+++ b/packages/site/src/content/AnimatedPresence/index.tsx
@@ -53,7 +53,6 @@ export default {
     },
   },
   title: "AnimatedPresence",
-  description: "AnimatedPresences are a ...",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/AnimatedSwitcher/index.tsx
+++ b/packages/site/src/content/AnimatedSwitcher/index.tsx
@@ -18,7 +18,6 @@ export default {
     },
   },
   title: "AnimatedSwitcher",
-  description: "AnimatedSwitchers are a ...",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/Autocomplete/index.tsx
+++ b/packages/site/src/content/Autocomplete/index.tsx
@@ -34,7 +34,6 @@ export default {
     },
   },
   title: "Autocomplete",
-  description: "Autocompletes are a ...",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/Button/index.tsx
+++ b/packages/site/src/content/Button/index.tsx
@@ -12,8 +12,6 @@ export default {
     defaultProps: { label: "Button" },
   },
   title: "Button",
-  description:
-    "Buttons are a core user interface component, as they allow users to initiate, complete, and reverse actions.",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/ButtonDismiss/index.tsx
+++ b/packages/site/src/content/ButtonDismiss/index.tsx
@@ -11,7 +11,6 @@ export default {
     defaultProps: {},
   },
   title: "ButtonDismiss",
-  description: "",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/Checkbox/index.tsx
+++ b/packages/site/src/content/Checkbox/index.tsx
@@ -12,8 +12,6 @@ export default {
     defaultProps: { label: "Checkbox" },
   },
   title: "Checkbox",
-  description:
-    "A checkbox lets a user select one or more items from a set of options.",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/Chip/index.tsx
+++ b/packages/site/src/content/Chip/index.tsx
@@ -18,8 +18,6 @@ export default {
     defaultProps: { label: "Chip!" },
   },
   title: "Chip",
-  description:
-    "Chip allows selections and actions with a robust variety of content and presentation methods.",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/Countdown/index.tsx
+++ b/packages/site/src/content/Countdown/index.tsx
@@ -15,7 +15,6 @@ export default {
     },
   },
   title: "Countdown",
-  description: "",
   links: [
     {
       label: "Storybook",

--- a/packages/site/src/content/Disclosure/index.tsx
+++ b/packages/site/src/content/Disclosure/index.tsx
@@ -12,7 +12,6 @@ export default {
     defaultProps: { title: "Disclosure" },
   },
   title: "Disclosure",
-  description: "Disclosure is neater.",
   links: [
     {
       label: "Disclosure Storybook",

--- a/packages/site/src/content/StatusLabel/index.tsx
+++ b/packages/site/src/content/StatusLabel/index.tsx
@@ -12,7 +12,6 @@ export default {
     defaultProps: { label: "StatusLabel!" },
   },
   title: "StatusLabel",
-  description: "StatusLabel is neater.",
   links: [
     {
       label: "StatusLabel Storybook",

--- a/packages/site/src/content/Switch/index.tsx
+++ b/packages/site/src/content/Switch/index.tsx
@@ -12,7 +12,6 @@ export default {
     defaultProps: {},
   },
   title: "Switch",
-  description: "Switch is cool too I guess",
   links: [
     {
       label: "Switch Storybook",

--- a/packages/site/src/layout/ComponentView.tsx
+++ b/packages/site/src/layout/ComponentView.tsx
@@ -34,11 +34,7 @@ export const ComponentView = () => {
   return PageMeta ? (
     <Grid>
       <Grid.Cell size={{ xs: 12, md: 9 }}>
-        <Page
-          width="fill"
-          title={PageMeta.title}
-          subtitle={PageMeta.description}
-        >
+        <Page width="fill" title={PageMeta.title}>
           <PageWrapper>
             <Box>
               <Content spacing="large">


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We are not using the Description field because it conflicts/duplicates the existing descriptions in most Stories.mdx files

## Changes

### Removed

- individual descriptions, as well as the rendering of the subtle in the ComponentView

## Testing

View component pages

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
