### PR TITLE
docs(components): Adding StatusIndicator to New Docs Site [JOB-110402]

### DIFF
--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -125,6 +125,7 @@ const components = [
   "InlineLabel",
   "Link",
   "ProgressBar",
+  "StatusIndicator",
   "StatusLabel",
   "Switch",
 ];

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -120,6 +120,11 @@ export const componentList = [
     additionalMatches: ["Progress", "Loader"],
   },
   {
+    title: "StatusIndicator",
+    to: "/components/StatusIndicator",
+    imageURL: "/StatusIndicator.png",
+  },
+  {
     title: "StatusLabel",
     to: "/components/StatusLabel",
     imageURL: "/StatusLabel.png",

--- a/packages/site/src/content/StatusIndicator/StatusIndicator.props.json
+++ b/packages/site/src/content/StatusIndicator/StatusIndicator.props.json
@@ -1,0 +1,24 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/StatusIndicator/StatusIndicator.tsx",
+    "description": "",
+    "displayName": "StatusIndicator",
+    "methods": [],
+    "props": {
+      "status": {
+        "defaultValue": null,
+        "description": "",
+        "name": "status",
+        "parent": {
+          "fileName": "../components/src/StatusIndicator/StatusIndicator.tsx",
+          "name": "StatusIndicatorProps"
+        },
+        "required": true,
+        "type": {
+          "name": "StatusIndicatorType"
+        }
+      }
+    }
+  }
+]

--- a/packages/site/src/content/StatusIndicator/index.tsx
+++ b/packages/site/src/content/StatusIndicator/index.tsx
@@ -1,0 +1,20 @@
+import { StatusIndicator } from "@jobber/components";
+import StatusIndicatorContent from "@atlantis/docs/components/StatusIndicator/StatusIndicator.stories.mdx";
+import Props from "./StatusIndicator.props.json";
+import { ContentExport } from "../../types/content";
+
+export default {
+  content: () => <StatusIndicatorContent />,
+  props: Props,
+  component: {
+    element: StatusIndicator,
+    defaultProps: { status: "success" },
+  },
+  title: "StatusIndicator",
+  links: [
+    {
+      label: "Storybook",
+      url: "http://localhost:6006/?path=/docs/components-utilities-StatusIndicator-web--docs",
+    },
+  ],
+} as const satisfies ContentExport;

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -16,6 +16,7 @@ import IconContent from "./Icon";
 import InlineLabelContent from "./InlineLabel";
 import LinkContent from "./Link";
 import ProgressBarContent from "./ProgressBar";
+import StatusIndicatorContent from "./StatusIndicator";
 import StatusLabelContent from "./StatusLabel";
 import SwitchContent from "./Switch";
 import AvatarContent from "./Avatar";
@@ -78,6 +79,9 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   ProgressBar: {
     ...ProgressBarContent,
+  },
+  StatusIndicator: {
+    ...StatusIndicatorContent,
   },
   StatusLabel: {
     ...StatusLabelContent,


### PR DESCRIPTION
### Changed

Added the StatusIndicator component to the new docs site.

## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see a 'StatusIndicator' option after clicking on Components.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
