### PR TITLE
docs(components): Adding FormateDate to New Docs Site [JOB-110497]

### DIFF
--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -120,6 +120,7 @@ const components = [
   "Countdown",
   "Disclosure",
   "Emphasis",
+  "FormatDate",
   "Heading",
   "Icon",
   "InlineLabel",

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -83,6 +83,11 @@ export const componentList = [
     additionalMatches: ["Highlight", "Strong", "Bold", "Italic"],
   },
   {
+    title: "FormatDate",
+    to: "/components/FormatDate",
+    imageURL: "/FormatDate.png",
+  },
+  {
     title: "Heading",
     to: "/components/Heading",
     imageURL: "/Heading.png",

--- a/packages/site/src/content/FormatDate/FormatDate.props.json
+++ b/packages/site/src/content/FormatDate/FormatDate.props.json
@@ -1,0 +1,39 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/FormatDate/FormatDate.tsx",
+    "description": "",
+    "displayName": "FormatDate",
+    "methods": [],
+    "props": {
+      "date": {
+        "defaultValue": null,
+        "description": "Date to be formatted.\n\nA `string` should be an ISO 8601 format date string.",
+        "name": "date",
+        "parent": {
+          "fileName": "../components/src/FormatDate/FormatDate.tsx",
+          "name": "FormatDateProps"
+        },
+        "required": true,
+        "type": {
+          "name": "string | Date"
+        }
+      },
+      "showYear": {
+        "defaultValue": {
+          "value": true
+        },
+        "description": "Boolean to show year or not.",
+        "name": "showYear",
+        "parent": {
+          "fileName": "../components/src/FormatDate/FormatDate.tsx",
+          "name": "FormatDateProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      }
+    }
+  }
+]

--- a/packages/site/src/content/FormatDate/index.tsx
+++ b/packages/site/src/content/FormatDate/index.tsx
@@ -1,0 +1,20 @@
+import { FormatDate } from "@jobber/components";
+import FormatDateContent from "@atlantis/docs/components/FormatDate/FormatDate.stories.mdx";
+import Props from "./FormatDate.props.json";
+import { ContentExport } from "../../types/content";
+
+export default {
+  content: () => <FormatDateContent />,
+  props: Props,
+  component: {
+    element: FormatDate,
+    defaultProps: { date: "2024-11-28T14:44:15.635Z" },
+  },
+  title: "FormatDate",
+  links: [
+    {
+      label: "Storybook",
+      url: "http://localhost:6006/?path=/docs/components-utilities-FormatDate-web--docs",
+    },
+  ],
+} as const satisfies ContentExport;

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -11,6 +11,7 @@ import ChipsContent from "./Chips";
 import CountdownContent from "./Countdown";
 import DisclosureContent from "./Disclosure";
 import EmphasisContent from "./Emphasis";
+import FormatDateContent from "./FormatDate";
 import HeadingContent from "./Heading";
 import IconContent from "./Icon";
 import InlineLabelContent from "./InlineLabel";
@@ -63,6 +64,9 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   Emphasis: {
     ...EmphasisContent,
+  },
+  FormatDate: {
+    ...FormatDateContent,
   },
   Heading: {
     ...HeadingContent,


### PR DESCRIPTION
### Changed

Added the FormateDate component to the new docs site.

## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see a 'FormateDate' option after clicking on Components.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
