### PR TITLE
docs(components): Adding FormatEmail to New Docs Site [JOB-110499]

### DIFF
--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -123,6 +123,7 @@ const components = [
   "Disclosure",
   "Emphasis",
   "FormatDate",
+  "FormatEmail",
   "Heading",
   "Icon",
   "InlineLabel",

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -98,6 +98,11 @@ export const componentList = [
     imageURL: "/FormatDate.png",
   },
   {
+    title: "FormatEmail",
+    to: "/components/FormatEmail",
+    imageURL: "/FormatEmail.png",
+  },
+  {
     title: "Heading",
     to: "/components/Heading",
     imageURL: "/Heading.png",

--- a/packages/site/src/content/Autocomplete/Autocomplete.props.json
+++ b/packages/site/src/content/Autocomplete/Autocomplete.props.json
@@ -29,7 +29,7 @@
         },
         "required": false,
         "type": {
-          "name": "{ [x: number]: GroupOption; length: number; toString: (() => string) & (() => string); toLocaleString: (() => string) & (() => string); pop: () => GroupOption; push: (...items: GroupOption[]) => number; ... 29 more ...; [Symbol.unscopables]: () => { ...; }; } | { ...; }"
+          "name": "{ [x: number]: GroupOption; length: number; toString: () => string; toLocaleString: { (): string; (locales: string | string[], options?: NumberFormatOptions & DateTimeFormatOptions): string; }; ... 37 more ...; readonly [Symbol.unscopables]: { ...; }; } | { ...; }"
         }
       },
       "value": {
@@ -98,7 +98,7 @@
         },
         "required": true,
         "type": {
-          "name": "(newInputText: string) => { [x: number]: GroupOption; length: number; toString: (() => string) & (() => string); toLocaleString: (() => string) & (() => string); pop: () => GroupOption; ... 30 more ...; [Symbol.unscopables]: () => { ...; }; } | { ...; } | Promise<...>"
+          "name": "(newInputText: string) => { [x: number]: GroupOption; length: number; toString: () => string; toLocaleString: { (): string; (locales: string | string[], options?: NumberFormatOptions & DateTimeFormatOptions): string; }; ... 37 more ...; readonly [Symbol.unscopables]: { ...; }; } | { ...; } | Promise<...>"
         }
       },
       "placeholder": {
@@ -228,7 +228,7 @@
         },
         "required": false,
         "type": {
-          "name": "RegisterOptions<FieldValues, string>"
+          "name": "RegisterOptions"
         }
       },
       "ref": {

--- a/packages/site/src/content/FormatEmail/FormatEmail.props.json
+++ b/packages/site/src/content/FormatEmail/FormatEmail.props.json
@@ -1,0 +1,24 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/FormatEmail/FormatEmail.tsx",
+    "description": "",
+    "displayName": "FormatEmail",
+    "methods": [],
+    "props": {
+      "email": {
+        "defaultValue": null,
+        "description": "Email address to format",
+        "name": "email",
+        "parent": {
+          "fileName": "../components/src/FormatEmail/FormatEmail.tsx",
+          "name": "FormatEmailProps"
+        },
+        "required": true,
+        "type": {
+          "name": "string"
+        }
+      }
+    }
+  }
+]

--- a/packages/site/src/content/FormatEmail/index.tsx
+++ b/packages/site/src/content/FormatEmail/index.tsx
@@ -1,0 +1,20 @@
+import { FormatEmail } from "@jobber/components";
+import FormatEmailContent from "@atlantis/docs/components/FormatEmail/FormatEmail.stories.mdx";
+import Props from "./FormatEmail.props.json";
+import { ContentExport } from "../../types/content";
+
+export default {
+  content: () => <FormatEmailContent />,
+  props: Props,
+  component: {
+    element: FormatEmail,
+    defaultProps: { email: "myemail@address.me" },
+  },
+  title: "FormatEmail",
+  links: [
+    {
+      label: "Storybook",
+      url: "http://localhost:6006/?path=/docs/components-utilities-FormatEmail-web--docs",
+    },
+  ],
+} as const satisfies ContentExport;

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -14,6 +14,7 @@ import DataListContent from "./DataList";
 import DisclosureContent from "./Disclosure";
 import EmphasisContent from "./Emphasis";
 import FormatDateContent from "./FormatDate";
+import FormatEmailContent from "./FormatEmail";
 import HeadingContent from "./Heading";
 import IconContent from "./Icon";
 import InlineLabelContent from "./InlineLabel";
@@ -76,6 +77,9 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   FormatDate: {
     ...FormatDateContent,
+  },
+  FormatEmail: {
+    ...FormatEmailContent,
   },
   Heading: {
     ...HeadingContent,


### PR DESCRIPTION
### Changed

Added the FormatEmail component to the new docs site.

## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see an 'FormatEmail' option after clicking on Components.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
