### PR TITLE
docs(components): Adding FormatTime to New Docs Site [JOB-110501]

### DIFF
--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -123,6 +123,7 @@ const components = [
   "Disclosure",
   "Emphasis",
   "FormatDate",
+  "FormatTime",
   "Heading",
   "Icon",
   "InlineLabel",

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -98,6 +98,11 @@ export const componentList = [
     imageURL: "/FormatDate.png",
   },
   {
+    title: "FormatTime",
+    to: "/components/FormatTime",
+    imageURL: "/FormatTime.png",
+  },
+  {
     title: "Heading",
     to: "/components/Heading",
     imageURL: "/Heading.png",

--- a/packages/site/src/content/Autocomplete/Autocomplete.props.json
+++ b/packages/site/src/content/Autocomplete/Autocomplete.props.json
@@ -29,7 +29,7 @@
         },
         "required": false,
         "type": {
-          "name": "{ [x: number]: GroupOption; length: number; toString: (() => string) & (() => string); toLocaleString: (() => string) & (() => string); pop: () => GroupOption; push: (...items: GroupOption[]) => number; ... 29 more ...; [Symbol.unscopables]: () => { ...; }; } | { ...; }"
+          "name": "{ [x: number]: GroupOption; length: number; toString: () => string; toLocaleString: { (): string; (locales: string | string[], options?: NumberFormatOptions & DateTimeFormatOptions): string; }; ... 37 more ...; readonly [Symbol.unscopables]: { ...; }; } | { ...; }"
         }
       },
       "value": {
@@ -98,7 +98,7 @@
         },
         "required": true,
         "type": {
-          "name": "(newInputText: string) => { [x: number]: GroupOption; length: number; toString: (() => string) & (() => string); toLocaleString: (() => string) & (() => string); pop: () => GroupOption; ... 30 more ...; [Symbol.unscopables]: () => { ...; }; } | { ...; } | Promise<...>"
+          "name": "(newInputText: string) => { [x: number]: GroupOption; length: number; toString: () => string; toLocaleString: { (): string; (locales: string | string[], options?: NumberFormatOptions & DateTimeFormatOptions): string; }; ... 37 more ...; readonly [Symbol.unscopables]: { ...; }; } | { ...; } | Promise<...>"
         }
       },
       "placeholder": {
@@ -228,7 +228,7 @@
         },
         "required": false,
         "type": {
-          "name": "RegisterOptions<FieldValues, string>"
+          "name": "RegisterOptions"
         }
       },
       "ref": {

--- a/packages/site/src/content/FormatTime/FormatTime.props.json
+++ b/packages/site/src/content/FormatTime/FormatTime.props.json
@@ -1,0 +1,37 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/FormatTime/FormatTime.tsx",
+    "description": "",
+    "displayName": "FormatTime",
+    "methods": [],
+    "props": {
+      "time": {
+        "defaultValue": null,
+        "description": "Time (as JS Date) to be displayed.\n\nA `string` should be an ISO 8601 format date string.",
+        "name": "time",
+        "parent": {
+          "fileName": "../components/src/FormatTime/FormatTime.tsx",
+          "name": "FormatTimeProps"
+        },
+        "required": true,
+        "type": {
+          "name": "string | Date"
+        }
+      },
+      "use24HourClock": {
+        "defaultValue": null,
+        "description": "Optionally specify clock format. If `undefined` system format will be respected.",
+        "name": "use24HourClock",
+        "parent": {
+          "fileName": "../components/src/FormatTime/FormatTime.tsx",
+          "name": "FormatTimeProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      }
+    }
+  }
+]

--- a/packages/site/src/content/FormatTime/index.tsx
+++ b/packages/site/src/content/FormatTime/index.tsx
@@ -1,0 +1,20 @@
+import { FormatTime } from "@jobber/components";
+import FormatTimeContent from "@atlantis/docs/components/FormatTime/FormatTime.stories.mdx";
+import Props from "./FormatTime.props.json";
+import { ContentExport } from "../../types/content";
+
+export default {
+  content: () => <FormatTimeContent />,
+  props: Props,
+  component: {
+    element: FormatTime,
+    defaultProps: { time: "2020-07-10 15:22:00.000" },
+  },
+  title: "FormatTime",
+  links: [
+    {
+      label: "Storybook",
+      url: "http://localhost:6006/?path=/docs/components-utilities-FormatTime-web--docs",
+    },
+  ],
+} as const satisfies ContentExport;

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -14,6 +14,7 @@ import DataListContent from "./DataList";
 import DisclosureContent from "./Disclosure";
 import EmphasisContent from "./Emphasis";
 import FormatDateContent from "./FormatDate";
+import FormatTimeContent from "./FormatTime";
 import HeadingContent from "./Heading";
 import IconContent from "./Icon";
 import InlineLabelContent from "./InlineLabel";
@@ -76,6 +77,9 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   FormatDate: {
     ...FormatDateContent,
+  },
+  FormatTime: {
+    ...FormatTimeContent,
   },
   Heading: {
     ...HeadingContent,


### PR DESCRIPTION
### Changed

Added the FormatTime component to the new docs site.

## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see a 'FormatTime' option after clicking on Components.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
