### PR TITLE
docs(components): Adding InputDate to New Docs Site [JOB-110588]

### DIFF
--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -130,6 +130,7 @@ const components = [
   "Heading",
   "Icon",
   "InlineLabel",
+  "InputDate",
   "Link",
   "ProgressBar",
   "StatusIndicator",

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -144,6 +144,12 @@ export const componentList = [
     ],
   },
   {
+    title: "InputDate",
+    to: "/components/InputDate",
+    imageURL: "/InputDate.png",
+    additionalMatches: ["Datepicker", "Datetime Picker", "Calendar"],
+  },
+  {
     title: "Link",
     to: "/components/Link",
     imageURL: "/Link.png",

--- a/packages/site/src/content/InputDate/InputDate.props.json
+++ b/packages/site/src/content/InputDate/InputDate.props.json
@@ -1,0 +1,299 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/InputDate/InputDate.tsx",
+    "description": "",
+    "displayName": "InputDate",
+    "methods": [],
+    "props": {
+      "value": {
+        "defaultValue": null,
+        "description": "A Date object value\n(e.g., `new Date(\"11/11/2011\")`)",
+        "name": "value",
+        "parent": {
+          "fileName": "../components/src/InputDate/InputDate.tsx",
+          "name": "InputDateProps"
+        },
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "onChange": {
+        "defaultValue": null,
+        "description": "onChange handler that provides the new value (or event)",
+        "name": "onChange",
+        "parent": {
+          "fileName": "../components/src/InputDate/InputDate.tsx",
+          "name": "InputDateProps"
+        },
+        "required": true,
+        "type": {
+          "name": "(newValue: Date) => void"
+        }
+      },
+      "maxDate": {
+        "defaultValue": null,
+        "description": "The maximum selectable date.",
+        "name": "maxDate",
+        "parent": {
+          "fileName": "../components/src/InputDate/InputDate.tsx",
+          "name": "InputDateProps"
+        },
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "minDate": {
+        "defaultValue": null,
+        "description": "The minimum selectable date.",
+        "name": "minDate",
+        "parent": {
+          "fileName": "../components/src/InputDate/InputDate.tsx",
+          "name": "InputDateProps"
+        },
+        "required": false,
+        "type": {
+          "name": "Date"
+        }
+      },
+      "showIcon": {
+        "defaultValue": {
+          "value": "true"
+        },
+        "description": "Whether to show the calendar icon",
+        "name": "showIcon",
+        "parent": {
+          "fileName": "../components/src/InputDate/InputDate.tsx",
+          "name": "InputDateProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "emptyValueLabel": {
+        "defaultValue": null,
+        "description": "Text to display instead of a date value",
+        "name": "emptyValueLabel",
+        "parent": {
+          "fileName": "../components/src/InputDate/InputDate.tsx",
+          "name": "InputDateProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "align": {
+        "defaultValue": null,
+        "description": "Determines the alignment of the text inside the input.",
+        "name": "align",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"center\" | \"right\""
+        }
+      },
+      "description": {
+        "defaultValue": null,
+        "description": "Further description of the input, can be used for a hint.",
+        "name": "description",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "disabled": {
+        "defaultValue": null,
+        "description": "Disable the input",
+        "name": "disabled",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "invalid": {
+        "defaultValue": null,
+        "description": "Highlights the field red to indicate an error.",
+        "name": "invalid",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "inline": {
+        "defaultValue": null,
+        "description": "Adjusts the form field to go inline with a content. This also silences the\ngiven `validations` prop. You'd have to used the `onValidate` prop to\ncapture the message and render it somewhere else using the\n`InputValidation` component.",
+        "name": "inline",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "loading": {
+        "defaultValue": null,
+        "description": "Show a spinner to indicate loading",
+        "name": "loading",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "name": {
+        "defaultValue": null,
+        "description": "Name of the input.",
+        "name": "name",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "onValidation": {
+        "defaultValue": null,
+        "description": "Callback to get the the status and message when validating a field\n@param message",
+        "name": "onValidation",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(message: string) => void"
+        }
+      },
+      "placeholder": {
+        "defaultValue": null,
+        "description": "Hint text that goes above the value once the form is filled out.",
+        "name": "placeholder",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "size": {
+        "defaultValue": null,
+        "description": "Adjusts the interface to either have small or large spacing.",
+        "name": "size",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "CommonFormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"small\" | \"large\""
+        }
+      },
+      "readonly": {
+        "defaultValue": null,
+        "description": "Prevents users from editing the value.",
+        "name": "readonly",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "FormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "onEnter": {
+        "defaultValue": null,
+        "description": "A callback to handle \"Enter\" keypress. This will only run\nif Enter is the only key. Will not run if Shift or Control\nare being held.",
+        "name": "onEnter",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "FormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(event: KeyboardEvent<Element>) => void"
+        }
+      },
+      "onFocus": {
+        "defaultValue": null,
+        "description": "Focus callback.",
+        "name": "onFocus",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "FormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      },
+      "inputRef": {
+        "defaultValue": null,
+        "description": "",
+        "name": "inputRef",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "FormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "RefObject<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>"
+        }
+      },
+      "validations": {
+        "defaultValue": null,
+        "description": "Show an error message above the field. This also\nhighlights the the field red if an error message shows up.",
+        "name": "validations",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "FormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "RegisterOptions"
+        }
+      },
+      "onBlur": {
+        "defaultValue": null,
+        "description": "Blur callback.",
+        "name": "onBlur",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "FormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      }
+    }
+  }
+]

--- a/packages/site/src/content/InputDate/index.tsx
+++ b/packages/site/src/content/InputDate/index.tsx
@@ -1,0 +1,27 @@
+import { InputDate as InputDateRoot } from "@jobber/components";
+import InputDateContent from "@atlantis/docs/components/InputDate/InputDate.stories.mdx";
+import { useState } from "react";
+import Props from "./InputDate.props.json";
+import { ContentExport } from "../../types/content";
+
+const InputDate = () => {
+  const [date, setDate] = useState(new Date());
+
+  return <InputDateRoot value={date} onChange={setDate} />;
+};
+
+export default {
+  content: () => <InputDateContent />,
+  props: Props,
+  component: {
+    element: InputDate,
+    defaultProps: {},
+  },
+  title: "InputDate",
+  links: [
+    {
+      label: "Storybook",
+      url: "http://localhost:6006/?path=/docs/components-utilities-InputDate-web--docs",
+    },
+  ],
+} as const satisfies ContentExport;

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -21,6 +21,7 @@ import GlimmerContent from "./Glimmer";
 import HeadingContent from "./Heading";
 import IconContent from "./Icon";
 import InlineLabelContent from "./InlineLabel";
+import InputDateContent from "./InputDate";
 import LinkContent from "./Link";
 import ProgressBarContent from "./ProgressBar";
 import StatusIndicatorContent from "./StatusIndicator";
@@ -101,6 +102,9 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   InlineLabel: {
     ...InlineLabelContent,
+  },
+  InputDate: {
+    ...InputDateContent,
   },
   Link: {
     ...LinkContent,


### PR DESCRIPTION
### Changed

Added the InputDate component to the new docs site.

## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see an 'InputDate' option after clicking on Components.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
