### PR TITLE
docs: give components more room to breathe [JOB-110749]

### DIFF
--- a/packages/site/src/components/BodyBlock.tsx
+++ b/packages/site/src/components/BodyBlock.tsx
@@ -14,7 +14,13 @@ export const BodyBlock = ({ children, title }: BodyBlockProps) => {
   return (
     <Box padding={"extravagant"}>
       <Content>
-        <Typography size="larger" fontWeight="bold">
+        <Typography
+          size={"base"}
+          fontWeight={"bold"}
+          textCase={"uppercase"}
+          textColor={"textSecondary"}
+          element="h2"
+        >
           {title}
         </Typography>
         <Box direction="row" alignItems="stretch" gap={"base"}>

--- a/packages/site/src/components/ContentCard.tsx
+++ b/packages/site/src/components/ContentCard.tsx
@@ -20,6 +20,7 @@ export const ContentCard = ({
 
   return (
     <Card
+      elevation="low"
       onClick={() => {
         history.push(to);
         onClick?.();

--- a/packages/site/src/components/ContentCardWrapper.tsx
+++ b/packages/site/src/components/ContentCardWrapper.tsx
@@ -14,7 +14,7 @@ export const ContentCardWrapper = ({ children }: PropsWithChildren) => {
         width: "100%",
         gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
         gridTemplateRows: "auto",
-        gap: "var(--space-base)",
+        gap: "var(--space-larger)",
       }}
     >
       {children}

--- a/packages/site/src/pages/ComponentsPage.tsx
+++ b/packages/site/src/pages/ComponentsPage.tsx
@@ -6,8 +6,8 @@ export const ComponentsPage = () => {
     <PageBlock
       structure={{
         header: {
-          title: "Web components",
-          body: "They are the best",
+          title: "Components",
+          body: "The building blocks of Jobber's interfaces",
         },
         body: {
           title: "Components",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Address some visual tightness caused by spacing visually dense cards in close proximity to each other

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Increased spacing between cards (referenced some other docs sites that I like to land on a more generous 32px)
- Applied low elevation to use a subtle shadow instead of border
- reduced prominence of section heading in BodyBlock
![image](https://github.com/user-attachments/assets/b944e741-ed44-4686-8c6e-ec8726bcae00)

## Testing

View Components list page, or the Search modal

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
