### PR TITLE
docs(components): Add InputAvatar to New Docs Site [JOB-110586]

### DIFF
--- a/packages/site/src/content/InputAvatar/index.tsx
+++ b/packages/site/src/content/InputAvatar/index.tsx
@@ -1,14 +1,30 @@
-import { InputAvatar } from "@jobber/components";
-import Content from "@atlantis/docs/components/InputAvatar/InputAvatar.stories.mdx";
+import InputAvatarContent from "@atlantis/docs/components/InputAvatar/InputAvatar.stories.mdx";
 import Props from "./InputAvatar.props.json";
 import { ContentExport } from "../../types/content";
 
 export default {
-  content: () => <Content />,
+  content: () => <InputAvatarContent />,
   props: Props,
   component: {
-    element: InputAvatar,
-    defaultProps: {},
+    element: `
+      const [avatarUrl, setAvatarUrl] = useState("https://picsum.photos/250");
+
+      async function handleChange(newAvatar) {
+        if (newAvatar) {
+          setAvatarUrl(await newAvatar.src());
+        } else {
+          setAvatarUrl(undefined);
+        }
+      }
+
+      return (
+        <InputAvatar
+          imageUrl={avatarUrl}
+          getUploadParams={() => Promise.resolve({ url: "https://httpbin.org/post" })}
+          onChange={handleChange}
+        />
+      );
+    `,
   },
   title: "InputAvatar",
   links: [


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Adding `InputAvatar` to the new docs site

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

Added the `InputAvatar` component to the new docs site.

## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see a `InputAvatar` option after clicking on Components.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
