### PR TITLE
docs(components): Add ConfirmationModal to New Docs Site

### DIFF
--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -119,6 +119,7 @@ const components = [
   "Chip",
   "Chips",
   "Combobox",
+  "ConfirmationModal",
   "Countdown",
   "DataDump",
   "DataList",

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -70,6 +70,12 @@ export const componentList = [
     imageURL: "/Combobox.png",
   },
   {
+    title: "ConfirmationModal",
+    to: "/components/ConfirmationModal",
+    imageURL: "/ConfirmationModal.png",
+    additionalMatches: ["Confirm", "Prompt", "Modal"],
+  },
+  {
     title: "Countdown",
     to: "/components/Countdown",
     imageURL: "/Countdown.png",

--- a/packages/site/src/components/AtlantisPreviewEditorProvider.tsx
+++ b/packages/site/src/components/AtlantisPreviewEditorProvider.tsx
@@ -99,6 +99,7 @@ export const AtlantisPreviewEditorProvider = ({
               Chips,
               Content,
               Combobox,
+              ConfirmationModal,
               Countdown,
               DataDump,
               DataList,
@@ -162,11 +163,11 @@ export const AtlantisPreviewEditorProvider = ({
               useEffect,
               ReactDOM
             } from '@jobber/components';
-             
+
 
                 ${transpiledCode}
-             
-           
+
+
           if (rootElement) {
               ReactDOM.unmountComponentAtNode(rootElement);
             }
@@ -326,7 +327,7 @@ html,body,#root {
         }
       });
       </script>
-     
-    
+
+
       </body>
       </html>`;

--- a/packages/site/src/content/ConfirmationModal/ConfirmationModal.props.json
+++ b/packages/site/src/content/ConfirmationModal/ConfirmationModal.props.json
@@ -1,0 +1,188 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+    "description": "",
+    "displayName": "ConfirmationModal",
+    "methods": [],
+    "props": {
+      "open": {
+        "defaultValue": {
+          "value": false
+        },
+        "description": "Controls if the modal is open or not.",
+        "name": "open",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "SimpleConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "confirmLabel": {
+        "defaultValue": {
+          "value": "Confirm"
+        },
+        "description": "Label for the confirm button.",
+        "name": "confirmLabel",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "SimpleConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "title": {
+        "defaultValue": null,
+        "description": "Title for the modal.",
+        "name": "title",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "message": {
+        "defaultValue": null,
+        "description": "Text or rich text content for the body of the modal.\nNot displayed if **children** prop is passed.",
+        "name": "message",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "cancelLabel": {
+        "defaultValue": {
+          "value": "Cancel"
+        },
+        "description": "Label for the cancel button.",
+        "name": "cancelLabel",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "variation": {
+        "defaultValue": {
+          "value": "work"
+        },
+        "description": "Type (Work or destructive) for confirm button.",
+        "name": "variation",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"work\" | \"destructive\""
+        }
+      },
+      "size": {
+        "defaultValue": null,
+        "description": "Size of the modal (small, large),",
+        "name": "size",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"small\" | \"large\""
+        }
+      },
+      "children": {
+        "defaultValue": null,
+        "description": "Child component. Not displayed if **message** prop is passed.",
+        "name": "children",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "ReactNode"
+        }
+      },
+      "onConfirm": {
+        "defaultValue": null,
+        "description": "Callback for when the confirm button is pressed.",
+        "name": "onConfirm",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      },
+      "onCancel": {
+        "defaultValue": null,
+        "description": "Callback for when the cancel button is pressed.",
+        "name": "onCancel",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      },
+      "onRequestClose": {
+        "defaultValue": null,
+        "description": "Callback for whenever a user's action should close the modal.",
+        "name": "onRequestClose",
+        "parent": {
+          "fileName": "../components/src/ConfirmationModal/ConfirmationModal.tsx",
+          "name": "BaseConfirmationModalProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      },
+      "ref": {
+        "defaultValue": null,
+        "description": "",
+        "name": "ref",
+        "parent": {
+          "fileName": "atlantis/node_modules/@types/react/index.d.ts",
+          "name": "RefAttributes"
+        },
+        "required": false,
+        "type": {
+          "name": "Ref<ConfirmationModalRef>"
+        }
+      },
+      "key": {
+        "defaultValue": null,
+        "description": "",
+        "name": "key",
+        "parent": {
+          "fileName": "atlantis/node_modules/@types/react/index.d.ts",
+          "name": "Attributes"
+        },
+        "required": false,
+        "type": {
+          "name": "Key"
+        }
+      }
+    }
+  }
+]

--- a/packages/site/src/content/ConfirmationModal/index.tsx
+++ b/packages/site/src/content/ConfirmationModal/index.tsx
@@ -1,0 +1,34 @@
+import ConfirmationModalContent from "@atlantis/docs/components/ConfirmationModal/ConfirmationModal.stories.mdx";
+import Props from "./ConfirmationModal.props.json";
+import { ContentExport } from "../../types/content";
+
+export default {
+  content: () => <ConfirmationModalContent />,
+  props: Props,
+  component: {
+    element: `const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <Button label="Open" onClick={() => setOpen(true)} />
+        <ConfirmationModal
+          title={"Should we?"}
+          message={"Let's do **something**!"}
+          open={open}
+          confirmLabel="Do it"
+          onConfirm={() => alert("✅")}
+          onCancel={() => alert("🙅‍♂️")}
+          onRequestClose={() => setOpen(false)}
+        />
+      </>
+    );
+  `,
+  },
+  title: "ConfirmationModal",
+  links: [
+    {
+      label: "Storybook",
+      url: "http://localhost:6006/?path=/docs/components-utilities-ConfirmationModal-web--docs",
+    },
+  ],
+} as const satisfies ContentExport;

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -11,6 +11,7 @@ import CardContent from "./Card";
 import ChipContent from "./Chip";
 import ChipsContent from "./Chips";
 import ComboboxContent from "./Combobox";
+import ConfirmationModalContent from "./ConfirmationModal";
 import CountdownContent from "./Countdown";
 import DataDumpContent from "./DataDump";
 import DataListContent from "./DataList";
@@ -110,6 +111,9 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   Combobox: {
     ...ComboboxContent,
+  },
+  ConfirmationModal: {
+    ...ConfirmationModalContent,
   },
   Countdown: {
     ...CountdownContent,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Adding `ConfirmationModal` to the new docs site

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

Added the `ConfirmationModal` component to the new docs site.

## Testing

Run the docs site from the packages/site directory with `npm run dev`.
You should see a `ConfirmationModal` option after clicking on Components.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
