### PR TITLE
docs: Fix RecurringSelect typo

### DIFF
--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -323,7 +323,7 @@ export const componentList = [
     imageURL: "/RadioGroup.png",
   },
   {
-    title: "ReccuringSelect",
+    title: "RecurringSelect",
     to: "/components/RecurringSelect",
     imageURL: "/RecurringSelect.png",
   },


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Fixing a small typo in RecurringSelect card

<!-- Why did you do what you did? -->

Before:

![Screenshot 2024-12-03 at 5 56 53 PM](https://github.com/user-attachments/assets/db076b73-18ae-40a2-b5bd-de13558f9122)

After:

![Screenshot 2024-12-03 at 5 56 42 PM](https://github.com/user-attachments/assets/c2261175-c26d-4dd9-89b8-df3536192121)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
