### PR TITLE
feat(components): Add controlled option to Tabs

### DIFF
--- a/docs/components/Tabs/Web.stories.tsx
+++ b/docs/components/Tabs/Web.stories.tsx
@@ -140,10 +140,38 @@ const WithCustomReactNodeTemplate: ComponentStory<typeof Tabs> = () => {
   );
 };
 
+const ControlledTemplate: ComponentStory<typeof Tabs> = args => {
+  const [activeTab, setActiveTab] = useState(1);
+
+  return (
+    <div>
+      <p>Active tab index: {activeTab}</p>
+      <Tabs {...args} activeTab={activeTab} onTabChange={setActiveTab}>
+        <Tab label="Eggs">
+          🍳 Some eggs are laid by female animals of many different species,
+          including birds, reptiles, amphibians, mammals, and fish, and have
+          been eaten by humans for thousands of years.
+        </Tab>
+        <Tab label="Cheese">
+          🧀 Cheese is a dairy product derived from milk that is produced in a
+          wide range of flavors, textures, and forms by coagulation of the milk
+          protein casein.
+        </Tab>
+        <Tab label="Berries">
+          🍓 A berry is a small, pulpy, and often edible fruit. Typically,
+          berries are juicy, rounded, brightly colored, sweet, sour or tart, and
+          do not have a stone or pit.
+        </Tab>
+      </Tabs>
+    </div>
+  );
+};
+
 export const Basic = BasicTemplate.bind({});
 export const WithDefaultTab = WithDefaultTabTemplate.bind({});
 export const WithTabChangeCallback = WithTabChangeCallbackTemplate.bind({});
 export const WithCustomReactNode = WithCustomReactNodeTemplate.bind({});
+export const Controlled = ControlledTemplate.bind({});
 
 Basic.args = {
   label: "Eggs",
@@ -157,4 +185,4 @@ WithTabChangeCallback.args = {
   defaultTab: 1,
 };
 
-WithCustomReactNode.args = {};
+Controlled.args = {};

--- a/docs/components/Tabs/Web.stories.tsx
+++ b/docs/components/Tabs/Web.stories.tsx
@@ -70,7 +70,7 @@ const WithTabChangeCallbackTemplate: ComponentStory<typeof Tabs> = args => {
   return (
     <div>
       <p>Active tab index: {tab}</p>
-      <Tabs {...args} onTabChange={setTab}>
+      <Tabs onTabChange={setTab}>
         <Tab label="Eggs">
           🍳 Some eggs are laid by female animals of many different species,
           including birds, reptiles, amphibians, mammals, and fish, and have
@@ -184,5 +184,3 @@ WithDefaultTab.args = {
 WithTabChangeCallback.args = {
   defaultTab: 1,
 };
-
-Controlled.args = {};

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -121,6 +121,45 @@ describe("Tabs", () => {
     expect(queryByText("🧀")).not.toBeInTheDocument();
   });
 
+  it("handles controlled activeTab prop", () => {
+    const ControlledTabs = () => {
+      const [activeTab, setActiveTab] = React.useState(0);
+
+      return (
+        <div>
+          <button type="button" onClick={() => setActiveTab(0)}>
+            Set Tab 0
+          </button>
+          <button type="button" onClick={() => setActiveTab(1)}>
+            Set Tab 1
+          </button>
+          <Tabs activeTab={activeTab} onTabChange={setActiveTab}>
+            <Tab label="Eggs">
+              <p>🍳</p>
+              <p>Eggs</p>
+            </Tab>
+            <Tab label="Cheese">
+              <p>🧀</p>
+            </Tab>
+          </Tabs>
+        </div>
+      );
+    };
+
+    const { getByText, queryByText } = render(<ControlledTabs />);
+
+    expect(queryByText("🍳")).toBeInTheDocument();
+    expect(queryByText("🧀")).not.toBeInTheDocument();
+
+    fireEvent.click(getByText("Set Tab 1"));
+    expect(queryByText("🍳")).not.toBeInTheDocument();
+    expect(queryByText("🧀")).toBeInTheDocument();
+
+    fireEvent.click(getByText("Set Tab 0"));
+    expect(queryByText("🍳")).toBeInTheDocument();
+    expect(queryByText("🧀")).not.toBeInTheDocument();
+  });
+
   describe("overflow", () => {
     beforeAll(() => {
       Object.defineProperty(HTMLElement.prototype, "clientWidth", {

--- a/packages/components/src/Tabs/Tabs.test.tsx
+++ b/packages/components/src/Tabs/Tabs.test.tsx
@@ -136,7 +136,6 @@ describe("Tabs", () => {
           <Tabs activeTab={activeTab} onTabChange={setActiveTab}>
             <Tab label="Eggs">
               <p>🍳</p>
-              <p>Eggs</p>
             </Tab>
             <Tab label="Cheese">
               <p>🧀</p>

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -15,16 +15,32 @@ interface TabsProps {
   readonly defaultTab?: number;
 
   /**
+   * Specifies the index of the active tab.
+   * If provided, the component will be controlled and the active tab will be determined by this prop.
+   * If not provided, the component will manage its own state internally.
+   */
+  readonly activeTab?: number;
+
+  /**
    * Callback that fires when the active tab changes
    * @param newTabIndex
    */
   onTabChange?(newTabIndex: number): void;
 }
 
-export function Tabs({ children, defaultTab = 0, onTabChange }: TabsProps) {
+export function Tabs({
+  children,
+  defaultTab = 0,
+  activeTab: controlledActiveTab,
+  onTabChange,
+}: TabsProps) {
   const activeTabInitialValue =
     defaultTab < React.Children.count(children) ? defaultTab : 0;
-  const [activeTab, setActiveTab] = useState(activeTabInitialValue);
+  const [internalActiveTab, setInternalActiveTab] = useState(
+    activeTabInitialValue,
+  );
+  const activeTab =
+    controlledActiveTab !== undefined ? controlledActiveTab : internalActiveTab;
   const { overflowRight, overflowLeft, tabRow } = useTabsOverflow();
   const overflowClassNames = classnames(styles.overflow, {
     [styles.overflowRight]: overflowRight,
@@ -33,7 +49,9 @@ export function Tabs({ children, defaultTab = 0, onTabChange }: TabsProps) {
 
   const activateTab = (index: number) => {
     return () => {
-      setActiveTab(index);
+      if (controlledActiveTab === undefined) {
+        setInternalActiveTab(index);
+      }
 
       if (onTabChange) {
         onTabChange(index);
@@ -47,7 +65,7 @@ export function Tabs({ children, defaultTab = 0, onTabChange }: TabsProps) {
 
   useEffect(() => {
     if (activeTab > React.Children.count(children) - 1) {
-      setActiveTab(activeTabInitialValue);
+      setInternalActiveTab(activeTabInitialValue);
     }
   }, [React.Children.count(children)]);
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Adding a controlled option to the `Tabs` component

In this PR, the `Tabs` component checks if the `activeTab` prop is provided. If it is, the component uses this prop to determine which tab is active. This means the parent component can control the active tab by updating the `activeTab` prop. If the `activeTab` prop is not provided, the `Tabs` component falls back to managing its own state internally using the `internalActiveTab` state variable.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- new optional prop `activeTab` to allow `Tabs` to be controlled
- new test for controlled version
- storybook example for controlled version


## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
