### PR TITLE
docs: tweaks to dark mode experience

### DIFF
--- a/packages/site/src/components/ContentCard.tsx
+++ b/packages/site/src/components/ContentCard.tsx
@@ -39,7 +39,7 @@ export const ContentCard = ({
             style={
               imageURL && theme === "dark"
                 ? {
-                    background: "var(--color-surface)",
+                    background: "var(--color-base-blue--200)",
                     borderRadius: "var(--radius-base) var(--radius-base) 0 0",
                   }
                 : {}

--- a/packages/site/src/components/ToggleThemeButton.tsx
+++ b/packages/site/src/components/ToggleThemeButton.tsx
@@ -26,7 +26,7 @@ export const ToggleThemeButton = () => {
     >
       <Button
         type="secondary"
-        label={isDark ? "☀️" : "🌕"}
+        label={isDark ? "☀️" : "🌒"}
         onClick={handleClick}
       />
     </div>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Felt like I could make the collection thumbnails less glaring until we have a better solution (ie mode-responsive images)

## Changes

### Changed

- gently darken thumbnail backgrounds and used a darker moon icon

## Testing

Throw the new docs site in dark mode

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
