### PR TITLE
feat(components): Add arrow key navigation to Tabs

### DIFF
--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -146,10 +146,7 @@ const InternalTab = React.forwardRef<HTMLButtonElement, InternalTabProps>(
           className={className}
           onClick={event => {
             activateTab();
-
-            if (onClick) {
-              onClick(event);
-            }
+            onClick?.(event);
           }}
           ref={ref}
           tabIndex={tabIndex}

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -8,6 +8,7 @@ import React, {
 import classnames from "classnames";
 import styles from "./Tabs.module.css";
 import { useTabsOverflow } from "./hooks/useTabsOverflow";
+import { useArrowKeyNavigation } from "./hooks/useArrowKeyNavigation";
 import { Typography } from "../Typography";
 
 interface TabsProps {
@@ -67,29 +68,10 @@ export function Tabs({
     };
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
-    const currentIndex = tabRefs.current.findIndex(
-      tab => tab === document.activeElement,
-    );
-
-    if (currentIndex === -1) return;
-
-    const focusAndActivateTab = (index: number) => {
-      tabRefs.current[index]?.focus();
-      activateTab(index)();
-    };
-
-    if (event.key === "ArrowRight") {
-      event.preventDefault();
-      const nextIndex = (currentIndex + 1) % tabRefs.current.length;
-      focusAndActivateTab(nextIndex);
-    } else if (event.key === "ArrowLeft") {
-      event.preventDefault();
-      const prevIndex =
-        (currentIndex - 1 + tabRefs.current.length) % tabRefs.current.length;
-      focusAndActivateTab(prevIndex);
-    }
-  };
+  const handleKeyDown = useArrowKeyNavigation({
+    elementsRef: tabRefs,
+    onActivate: index => activateTab(index)(),
+  });
 
   const activeTabProps = (React.Children.toArray(children) as ReactElement[])[
     activeTab

--- a/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tabs displays the label when it is a ReactNode 1`] = `
+exports[`Tabs Component Rendering displays the label when it is a ReactNode 1`] = `
 <div>
   <div
     class="tabs"
@@ -47,7 +47,7 @@ exports[`Tabs displays the label when it is a ReactNode 1`] = `
 </div>
 `;
 
-exports[`Tabs renders Tabs 1`] = `
+exports[`Tabs Component Rendering renders Tabs 1`] = `
 <div>
   <div
     class="tabs"

--- a/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Tabs displays the label when it is a ReactNode 1`] = `
           <button
             class="tab selected"
             role="tab"
+            tabindex="0"
             type="button"
           >
             <span
@@ -64,6 +65,7 @@ exports[`Tabs renders Tabs 1`] = `
           <button
             class="tab selected"
             role="tab"
+            tabindex="0"
             type="button"
           >
             <span
@@ -79,6 +81,7 @@ exports[`Tabs renders Tabs 1`] = `
           <button
             class="tab"
             role="tab"
+            tabindex="-1"
             type="button"
           >
             <span

--- a/packages/components/src/Tabs/hooks/useArrowKeyNavigation.ts
+++ b/packages/components/src/Tabs/hooks/useArrowKeyNavigation.ts
@@ -1,0 +1,47 @@
+import { useCallback } from "react";
+
+interface UseArrowKeyNavigationProps {
+  elementsRef: React.RefObject<(HTMLElement | null)[]>;
+  onActivate: (index: number) => void;
+}
+
+export const useArrowKeyNavigation = ({
+  elementsRef,
+  onActivate,
+}: UseArrowKeyNavigationProps) => {
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      const elements = elementsRef.current;
+      if (!elements) return;
+
+      const currentIndex = elements.findIndex(
+        element => element === document.activeElement,
+      );
+
+      if (currentIndex === -1) return;
+
+      const focusAndActivateTab = (index: number) => {
+        const element = elements[index];
+
+        if (element) {
+          element.focus();
+          onActivate(index);
+        }
+      };
+
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        const nextIndex = (currentIndex + 1) % elements.length;
+        focusAndActivateTab(nextIndex);
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        const prevIndex =
+          (currentIndex - 1 + elements.length) % elements.length;
+        focusAndActivateTab(prevIndex);
+      }
+    },
+    [elementsRef, onActivate],
+  );
+
+  return handleKeyDown;
+};


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

In the `Tabs` component, keyboard navigation can be improved when navigating between tabs and to children within individual tabs.  Currently the only way to navigate between tabs is with the tab key and hitting enter to view the focused tab's children. 

Here is a demo of what we should now expect for navigation between tabs:

https://github.com/user-attachments/assets/cc5d24b4-47a9-48ac-936c-7d62c98b6325


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed



In the Tabs component users can:
- tab key will enter or exit the Tabs component
- use arrow keys to navigate between tabs
- while focused on a Tab, if the children of that tab have focusable items, hitting tab will move focus to the child element
- while focused on the content of children in a Tab, shift-tabbing “upwards” out of the content will return focus to the active Tab selector

If 2 Tabs sets are in one page: 
- arrow key navigating will keep you within the current Tabs set
- you can move from the first tab set to the second but using the tab key

I also added a hook within the `Tabs` component called `useArrowKeyNavigation`.  There is an inline comment below, explaining why I chose to keep the hook internal to `Tab` for now.

## Testing

<!-- How to test your changes. -->
I did not push the example, but if you'd like to test functionality with 2 `Tabs` on one page, you can use this example:

```
const TwoTabsExample: ComponentStory<typeof Tabs> = () => {
  return (
    <div>
      <h3>First Tab Set</h3>
      <Tabs>
        <Tab label="Tab 1">
          <div>
            Content for Tab 1 in the first set.
            <Button label="Cancel" type="primary" variation="subtle" />
          </div>
        </Tab>
        <Tab label="Tab 2">Content for Tab 2 in the first set.</Tab>
      </Tabs>
      <h3>Second Tab Set</h3>
      <Tabs>
        <Tab label="Tab A">Content for Tab A in the second set.</Tab>
        <Tab label="Tab B">
          <div>
            Content for Tab B in the second set.
            <a
              href="https://www.example.com"
              target="_blank"
              rel="noopener noreferrer"
            >
              Visit Example
            </a>
          </div>
        </Tab>
      </Tabs>
    </div>
  );
};
```

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
