### PR TITLE
docs: improve collection page styling and semantics

### DIFF
--- a/packages/site/src/components/HeaderBlock.tsx
+++ b/packages/site/src/components/HeaderBlock.tsx
@@ -28,7 +28,7 @@ export const HeaderBlock = ({
 
   return (
     <Box background="base-blue--900">
-      <div
+      <header
         style={{ backgroundImage: `url(${imageURL})` }}
         className="headerBlock"
       >
@@ -41,7 +41,9 @@ export const HeaderBlock = ({
           >
             {title}
           </Typography>
-          <Typography size="large">{body}</Typography>
+          <Typography size="large" fontWeight={"semiBold"}>
+            {body}
+          </Typography>
           {to && ctaLabel && (
             <Button
               type="secondary"
@@ -51,7 +53,7 @@ export const HeaderBlock = ({
             />
           )}
         </Content>
-      </div>
+      </header>
     </Box>
   );
 };


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The "subtitle" on the collection pages didn't match the Figma

## Changes

### Changed

- div in `HeaderBlock` to use `header`
- weight of subtitle to `semiBold`

![image](https://github.com/user-attachments/assets/bebf0c3d-3575-451e-a24d-d8fe0db27a92)

## Testing

View Home, Components, Design in the new site

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
