### PR TITLE
docs: elevate cardcontentwrapper and theme button for dark mode

### DIFF
--- a/packages/site/src/components/ContentCardWrapper.tsx
+++ b/packages/site/src/components/ContentCardWrapper.tsx
@@ -16,6 +16,7 @@ export const ContentCardWrapper = ({ children }: PropsWithChildren) => {
         gridTemplateRows: "auto",
         gap: "var(--space-larger)",
       }}
+      data-elevation="elevated"
     >
       {children}
     </div>

--- a/packages/site/src/components/ToggleThemeButton.tsx
+++ b/packages/site/src/components/ToggleThemeButton.tsx
@@ -22,10 +22,14 @@ export const ToggleThemeButton = () => {
         position: "fixed",
         bottom: "var(--space-base)",
         right: "var(--space-base)",
+        boxShadow: "var(--shadow-base)",
+        borderRadius: "var(--radius-base)",
       }}
+      data-elevation="elevated"
     >
       <Button
         type="secondary"
+        variation="subtle"
         label={isDark ? "☀️" : "🌒"}
         onClick={handleClick}
       />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The theme switcher button and the swatches of cards were getting a bit lost in dark mode

we have the concept of elevation lightening surfaces in dark mode for just such an occasion!

## Changes

### Changed

- Elevation applied to the cards and button makes them lighter in dark mode. No change to light mode other than the shadow on the Button wrapper

![image](https://github.com/user-attachments/assets/bbfbdfd7-aa89-4d7e-9bd3-8bfde2d8a779)
![image](https://github.com/user-attachments/assets/4ebe7590-86b0-45e0-b229-4c667963807c)


## Testing

Check out the Search or collection pages

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
