### PR TITLE
fix(components): Expose description as a prop for Autocomplete

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -121,13 +121,15 @@ function AutocompleteInternal(
         validations={validations}
         {...inputProps}
       />
-      <Menu
-        attachTo={autocompleteRef}
-        visible={true}
-        options={options}
-        selectedOption={value}
-        onOptionSelect={handleMenuChange}
-      />
+      {menuVisible && (
+        <Menu
+          attachTo={autocompleteRef}
+          visible={menuVisible && options.length > 0}
+          options={options}
+          selectedOption={value}
+          onOptionSelect={handleMenuChange}
+        />
+      )}
     </div>
   );
 

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -13,6 +13,7 @@ interface AutocompleteProps
   extends Pick<
     FormFieldProps,
     | "clearable"
+    | "description"
     | "invalid"
     | "name"
     | "onBlur"
@@ -120,15 +121,13 @@ function AutocompleteInternal(
         validations={validations}
         {...inputProps}
       />
-      {menuVisible && (
-        <Menu
-          attachTo={autocompleteRef}
-          visible={menuVisible && options.length > 0}
-          options={options}
-          selectedOption={value}
-          onOptionSelect={handleMenuChange}
-        />
-      )}
+      <Menu
+        attachTo={autocompleteRef}
+        visible={true}
+        options={options}
+        selectedOption={value}
+        onOptionSelect={handleMenuChange}
+      />
     </div>
   );
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We'd like to have a `InputText` style description on an `Autocomplete` component. This prop works when supplied as props are passed through to the child `InputText` but typescript flags it as an error. 


## Changes

### Changed

Define `description` as a valid prop for `Autocomplete`


![Screenshot 2024-12-10 at 8 31 24 AM](https://github.com/user-attachments/assets/82c0e91d-8df5-4721-8700-6bc7990dd0ba)



## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
