### PR TITLE
refactor(components-native): surface--element instead of background as background color for non surface/container components

### DIFF
--- a/packages/components-native/src/Chip/Chip.style.ts
+++ b/packages/components-native/src/Chip/Chip.style.ts
@@ -29,6 +29,6 @@ export const styles = StyleSheet.create({
     padding: tokens["space-smaller"],
   },
   activeDismissIcon: {
-    backgroundColor: tokens["color-surface--background"],
+    backgroundColor: tokens["color-surface--element"],
   },
 });

--- a/packages/components-native/src/FormatFile/FormatFile.style.ts
+++ b/packages/components-native/src/FormatFile/FormatFile.style.ts
@@ -3,7 +3,7 @@ import { tokens } from "../utils/design";
 
 export const styles = StyleSheet.create({
   thumbnailContainer: {
-    backgroundColor: tokens["color-surface--background"],
+    backgroundColor: tokens["color-surface--element"],
     borderWidth: tokens["border-base"],
     borderColor: tokens["color-border"],
     borderRadius: tokens["radius-base"],

--- a/packages/components-native/src/FormatFile/components/ProgressBar/ProgressBar.style.tsx
+++ b/packages/components-native/src/FormatFile/components/ProgressBar/ProgressBar.style.tsx
@@ -7,7 +7,7 @@ export const styles = StyleSheet.create({
     height: 8,
     borderRadius: tokens["radius-circle"],
     overflow: "hidden",
-    backgroundColor: tokens["color-surface--background"],
+    backgroundColor: tokens["color-surface--element"],
   },
   progress: {
     height: "100%",

--- a/packages/components-native/src/InputFieldWrapper/components/ClearAction/ClearAction.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/components/ClearAction/ClearAction.style.ts
@@ -13,7 +13,7 @@ export const styles = StyleSheet.create({
     alignSelf: "center",
   },
   circle: {
-    backgroundColor: tokens["color-surface--background"],
+    backgroundColor: tokens["color-surface--element"],
     borderRadius: tokens["radius-circle"],
     width: tokens["space-large"],
     height: tokens["space-large"],

--- a/packages/components-native/src/InputText/context/InputAccessoriesProvider.style.tsx
+++ b/packages/components-native/src/InputText/context/InputAccessoriesProvider.style.tsx
@@ -14,7 +14,7 @@ export const styles = StyleSheet.create({
     height: BAR_HEIGHT,
   },
   lightTheme: {
-    backgroundColor: tokens["color-surface--background"],
+    backgroundColor: tokens["color-surface--element"],
   },
   darkTheme: {
     // PlatformColor has to be conditional for Storybook to run without error

--- a/packages/components-native/src/InputText/context/InputAccessory.style.ts
+++ b/packages/components-native/src/InputText/context/InputAccessory.style.ts
@@ -7,7 +7,7 @@ export const styles = StyleSheet.create({
     justifyContent: "space-between",
     alignItems: "center",
     paddingHorizontal: tokens["space-small"],
-    backgroundColor: tokens["color-surface--background"],
+    backgroundColor: tokens["color-surface--element"],
     borderTopWidth: tokens["space-minuscule"],
     borderTopColor: tokens["color-border"],
   },

--- a/packages/components-native/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components-native/src/ProgressBar/ProgressBar.tsx
@@ -31,7 +31,7 @@ export function ProgressBar({
         <ProgressBarStepped
           total={total}
           current={current}
-          color={reverseTheme ? undefined : tokens["color-surface--background"]}
+          color={reverseTheme ? undefined : tokens["color-surface--element"]}
           loading={loading}
           inProgress={inProgress}
         />
@@ -40,9 +40,7 @@ export function ProgressBar({
           <ProgressBarInner
             width={100}
             animationDuration={0}
-            color={
-              reverseTheme ? undefined : tokens["color-surface--background"]
-            }
+            color={reverseTheme ? undefined : tokens["color-surface--element"]}
           />
           {!loading && (
             <>

--- a/packages/components-native/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/components-native/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`renders blue inProgress bar when 1 or more jobs is in progress 1`] = `
             "width": "100%",
           },
           {
-            "backgroundColor": "hsl(53, 21%, 93%)",
+            "backgroundColor": "hsl(51, 17%, 85%)",
             "width": "100%",
           },
         ]
@@ -116,7 +116,7 @@ exports[`renders green CompletedProgress bar when 1 or more jobs is completed 1`
             "width": "100%",
           },
           {
-            "backgroundColor": "hsl(53, 21%, 93%)",
+            "backgroundColor": "hsl(51, 17%, 85%)",
             "width": "100%",
           },
         ]

--- a/packages/components-native/src/Switch/components/BaseSwitch/BaseSwitch.tsx
+++ b/packages/components-native/src/Switch/components/BaseSwitch/BaseSwitch.tsx
@@ -58,7 +58,7 @@ export function BaseSwitch({
       } else if (internalValue) {
         return tokens["color-interactive"];
       } else {
-        return tokens["color-surface--background"];
+        return tokens["color-surface--element"];
       }
     }
 
@@ -79,7 +79,7 @@ export function BaseSwitch({
       //iOS
       return {
         true: tokens["color-interactive"],
-        false: tokens["color-surface--background"],
+        false: tokens["color-surface--element"],
       };
     }
   }
@@ -96,7 +96,7 @@ export function BaseSwitch({
       disabled={disabled}
       thumbColor={getThumbColor()}
       trackColor={getTrackColors()}
-      ios_backgroundColor={tokens["color-surface--background"]}
+      ios_backgroundColor={tokens["color-surface--element"]}
       accessibilityLabel={accessibilityLabel}
       accessibilityRole={"switch"}
       accessibilityState={{

--- a/packages/components-native/src/Switch/components/BaseSwitch/__snapshots__/BaseSwitch.test.tsx.snap
+++ b/packages/components-native/src/Switch/components/BaseSwitch/__snapshots__/BaseSwitch.test.tsx.snap
@@ -26,12 +26,12 @@ exports[`renders a Switch with defaultValue false 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={false}
 />
 `;
@@ -62,12 +62,12 @@ exports[`renders a Switch with defaultValue true 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={true}
 />
 `;
@@ -98,12 +98,12 @@ exports[`renders a Switch with value false 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={false}
 />
 `;
@@ -134,12 +134,12 @@ exports[`renders a Switch with value true 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={true}
 />
 `;
@@ -170,12 +170,12 @@ exports[`renders a disabled Switch with value false 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={false}
 />
 `;
@@ -206,12 +206,12 @@ exports[`renders a disabled Switch with value true 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={true}
 />
 `;

--- a/packages/components-native/src/ThumbnailList/__snapshots__/ThumbnailList.test.tsx.snap
+++ b/packages/components-native/src/ThumbnailList/__snapshots__/ThumbnailList.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`renders a thumbnail component with attachments 1`] = `
             style={
               [
                 {
-                  "backgroundColor": "hsl(53, 21%, 93%)",
+                  "backgroundColor": "hsl(51, 17%, 85%)",
                   "borderColor": "hsl(200, 13%, 87%)",
                   "borderRadius": 8,
                   "borderWidth": 1,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
- UI components that use `surface--background` have poor contrast on some surfaces

## Changes
- Components in components-native that use `surface--background` now have better visibility on all surfaces

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed
- Changed all UI components in the components-native package (excluding surfaces & containers) that used `color-surface--background` to use `color-surface--element` instead


### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
