### PR TITLE
feat(components): Properly Exporting DataListProps from DataList

### DIFF
--- a/packages/components/src/DataList/index.ts
+++ b/packages/components/src/DataList/index.ts
@@ -6,5 +6,6 @@ export {
   DataListSortable,
   DataListSelectedType,
   DataListSelectedAllType,
+  DataListProps,
   DataListEmptyStateProps,
 } from "./DataList.types";


### PR DESCRIPTION
## Motivations

DataListProps was not being properly exported by Atlantis.

## Changes

DataListProps is not being properly exported from Atlantis.


## Testing

Everything should be exactly the same, except you can now import DataListProps from ESM based environments.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
