### PR TITLE
fix(components): Docs Site not rendering Design items properly

### DIFF
--- a/packages/site/src/layout/Layout.tsx
+++ b/packages/site/src/layout/Layout.tsx
@@ -1,7 +1,6 @@
 import { PropsWithChildren, useEffect } from "react";
 import { Route, Switch, useLocation } from "react-router";
 import { NavMenu } from "./NavMenu";
-import { ComponentView } from "./ComponentView";
 import { AtlantisRoute, routes } from "../routes";
 import "./code-theme.css";
 import { ToggleThemeButton } from "../components/ToggleThemeButton";
@@ -25,8 +24,6 @@ export const Layout = () => {
         <Switch>
           <>
             {routes?.map((route, routeIndex) => {
-              if (route.inNav === false) return null;
-
               const iterateSubMenu = (childroutes: AtlantisRoute[]) => {
                 return childroutes.map((child, childIndex) => {
                   // We don't want to loop through the components
@@ -68,14 +65,6 @@ export const Layout = () => {
                 />
               );
             })}
-
-            {/* The component page */}
-            <Route
-              key={"component"}
-              exact={true}
-              path={"/components/:name"}
-              component={ComponentView}
-            />
           </>
         </Switch>
       </div>


### PR DESCRIPTION

## Motivations

We pushed a change recently that removed the design sections from the routing table (erroneously)

This change puts them back in! :)

## Changes

Removed a line preventing `inNav` items from being added to the routing table.

We also added a manual routing table entry used to allow the components to keep rendering.

## Testing
Everything should be as it was before this change, but with the design content pages working properly.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
