### PR TITLE
docs: Fix Border size calculation to avoid appending elements to the DOM

### DIFF
--- a/docs/design/Borders.stories.mdx
+++ b/docs/design/Borders.stories.mdx
@@ -34,10 +34,9 @@ export function Example({ of: size }) {
 }
 
 export function BorderSize({ of: size }) {
-  const element = document.createElement("div");
-  Object.assign(element.style, BaseStyle({ of: size }));
-  document.body.appendChild(element);
-  return getComputedStyle(element).borderBottomWidth;
+  return getComputedStyle(document.documentElement).getPropertyValue(
+    `--border-${size}`
+  );
 }
 
 | Width               | Visual                    | Value                        |


### PR DESCRIPTION

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The existing border calculation was injecting elements into the DOM, and on the new docs site, they hang around until you refresh due to it being a SPA.

This PR replaces that implementation with a simpler one: asking the DOM to compute the value of a CSS variable.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Simplified border width calculation for Border docs page

### Fixed

- Prevent elements from getting injected to the bottom of docs pages and persisting


## Before / After (no changes)

Before |  After
:---:|:---:
<img width="1481" alt="Screenshot 2024-12-12 at 7 49 36 AM" src="https://github.com/user-attachments/assets/485e9163-1b38-431d-b624-c5fa18930d6d" /> | <img width="1481" alt="Screenshot 2024-12-12 at 7 49 20 AM" src="https://github.com/user-attachments/assets/90c4e5ac-9732-48f3-8126-e493bd2e25e8" />



## Testing

* Navigate to the Design -> Borders page
* Observe there are no divs injected to the bottom of the DOM
* Observe the table results match what we currently have in [production](https://atlantis.getjobber.com/?path=/docs/design-borders--docs)