### PR TITLE
fix(components): Fixing an issue with the docs site.

### DIFF
--- a/packages/site/src/layout/Layout.tsx
+++ b/packages/site/src/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useEffect } from "react";
+import { PropsWithChildren, useEffect, useRef } from "react";
 import { Route, Switch, useLocation } from "react-router";
 import { NavMenu } from "./NavMenu";
 import { AtlantisRoute, routes } from "../routes";
@@ -12,15 +12,20 @@ import { ToggleThemeButton } from "../components/ToggleThemeButton";
 
 export const Layout = () => {
   const location = useLocation();
-
+  const scrollPane = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    window.scrollTo({ top: 0 });
-  }, [location]);
+    if (scrollPane?.current) {
+      scrollPane?.current.scrollTo({ top: 0 });
+    }
+  }, [location, scrollPane?.current]);
 
   return (
     <LayoutWrapper>
       <NavMenu />
-      <div style={{ overflow: "auto", width: "100%", height: "100dvh" }}>
+      <div
+        style={{ overflow: "auto", width: "100%", height: "100dvh" }}
+        ref={scrollPane}
+      >
         <Switch>
           <>
             {routes?.map((route, routeIndex) => {


### PR DESCRIPTION
## Motivations

1. We recently regressed on the scroll to top of page functionality when switching pages after we moved the scroll pane from the window to another element in the DOM.
2. We wanted to fix that! :)

## Changes

1. Corrected a regression where the scroll to top was no longer functional (after fixing much larger issues with the site)

## Testing

Clicking from the components page to an individual component page should bring you to the top of the page.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
