### PR TITLE
docs: Update site layout structure [JOB-111448]

### DIFF
--- a/packages/site/src/components/ComponentLinks.tsx
+++ b/packages/site/src/components/ComponentLinks.tsx
@@ -55,7 +55,7 @@ export const ComponentLinks = ({
     <aside
       style={{
         width: "200px",
-        padding: "36px var(--space-base) var(--space-base) var(--space-base)",
+        padding: "36px var(--space-base)",
         display: "flex",
         flexDirection: "column",
         flexShrink: "0",

--- a/packages/site/src/components/ComponentLinks.tsx
+++ b/packages/site/src/components/ComponentLinks.tsx
@@ -64,7 +64,9 @@ export const ComponentLinks = ({
     >
       <Content spacing={"larger"}>
         <Content>
-          <Heading level={6} element="h3">Design</Heading>
+          <Heading level={6} element="h3">
+            Design
+          </Heading>
           <Content spacing="small">
             {hlinks?.map((link, index) => (
               <Box key={index}>
@@ -77,7 +79,9 @@ export const ComponentLinks = ({
         </Content>
         {webEnabled && (
           <Content>
-            <Heading level={6} element="h3">Web</Heading>
+            <Heading level={6} element="h3">
+              Web
+            </Heading>
             <Content spacing="small">
               <Box>
                 <a onClick={() => goToUsage("web")} href={`#`}>
@@ -94,7 +98,9 @@ export const ComponentLinks = ({
         )}
         {mobileEnabled && (
           <Content>
-            <Heading level={6} element="h3">Mobile</Heading>
+            <Heading level={6} element="h3">
+              Mobile
+            </Heading>
             <Content spacing="small">
               <Box>
                 <a onClick={() => goToUsage("mobile")} href={`#`}>
@@ -110,7 +116,9 @@ export const ComponentLinks = ({
           </Content>
         )}
         <Content>
-          <Heading level={6} element="h3">Links</Heading>
+          <Heading level={6} element="h3">
+            Links
+          </Heading>
           <Content spacing="smaller">
             <Box direction="row" gap="smaller" alignItems="center">
               <Icon size="small" color="interactive" name="link" />

--- a/packages/site/src/components/ComponentLinks.tsx
+++ b/packages/site/src/components/ComponentLinks.tsx
@@ -52,72 +52,79 @@ export const ComponentLinks = ({
   if (isMinimal) return null;
 
   return (
-    <Content>
-      <Box padding="base" direction="column">
-        <Content spacing={"larger"}>
-          <Content>
-            <Heading level={3}>Design</Heading>
-            <Content spacing="small">
-              {hlinks?.map((link, index) => (
-                <Box key={index}>
-                  <a onClick={click} href={`#${link.id}`}>
-                    {link.textContent}
-                  </a>
-                </Box>
-              ))}
-            </Content>
+    <aside
+      style={{
+        width: "200px",
+        padding: "36px var(--space-base) var(--space-base) var(--space-base)",
+        display: "flex",
+        flexDirection: "column",
+        flexShrink: "0",
+        boxSizing: "border-box",
+      }}
+    >
+      <Content spacing={"larger"}>
+        <Content>
+          <Heading level={6} element="h3">Design</Heading>
+          <Content spacing="small">
+            {hlinks?.map((link, index) => (
+              <Box key={index}>
+                <a onClick={click} href={`#${link.id}`}>
+                  {link.textContent}
+                </a>
+              </Box>
+            ))}
           </Content>
-          {webEnabled && (
-            <Content>
-              <Heading level={3}>Web</Heading>
-              <Content spacing="small">
-                <Box>
-                  <a onClick={() => goToUsage("web")} href={`#`}>
-                    Usage
-                  </a>
-                </Box>
-                <Box>
-                  <a onClick={() => goToProps("web")} href={`#`}>
-                    Props
-                  </a>
-                </Box>
-              </Content>
-            </Content>
-          )}
-          {mobileEnabled && (
-            <Content>
-              <Heading level={3}>Mobile</Heading>
-              <Content spacing="small">
-                <Box>
-                  <a onClick={() => goToUsage("mobile")} href={`#`}>
-                    Usage
-                  </a>
-                </Box>
-                <Box>
-                  <a onClick={() => goToProps("mobile")} href={`#`}>
-                    Props
-                  </a>
-                </Box>
-              </Content>
-            </Content>
-          )}
+        </Content>
+        {webEnabled && (
           <Content>
-            <Heading level={3}>Links</Heading>
-            <Content spacing="smaller">
-              <Box direction="row" gap="small">
-                <Icon name="link" />
-                {links?.map((link, index) => (
-                  <div key={index} data-storybook-link>
-                    <Link key={index} url={link.url} external>
-                      {link.label}
-                    </Link>
-                  </div>
-                ))}
+            <Heading level={6} element="h3">Web</Heading>
+            <Content spacing="small">
+              <Box>
+                <a onClick={() => goToUsage("web")} href={`#`}>
+                  Usage
+                </a>
+              </Box>
+              <Box>
+                <a onClick={() => goToProps("web")} href={`#`}>
+                  Props
+                </a>
               </Box>
             </Content>
           </Content>
+        )}
+        {mobileEnabled && (
+          <Content>
+            <Heading level={6} element="h3">Mobile</Heading>
+            <Content spacing="small">
+              <Box>
+                <a onClick={() => goToUsage("mobile")} href={`#`}>
+                  Usage
+                </a>
+              </Box>
+              <Box>
+                <a onClick={() => goToProps("mobile")} href={`#`}>
+                  Props
+                </a>
+              </Box>
+            </Content>
+          </Content>
+        )}
+        <Content>
+          <Heading level={6} element="h3">Links</Heading>
+          <Content spacing="smaller">
+            <Box direction="row" gap="smaller" alignItems="center">
+              <Icon size="small" color="interactive" name="link" />
+              {links?.map((link, index) => (
+                <div key={index} data-storybook-link>
+                  <Link key={index} url={link.url} external>
+                    {link.label}
+                  </Link>
+                </div>
+              ))}
+            </Box>
+          </Content>
         </Content>
-      </Box>
-    </Content>
+      </Content>
+    </aside>
   );
 };

--- a/packages/site/src/layout/ComponentView.tsx
+++ b/packages/site/src/layout/ComponentView.tsx
@@ -187,35 +187,46 @@ export const ComponentView = () => {
   };
 
   return PageMeta ? (
-    <Grid>
-      <Grid.Cell size={isMinimal ? { xs: 12, md: 12 } : { xs: 12, md: 9 }}>
-        <Page width="fill" title={PageMeta.title}>
-          <PageWrapper>
-            <Box>
-              <Content spacing="large">
-                <Box direction="column" gap="small" alignItems="flex-end">
-                  <CodePreviewWindow>
-                    <AtlantisPreviewViewer />
-                  </CodePreviewWindow>
+    <div style={{ display: "flex", height: "100dvh" }}>
+      <main
+        style={{
+          overflowY: "scroll",
+          backgroundColor: "var(--color-surface)",
+          boxShadow: "var(--shadow-low)",
+        }}
+      >
+        <Grid>
+          <Grid.Cell size={isMinimal ? { xs: 12, md: 12 } : { xs: 12, md: 8 }}>
+            <Page width="narrow" title={PageMeta.title}>
+              <PageWrapper>
+                <Box>
+                  <Content spacing="large">
+                    <Box direction="column" gap="small" alignItems="flex-end">
+                      <CodePreviewWindow>
+                        <AtlantisPreviewViewer />
+                      </CodePreviewWindow>
+                    </Box>
+                    <span
+                      style={
+                        { "--public-tab--inset": 0 } as React.CSSProperties
+                      }
+                    >
+                      <Tabs onTabChange={handleTabChange}>
+                        {activeTabs.map((tab, index) => (
+                          <Tab key={index} label={tab.label}>
+                            {tab.children}
+                          </Tab>
+                        ))}
+                      </Tabs>
+                    </span>
+                  </Content>
                 </Box>
-                <span
-                  style={{ "--public-tab--inset": 0 } as React.CSSProperties}
-                >
-                  <Tabs onTabChange={handleTabChange} activeTab={tab}>
-                    {activeTabs.map((tabyeah, index) => (
-                      <Tab key={index} label={tabyeah.label}>
-                        {tabyeah.children}
-                      </Tab>
-                    ))}
-                  </Tabs>
-                </span>
-              </Content>
-            </Box>
-          </PageWrapper>
-        </Page>
-      </Grid.Cell>
-      <Grid.Cell size={{ xs: 12, md: 3 }}>
-        <ComponentLinks
+              </PageWrapper>
+            </Page>
+          </Grid.Cell>
+        </Grid>
+      </main>
+      <ComponentLinks
           links={PageMeta?.links}
           mobileEnabled={!!PageMeta?.component?.mobileElement}
           webEnabled={!!PageMeta?.component?.element}
@@ -223,8 +234,7 @@ export const ComponentView = () => {
           goToProps={goToProps}
           goToUsage={goToUsage}
         />
-      </Grid.Cell>
-    </Grid>
+    </div>
   ) : (
     <ComponentNotFound />
   );

--- a/packages/site/src/layout/ComponentView.tsx
+++ b/packages/site/src/layout/ComponentView.tsx
@@ -1,4 +1,4 @@
-import { Box, Content, Grid, Page, Tab, Tabs } from "@jobber/components";
+import { Box, Content, Page, Tab, Tabs } from "@jobber/components";
 import { useParams } from "react-router";
 import { useEffect, useMemo, useState } from "react";
 import { PageWrapper } from "./PageWrapper";
@@ -32,8 +32,7 @@ export const ComponentView = () => {
   const { updateStyles } = useStyleUpdater();
   const [tab, setTab] = useState(0);
   const { stateValues } = usePropsAsDataList(PageMeta, type);
-  const { enableMinimal, minimal, disableMinimal, isMinimal } =
-    useAtlantisSite();
+  const { enableMinimal, minimal, disableMinimal } = useAtlantisSite();
 
   useEffect(() => {
     if (minimal.requested && !minimal.enabled) {
@@ -193,10 +192,11 @@ export const ComponentView = () => {
           overflowY: "scroll",
           backgroundColor: "var(--color-surface)",
           boxShadow: "var(--shadow-low)",
+          flexGrow: 1,
         }}
       >
-        <Grid>
-          <Grid.Cell size={isMinimal ? { xs: 12, md: 12 } : { xs: 12, md: 8 }}>
+        <Box alignItems="center">
+          <div style={{ maxWidth: "768px" }}>
             <Page width="narrow" title={PageMeta.title}>
               <PageWrapper>
                 <Box>
@@ -212,9 +212,9 @@ export const ComponentView = () => {
                       }
                     >
                       <Tabs onTabChange={handleTabChange}>
-                        {activeTabs.map((tab, index) => (
-                          <Tab key={index} label={tab.label}>
-                            {tab.children}
+                        {activeTabs.map((activeTab, index) => (
+                          <Tab key={index} label={activeTab.label}>
+                            {activeTab.children}
                           </Tab>
                         ))}
                       </Tabs>
@@ -223,8 +223,8 @@ export const ComponentView = () => {
                 </Box>
               </PageWrapper>
             </Page>
-          </Grid.Cell>
-        </Grid>
+          </div>
+        </Box>
       </main>
       <ComponentLinks
         links={PageMeta?.links}

--- a/packages/site/src/layout/ComponentView.tsx
+++ b/packages/site/src/layout/ComponentView.tsx
@@ -196,7 +196,7 @@ export const ComponentView = () => {
         }}
       >
         <Box alignItems="center">
-          <div style={{ maxWidth: "768px" }}>
+          <div style={{ width: "100%", maxWidth: "768px" }}>
             <Page width="narrow" title={PageMeta.title}>
               <PageWrapper>
                 <Box>

--- a/packages/site/src/layout/ComponentView.tsx
+++ b/packages/site/src/layout/ComponentView.tsx
@@ -227,13 +227,13 @@ export const ComponentView = () => {
         </Grid>
       </main>
       <ComponentLinks
-          links={PageMeta?.links}
-          mobileEnabled={!!PageMeta?.component?.mobileElement}
-          webEnabled={!!PageMeta?.component?.element}
-          goToDesign={goToDesign}
-          goToProps={goToProps}
-          goToUsage={goToUsage}
-        />
+        links={PageMeta?.links}
+        mobileEnabled={!!PageMeta?.component?.mobileElement}
+        webEnabled={!!PageMeta?.component?.element}
+        goToDesign={goToDesign}
+        goToProps={goToProps}
+        goToUsage={goToUsage}
+      />
     </div>
   ) : (
     <ComponentNotFound />

--- a/packages/site/src/layout/Layout.tsx
+++ b/packages/site/src/layout/Layout.tsx
@@ -23,7 +23,11 @@ export const Layout = () => {
     <LayoutWrapper>
       <NavMenu />
       <div
-        style={{ overflow: "auto", width: "100%", height: "100dvh" }}
+        style={{
+          overflow: "auto",
+          width: "100%",
+          height: "100dvh",
+        }}
         ref={scrollPane}
       >
         <Switch>

--- a/packages/site/src/layout/Layout.tsx
+++ b/packages/site/src/layout/Layout.tsx
@@ -84,7 +84,7 @@ export const LayoutWrapper = ({ children }: PropsWithChildren) => {
     <div
       style={{
         display: "flex",
-        background: "var(--color-surface)",
+        background: "var(--color-surface--background)",
       }}
     >
       {children}

--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -7,7 +7,6 @@
     flex-direction: column;
     padding: 36px 0 0 0;
     height: 100dvh;
-    background-color: var(--color-surface--background);
     width: 200px;
     box-sizing: border-box;
 }
@@ -108,4 +107,11 @@
     mix-blend-mode: multiply;
   }
 }
+
+:root[data-theme="dark"] .disclosureNavItem {
+  button {
+    mix-blend-mode: screen;
+  }
+}
+
 

--- a/packages/site/src/layout/PageWrapper.tsx
+++ b/packages/site/src/layout/PageWrapper.tsx
@@ -7,15 +7,14 @@ import { PropsWithChildren } from "react";
  */
 export const PageWrapper = ({ children }: PropsWithChildren) => {
   return (
-    <main
+    <div
       style={{
         width: "100%",
         minHeight: "100%",
         backgroundColor: "var(--color-surface)",
-        boxShadow: "var(--shadow-low)",
       }}
     >
       {children}
-    </main>
+    </div>
   );
 };

--- a/packages/site/src/layout/PageWrapper.tsx
+++ b/packages/site/src/layout/PageWrapper.tsx
@@ -11,6 +11,8 @@ export const PageWrapper = ({ children }: PropsWithChildren) => {
       style={{
         width: "100%",
         minHeight: "100%",
+        backgroundColor: "var(--color-surface)",
+        boxShadow: "var(--shadow-low)",
       }}
     >
       {children}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

To get the docs site looking the way it was mocked up and address early feedback, we're structuring the component detail pages a little differently.

![image](https://github.com/user-attachments/assets/972ea3a1-161f-488d-b511-5c88025fb5a9)

## Changes

### Changed

- Pull the side rail out of the Grid on the components view
- remove the Grid on the Components view
- reduce max-width of the content for readability

## Testing

View a component detail page!

Also view a collection page because it uses _some_ of the same components.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
