### PR TITLE
fix: nav disclosure section dark mode [JOB-111816]

### DIFF
--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -109,3 +109,9 @@
   }
 }
 
+:root[data-theme="dark"] .navMenuContainer {
+  button {
+    mix-blend-mode: screen;
+  }
+}
+


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The arrow on the nav disclosure items was invisible because of the blend mode being applied
![image](https://github.com/user-attachments/assets/5716b3a4-95b1-481d-bd88-c74f3af63d63)

### Fixed

- disclosure arrow visible in dark mode
![image](https://github.com/user-attachments/assets/cb08cf77-9869-4401-97d9-052675f31b98)

## Testing

Run the new docs site in dark mode
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
