### PR TITLE
docs: use default image for ContentCard

### DIFF
--- a/packages/site/src/components/ContentCard.tsx
+++ b/packages/site/src/components/ContentCard.tsx
@@ -19,7 +19,7 @@ export const ContentCard = ({
   title,
   to,
   component,
-  imageURL,
+  imageURL = "../Placeholder.png",
   onClick,
 }: ContentCardProps) => {
   const history = useHistory();

--- a/packages/site/src/components/ContentCard.tsx
+++ b/packages/site/src/components/ContentCard.tsx
@@ -33,27 +33,28 @@ export const ContentCard = ({
         onClick?.();
       }}
     >
-      {!component ? (
-        <AtlantisThemeContextProvider dangerouslyOverrideTheme="light">
-          <div
-            style={
-              imageURL && theme === "dark"
-                ? {
-                    background: "var(--color-base-blue--200)",
-                    borderRadius: "var(--radius-base) var(--radius-base) 0 0",
-                  }
-                : {}
-            }
-          >
-            <img
-              style={{ width: "100%", mixBlendMode: "multiply" }}
-              src={imageURL}
-            />
-          </div>
-        </AtlantisThemeContextProvider>
-      ) : (
-        <ComponentWrapper>{component()}</ComponentWrapper>
-      )}
+      {imageURL &&
+        (!component ? (
+          <AtlantisThemeContextProvider dangerouslyOverrideTheme="light">
+            <div
+              style={
+                theme === "dark"
+                  ? {
+                      background: "var(--color-base-blue--200)",
+                      borderRadius: "var(--radius-base) var(--radius-base) 0 0",
+                    }
+                  : {}
+              }
+            >
+              <img
+                style={{ width: "100%", mixBlendMode: "multiply" }}
+                src={imageURL}
+              />
+            </div>
+          </AtlantisThemeContextProvider>
+        ) : (
+          <ComponentWrapper>{component()}</ComponentWrapper>
+        ))}
       <Content>
         <Heading level={4}>{title}</Heading>
       </Content>

--- a/packages/site/src/components/ContentCard.tsx
+++ b/packages/site/src/components/ContentCard.tsx
@@ -33,28 +33,27 @@ export const ContentCard = ({
         onClick?.();
       }}
     >
-      {imageURL &&
-        (!component ? (
-          <AtlantisThemeContextProvider dangerouslyOverrideTheme="light">
-            <div
-              style={
-                theme === "dark"
-                  ? {
-                      background: "var(--color-base-blue--200)",
-                      borderRadius: "var(--radius-base) var(--radius-base) 0 0",
-                    }
-                  : {}
-              }
-            >
-              <img
-                style={{ width: "100%", mixBlendMode: "multiply" }}
-                src={imageURL}
-              />
-            </div>
-          </AtlantisThemeContextProvider>
-        ) : (
-          <ComponentWrapper>{component()}</ComponentWrapper>
-        ))}
+      {!component ? (
+        <AtlantisThemeContextProvider dangerouslyOverrideTheme="light">
+          <div
+            style={
+              imageURL && theme === "dark"
+                ? {
+                    background: "var(--color-base-blue--200)",
+                    borderRadius: "var(--radius-base) var(--radius-base) 0 0",
+                  }
+                : {}
+            }
+          >
+            <img
+              style={{ width: "100%", mixBlendMode: "multiply" }}
+              src={imageURL}
+            />
+          </div>
+        </AtlantisThemeContextProvider>
+      ) : (
+        <ComponentWrapper>{component()}</ComponentWrapper>
+      )}
       <Content>
         <Heading level={4}>{title}</Heading>
       </Content>

--- a/packages/site/src/contentList.ts
+++ b/packages/site/src/contentList.ts
@@ -2,17 +2,14 @@ export const contentList = [
   {
     title: "Formatting",
     to: "/content/formatting",
-    imageURL: "/Placeholder.png",
   },
   {
     title: "Product vocabulary",
     to: "/content/product-vocabulary",
-    imageURL: "/Placeholder.png",
     additionalMatches: ["Words"],
   },
   {
     title: "Voice and tone",
     to: "/content/voice-and-tone",
-    imageURL: "/Placeholder.png",
   },
 ];


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Rather than have a broken image symbol if a thumbnail doesn't exist, use the placeholder image when no imageURL is passed in.

I did consider wrapping the image section in a conditional and not rendering if there's no URL passed in, but early feedback was this is a more lightweight approach for now as we don't have to worry about layout shifts etc so addressed that before pushing this up!

## Changes

### Changed

- ContentCards with no URL provided will return the placeholder image
- Removed explicit declarations of the image URL in `contentList` that were just declaring the placeholder

## Testing

View ContentCard in the Content guides, or try removing an imageURL from any `___List` item that has an actual thumbnail image defined.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
