### PR TITLE
docs: Refactor Design item in side nav to use AnimatedPresenceDisclosure

### DIFF
--- a/packages/site/src/designList.ts
+++ b/packages/site/src/designList.ts
@@ -13,7 +13,7 @@ export const designList = [
   },
   {
     title: "Breakpoints",
-    to: "/design/responsive-breakpoint",
+    to: "/design/breakpoints",
     imageURL: "/Breakpoints.png",
     additionalMatches: ["Responsive"],
   },

--- a/packages/site/src/maps/designContent.tsx
+++ b/packages/site/src/maps/designContent.tsx
@@ -47,9 +47,9 @@ export const designContentMap: ContentMapItems = {
     title: "Radii",
     content: () => <RadiiDocs />,
   },
-  "responsive-breakpoint": {
-    intro: "Responsive Breakpoints",
-    title: "Responsive Breakpoints",
+  breakpoints: {
+    intro: "Breakpoints",
+    title: "Breakpoints",
     content: () => <ResponsiveBreakpointsDocs />,
   },
   spacing: {

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -86,6 +86,53 @@ export const routes: Array<AtlantisRoute> = [
     handle: "Design",
     exact: true,
     component: DesignPage,
+    children: [
+      {
+        path: "/design/animation",
+        handle: "Animation",
+        exact: true,
+      },
+      {
+        path: "/design/borders",
+        handle: "Borders",
+        exact: true,
+      },
+      {
+        path: "/design/colors",
+        handle: "Colors",
+        exact: true,
+      },
+      {
+        path: "/design/elevations",
+        handle: "Elevations",
+        exact: true,
+      },
+      {
+        path: "/design/opacity",
+        handle: "Opacity",
+        exact: true,
+      },
+      {
+        path: "/design/radii",
+        handle: "Radii",
+        exact: true,
+      },
+      {
+        path: "/design/breakpoints",
+        handle: "Breakpoints",
+        exact: true,
+      },
+      {
+        path: "/design/spacing",
+        handle: "Spacing",
+        exact: true,
+      },
+      {
+        path: "/design/typography",
+        handle: "Typography",
+        exact: true,
+      },
+    ],
   },
   {
     path: "/changelog",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
The Design section in the side nav was not utilizing `AnimatedPresenceDisclosure`, so this PR makes that change.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Design in the side nav is now a disclosure!

### Changed

- updated the URL from `responsive-breakpoints` to just `breakpoints`. This matches the current url from Storybook (which doesn't have "responsive" in it). I also removed the word responsive from the side nav item. We only have "Breakpoints" in the content cards also. Now everything matches! Less words! Horray!

## Testing

<!-- How to test your changes. -->
All Design content loads as it should from Home/Search/Disclosure

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
