### PR TITLE
docs: Fix broken url for Get Started button on Home

### DIFF
--- a/packages/site/src/pages/HomePage.tsx
+++ b/packages/site/src/pages/HomePage.tsx
@@ -8,7 +8,7 @@ export const HomePage = () => {
           title: "Atlantis",
           body: "Jobber's toolkit for building consumer-grade experiences",
           ctaLabel: "Get Started",
-          to: "/content/design/welcome-guide",
+          to: "/design/welcome-guide",
           imageURL: "/img_collage.jpg",
         },
         body: {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
We recently updated urls to not all have `/content` preceding other collections like `/design`, etc

This actually broke the `Get Started` button on Home. This PR just removes `/content` to make it work again.

<img width="747" alt="Screenshot 2024-12-13 at 10 32 31 PM" src="https://github.com/user-attachments/assets/00b4874e-0d74-4c71-abd9-bb0a7a7e1ecc" />

### Fixed

- Get Started button is no longer broken

## Testing

<!-- How to test your changes. -->
Click Get Started on Home and make sure you see the welcome/introduction page.


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
