### PR TITLE
docs: Remove blue border around Layout on focus

### DIFF
--- a/packages/site/src/layout/Layout.tsx
+++ b/packages/site/src/layout/Layout.tsx
@@ -27,6 +27,7 @@ export const Layout = () => {
           overflow: "auto",
           width: "100%",
           height: "100dvh",
+          outline: "transparent",
         }}
         ref={scrollPane}
         tabIndex={0}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Removing a blue focus outline on Layout when focused

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Before

 <!-- new features -->
<img width="938" alt="Screenshot 2024-12-17 at 7 11 25 AM" src="https://github.com/user-attachments/assets/71ccaf6d-79ae-47ab-bc30-35fcf5a50f26" />


### After

 <!-- changes in existing functionality -->

<img width="949" alt="Screenshot 2024-12-17 at 7 10 44 AM" src="https://github.com/user-attachments/assets/54e0cce5-0aa4-4fa8-a69c-17544942a8b5" />

## Testing

Hit tab in side nav to engage "Skip to Content" button, select it and see that when focus moves to the content, there is no blue line.
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
