### PR TITLE
docs: Home Page categorization on New Docs Site

### DIFF
--- a/packages/site/src/components/PageBlock.tsx
+++ b/packages/site/src/components/PageBlock.tsx
@@ -21,6 +21,7 @@ interface PageBlockProps {
       content: ContentCardProps[];
     };
     useCategories?: boolean;
+    showSegmentedControl?: boolean;
   };
 }
 
@@ -62,7 +63,7 @@ export const PageBlock = ({ structure }: PageBlockProps) => {
     <PageWrapper>
       <HeaderBlock {...structure.header} />
       <BodyBlock>
-        {structure.useCategories && (
+        {structure.showSegmentedControl !== false && (
           <div
             style={{
               width: "240px",
@@ -84,7 +85,7 @@ export const PageBlock = ({ structure }: PageBlockProps) => {
           </div>
         )}
 
-        {cardView === "category" ? (
+        {structure.useCategories && cardView === "category" ? (
           <>
             {sectionedComponents().map(({ section, items }) => (
               <CategoryCardSection key={section} category={section}>

--- a/packages/site/src/components/PageBlock.tsx
+++ b/packages/site/src/components/PageBlock.tsx
@@ -63,7 +63,7 @@ export const PageBlock = ({ structure }: PageBlockProps) => {
     <PageWrapper>
       <HeaderBlock {...structure.header} />
       <BodyBlock>
-        {structure.showSegmentedControl !== false && (
+        {structure.showSegmentedControl && (
           <div
             style={{
               width: "240px",

--- a/packages/site/src/pages/ComponentsPage.tsx
+++ b/packages/site/src/pages/ComponentsPage.tsx
@@ -14,6 +14,7 @@ export const ComponentsPage = () => {
           content: componentList,
         },
         useCategories: true,
+        showSegmentedControl: true,
       }}
     />
   );

--- a/packages/site/src/pages/HomePage.tsx
+++ b/packages/site/src/pages/HomePage.tsx
@@ -46,7 +46,6 @@ export const HomePage = () => {
           ],
         },
         useCategories: true,
-        showSegmentedControl: false,
       }}
     />
   );

--- a/packages/site/src/pages/HomePage.tsx
+++ b/packages/site/src/pages/HomePage.tsx
@@ -17,17 +17,36 @@ export const HomePage = () => {
               title: "Components",
               to: "/components",
               imageURL: "/Components.png",
+              sections: ["Packages"],
             },
-            { title: "Design", to: "/design", imageURL: "/Design.png" },
-            { title: "Content", to: "/content", imageURL: "/Placeholder.png" },
-            { title: "Guides", to: "/guides", imageURL: "/Placeholder.png" },
+            {
+              title: "Design",
+              to: "/design",
+              imageURL: "/Design.png",
+              sections: ["Packages"],
+            },
+            {
+              title: "Content",
+              to: "/content",
+              imageURL: "/Placeholder.png",
+              sections: ["Resources"],
+            },
+            {
+              title: "Guides",
+              to: "/guides",
+              imageURL: "/Placeholder.png",
+              sections: ["Resources"],
+            },
             {
               title: "Changelog",
               to: "/changelog",
               imageURL: "/Placeholder.png",
+              sections: ["Changelog"],
             },
           ],
         },
+        useCategories: true,
+        showSegmentedControl: false,
       }}
     />
   );


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
On the Home Page, we want sections just like on the Components Page.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

1. New prop on `PageBlock` called `showSegmentedControl`. We want to categorize Home but there are not enough items to warrant a `SegmentedControl`. This way, other pages can use the organization of sections but without `SegmentedControl` if needed
2. `sections` have been added to all current items in `HomePage.tsx`

### Before

![Screenshot 2024-12-17 at 5 32 25 PM](https://github.com/user-attachments/assets/4ec74ef7-d212-4a73-bce7-b5aef23e4a32)

### After

![Screenshot 2024-12-17 at 5 32 01 PM](https://github.com/user-attachments/assets/0881e076-7e87-4c33-8629-ddbc4ec552ab)



## Testing

Make sure the Home Page is in categories. No `SegmentedControl`.

Also make sure the Components page still has categories and there is a `SegmentedControl` for further display options.
<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
