### PR TITLE
docs: Add siderail for content pages and improve layouts [Job 111086]

### DIFF
--- a/packages/site/src/components/AnchorLinks.tsx
+++ b/packages/site/src/components/AnchorLinks.tsx
@@ -1,0 +1,62 @@
+import { Box, Content, Heading } from "@jobber/components";
+import { MouseEvent, useEffect, useState } from "react";
+
+interface AnchorLinksProps {
+  /**
+   * An additional action to perform along with scrolling to the selected anchor
+   */
+  readonly header: string;
+
+  /**
+   * An additional action to perform along with scrolling to the selected anchor
+   */
+  readonly additionalOnClickAction?: () => void;
+}
+
+export function AnchorLinks({
+  header,
+  additionalOnClickAction,
+}: AnchorLinksProps) {
+  const [hlinks, setHlinks] = useState<Element[] | null>(null);
+
+  useEffect(() => {
+    const hdd = document.querySelectorAll("[data-heading-link]");
+
+    if (hdd.length > 0) {
+      setHlinks(Array.from(hdd));
+    }
+  }, []);
+
+  const click = (e: MouseEvent) => {
+    e.preventDefault();
+    const id = e.currentTarget?.getAttribute("href")?.replace("#", "");
+
+    if (id) {
+      additionalOnClickAction?.();
+      setTimeout(() => {
+        const element = document.getElementById(id);
+
+        if (element) {
+          element.scrollIntoView({ behavior: "smooth" });
+        }
+      }, 100);
+    }
+  };
+
+  return (
+    <Content>
+      <Heading level={6} element="h3">
+        {header}
+      </Heading>
+      <Content spacing="small">
+        {hlinks?.map((link, index) => (
+          <Box key={index}>
+            <a onClick={click} href={`#${link.id}`}>
+              {link.textContent}
+            </a>
+          </Box>
+        ))}
+      </Content>
+    </Content>
+  );
+}

--- a/packages/site/src/components/AnchorLinks.tsx
+++ b/packages/site/src/components/AnchorLinks.tsx
@@ -8,6 +8,11 @@ interface AnchorLinksProps {
   readonly header: string;
 
   /**
+   * A key unique to the page that controls re-rendering of the component
+   */
+  readonly key: string;
+
+  /**
    * An additional action to perform along with scrolling to the selected anchor
    */
   readonly additionalOnClickAction?: () => void;
@@ -15,6 +20,7 @@ interface AnchorLinksProps {
 
 export function AnchorLinks({
   header,
+  key,
   additionalOnClickAction,
 }: AnchorLinksProps) {
   const [hlinks, setHlinks] = useState<Element[] | null>(null);
@@ -25,7 +31,7 @@ export function AnchorLinks({
     if (hdd.length > 0) {
       setHlinks(Array.from(hdd));
     }
-  }, []);
+  }, [key]);
 
   const click = (e: MouseEvent) => {
     e.preventDefault();
@@ -44,19 +50,23 @@ export function AnchorLinks({
   };
 
   return (
-    <Content>
-      <Heading level={6} element="h3">
-        {header}
-      </Heading>
-      <Content spacing="small">
-        {hlinks?.map((link, index) => (
-          <Box key={index}>
-            <a onClick={click} href={`#${link.id}`}>
-              {link.textContent}
-            </a>
-          </Box>
-        ))}
-      </Content>
-    </Content>
+    <>
+      {hlinks && hlinks.length > 0 && (
+        <Content>
+          <Heading level={6} element="h3">
+            {header}
+          </Heading>
+          <Content spacing="small">
+            {hlinks?.map((link, index) => (
+              <Box key={index}>
+                <a onClick={click} href={`#${link.id}`}>
+                  {link.textContent}
+                </a>
+              </Box>
+            ))}
+          </Content>
+        </Content>
+      )}
+    </>
   );
 }

--- a/packages/site/src/components/ComponentLinks.tsx
+++ b/packages/site/src/components/ComponentLinks.tsx
@@ -9,6 +9,7 @@ import { useAtlantisSite } from "../providers/AtlantisSiteProvider";
  * @returns ReactNode
  */
 export const ComponentLinks = ({
+  key,
   links,
   goToProps,
   goToUsage,
@@ -16,6 +17,7 @@ export const ComponentLinks = ({
   webEnabled,
   mobileEnabled,
 }: {
+  readonly key: string;
   readonly links?: ContentExportLinks[];
   readonly goToProps: (type: string) => void;
   readonly goToUsage: (type: string) => void;
@@ -27,74 +29,67 @@ export const ComponentLinks = ({
   if (isMinimal) return null;
 
   return (
-    <aside
-      style={{
-        width: "200px",
-        padding: "36px var(--space-base)",
-        display: "flex",
-        flexDirection: "column",
-        flexShrink: "0",
-        boxSizing: "border-box",
-      }}
-    >
-      <Content spacing={"larger"}>
-        <AnchorLinks header="Design" additionalOnClickAction={goToDesign} />
-        {webEnabled && (
-          <Content>
-            <Heading level={6} element="h3">
-              Web
-            </Heading>
-            <Content spacing="small">
-              <Box>
-                <a onClick={() => goToUsage("web")} href={`#`}>
-                  Usage
-                </a>
-              </Box>
-              <Box>
-                <a onClick={() => goToProps("web")} href={`#`}>
-                  Props
-                </a>
-              </Box>
-            </Content>
-          </Content>
-        )}
-        {mobileEnabled && (
-          <Content>
-            <Heading level={6} element="h3">
-              Mobile
-            </Heading>
-            <Content spacing="small">
-              <Box>
-                <a onClick={() => goToUsage("mobile")} href={`#`}>
-                  Usage
-                </a>
-              </Box>
-              <Box>
-                <a onClick={() => goToProps("mobile")} href={`#`}>
-                  Props
-                </a>
-              </Box>
-            </Content>
-          </Content>
-        )}
+    <Content spacing={"larger"}>
+      <AnchorLinks
+        key={key}
+        header="Design"
+        additionalOnClickAction={goToDesign}
+      />
+      {webEnabled && (
         <Content>
           <Heading level={6} element="h3">
-            Links
+            Web
           </Heading>
-          <Content spacing="smaller">
-            <Box direction="row" gap="smaller" alignItems="center">
-              <Icon size="small" color="interactive" name="link" />
-              {links?.map((link, index) => (
-                <div key={index} data-storybook-link>
-                  <Link key={index} url={link.url} external>
-                    {link.label}
-                  </Link>
-                </div>
-              ))}
+          <Content spacing="small">
+            <Box>
+              <a onClick={() => goToUsage("web")} href={`#`}>
+                Usage
+              </a>
+            </Box>
+            <Box>
+              <a onClick={() => goToProps("web")} href={`#`}>
+                Props
+              </a>
             </Box>
           </Content>
         </Content>
+      )}
+      {mobileEnabled && (
+        <Content>
+          <Heading level={6} element="h3">
+            Mobile
+          </Heading>
+          <Content spacing="small">
+            <Box>
+              <a onClick={() => goToUsage("mobile")} href={`#`}>
+                Usage
+              </a>
+            </Box>
+            <Box>
+              <a onClick={() => goToProps("mobile")} href={`#`}>
+                Props
+              </a>
+            </Box>
+          </Content>
+        </Content>
+      )}
+      <Content>
+        <Heading level={6} element="h3">
+          Links
+        </Heading>
+        <Content spacing="smaller">
+          <Box direction="row" gap="smaller" alignItems="center">
+            <Icon size="small" color="interactive" name="link" />
+            {links?.map((link, index) => (
+              <div key={index} data-storybook-link>
+                <Link key={index} url={link.url} external>
+                  {link.label}
+                </Link>
+              </div>
+            ))}
+          </Box>
+        </Content>
       </Content>
-    </aside>
+    </Content>
   );
 };

--- a/packages/site/src/components/ComponentLinks.tsx
+++ b/packages/site/src/components/ComponentLinks.tsx
@@ -1,5 +1,5 @@
 import { Box, Content, Heading, Icon, Link } from "@jobber/components";
-import { MouseEvent, useEffect, useState } from "react";
+import { AnchorLinks } from "./AnchorLinks";
 import { ContentExportLinks } from "../types/content";
 import { useAtlantisSite } from "../providers/AtlantisSiteProvider";
 
@@ -23,31 +23,6 @@ export const ComponentLinks = ({
   readonly webEnabled: boolean;
   readonly mobileEnabled: boolean;
 }) => {
-  const [hlinks, setHlinks] = useState<Element[] | null>(null);
-
-  useEffect(() => {
-    const hdd = document.querySelectorAll("[data-heading-link]");
-
-    if (hdd.length > 0) {
-      setHlinks(Array.from(hdd));
-    }
-  }, []);
-
-  const click = (e: MouseEvent) => {
-    e.preventDefault();
-    const id = e.currentTarget?.getAttribute("href")?.replace("#", "");
-
-    if (id) {
-      goToDesign();
-      setTimeout(() => {
-        const element = document.getElementById(id);
-
-        if (element) {
-          element.scrollIntoView({ behavior: "smooth" });
-        }
-      }, 100);
-    }
-  };
   const { isMinimal } = useAtlantisSite();
   if (isMinimal) return null;
 
@@ -63,20 +38,7 @@ export const ComponentLinks = ({
       }}
     >
       <Content spacing={"larger"}>
-        <Content>
-          <Heading level={6} element="h3">
-            Design
-          </Heading>
-          <Content spacing="small">
-            {hlinks?.map((link, index) => (
-              <Box key={index}>
-                <a onClick={click} href={`#${link.id}`}>
-                  {link.textContent}
-                </a>
-              </Box>
-            ))}
-          </Content>
-        </Content>
+        <AnchorLinks header="Design" additionalOnClickAction={goToDesign} />
         {webEnabled && (
           <Content>
             <Heading level={6} element="h3">

--- a/packages/site/src/components/ContentLoader.tsx
+++ b/packages/site/src/components/ContentLoader.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useParams } from "react-router";
-import { ContentView } from "../pages/ContentView";
+import { ContentView } from "../layout/ContentView";
 import { contentMap } from "../maps";
 
 /**

--- a/packages/site/src/components/ContentLoader.tsx
+++ b/packages/site/src/components/ContentLoader.tsx
@@ -28,11 +28,5 @@ export const ContentLoader = () => {
 
   const content = contentMap[type][name];
 
-  return (
-    <ContentView
-      intro={content.intro}
-      title={content.title}
-      content={content.content}
-    />
-  );
+  return <ContentView key={`${type}-${name}`} content={content.content} />;
 };

--- a/packages/site/src/layout/BaseView.tsx
+++ b/packages/site/src/layout/BaseView.tsx
@@ -40,6 +40,8 @@ BaseView.Siderail = function Siderail({
         flexDirection: "column",
         flexShrink: "0",
         boxSizing: "border-box",
+        overflowY: "auto",
+        height: "100%",
       }}
     >
       {children}

--- a/packages/site/src/layout/BaseView.tsx
+++ b/packages/site/src/layout/BaseView.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@jobber/components";
-import React from "react";
+import { PropsWithChildren } from "react";
 
 export function BaseView({ children }: PropsWithChildren) {
   return <div style={{ display: "flex", height: "100dvh" }}>{children}</div>;

--- a/packages/site/src/layout/BaseView.tsx
+++ b/packages/site/src/layout/BaseView.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@jobber/components";
 import React from "react";
 
-export function BaseView({ children }: { readonly children: React.ReactNode }) {
+export function BaseView({ children }: PropsWithChildren) {
   return <div style={{ display: "flex", height: "100dvh" }}>{children}</div>;
 }
 

--- a/packages/site/src/layout/BaseView.tsx
+++ b/packages/site/src/layout/BaseView.tsx
@@ -1,0 +1,48 @@
+import { Box } from "@jobber/components";
+import React from "react";
+
+export function BaseView({ children }: { readonly children: React.ReactNode }) {
+  return <div style={{ display: "flex", height: "100dvh" }}>{children}</div>;
+}
+
+BaseView.Main = function Main({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <main
+      style={{
+        overflowY: "scroll",
+        backgroundColor: "var(--color-surface)",
+        boxShadow: "var(--shadow-low)",
+        flexGrow: 1,
+      }}
+    >
+      <Box alignItems="center">
+        <div style={{ width: "100%", maxWidth: "768px" }}>{children}</div>
+      </Box>
+    </main>
+  );
+};
+
+BaseView.Siderail = function Siderail({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <aside
+      style={{
+        width: "200px",
+        padding: "36px var(--space-base)",
+        display: "flex",
+        flexDirection: "column",
+        flexShrink: "0",
+        boxSizing: "border-box",
+      }}
+    >
+      {children}
+    </aside>
+  );
+};

--- a/packages/site/src/layout/ComponentView.tsx
+++ b/packages/site/src/layout/ComponentView.tsx
@@ -2,6 +2,7 @@ import { Box, Content, Page, Tab, Tabs } from "@jobber/components";
 import { useParams } from "react-router";
 import { useEffect, useMemo, useState } from "react";
 import { PageWrapper } from "./PageWrapper";
+import { BaseView } from "./BaseView";
 import { PropsList } from "../components/PropsList";
 import { ComponentNotFound } from "../components/ComponentNotFound";
 import { ComponentLinks } from "../components/ComponentLinks";
@@ -186,55 +187,45 @@ export const ComponentView = () => {
   };
 
   return PageMeta ? (
-    <div style={{ display: "flex", height: "100dvh" }}>
-      <main
-        style={{
-          overflowY: "scroll",
-          backgroundColor: "var(--color-surface)",
-          boxShadow: "var(--shadow-low)",
-          flexGrow: 1,
-        }}
-      >
-        <Box alignItems="center">
-          <div style={{ width: "100%", maxWidth: "768px" }}>
-            <Page width="narrow" title={PageMeta.title}>
-              <PageWrapper>
-                <Box>
-                  <Content spacing="large">
-                    <Box direction="column" gap="small" alignItems="flex-end">
-                      <CodePreviewWindow>
-                        <AtlantisPreviewViewer />
-                      </CodePreviewWindow>
-                    </Box>
-                    <span
-                      style={
-                        { "--public-tab--inset": 0 } as React.CSSProperties
-                      }
-                    >
-                      <Tabs onTabChange={handleTabChange} activeTab={tab}>
-                        {activeTabs.map((activeTab, index) => (
-                          <Tab key={index} label={activeTab.label}>
-                            {activeTab.children}
-                          </Tab>
-                        ))}
-                      </Tabs>
-                    </span>
-                  </Content>
+    <BaseView>
+      <BaseView.Main>
+        <Page width="narrow" title={PageMeta.title}>
+          <PageWrapper>
+            <Box>
+              <Content spacing="large">
+                <Box direction="column" gap="small" alignItems="flex-end">
+                  <CodePreviewWindow>
+                    <AtlantisPreviewViewer />
+                  </CodePreviewWindow>
                 </Box>
-              </PageWrapper>
-            </Page>
-          </div>
-        </Box>
-      </main>
-      <ComponentLinks
-        links={PageMeta?.links}
-        mobileEnabled={!!PageMeta?.component?.mobileElement}
-        webEnabled={!!PageMeta?.component?.element}
-        goToDesign={goToDesign}
-        goToProps={goToProps}
-        goToUsage={goToUsage}
-      />
-    </div>
+                <span
+                  style={{ "--public-tab--inset": 0 } as React.CSSProperties}
+                >
+                  <Tabs onTabChange={handleTabChange} activeTab={tab}>
+                    {activeTabs.map((activeTab, index) => (
+                      <Tab key={index} label={activeTab.label}>
+                        {activeTab.children}
+                      </Tab>
+                    ))}
+                  </Tabs>
+                </span>
+              </Content>
+            </Box>
+          </PageWrapper>
+        </Page>
+      </BaseView.Main>
+      <BaseView.Siderail>
+        <ComponentLinks
+          key={`component-${name}`}
+          links={PageMeta?.links}
+          mobileEnabled={!!PageMeta?.component?.mobileElement}
+          webEnabled={!!PageMeta?.component?.element}
+          goToDesign={goToDesign}
+          goToProps={goToProps}
+          goToUsage={goToUsage}
+        />
+      </BaseView.Siderail>
+    </BaseView>
   ) : (
     <ComponentNotFound />
   );

--- a/packages/site/src/layout/ComponentView.tsx
+++ b/packages/site/src/layout/ComponentView.tsx
@@ -1,7 +1,6 @@
 import { Box, Content, Page, Tab, Tabs } from "@jobber/components";
 import { useParams } from "react-router";
 import { useEffect, useMemo, useState } from "react";
-import { PageWrapper } from "./PageWrapper";
 import { BaseView } from "./BaseView";
 import { PropsList } from "../components/PropsList";
 import { ComponentNotFound } from "../components/ComponentNotFound";
@@ -190,28 +189,24 @@ export const ComponentView = () => {
     <BaseView>
       <BaseView.Main>
         <Page width="narrow" title={PageMeta.title}>
-          <PageWrapper>
-            <Box>
-              <Content spacing="large">
-                <Box direction="column" gap="small" alignItems="flex-end">
-                  <CodePreviewWindow>
-                    <AtlantisPreviewViewer />
-                  </CodePreviewWindow>
-                </Box>
-                <span
-                  style={{ "--public-tab--inset": 0 } as React.CSSProperties}
-                >
-                  <Tabs onTabChange={handleTabChange} activeTab={tab}>
-                    {activeTabs.map((activeTab, index) => (
-                      <Tab key={index} label={activeTab.label}>
-                        {activeTab.children}
-                      </Tab>
-                    ))}
-                  </Tabs>
-                </span>
-              </Content>
-            </Box>
-          </PageWrapper>
+          <Box>
+            <Content spacing="large">
+              <Box direction="column" gap="small" alignItems="flex-end">
+                <CodePreviewWindow>
+                  <AtlantisPreviewViewer />
+                </CodePreviewWindow>
+              </Box>
+              <span style={{ "--public-tab--inset": 0 } as React.CSSProperties}>
+                <Tabs onTabChange={handleTabChange} activeTab={tab}>
+                  {activeTabs.map((activeTab, index) => (
+                    <Tab key={index} label={activeTab.label}>
+                      {activeTab.children}
+                    </Tab>
+                  ))}
+                </Tabs>
+              </span>
+            </Content>
+          </Box>
         </Page>
       </BaseView.Main>
       <BaseView.Siderail>

--- a/packages/site/src/layout/ContentView.tsx
+++ b/packages/site/src/layout/ContentView.tsx
@@ -1,7 +1,7 @@
 import { Content } from "@jobber/components";
+import { BaseView } from "./BaseView";
 import { ContentExport } from "../types/content";
 import { AnchorLinks } from "../components/AnchorLinks";
-import { BaseView } from "../layout/BaseView";
 
 export const ContentView = ({
   key,

--- a/packages/site/src/pages/ContentView.tsx
+++ b/packages/site/src/pages/ContentView.tsx
@@ -1,22 +1,25 @@
-import { Box, Content } from "@jobber/components";
+import { Content } from "@jobber/components";
 import { ContentExport } from "../types/content";
 import { AnchorLinks } from "../components/AnchorLinks";
+import { BaseView } from "../layout/BaseView";
 
 export const ContentView = ({
+  key,
   content,
 }: {
+  readonly key: string;
   readonly content: ContentExport["content"];
-  readonly intro: string;
-  readonly title: string;
 }) => {
   return (
-    <div style={{ backgroundColor: "var(--color-surface" }}>
-      <custom-elements>
-        <Box padding={"larger"}>
+    <BaseView>
+      <BaseView.Main>
+        <custom-elements>
           <Content>{content()}</Content>
-        </Box>
-        <AnchorLinks header="Details" />
-      </custom-elements>
-    </div>
+        </custom-elements>
+      </BaseView.Main>
+      <BaseView.Siderail>
+        <AnchorLinks header="Jump To" key={key} />
+      </BaseView.Siderail>
+    </BaseView>
   );
 };

--- a/packages/site/src/pages/ContentView.tsx
+++ b/packages/site/src/pages/ContentView.tsx
@@ -1,5 +1,6 @@
 import { Box, Content } from "@jobber/components";
 import { ContentExport } from "../types/content";
+import { AnchorLinks } from "../components/AnchorLinks";
 
 export const ContentView = ({
   content,
@@ -14,6 +15,7 @@ export const ContentView = ({
         <Box padding={"larger"}>
           <Content>{content()}</Content>
         </Box>
+        <AnchorLinks header="Details" />
       </custom-elements>
     </div>
   );


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Changes

- Adds a `BaseView` component that contains the styles that are shared between `ComponentView` and `ContentView`
- Related to this the page layout on content pages should now be consistent with component pages
- Content pages now have a siderail with anchor tags to jump to parts of the page
- If the siderail has many links (like on changelog pages) the siderail has a scrollbar independent of the main content scrollbar
- Some other cleanup and refactoring

## Testing

- Click around content and component pages and compare the two. The layouts should be matching
- The content pages should now have anchor links in the siderail. That being said as [Taylor recently pointed out](https://getjobber.slack.com/archives/C081WMPQLUV/p1734460480376659) there are issues with many of the anchor links in the site. So testing on this is more about confirming that the links are appearing (on most pages) and when the links are correct the styles and behaviour are as expected. Fixing all of the links will come in a later PR
- Go to a changelog page and ensure the behaviour when there are a huge number of links in the siderail is a good user experience

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
