### PR TITLE
docs: Make current page apparent in side nav

### DIFF
--- a/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
+++ b/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
@@ -1,5 +1,5 @@
 import { AnimatedPresence, Button, Typography } from "@jobber/components";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import styles from "./NavMenu.module.css";
 
@@ -18,8 +18,13 @@ function AnimatedPresenceDisclosure({
 }: AnimatedPresenceDisclosureProps) {
   const { pathname } = useLocation();
 
+  const childrenArray = useMemo(
+    () => React.Children.toArray(children),
+    [children],
+  );
+
   // Determine if any child is selected based on the current URL
-  const hasSelectedChild = React.Children.toArray(children).some(
+  const hasSelectedChild = childrenArray.some(
     child => React.isValidElement(child) && pathname === child.props.to,
   );
 
@@ -76,7 +81,7 @@ function AnimatedPresenceDisclosure({
       <AnimatedPresence>
         {isOpen && (
           <ul style={{ padding: "0" }}>
-            {React.Children.toArray(children)
+            {childrenArray
               .filter((child): child is React.ReactElement =>
                 React.isValidElement(child),
               )

--- a/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
+++ b/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
@@ -7,12 +7,16 @@ interface AnimatedPresenceDisclosureProps {
   readonly children: React.ReactNode;
   readonly title: React.ReactNode;
   readonly to: string;
+  readonly className?: string;
+  readonly selected?: boolean;
 }
 
 function AnimatedPresenceDisclosure({
   children,
   title,
   to,
+  className,
+  selected,
 }: AnimatedPresenceDisclosureProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -22,8 +26,13 @@ function AnimatedPresenceDisclosure({
   };
 
   return (
-    <div>
-      <span className={styles.disclosureNavItem}>
+    <div className={className}>
+      <span
+        className={`${styles.disclosureNavItem} ${
+          selected ? styles.selected : ""
+        }`}
+      >
+        {" "}
         <Link to={to ?? "/"} tabIndex={0}>
           <Typography fontWeight="semiBold" size="large" textColor="heading">
             {title}

--- a/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
+++ b/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
@@ -51,6 +51,7 @@ function AnimatedPresenceDisclosure({
     setIsOpen(!isOpen);
   };
 
+  // Keeps from having the Disclosure title and the child both highlighted
   const isTitleSelected = location.pathname === to;
 
   return (

--- a/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
+++ b/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
@@ -7,7 +7,7 @@ interface AnimatedPresenceDisclosureProps {
   readonly children: React.ReactNode;
   readonly title: React.ReactNode;
   readonly to: string;
-  readonly className?: string;
+  // readonly className?: string;
   readonly selected?: boolean;
 }
 
@@ -15,7 +15,7 @@ function AnimatedPresenceDisclosure({
   children,
   title,
   to,
-  className,
+  // className,
   selected,
 }: AnimatedPresenceDisclosureProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -26,7 +26,7 @@ function AnimatedPresenceDisclosure({
   };
 
   return (
-    <div className={className}>
+    <div>
       <span
         className={`${styles.disclosureNavItem} ${
           selected ? styles.selected : ""

--- a/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
+++ b/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
@@ -16,12 +16,11 @@ function AnimatedPresenceDisclosure({
   to,
   selected,
 }: AnimatedPresenceDisclosureProps) {
-  const location = useLocation();
+  const { pathname } = useLocation();
 
   // Determine if any child is selected based on the current URL
   const hasSelectedChild = React.Children.toArray(children).some(
-    child =>
-      React.isValidElement(child) && location.pathname === child.props.to,
+    child => React.isValidElement(child) && pathname === child.props.to,
   );
 
   const [isOpen, setIsOpen] = useState(selected || hasSelectedChild);
@@ -36,15 +35,13 @@ function AnimatedPresenceDisclosure({
   // Scroll the selected element into view when the disclosure is open
   useEffect(() => {
     if (isOpen) {
-      const selectedElement = document.querySelector(
-        `[href="${location.pathname}"]`,
-      );
+      const selectedElement = document.querySelector(`[href="${pathname}"]`);
 
       if (selectedElement) {
         selectedElement.scrollIntoView({ behavior: "smooth", block: "center" });
       }
     }
-  }, [isOpen, location.pathname]);
+  }, [isOpen, pathname]);
 
   const handleButtonClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -52,7 +49,7 @@ function AnimatedPresenceDisclosure({
   };
 
   // Keeps from having the Disclosure title and the child both highlighted
-  const isTitleSelected = location.pathname === to;
+  const isTitleSelected = pathname === to;
 
   return (
     <div>
@@ -85,7 +82,7 @@ function AnimatedPresenceDisclosure({
               )
               .map(child =>
                 React.cloneElement(child, {
-                  selected: location.pathname === child.props.to,
+                  selected: pathname === child.props.to,
                 }),
               )}
           </ul>

--- a/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
+++ b/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
@@ -1,5 +1,5 @@
 import { AnimatedPresence, Button, Typography } from "@jobber/components";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import styles from "./NavMenu.module.css";
 
@@ -18,13 +18,33 @@ function AnimatedPresenceDisclosure({
 }: AnimatedPresenceDisclosureProps) {
   const location = useLocation();
 
-  // Check if any child is selected based on location
+  // Determine if any child is selected based on the current URL
   const hasSelectedChild = React.Children.toArray(children).some(
     child =>
       React.isValidElement(child) && location.pathname === child.props.to,
   );
 
   const [isOpen, setIsOpen] = useState(selected || hasSelectedChild);
+
+  // Open the disclosure if the parent or any child is selected
+  useEffect(() => {
+    if (selected || hasSelectedChild) {
+      setIsOpen(true);
+    }
+  }, [selected, hasSelectedChild]);
+
+  // Scroll the selected element into view when the disclosure is open
+  useEffect(() => {
+    if (isOpen) {
+      const selectedElement = document.querySelector(
+        `[href="${location.pathname}"]`,
+      );
+
+      if (selectedElement) {
+        selectedElement.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
+  }, [isOpen, location.pathname]);
 
   const handleButtonClick = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
+++ b/packages/site/src/layout/AnimatedPresenceDisclosure.tsx
@@ -1,13 +1,12 @@
 import { AnimatedPresence, Button, Typography } from "@jobber/components";
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import styles from "./NavMenu.module.css";
 
 interface AnimatedPresenceDisclosureProps {
   readonly children: React.ReactNode;
   readonly title: React.ReactNode;
   readonly to: string;
-  // readonly className?: string;
   readonly selected?: boolean;
 }
 
@@ -15,24 +14,32 @@ function AnimatedPresenceDisclosure({
   children,
   title,
   to,
-  // className,
   selected,
 }: AnimatedPresenceDisclosureProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const location = useLocation();
+
+  // Check if any child is selected based on location
+  const hasSelectedChild = React.Children.toArray(children).some(
+    child =>
+      React.isValidElement(child) && location.pathname === child.props.to,
+  );
+
+  const [isOpen, setIsOpen] = useState(selected || hasSelectedChild);
 
   const handleButtonClick = (e: React.MouseEvent) => {
     e.preventDefault();
     setIsOpen(!isOpen);
   };
 
+  const isTitleSelected = location.pathname === to;
+
   return (
     <div>
       <span
         className={`${styles.disclosureNavItem} ${
-          selected ? styles.selected : ""
+          isTitleSelected ? styles.selected : ""
         }`}
       >
-        {" "}
         <Link to={to ?? "/"} tabIndex={0}>
           <Typography fontWeight="semiBold" size="large" textColor="heading">
             {title}
@@ -51,9 +58,15 @@ function AnimatedPresenceDisclosure({
       <AnimatedPresence>
         {isOpen && (
           <ul style={{ padding: "0" }}>
-            {React.Children.map(children, child => (
-              <>{child}</>
-            ))}
+            {React.Children.toArray(children)
+              .filter((child): child is React.ReactElement =>
+                React.isValidElement(child),
+              )
+              .map(child =>
+                React.cloneElement(child, {
+                  selected: location.pathname === child.props.to,
+                }),
+              )}
           </ul>
         )}
       </AnimatedPresence>

--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -44,8 +44,8 @@
   user-select: none;
 }
 
-.selected {
-  background-color: var(--color-surface) !important;
+.navMenuContainer .selected {
+  background-color: var(--color-surface);
   border-radius: var(--radius-small);
 }
 

--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -44,6 +44,11 @@
   user-select: none;
 }
 
+.selected {
+  background-color: var(--color-surface) !important;
+  border-radius: var(--radius-small);
+}
+
 .searchButton {
   display: flex;
   align-items: center;
@@ -150,9 +155,4 @@
   button {
     mix-blend-mode: screen;
   }
-}
-
-.selected {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-small);
 }

--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -151,3 +151,9 @@
     mix-blend-mode: screen;
   }
 }
+
+.selected {
+  border: 2px solid red;
+  border-radius: 4px;
+  /* Optional: for rounded borders */
+}

--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -153,7 +153,6 @@
 }
 
 .selected {
-  border: 2px solid red;
-  border-radius: 4px;
-  /* Optional: for rounded borders */
+  background-color: var(--color-surface);
+  border-radius: var(--radius-small);
 }

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -1,6 +1,12 @@
 import { Box, Button, Content, Icon, Typography } from "@jobber/components";
 import { Link, useLocation } from "react-router-dom";
-import { Fragment, PropsWithChildren, useState } from "react";
+import {
+  Fragment,
+  PropsWithChildren,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { SearchBox } from "./SearchBox";
 import AnimatedPresenceDisclosure from "./AnimatedPresenceDisclosure";
 import styles from "./NavMenu.module.css";
@@ -21,8 +27,18 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
   const [open, setOpen] = useState(false);
   const { isMinimal } = useAtlantisSite();
   const location = useLocation();
+  const selectedRef = useRef<HTMLAnchorElement | null>(null);
 
   if (isMinimal) return null;
+
+  useEffect(() => {
+    if (selectedRef.current) {
+      selectedRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+  }, [location.pathname]);
 
   interface MenuItem {
     handle: string;
@@ -34,7 +50,10 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
     return menuItems.map((menuItem, menuItemIndex) => {
       return (
         <MenuSubItem key={`${routeIndex}-${menuItemIndex}`}>
-          <StyledSubLink to={`/components/${menuItem.handle}`}>
+          <StyledSubLink
+            to={`/components/${menuItem.handle}`}
+            selectedRef={selectedRef}
+          >
             {menuItem.handle}
           </StyledSubLink>
         </MenuSubItem>
@@ -55,7 +74,7 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
 
       return (
         <MenuSubItem key={`${routeIndex}-${menuItemIndex}`}>
-          <StyledSubLink to={menuItem.path ?? "/"}>
+          <StyledSubLink to={menuItem.path ?? "/"} selectedRef={selectedRef}>
             {menuItem.handle}
           </StyledSubLink>
         </MenuSubItem>
@@ -123,7 +142,10 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
 
               return (
                 <MenuItem key={routeIndex}>
-                  <StyledLink to={getRoutePath(route.path) ?? "/"}>
+                  <StyledLink
+                    to={getRoutePath(route.path) ?? "/"}
+                    selectedRef={selectedRef}
+                  >
                     {route.handle}
                   </StyledLink>
                 </MenuItem>
@@ -139,7 +161,13 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
 export const StyledLink = ({
   to,
   children,
-}: PropsWithChildren<{ readonly to: string }>) => {
+  // isSelected,
+  selectedRef,
+}: PropsWithChildren<{
+  readonly to: string;
+  // readonly isSelected: boolean;
+  readonly selectedRef: React.RefObject<HTMLAnchorElement>;
+}>) => {
   // const location = useLocation();
   const isSelected =
     location.pathname === to || (location.pathname === "/" && to === "/?new");
@@ -150,6 +178,7 @@ export const StyledLink = ({
       className={`${styles.navMenuItem} ${styles.navMenuLink} ${
         isSelected ? styles.selected : ""
       }`}
+      ref={isSelected ? selectedRef : null}
     >
       {children}
     </Link>
@@ -159,7 +188,11 @@ export const StyledLink = ({
 export const StyledSubLink = ({
   to,
   children,
-}: PropsWithChildren<{ readonly to: string }>) => {
+  selectedRef,
+}: PropsWithChildren<{
+  readonly to: string;
+  readonly selectedRef: React.RefObject<HTMLAnchorElement>;
+}>) => {
   // const location = useLocation();
   const isSelected = location.pathname === to;
 
@@ -169,6 +202,7 @@ export const StyledSubLink = ({
       className={`${styles.navMenuItem} ${styles.navMenuSubItem} ${
         styles.navMenuLink
       } ${isSelected ? styles.selected : ""}`}
+      ref={isSelected ? selectedRef : null}
     >
       {children}
     </Link>

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -143,6 +143,14 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
   );
 };
 
+const getLinkClassName = (
+  baseClasses: string,
+  isSelected: boolean,
+  selectedClass: string,
+): string => {
+  return `${baseClasses} ${isSelected ? selectedClass : ""}`.trim();
+};
+
 export const StyledLink = ({
   to,
   children,
@@ -153,13 +161,16 @@ export const StyledLink = ({
 }>) => {
   const { pathname } = useLocation();
   const isSelected = pathname === to || (pathname === "/" && to === "/?new");
+  const className = getLinkClassName(
+    `${styles.navMenuItem} ${styles.navMenuLink}`,
+    isSelected,
+    styles.selected,
+  );
 
   return (
     <Link
       to={to ?? "/"}
-      className={`${styles.navMenuItem} ${styles.navMenuLink} ${
-        isSelected ? styles.selected : ""
-      }`}
+      className={className}
       ref={isSelected ? selectedRef : null}
     >
       {children}
@@ -177,13 +188,16 @@ export const StyledSubLink = ({
 }>) => {
   const { pathname } = useLocation();
   const isSelected = pathname === to;
+  const className = getLinkClassName(
+    `${styles.navMenuItem} ${styles.navMenuSubItem} ${styles.navMenuLink}`,
+    isSelected,
+    styles.selected,
+  );
 
   return (
     <Link
       to={to ?? "/"}
-      className={`${styles.navMenuItem} ${styles.navMenuSubItem} ${
-        styles.navMenuLink
-      } ${isSelected ? styles.selected : ""}`}
+      className={className}
       ref={isSelected ? selectedRef : null}
     >
       {children}

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -160,6 +160,8 @@ export const StyledLink = ({
   readonly selectedRef: React.RefObject<HTMLAnchorElement>;
 }>) => {
   const { pathname } = useLocation();
+  // The `to === "/?new"` check allows Home to be highlighted in the side nav
+  // TODO: remove when we roll out the new docs site & double check Home is still highlighted
   const isSelected = pathname === to || (pathname === "/" && to === "/?new");
   const className = getLinkClassName(
     `${styles.navMenuItem} ${styles.navMenuLink}`,

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -20,6 +20,7 @@ interface NavMenuProps {
 export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
   const [open, setOpen] = useState(false);
   const { isMinimal } = useAtlantisSite();
+  const location = useLocation();
 
   if (isMinimal) return null;
 
@@ -141,8 +142,9 @@ export const StyledLink = ({
   to,
   children,
 }: PropsWithChildren<{ readonly to: string }>) => {
-  const location = useLocation();
-  const isSelected = location.pathname === to;
+  // const location = useLocation();
+  const isSelected =
+    location.pathname === to || (location.pathname === "/" && to === "/?new");
 
   return (
     <Link
@@ -160,7 +162,7 @@ export const StyledSubLink = ({
   to,
   children,
 }: PropsWithChildren<{ readonly to: string }>) => {
-  const location = useLocation();
+  // const location = useLocation();
   const isSelected = location.pathname === to;
 
   return (

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -1,12 +1,6 @@
 import { Box, Button, Content, Icon, Typography } from "@jobber/components";
 import { Link, useLocation } from "react-router-dom";
-import {
-  Fragment,
-  PropsWithChildren,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { Fragment, PropsWithChildren, useRef, useState } from "react";
 import { SearchBox } from "./SearchBox";
 import AnimatedPresenceDisclosure from "./AnimatedPresenceDisclosure";
 import styles from "./NavMenu.module.css";
@@ -30,15 +24,6 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
   const selectedRef = useRef<HTMLAnchorElement | null>(null);
 
   if (isMinimal) return null;
-
-  useEffect(() => {
-    if (selectedRef.current) {
-      selectedRef.current.scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-      });
-    }
-  }, [location.pathname]);
 
   interface MenuItem {
     handle: string;
@@ -161,14 +146,11 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
 export const StyledLink = ({
   to,
   children,
-  // isSelected,
   selectedRef,
 }: PropsWithChildren<{
   readonly to: string;
-  // readonly isSelected: boolean;
   readonly selectedRef: React.RefObject<HTMLAnchorElement>;
 }>) => {
-  // const location = useLocation();
   const isSelected =
     location.pathname === to || (location.pathname === "/" && to === "/?new");
 
@@ -193,7 +175,6 @@ export const StyledSubLink = ({
   readonly to: string;
   readonly selectedRef: React.RefObject<HTMLAnchorElement>;
 }>) => {
-  // const location = useLocation();
   const isSelected = location.pathname === to;
 
   return (

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -106,12 +106,15 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
             {routes?.map((route, routeIndex) => {
               if (route.inNav === false) return null;
 
+              const isSelected = location.pathname === route.path;
+
               if (route.children) {
                 return (
                   <Box key={routeIndex}>
                     <AnimatedPresenceDisclosure
                       to={route.path ?? "/"}
                       title={route.handle}
+                      selected={isSelected}
                     >
                       {iterateSubMenu(route.children, routeIndex)}
                     </AnimatedPresenceDisclosure>

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -107,15 +107,13 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
             {routes?.map((route, routeIndex) => {
               if (route.inNav === false) return null;
 
-              const isSelected = location.pathname === route.path;
-
               if (route.children) {
                 return (
                   <Box key={routeIndex}>
                     <AnimatedPresenceDisclosure
                       to={route.path ?? "/"}
                       title={route.handle}
-                      selected={isSelected}
+                      selected={location.pathname.startsWith(route.path ?? "/")}
                     >
                       {iterateSubMenu(route.children, routeIndex)}
                     </AnimatedPresenceDisclosure>

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Content, Icon, Typography } from "@jobber/components";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { Fragment, PropsWithChildren, useState } from "react";
 import { SearchBox } from "./SearchBox";
 import AnimatedPresenceDisclosure from "./AnimatedPresenceDisclosure";
@@ -138,10 +138,15 @@ export const StyledLink = ({
   to,
   children,
 }: PropsWithChildren<{ readonly to: string }>) => {
+  const location = useLocation();
+  const isSelected = location.pathname === to;
+
   return (
     <Link
       to={to ?? "/"}
-      className={`${styles.navMenuItem} ${styles.navMenuLink}`}
+      className={`${styles.navMenuItem} ${styles.navMenuLink} ${
+        isSelected ? styles.selected : ""
+      }`}
     >
       {children}
     </Link>
@@ -152,10 +157,15 @@ export const StyledSubLink = ({
   to,
   children,
 }: PropsWithChildren<{ readonly to: string }>) => {
+  const location = useLocation();
+  const isSelected = location.pathname === to;
+
   return (
     <Link
       to={to ?? "/"}
-      className={`${styles.navMenuItem} ${styles.navMenuSubItem} ${styles.navMenuLink}`}
+      className={`${styles.navMenuItem} ${styles.navMenuSubItem} ${
+        styles.navMenuLink
+      } ${isSelected ? styles.selected : ""}`}
     >
       {children}
     </Link>

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -20,7 +20,7 @@ interface NavMenuProps {
 export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
   const [open, setOpen] = useState(false);
   const { isMinimal } = useAtlantisSite();
-  const location = useLocation();
+  const { pathname } = useLocation();
   const selectedRef = useRef<HTMLAnchorElement | null>(null);
 
   if (isMinimal) return null;
@@ -117,7 +117,7 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
                     <AnimatedPresenceDisclosure
                       to={route.path ?? "/"}
                       title={route.handle}
-                      selected={location.pathname.startsWith(route.path ?? "/")}
+                      selected={pathname.startsWith(route.path ?? "/")}
                     >
                       {iterateSubMenu(route.children, routeIndex)}
                     </AnimatedPresenceDisclosure>
@@ -151,8 +151,8 @@ export const StyledLink = ({
   readonly to: string;
   readonly selectedRef: React.RefObject<HTMLAnchorElement>;
 }>) => {
-  const isSelected =
-    location.pathname === to || (location.pathname === "/" && to === "/?new");
+  const { pathname } = useLocation();
+  const isSelected = pathname === to || (pathname === "/" && to === "/?new");
 
   return (
     <Link
@@ -175,7 +175,8 @@ export const StyledSubLink = ({
   readonly to: string;
   readonly selectedRef: React.RefObject<HTMLAnchorElement>;
 }>) => {
-  const isSelected = location.pathname === to;
+  const { pathname } = useLocation();
+  const isSelected = pathname === to;
 
   return (
     <Link


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

When navigating through the New Docs site, we want to indicate where the user is, by highlighting the current page in the side nav.

Quick Demo:

https://github.com/user-attachments/assets/3bc7bff6-e06b-4efc-8c63-1b27ed09c3a4


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added/Changed

1. New `selected` prop in `AnimatedPresenceDisclosure`
The `selected` prop is passed to each child element to determine if it matches the current URL path. This allows us to apply styles indicating the item is selected in the side nav.

2. `selectedRef` in `NavMenu`.
This allows us to perform actions on selected link like scrolling the item into view in the side nav.
We use `isSelected` to determine if the current URL matches `to` and if it does, the link is considered selected. Then, `selectedRef` is assigned to `ref` of the `Link` component.

## Testing

<!-- How to test your changes. -->

See how the side nav indicates what page you are on by:
- updating the url
- using search to navigate to a page
- clicking content cards in Home/wherever there's a content card
The side nav should scroll the child/page you are on, into view

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
