### PR TITLE
docs(docx): Adding Packages Section to New Docs Site [JOB-111818]

### DIFF
--- a/packages/site/.eslintrc.cjs
+++ b/packages/site/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
     "import/no-unresolved": [
       "error",
       {
-        ignore: ["^@atlantis/docs"],
+        ignore: ["^@atlantis/docs", "^@atlantis/packages"],
       },
     ],
   },

--- a/packages/site/src/components/ContentLoader.tsx
+++ b/packages/site/src/components/ContentLoader.tsx
@@ -25,6 +25,9 @@ export const ContentLoader = () => {
     case location.pathname.startsWith("/guides"):
       type = "guides";
       break;
+    case location.pathname.startsWith("/packages"):
+      type = "packages";
+      break;
     default:
       type = "content";
   }

--- a/packages/site/src/layout/Layout.tsx
+++ b/packages/site/src/layout/Layout.tsx
@@ -1,9 +1,10 @@
 import { PropsWithChildren, useEffect, useRef } from "react";
-import { Route, Switch, useLocation } from "react-router";
+import { Route, Switch, useHistory, useLocation } from "react-router";
 import { NavMenu } from "./NavMenu";
 import { AtlantisRoute, routes } from "../routes";
 import "./code-theme.css";
 import { ToggleThemeButton } from "../components/ToggleThemeButton";
+import { hooksList } from "../hooksList";
 
 /**
  * Layout for whole application. This will display the NavMenu and the content of the page.
@@ -13,11 +14,26 @@ import { ToggleThemeButton } from "../components/ToggleThemeButton";
 export const Layout = () => {
   const location = useLocation();
   const scrollPane = useRef<HTMLDivElement>(null);
+  const path = new URLSearchParams(location.search).get("path");
+  const history = useHistory();
+
   useEffect(() => {
     if (scrollPane?.current) {
       scrollPane?.current.scrollTo({ top: 0 });
     }
   }, [location, scrollPane?.current]);
+
+  // Redirects for the links on the hooks packages page
+  if (path && path.includes("hooks")) {
+    const pathRegex = /hooks-(.*)--docs/g.exec(path);
+    const match = hooksList.find(
+      hook => pathRegex?.[1] === hook.title.toLowerCase(),
+    );
+
+    if (match) {
+      history.push(match.to);
+    }
+  }
 
   return (
     <LayoutWrapper>

--- a/packages/site/src/layout/SearchBox.tsx
+++ b/packages/site/src/layout/SearchBox.tsx
@@ -21,6 +21,7 @@ import { designList } from "../designList";
 import { guidesList } from "../guidesList";
 import { changelogList } from "../changelogList";
 import { hooksList } from "../hooksList";
+import { packagesList } from "../packagesList";
 import { ContentListItem } from "../types/components";
 
 /**
@@ -76,6 +77,19 @@ export const SearchBox = ({
   const filteredHooksList = useMemo(() => {
     return hooksList.filter(d => filterFunction(d));
   }, [search]);
+
+  const filteredPackagesList = useMemo(() => {
+    return packagesList.filter(d => filterFunction(d));
+  }, [search]);
+
+  const emptyResults =
+    !filteredContentList.length &&
+    !filteredDesignList.length &&
+    !filteredComponentList.length &&
+    !filteredChangelogList.length &&
+    !filteredGuidesList.length &&
+    !filteredHooksList.length &&
+    !filteredPackagesList.length;
 
   useEffect(() => {
     if (open) {
@@ -155,7 +169,16 @@ export const SearchBox = ({
                 />
               </Content>
             )}
-            {!filteredComponentList.length && !filteredDesignList.length && (
+            {filteredPackagesList.length > 0 && (
+              <Content>
+                <SearchBoxSection
+                  sectionTitle="Packages"
+                  filteredListItems={filteredPackagesList}
+                  handleCloseModal={closeModal}
+                />
+              </Content>
+            )}
+            {emptyResults && (
               <Box
                 height={"100%"}
                 direction={"column"}

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -40,6 +40,10 @@ a:visited {
   color: var(--color-interactive--hover);
 }
 
+custom-elements {
+  min-height: 100dvh;
+}
+
 custom-elements,
 section[role="tabpanel"] {
   & table {

--- a/packages/site/src/maps/index.ts
+++ b/packages/site/src/maps/index.ts
@@ -3,6 +3,7 @@ import { contentContentMap } from "./contentContent";
 import { changelogContentMap } from "./changelogContent";
 import { hooksContentMap } from "./hooksContent";
 import { guidesContentMap } from "./guidesContent";
+import { packagesContentMap } from "./packagesContent";
 import { ContentMap } from "../types/maps";
 
 export const contentMap: ContentMap = {
@@ -11,4 +12,5 @@ export const contentMap: ContentMap = {
   hooks: hooksContentMap,
   changelog: changelogContentMap,
   guides: guidesContentMap,
+  packages: packagesContentMap,
 };

--- a/packages/site/src/maps/packagesContent.tsx
+++ b/packages/site/src/maps/packagesContent.tsx
@@ -1,0 +1,37 @@
+import ComponentsPackageComponent from "@atlantis/packages/components/README.md";
+import DesignPackageComponent from "@atlantis/packages/design/README.md";
+import EslintConfigPackageComponent from "@atlantis/packages/eslint-config/README.md";
+import HooksPackageComponent from "@atlantis/packages/hooks/README.md";
+import StylelintConfigPackageComponent from "@atlantis/packages/stylelint-config/README.md";
+import { ContentMapItems } from "../types/maps";
+
+export const packagesContentMap: ContentMapItems = {
+  components: {
+    intro:
+      "This package contains the base set of React components for Atlantis.",
+    title: "Jobber Atlantis Components",
+    content: () => <ComponentsPackageComponent />,
+  },
+  design: {
+    intro:
+      "Foundational colors, styling and design tokens for the Jobber Atlantis Design System.",
+    title: "Foundation",
+    content: () => <DesignPackageComponent />,
+  },
+  "eslint-config": {
+    intro: "This package contains the base set of ESLint rules for Atlantis.",
+    title: "ESLint Config",
+    content: () => <EslintConfigPackageComponent />,
+  },
+  hooks: {
+    intro: "Shared hooks for components in Atlantis.",
+    title: "Hooks",
+    content: () => <HooksPackageComponent />,
+  },
+  "stylelint-config": {
+    intro:
+      "This package contains the base set of Stylelint rules for Atlantis.",
+    title: "Stylelint Config",
+    content: () => <StylelintConfigPackageComponent />,
+  },
+};

--- a/packages/site/src/packagesList.ts
+++ b/packages/site/src/packagesList.ts
@@ -1,0 +1,27 @@
+export const packagesList = [
+  {
+    title: "Components",
+    to: "/packages/components",
+    imageURL: "/Placeholder.png",
+  },
+  {
+    title: "Design",
+    to: "/packages/design",
+    imageURL: "/Placeholder.png",
+  },
+  {
+    title: "Eslint Config",
+    to: "/packages/eslint-config",
+    imageURL: "/Placeholder.png",
+  },
+  {
+    title: "Hooks",
+    to: "/packages/hooks",
+    imageURL: "/Placeholder.png",
+  },
+  {
+    title: "Stylelint Config",
+    to: "/packages/stylelint-config",
+    imageURL: "/Placeholder.png",
+  },
+];

--- a/packages/site/src/pages/ContentView.tsx
+++ b/packages/site/src/pages/ContentView.tsx
@@ -9,7 +9,9 @@ export const ContentView = ({
   readonly title: string;
 }) => {
   return (
-    <div style={{ backgroundColor: "var(--color-surface" }}>
+    <div
+      style={{ backgroundColor: "var(--color-surface)", minHeight: "100dvh" }}
+    >
       <custom-elements>
         <Box padding={"larger"}>
           <Content>{content()}</Content>

--- a/packages/site/src/pages/HomePage.tsx
+++ b/packages/site/src/pages/HomePage.tsx
@@ -23,6 +23,11 @@ export const HomePage = () => {
             { title: "Hooks", to: "/hooks", imageURL: "/Hooks.png" },
             { title: "Guides", to: "/guides", imageURL: "/Placeholder.png" },
             {
+              title: "Packages",
+              to: "/packages",
+              imageURL: "/Placeholder.png",
+            },
+            {
               title: "Changelog",
               to: "/changelog",
               imageURL: "/Placeholder.png",

--- a/packages/site/src/pages/PackagesPage.tsx
+++ b/packages/site/src/pages/PackagesPage.tsx
@@ -1,0 +1,19 @@
+import { PageBlock } from "../components/PageBlock";
+import { packagesList } from "../packagesList";
+
+export const PackagesPage = () => {
+  return (
+    <PageBlock
+      structure={{
+        header: {
+          title: "Packages",
+          body: "Explore the Essentials: Must-Have NPM Packages for Your Projects",
+          imageURL: "/img-page-divider-collage.webp",
+        },
+        body: {
+          content: packagesList,
+        },
+      }}
+    />
+  );
+};

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -10,6 +10,7 @@ import { ChangelogPage } from "./pages/ChangelogPage";
 import { HooksPage } from "./pages/HooksPage";
 import { hooksList } from "./hooksList";
 import { GuidesPage } from "./pages/GuidesPage";
+import { PackagesPage } from "./pages/PackagesPage";
 
 export interface AtlantisRoute {
   path?: string;
@@ -195,6 +196,39 @@ export const routes: Array<AtlantisRoute> = [
     ],
   },
   {
+    path: "/packages",
+    handle: "Packages",
+    exact: true,
+    component: PackagesPage,
+    children: [
+      {
+        path: "/packages/components",
+        handle: "Components",
+        exact: true,
+      },
+      {
+        path: "/packages/design",
+        handle: "Design",
+        exact: true,
+      },
+      {
+        path: "/packages/eslint-config",
+        handle: "Eslint Config",
+        exact: true,
+      },
+      {
+        path: "/packages/hooks",
+        handle: "Hooks",
+        exact: true,
+      },
+      {
+        path: "/packages/stylelint-config",
+        handle: "Stylelint Config",
+        exact: true,
+      },
+    ],
+  },
+  {
     path: "/changelog",
     handle: "Changelog",
     exact: true,
@@ -279,6 +313,13 @@ export const routes: Array<AtlantisRoute> = [
     path: "/guides/:name",
     component: ContentLoader,
     handle: "GuidesContent",
+    inNav: false,
+    exact: true,
+  },
+  {
+    path: "/packages/:name",
+    component: ContentLoader,
+    handle: "PackagesContent",
     inNav: false,
     exact: true,
   },

--- a/packages/site/vite.config.ts
+++ b/packages/site/vite.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
       mdxUtils: path.resolve(__dirname, "../../.storybook/components"),
       "@jobber/docx": path.resolve(__dirname, "../docx/src"),
       "@atlantis/docs": path.resolve(__dirname, "../../docs"),
+      "@atlantis/packages": path.resolve(__dirname, "../../packages"),
     },
   },
   define: {


### PR DESCRIPTION

<img width="1426" alt="Screenshot 2024-12-18 at 9 02 15 AM" src="https://github.com/user-attachments/assets/d95e923d-705b-4846-86aa-0f92848f89be" />
<img width="1079" alt="Screenshot 2024-12-18 at 9 15 07 AM" src="https://github.com/user-attachments/assets/912eeabb-0808-4ca5-a7aa-cc0a2e071ece" />


### Added

- Packages section added to new docs site, with landing page, sidenav bar items, home item, and search functionality

### Fixed

- fixed the min height for the main content area to be 100% of viewport height
- fixed bug where empty search result was coming up when there were some search results

## Testing
- check out the side nav, make sure package pages are working as expected
- In the packages - hook page, test out some links (I set up a redirect for those)
- Test out search, make sure packages show up. Make sure if you search for something that doesn't return any component or design results that the empty search state does not appear

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
