### PR TITLE
docs: Add Jobber Pro font [JOB-111466]

### DIFF
--- a/packages/site/index.html
+++ b/packages/site/index.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Atlantis@next</title>
+  <link rel="preconnect" href="https://cdn.jobber.com">
+  <link href="https://cdn.jobber.com/fonts/fonts.css" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

### Added

Adds the Jobber font via the CDN. Included in this was allowing the local version of the docs site to access the CDN with [this PR](https://github.com/GetJobber/terraform-edge-services-app/pull/23).

## Testing

If you have a better 👁️  for fonts than me you can just navigate around and look. I was able to clearly show that Jobber Pro is being used in Firefox. I had trouble with this in Chrome but I verified by explicitly setting the font family to "Jobber Pro" on some text to verify that didn't change the appearance of the text at all.

![Screenshot 2024-12-19 at 10 51 04 AM](https://github.com/user-attachments/assets/fcda5699-dfa8-4aab-bd0a-976036356e61)

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
