### PR TITLE
docs: Hide NavMenu scrollbar when it's not needed

### DIFF
--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -28,7 +28,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-large);
-  overflow-y: scroll;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
 }
 
 .navMenu li {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

When the NavMenu was fully collapsed and there was no need for scrolling, a empty scrollbar was visible (especially on light mode).
We need to hide the scrollbar until it's necessary because a large disclosure is open, etc.

### Before

<img width="286" alt="Screenshot 2024-12-20 at 2 54 48 PM" src="https://github.com/user-attachments/assets/d8268ca6-bf8e-489c-bf74-679f41c054c6" />


### After

<img width="283" alt="Screenshot 2024-12-20 at 2 54 59 PM" src="https://github.com/user-attachments/assets/f09d7b83-c091-4067-9df9-5b4497e97f0b" />


## Testing

<!-- How to test your changes. -->
When there are not enough items in the NavMenu to warrant a scrollbar, make sure you don't see one.
Open Components and you should see a scrollbar appear and it works.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
