### PR TITLE
docs: Add id to AnchorLinks and Add keys to Switch in Layout

### DIFF
--- a/packages/site/src/components/AnchorLinks.tsx
+++ b/packages/site/src/components/AnchorLinks.tsx
@@ -8,9 +8,9 @@ interface AnchorLinksProps {
   readonly header: string;
 
   /**
-   * A key unique to the page that controls re-rendering of the component
+   * A unique identifier for the component
    */
-  readonly key: string;
+  readonly id: string;
 
   /**
    * An additional action to perform along with scrolling to the selected anchor
@@ -20,7 +20,7 @@ interface AnchorLinksProps {
 
 export function AnchorLinks({
   header,
-  key,
+  id,
   additionalOnClickAction,
 }: AnchorLinksProps) {
   const [hlinks, setHlinks] = useState<Element[] | null>(null);
@@ -31,16 +31,16 @@ export function AnchorLinks({
     if (hdd.length > 0) {
       setHlinks(Array.from(hdd));
     }
-  }, [key]);
+  }, [id]);
 
   const click = (e: MouseEvent) => {
     e.preventDefault();
-    const id = e.currentTarget?.getAttribute("href")?.replace("#", "");
+    const anchorId = e.currentTarget?.getAttribute("href")?.replace("#", "");
 
-    if (id) {
+    if (anchorId) {
       additionalOnClickAction?.();
       setTimeout(() => {
-        const element = document.getElementById(id);
+        const element = document.getElementById(anchorId);
 
         if (element) {
           element.scrollIntoView({ behavior: "smooth" });

--- a/packages/site/src/components/ComponentLinks.tsx
+++ b/packages/site/src/components/ComponentLinks.tsx
@@ -9,7 +9,6 @@ import { useAtlantisSite } from "../providers/AtlantisSiteProvider";
  * @returns ReactNode
  */
 export const ComponentLinks = ({
-  key,
   links,
   goToProps,
   goToUsage,
@@ -17,7 +16,6 @@ export const ComponentLinks = ({
   webEnabled,
   mobileEnabled,
 }: {
-  readonly key: string;
   readonly links?: ContentExportLinks[];
   readonly goToProps: (type: string) => void;
   readonly goToUsage: (type: string) => void;
@@ -31,7 +29,7 @@ export const ComponentLinks = ({
   return (
     <Content spacing={"larger"}>
       <AnchorLinks
-        key={key}
+        id="design"
         header="Design"
         additionalOnClickAction={goToDesign}
       />

--- a/packages/site/src/layout/ContentView.tsx
+++ b/packages/site/src/layout/ContentView.tsx
@@ -23,7 +23,7 @@ export const ContentView = ({
         </custom-elements>
       </BaseView.Main>
       <BaseView.Siderail>
-        <AnchorLinks header="Jump To" key={key} />
+        <AnchorLinks header="Jump To" id={key} />
       </BaseView.Siderail>
     </BaseView>
   );

--- a/packages/site/src/layout/Layout.tsx
+++ b/packages/site/src/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useEffect, useRef } from "react";
+import React, { PropsWithChildren, useEffect, useRef } from "react";
 import { Route, Switch, useHistory, useLocation } from "react-router";
 import { NavMenu } from "./NavMenu";
 import { AtlantisRoute, routes } from "../routes";
@@ -49,7 +49,7 @@ export const Layout = () => {
         tabIndex={0}
       >
         <Switch>
-          <>
+          <React.Fragment key={location.pathname}>
             {routes?.map((route, routeIndex) => {
               const iterateSubMenu = (childroutes: AtlantisRoute[]) => {
                 return childroutes.map((child, childIndex) => {
@@ -70,7 +70,7 @@ export const Layout = () => {
               // Top level items with children (Changelog)
               if (route.children) {
                 return (
-                  <>
+                  <React.Fragment key={route.path}>
                     <Route
                       key={routeIndex}
                       exact={route.exact ?? false}
@@ -78,7 +78,7 @@ export const Layout = () => {
                       component={route.component}
                     />
                     {iterateSubMenu(route.children)}
-                  </>
+                  </React.Fragment>
                 );
               }
 
@@ -92,7 +92,7 @@ export const Layout = () => {
                 />
               );
             })}
-          </>
+          </React.Fragment>
         </Switch>
       </div>
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
When viewing the site locally, the following errors were in the console:

![Screenshot 2024-12-23 at 5 07 44 PM](https://github.com/user-attachments/assets/7ba5bf8e-79e6-40e6-bcd3-a82e9e5a8d97)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

`ComponentLinks` which is using `AnchorLinks` had a `key` prop - however we should be avoiding calling a prop `key` to avoid confusion with React's `key` attribute.  That is why I renamed the prop to `id`.

`Layout` needed keys so I've added those to the previously empty fragments. The `React.Fragment` is grouping the dynamic routes under the Switch and adding keys makes React happy (we're aligning more with React's preference for list rendering).


## Testing

<!-- How to test your changes. -->

All side rail links should work as expected.
All component pages and sections render as expected.
---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
