### PR TITLE
docs(docx): Adding Design e2e tests [JOB-111581]

### DIFF
--- a/packages/site/baseDesignList.mjs
+++ b/packages/site/baseDesignList.mjs
@@ -1,0 +1,13 @@
+const designPages = [
+  "animation",
+  "borders",
+  "breakpoints",
+  "colors",
+  "elevations",
+  "opacity",
+  "radii",
+  "spacing",
+  "typography",
+];
+
+export const ListOfDesignPages = designPages;

--- a/packages/site/baseDesignList.mjs
+++ b/packages/site/baseDesignList.mjs
@@ -1,13 +1,40 @@
-const designPages = [
-  "animation",
-  "borders",
-  "breakpoints",
-  "colors",
-  "elevations",
-  "opacity",
-  "radii",
-  "spacing",
-  "typography",
+export const designPages = [
+  {
+    title: "Animation",
+    path: "animation",
+  },
+  {
+    title: "Responsive Breakpoints",
+    path: "breakpoints",
+  },
+  {
+    title: "Borders and Dividers",
+    path: "borders",
+  },
+  {
+    title: "Colors",
+    path: "colors",
+  },
+  {
+    title: "Elevation",
+    path: "elevations",
+  },
+  {
+    title: "Opacity",
+    path: "opacity",
+  },
+  {
+    title: "Border Radius",
+    path: "radii",
+  },
+  {
+    title: "Spacing",
+    path: "spacing",
+  },
+  {
+    title: "Typography",
+    path: "typography",
+  },
 ];
 
 export const ListOfDesignPages = designPages;

--- a/packages/site/tests/site.components.e2e.ts
+++ b/packages/site/tests/site.components.e2e.ts
@@ -59,35 +59,16 @@ uniqueList.forEach(component => {
 });
 
 ListOfDesignPages.forEach(
-  (design: string | RegExp | readonly (string | RegExp)[]) => {
+  ({ path, title }: { path: string; title: string }) => {
     // eslint-disable-next-line max-statements
-    test(`Design Page For: ${design}`, async ({ page }) => {
-      await page.goto(`http://localhost:5173/design/${design}`);
-      console.log(await page.content());
+    test(`Design Page For: ${title}`, async ({ page }) => {
+      await page.goto(`http://localhost:5173/design/${path}`);
 
-      if (typeof design === "string" || design instanceof RegExp) {
-        await expect(
-          page.getByRole("heading", { name: design, exact: true }),
-        ).toHaveText(design);
-      }
+      await expect(
+        page.getByRole("heading", { name: title, exact: true }),
+      ).toHaveText(title);
+
       await expect(page.getByText("Component not found")).not.toBeVisible();
-      const links = await page.locator("[data-storybook-link]");
-
-      for (const link of await links.all()) {
-        const actualLInk = link.locator("a");
-        const href = await actualLInk.getAttribute("href");
-
-        if (href) {
-          const heading = await goToLinkAndGetHeading(
-            page,
-            href,
-            design.toString(),
-          );
-
-          await checkThatHeadingExists(heading, page);
-          await page.goBack();
-        }
-      }
     });
   },
 );
@@ -120,7 +101,7 @@ async function checkThatHeadingExists(heading: Locator, page) {
 test("Home Loads", async ({ page }) => {
   await page.goto("http://localhost:5173");
 
-  await expect(page.locator("h1")).toHaveText("Atlantis");
+  await expect(page.locator("h1")).toHaveText("Home");
 });
 
 test("Design Loads", async ({ page }) => {

--- a/packages/site/tests/site.components.e2e.ts
+++ b/packages/site/tests/site.components.e2e.ts
@@ -60,7 +60,6 @@ uniqueList.forEach(component => {
 
 ListOfDesignPages.forEach(
   ({ path, title }: { path: string; title: string }) => {
-    // eslint-disable-next-line max-statements
     test(`Design Page For: ${title}`, async ({ page }) => {
       await page.goto(`http://localhost:5173/design/${path}`);
 


### PR DESCRIPTION
### Added

- basic e2e tests for design pages

### Fixed

- heading text test for the home page

## Testing

- Pull the branch and run `npm run e2e` 
- Note that my local environment does not load the Icon page, and so these tests break for me. The Icon page seems to load fine in prod though 🤔 

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
