### PR TITLE
feat(components): Add UNSAFE_className and UNSAFE_style to Popover

### DIFF
--- a/docs/guides/customizing-components.stories.mdx
+++ b/docs/guides/customizing-components.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta } from "@storybook/addon-docs";
+import { Banner } from "@jobber/components/Banner";
 
 <Meta title="Guides/Customizing components" />
 
@@ -80,14 +81,21 @@ fit.
 
 #### UNSAFE\_ props
 
-In some cases, we provide `UNSAFE_` props to allow for more advanced
-customization. These props are prefixed with `UNSAFE_` to indicate that they are
-not recommended for general use and may have unexpected side effects. We
-recommend using these props only when absolutely necessary.
+In some cases, we provide `UNSAFE_` props to allow for further advanced
+customization. These props are prefixed with `UNSAFE_` to indicate that they
+should only be used when absolutely necessary, as they may break the component's
+future compatibility.
 
-If considering using an `UNSAFE_` prop, we encourage you or your designers to
-talk to us. We may be able to suggest an alternative implementation, or your
-design can help inform future additions to Atlantis.
+<Banner type="warning">
+  <p>
+    Use of `UNSAFE_` props is **at your own risk** and should be considered a
+    **last resort**. Future Atlantis updates may lead to unintended breakages.
+  </p>
+</Banner>
+
+If you are considering using an `UNSAFE_` prop, we encourage you or your
+designers to talk to us. We may be able to suggest an alternative
+implementation, or your design can help inform future additions to Atlantis.
 
 - **`UNSAFE_className`**: Allows you to apply custom classnames to the
   component's wrapping container.
@@ -109,3 +117,7 @@ design can help inform future additions to Atlantis.
   UNSAFE_style={{ backgroundColor: "var(--color-surface--background)" }}
 />
 ```
+
+**Note:** Inspiration for this approach was taken from React Spectrum's
+philosophy and implementation of their own class based
+[escape hatches](https://react-spectrum.adobe.com/react-spectrum/styling.html#escape-hatches).

--- a/docs/guides/customizing-components.stories.mdx
+++ b/docs/guides/customizing-components.stories.mdx
@@ -57,11 +57,13 @@ items is customized.
 
 ### Other customization approaches
 
+#### ReactNode
+
 While custom render functions are our primary approach it is not used in all
 places. For simple cases where customization does not depend on internal state,
 we have chosen to extend prop types to allow for a `ReactNode` to be passed in.
 
-#### Example: Tab component (see [Tabs](..?path=/docs/components-navigation-tabs--docs))
+##### Example: Tab component (see [Tabs](..?path=/docs/components-navigation-tabs--docs))
 
 Instead of introducing `customRenderLabel`, the `Tab` component was updated to
 allow the `label` prop to accept a `ReactNode`.
@@ -75,3 +77,35 @@ Atlantis components. Customizing the `label` didn’t require exposing or
 interacting with the `Tab`’s internal state (e.g., active state styling). Once
 the design becomes more complex a custom render function would become a better
 fit.
+
+#### UNSAFE\_ props
+
+In some cases, we provide `UNSAFE_` props to allow for more advanced
+customization. These props are prefixed with `UNSAFE_` to indicate that they are
+not recommended for general use and may have unexpected side effects. We
+recommend using these props only when absolutely necessary.
+
+If considering using an `UNSAFE_` prop, we encourage you or your designers to
+talk to us. We may be able to suggest an alternative implementation, or your
+design can help inform future additions to Atlantis.
+
+- **`UNSAFE_className`**: Allows you to apply custom classnames to the
+  component's wrapping container.
+
+```tsx
+<Component UNSAFE_className={styles.customClass} />
+
+.customClass {
+  background-color: var(--color-surface);
+  padding: var(--space-base);
+}
+```
+
+- **`UNSAFE_style`**: Allows you to apply custom inline styles to the
+  component's wrapping container.
+
+```tsx
+<Component
+  UNSAFE_style={{ backgroundColor: "var(--color-surface--background)" }}
+/>
+```

--- a/docs/guides/customizing-components.stories.mdx
+++ b/docs/guides/customizing-components.stories.mdx
@@ -98,10 +98,10 @@ designers to talk to us. We may be able to suggest an alternative
 implementation, or your design can help inform future additions to Atlantis.
 
 - **`UNSAFE_className`**: Allows you to apply custom classnames to the
-  component's wrapping container.
+  component's container and in some cases, sub-components.
 
 ```tsx
-<Component UNSAFE_className={styles.customClass} />
+<Component UNSAFE_className={{ container: styles.customClass }} />
 
 .customClass {
   background-color: var(--color-surface);
@@ -109,12 +109,19 @@ implementation, or your design can help inform future additions to Atlantis.
 }
 ```
 
+```tsx
+<Component UNSAFE_className={{ container: "custom-container-class" }} />
+```
+
 - **`UNSAFE_style`**: Allows you to apply custom inline styles to the
-  component's wrapping container.
+  component's container and in some cases, sub-components.
 
 ```tsx
 <Component
-  UNSAFE_style={{ backgroundColor: "var(--color-surface--background)" }}
+  UNSAFE_style={{
+    container: { backgroundColor: "var(--color-surface--background)" },
+    subItem: { paddingRight: "var(--space-larger)" },
+  }}
 />
 ```
 

--- a/packages/components/src/Popover/Popover.test.tsx
+++ b/packages/components/src/Popover/Popover.test.tsx
@@ -7,7 +7,7 @@ import { PopoverProps } from "./Popover";
 const content = "Test Content";
 
 const PopoverTestComponent = (props: Omit<PopoverProps, "attachTo">) => {
-  const divRef = useRef(null);
+  const divRef = useRef<HTMLDivElement>(null);
 
   return (
     <>
@@ -19,15 +19,21 @@ const PopoverTestComponent = (props: Omit<PopoverProps, "attachTo">) => {
   );
 };
 
+const renderPopover = (props: Omit<PopoverProps, "attachTo">) => {
+  return render(
+    <PopoverTestComponent {...props}>{content}</PopoverTestComponent>,
+  );
+};
+
 describe("Popover", () => {
   it("should render a Popover with the content and dismiss button", async () => {
     const handleClose = jest.fn();
 
-    render(
-      <PopoverTestComponent open={true} onRequestClose={handleClose}>
-        {content}
-      </PopoverTestComponent>,
-    );
+    renderPopover({
+      open: true,
+      onRequestClose: handleClose,
+      children: content,
+    });
 
     expect(screen.queryByText(content)).toBeInstanceOf(HTMLElement);
 
@@ -36,35 +42,84 @@ describe("Popover", () => {
   });
 
   it("shouldn't render a popover when open is false", async () => {
-    render(<PopoverTestComponent open={false}>{content}</PopoverTestComponent>);
+    renderPopover({ open: false, children: content });
 
     expect(screen.queryByText(content)).toBeNull();
   });
 
   describe("UNSAFE_ props", () => {
-    it("should apply the UNSAFE_className to the Popover", () => {
-      render(
-        <PopoverTestComponent open={true} UNSAFE_className="custom-class">
-          {content}
-        </PopoverTestComponent>,
-      );
+    it("should apply the UNSAFE_className to the container", () => {
+      renderPopover({
+        open: true,
+        UNSAFE_className: { container: "custom-container-class" },
+        children: content,
+      });
 
-      const popover = screen.getByRole("dialog");
-      expect(popover).toHaveClass("custom-class");
+      const popover = screen.getByTestId("popover-container");
+      expect(popover).toHaveClass("custom-container-class");
     });
 
-    it("should apply the UNSAFE_style to the Popover", () => {
-      render(
-        <PopoverTestComponent
-          open={true}
-          UNSAFE_style={{ backgroundColor: "lightblue" }}
-        >
-          {content}
-        </PopoverTestComponent>,
-      );
+    it("should apply the UNSAFE_className to the dismiss button container", () => {
+      renderPopover({
+        open: true,
+        UNSAFE_className: {
+          dismissButtonContainer: "custom-dismiss-button-class",
+        },
+        children: content,
+      });
 
-      const popover = screen.getByRole("dialog");
+      const dismissButtonContainer = screen.getByTestId(
+        "popover-dismiss-button-container",
+      );
+      expect(dismissButtonContainer).toHaveClass("custom-dismiss-button-class");
+    });
+
+    it("should apply the UNSAFE_className to the arrow", () => {
+      renderPopover({
+        open: true,
+        UNSAFE_className: { arrow: "custom-arrow-class" },
+        children: content,
+      });
+
+      const arrow = screen.getByTestId("popover-arrow");
+      expect(arrow).toHaveClass("custom-arrow-class");
+    });
+
+    it("should apply the UNSAFE_style to the container", () => {
+      renderPopover({
+        open: true,
+        UNSAFE_style: { container: { backgroundColor: "lightblue" } },
+        children: content,
+      });
+
+      const popover = screen.getByTestId("popover-container");
       expect(getComputedStyle(popover).backgroundColor).toBe("lightblue");
+    });
+
+    it("should apply the UNSAFE_style to the dismiss button container", () => {
+      renderPopover({
+        open: true,
+        UNSAFE_style: { dismissButtonContainer: { backgroundColor: "red" } },
+        children: content,
+      });
+
+      const dismissButtonContainer = screen.getByTestId(
+        "popover-dismiss-button-container",
+      );
+      expect(getComputedStyle(dismissButtonContainer).backgroundColor).toBe(
+        "red",
+      );
+    });
+
+    it("should apply the UNSAFE_style to the arrow", () => {
+      renderPopover({
+        open: true,
+        UNSAFE_style: { arrow: { backgroundColor: "green" } },
+        children: content,
+      });
+
+      const arrow = screen.getByTestId("popover-arrow");
+      expect(getComputedStyle(arrow).backgroundColor).toBe("green");
     });
   });
 });

--- a/packages/components/src/Popover/Popover.test.tsx
+++ b/packages/components/src/Popover/Popover.test.tsx
@@ -19,23 +19,52 @@ const PopoverTestComponent = (props: Omit<PopoverProps, "attachTo">) => {
   );
 };
 
-it("should render a Popover with the content and dismiss button", async () => {
-  const handleClose = jest.fn();
+describe("Popover", () => {
+  it("should render a Popover with the content and dismiss button", async () => {
+    const handleClose = jest.fn();
 
-  render(
-    <PopoverTestComponent open={true} onRequestClose={handleClose}>
-      {content}
-    </PopoverTestComponent>,
-  );
+    render(
+      <PopoverTestComponent open={true} onRequestClose={handleClose}>
+        {content}
+      </PopoverTestComponent>,
+    );
 
-  expect(screen.queryByText(content)).toBeInstanceOf(HTMLElement);
+    expect(screen.queryByText(content)).toBeInstanceOf(HTMLElement);
 
-  await userEvent.click(screen.getByLabelText("Close dialog"));
-  expect(handleClose).toHaveBeenCalledTimes(1);
-});
+    await userEvent.click(screen.getByLabelText("Close dialog"));
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
 
-it("shouldn't render a popover when open is false", async () => {
-  render(<PopoverTestComponent open={false}>{content}</PopoverTestComponent>);
+  it("shouldn't render a popover when open is false", async () => {
+    render(<PopoverTestComponent open={false}>{content}</PopoverTestComponent>);
 
-  expect(screen.queryByText(content)).toBeNull();
+    expect(screen.queryByText(content)).toBeNull();
+  });
+
+  describe("UNSAFE_ props", () => {
+    it("should apply the UNSAFE_className to the Popover", () => {
+      render(
+        <PopoverTestComponent open={true} UNSAFE_className="custom-class">
+          {content}
+        </PopoverTestComponent>,
+      );
+
+      const popover = screen.getByRole("dialog");
+      expect(popover).toHaveClass("custom-class");
+    });
+
+    it("should apply the UNSAFE_style to the Popover", () => {
+      render(
+        <PopoverTestComponent
+          open={true}
+          UNSAFE_style={{ backgroundColor: "lightblue" }}
+        >
+          {content}
+        </PopoverTestComponent>,
+      );
+
+      const popover = screen.getByRole("dialog");
+      expect(getComputedStyle(popover).backgroundColor).toBe("lightblue");
+    });
+  });
 });

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -36,7 +36,7 @@ export interface PopoverProps {
   /**
    * **Use at your own risk:** Custom class names for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information [here](../?path=/docs/guides-customizing-components--docs#unsafe_-props).
+   * More information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
    */
   readonly UNSAFE_className?: {
     container?: string;
@@ -47,7 +47,7 @@ export interface PopoverProps {
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information [here](../?path=/docs/guides-customizing-components--docs#unsafe_-props).
+   * More information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
    */
   readonly UNSAFE_style?: {
     container?: CSSProperties;

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -34,12 +34,16 @@ export interface PopoverProps {
   readonly preferredPlacement?: "top" | "bottom" | "left" | "right" | "auto";
 
   /**
-   * Custom className for the wrapping container.
+   * Custom className for the wrapping container. This should only be used as a
+   * **last resort**. Using this may result in unintended side effects.
+   * More information [here](../?path=/docs/guides-customizing-components--docs#unsafe_-props).
    */
   readonly UNSAFE_className?: string;
 
   /**
-   * Custom style for the wrapping container.
+   * Custom style for the wrapping container. This should only be used as a
+   * **last resort**. Using this may result in unintended side effects.
+   * More information [here](../?path=/docs/guides-customizing-components--docs#unsafe_-props).
    */
   readonly UNSAFE_style?: CSSProperties;
 }

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -66,6 +66,8 @@ export function Popover({
   useRefocusOnActivator(open);
 
   const popoverClassNames = classnames(classes.popover, UNSAFE_className);
+  console.log(popoverClassNames);
+  console.log("UNSAFE_className:", UNSAFE_className);
 
   return (
     <>
@@ -75,7 +77,7 @@ export function Popover({
           data-elevation={"elevated"}
           ref={setPopperElement}
           style={{ ...popperStyles.popper, ...UNSAFE_style }}
-          className={popoverClassNames}
+          className={`${classes.popover} ${UNSAFE_className || ""}`}
           {...attributes.popper}
         >
           <div className={classes.dismissButton}>

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { CSSProperties, useState } from "react";
 import { usePopper } from "react-popper";
 import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
+import classnames from "classnames";
 import classes from "./Popover.module.css";
 import { ButtonDismiss } from "../ButtonDismiss";
 
@@ -31,6 +32,16 @@ export interface PopoverProps {
    * @default 'auto'
    */
   readonly preferredPlacement?: "top" | "bottom" | "left" | "right" | "auto";
+
+  /**
+   * Custom className for the wrapping container.
+   */
+  readonly UNSAFE_className?: string;
+
+  /**
+   * Custom style for the wrapping container.
+   */
+  readonly UNSAFE_style?: CSSProperties;
 }
 
 export function Popover({
@@ -39,6 +50,8 @@ export function Popover({
   attachTo,
   open,
   preferredPlacement = "auto",
+  UNSAFE_className,
+  UNSAFE_style,
 }: PopoverProps) {
   const [popperElement, setPopperElement] = useState<HTMLElement | null>();
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>();
@@ -52,6 +65,8 @@ export function Popover({
   );
   useRefocusOnActivator(open);
 
+  const popoverClassNames = classnames(classes.popover, UNSAFE_className);
+
   return (
     <>
       {open && (
@@ -59,8 +74,8 @@ export function Popover({
           role="dialog"
           data-elevation={"elevated"}
           ref={setPopperElement}
-          style={popperStyles.popper}
-          className={classes.popover}
+          style={{ ...popperStyles.popper, ...UNSAFE_style }}
+          className={popoverClassNames}
           {...attributes.popper}
         >
           <div className={classes.dismissButton}>

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -34,15 +34,15 @@ export interface PopoverProps {
   readonly preferredPlacement?: "top" | "bottom" | "left" | "right" | "auto";
 
   /**
-   * Custom className for the wrapping container. This should only be used as a
-   * **last resort**. Using this may result in unintended side effects.
+   * **Use at your own risk:** Custom className for the wrapping container. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
    * More information [here](../?path=/docs/guides-customizing-components--docs#unsafe_-props).
    */
   readonly UNSAFE_className?: string;
 
   /**
-   * Custom style for the wrapping container. This should only be used as a
-   * **last resort**. Using this may result in unintended side effects.
+   * **Use at your own risk:** Custom style for the wrapping container. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
    * More information [here](../?path=/docs/guides-customizing-components--docs#unsafe_-props).
    */
   readonly UNSAFE_style?: CSSProperties;

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -66,8 +66,6 @@ export function Popover({
   useRefocusOnActivator(open);
 
   const popoverClassNames = classnames(classes.popover, UNSAFE_className);
-  console.log(popoverClassNames);
-  console.log("UNSAFE_className:", UNSAFE_className);
 
   return (
     <>
@@ -77,7 +75,7 @@ export function Popover({
           data-elevation={"elevated"}
           ref={setPopperElement}
           style={{ ...popperStyles.popper, ...UNSAFE_style }}
-          className={`${classes.popover} ${UNSAFE_className || ""}`}
+          className={popoverClassNames}
           {...attributes.popper}
         >
           <div className={classes.dismissButton}>

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -34,18 +34,26 @@ export interface PopoverProps {
   readonly preferredPlacement?: "top" | "bottom" | "left" | "right" | "auto";
 
   /**
-   * **Use at your own risk:** Custom className for the wrapping container. This should only be used as a
+   * **Use at your own risk:** Custom class names for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
    * More information [here](../?path=/docs/guides-customizing-components--docs#unsafe_-props).
    */
-  readonly UNSAFE_className?: string;
+  readonly UNSAFE_className?: {
+    container?: string;
+    dismissButtonContainer?: string;
+    arrow?: string;
+  };
 
   /**
-   * **Use at your own risk:** Custom style for the wrapping container. This should only be used as a
+   * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
    * More information [here](../?path=/docs/guides-customizing-components--docs#unsafe_-props).
    */
-  readonly UNSAFE_style?: CSSProperties;
+  readonly UNSAFE_style?: {
+    container?: CSSProperties;
+    dismissButtonContainer?: CSSProperties;
+    arrow?: CSSProperties;
+  };
 }
 
 export function Popover({
@@ -54,8 +62,8 @@ export function Popover({
   attachTo,
   open,
   preferredPlacement = "auto",
-  UNSAFE_className,
-  UNSAFE_style,
+  UNSAFE_className = {},
+  UNSAFE_style = {},
 }: PopoverProps) {
   const [popperElement, setPopperElement] = useState<HTMLElement | null>();
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>();
@@ -69,7 +77,15 @@ export function Popover({
   );
   useRefocusOnActivator(open);
 
-  const popoverClassNames = classnames(classes.popover, UNSAFE_className);
+  const popoverClassNames = classnames(
+    classes.popover,
+    UNSAFE_className.container,
+  );
+  const dismissButtonClassNames = classnames(
+    classes.dismissButton,
+    UNSAFE_className.dismissButtonContainer,
+  );
+  const arrowClassNames = classnames(classes.arrow, UNSAFE_className.arrow);
 
   return (
     <>
@@ -78,18 +94,24 @@ export function Popover({
           role="dialog"
           data-elevation={"elevated"}
           ref={setPopperElement}
-          style={{ ...popperStyles.popper, ...UNSAFE_style }}
+          style={{ ...popperStyles.popper, ...(UNSAFE_style.container ?? {}) }}
           className={popoverClassNames}
           {...attributes.popper}
+          data-testid="popover-container"
         >
-          <div className={classes.dismissButton}>
+          <div
+            className={dismissButtonClassNames}
+            style={UNSAFE_style.dismissButtonContainer ?? {}}
+            data-testid="popover-dismiss-button-container"
+          >
             <ButtonDismiss onClick={onRequestClose} ariaLabel="Close dialog" />
           </div>
           {children}
           <div
             ref={setArrowElement}
-            className={classes.arrow}
-            style={popperStyles.arrow}
+            className={arrowClassNames}
+            style={{ ...popperStyles.arrow, ...(UNSAFE_style.arrow ?? {}) }}
+            data-testid="popover-arrow"
           />
         </div>
       )}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

We've been thinking about incorporating `UNSAFE_` classnames to our components, as an escape hatch. We recently had a request for a style override in `Popover` and thought this would be a great place to start.

## Decisions made:

Moving forward, our pattern for setting `UNSAFE_` props will be as follows:
- each component has `UNSAFE_className` & `UNSAFE_style` so consumers have flexibility to style inline or use a css module.
- each component will have a container _type_ for the wrapping container
- wherever possible, each component will also have _types_ for subcomponents (`dismissButtonContainer` & `arrow`)
- **_names for these sub types should be carefully considered_**; subcomponents may be other Atlantis components that will eventually have their own classnames.

```
  readonly UNSAFE_className?: {
    container?: string;
    dismissButtonContainer?: string;
    arrow?: string;
  };
  
  readonly UNSAFE_style?: {
    container?: CSSProperties;
    dismissButtonContainer?: CSSProperties;
    arrow?: CSSProperties;
  };
```

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Customizing Components page in our docs now has guidance on using `UNSAFE_` props
- `Popover` now has `UNSAFE_className` and `UNSAFE_style` props.  We chose to incorporate both because `_classname` will allow for css overrides in a `module` while `_style` will allow for inline styling overrides. This is the first time we're introducing this pattern into the design system and we should allow for both options from the start.
- `Popover` has updated tests for `UNSAFE_` props

## Testing

<!-- How to test your changes. -->
A testing branch in product has been linked below.

You can test in Storybook by adding this template in the `Popover` `Web.stories` file, and toggling between `UNSAFE_style` & `UNSAFE_className`:
```
import style from "./customStyles.module.css";

const CustomClassNamesTemplate: ComponentStory<typeof Popover> = args => {
  const divRef = useRef<HTMLSpanElement>(null);
  const [showPopover, setShowPopover] = useState(args.open);

  return (
    <>
      <span ref={divRef}>
        <Button
          label="Toggle Popover"
          onClick={() => setShowPopover(!showPopover)}
        />
      </span>
      <Popover
        {...args}
        attachTo={divRef}
        open={showPopover}
        onRequestClose={() => setShowPopover(false)}
        UNSAFE_className={{
          container: styles.customPopoverBackground,
          dismissButtonContainer: styles.customDismissButton,
        }}
        // UNSAFE_style={{
        //   container: { backgroundColor: "lightblue" },
        //   dismissButtonContainer: { paddingRight: "var(--space-larger)" },
        // }}
      >
        <Content>Here is your custom background Popover</Content>
      </Popover>
    </>
  );
};

export const CustomClassNames = CustomClassNamesTemplate.bind({});
CustomClassNames.args = {
  open: false,
};
```

and you can create a css file (`customStyles.module.css`) in the same folder:
```
.customPopoverBackground {
  background-color: #f5f5f5;
  padding: 1rem;
}

.customDismissButton {
  background-color: purple;
}

```

Using `UNSAFE_style`:
<img width="340" alt="Screenshot 2025-01-07 at 11 54 21 PM" src="https://github.com/user-attachments/assets/d3102052-be7b-4d87-8db6-5745d47b80af" />


Using `UNSAFE_className`:
<img width="384" alt="Screenshot 2025-01-07 at 11 53 39 PM" src="https://github.com/user-attachments/assets/be1f04c6-ddb2-4621-8c9a-deb269397719" />



Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
