### PR TITLE
docs: refine UI for search button

### DIFF
--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -58,6 +58,8 @@
   padding: var(--space-small);
   background: var(--color-surface);
   outline: transparent;
+  cursor: pointer;
+  transition: all var(--timing-base) ease-out;
 
   &:focus-visible {
     box-shadow: var(--shadow-focus);
@@ -85,6 +87,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  border-radius: var(--radius-small);
   box-shadow: var(--shadow-low);
 }
 

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -90,7 +90,7 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
             className={styles.searchButton}
             aria-label="Search"
           >
-            <Icon name="search" />
+            <Icon name="search" color="greyBlue" />
             <span className={styles.searchButtonText}>
               <Typography textColor={"textSecondary"}>Search</Typography>
             </span>

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -92,13 +92,7 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
           >
             <Icon name="search" />
             <span className={styles.searchButtonText}>
-              <Typography
-                size={"base"}
-                textColor={"text"}
-                fontWeight={"semiBold"}
-              >
-                Search
-              </Typography>
+              <Typography textColor={"textSecondary"}>Search</Typography>
             </span>
             <div className={styles.searchKeyIndicator}>/</div>
           </button>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Refining some details to make the docs site search button feel _more Jobber._

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Transition and cursor on hover
![image](https://github.com/user-attachments/assets/a5feb950-3938-41ae-8642-0e3c443d7347)

### Changed

- Icon and text color and weight to look more like an "input"
![image](https://github.com/user-attachments/assets/6d963fb3-d0d7-4979-a484-52d86d1cf4d4)
![image](https://github.com/user-attachments/assets/b39901d1-8662-4657-a78d-9a830b86f760) 
- Radius on keyboard-trigger indicator
![image](https://github.com/user-attachments/assets/79d5d01b-77b3-4fbe-954c-7a4fdf2f6dd7)

## Testing

Run docs site locally and interact with the Search feature


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
