### PR TITLE
fix(components): Garbled Component Names in Prod Site Build Canvas

### DIFF
--- a/packages/site/vite.config.ts
+++ b/packages/site/vite.config.ts
@@ -52,6 +52,9 @@ export default defineConfig({
       ],
     }),
   ],
+  build: {
+    minify: false,
+  },
   optimizeDeps: {
     include: ["@jobber/formatters", "@jobber/hooks", "@jobber/components"],
   },


### PR DESCRIPTION
## Motivations

1. We noticed an issue in our production build where the component names were garbled.

This is happening because currently the MDX files are being parsed through Vite via an external source.

I imagine when we move the MDX files into the project, we will not longer have disable minification of the prod code to prevent the garbled component names.

## Changes

1. Fixing an issue with how our component names render in prod


## Testing

1. Running `npm run build` locally will generate the prod build, which if you run, will see the proper component names.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
