### PR TITLE
fix(docx): Fixing issue with Minimal Mode on small Viewports

### DIFF
--- a/packages/site/src/layout/BaseView.tsx
+++ b/packages/site/src/layout/BaseView.tsx
@@ -28,9 +28,15 @@ BaseView.Main = function Main({
 
 BaseView.Siderail = function Siderail({
   children,
+  visible = true,
 }: {
   readonly children: React.ReactNode;
+  readonly visible: boolean;
 }) {
+  if (!visible) {
+    return null;
+  }
+
   return (
     <aside
       style={{

--- a/packages/site/src/layout/ComponentView.tsx
+++ b/packages/site/src/layout/ComponentView.tsx
@@ -31,7 +31,8 @@ export const ComponentView = () => {
   const { updateStyles } = useStyleUpdater();
   const [tab, setTab] = useState(0);
   const { stateValues } = usePropsAsDataList(PageMeta, type);
-  const { enableMinimal, minimal, disableMinimal } = useAtlantisSite();
+  const { enableMinimal, minimal, disableMinimal, isMinimal } =
+    useAtlantisSite();
 
   usePageTitle({ title: PageMeta?.title });
 
@@ -210,7 +211,7 @@ export const ComponentView = () => {
           </Box>
         </Page>
       </BaseView.Main>
-      <BaseView.Siderail>
+      <BaseView.Siderail visible={!isMinimal}>
         <ComponentLinks
           key={`component-${name}`}
           links={PageMeta?.links}


### PR DESCRIPTION
## Motivations

1. As part of the vscode plugin work, we noticed that minimal mode had an issue with some sidenav changes.
2. This PR fixes that so minimal mode looks good again on small viewports.

## Changes

1. Added  a `visible` prop to BaseView.SideRail, which is determined by `isMinimal` from the provider.

### Added

- A Visible prop to BaseView.SideRail


## Testing

1. Adding ?minimal to the URL should hide the navigation + sidenav on the component pages.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
