### PR TITLE
docs: fix h1s across the docs site [JOB-113010]

### DIFF
--- a/packages/site/index.html
+++ b/packages/site/index.html
@@ -10,7 +10,7 @@
   <title>Atlantis</title>
   <link rel="icon" type="image/svg+xml" href="/atlantis_favicon.svg" />
   <link rel="preconnect" href="https://cdn.jobber.com">
-  <link rel="prefetch" href="https://cdn.jobber.com/fonts/fonts.css" as="style">
+  <link rel="stylesheet" href="https://cdn.jobber.com/fonts/fonts.css">
   <link rel="prefetch" href="/styles.css" as="style">
   <link rel="prefetch" href="/foundation.css" as="style">
   <link rel="prefetch" href="/dark.mode.css" as="style">

--- a/packages/site/src/components/HeaderBlock.tsx
+++ b/packages/site/src/components/HeaderBlock.tsx
@@ -1,4 +1,10 @@
-import { Box, Button, Content, Typography } from "@jobber/components";
+import {
+  AtlantisThemeContextProvider,
+  Box,
+  Button,
+  Content,
+  Heading,
+} from "@jobber/components";
 import { useHistory } from "react-router";
 
 interface HeaderBlockProps {
@@ -33,17 +39,16 @@ export const HeaderBlock = ({
         className="headerBlock"
       >
         <Content spacing="large">
-          <Typography
-            element={"h1"}
-            size="extravagant"
-            fontWeight="bold"
-            fontFamily="display"
-          >
-            {title}
-          </Typography>
-          <Typography size="large" fontWeight={"semiBold"}>
-            {body}
-          </Typography>
+          <div>
+            <AtlantisThemeContextProvider dangerouslyOverrideTheme="dark">
+              <Content spacing="large">
+                <Heading level={1}>{title}</Heading>
+                <Heading level={4} element={"p"}>
+                  {body}
+                </Heading>
+              </Content>
+            </AtlantisThemeContextProvider>
+          </div>
           {to && ctaLabel && (
             <Button
               type="secondary"

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -140,7 +140,6 @@ iframe {
   padding: var(--space-large);
   width: 100%;
   height: 100%;
-  color: var(--color-base-white);
   text-shadow: 0px 4px 16px rgba(var(--color-black--rgb), 0.6);
   min-height: 30vh;
   display: flex;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

After a recent change to our index file, Jobber Pro was no longer being pulled in from the CDN.

Also, the h1s on our collection pages were set up using Typography to achieve a "white" version, but using the wrong weight of Jobber Pro. This is a great use case for the AtlantisThemeContextProvider.

## Changes

### Fixed

- Jobber Pro is back
- Collection and detail pages h1s have consistent font-weights

![image](https://github.com/user-attachments/assets/7cd24e1a-27fe-4a25-b493-b2748aa55ade)
![image](https://github.com/user-attachments/assets/0e380277-ed04-476c-a65d-f4346f588f0c)

## Testing

Run docs site locally/Cloudflare
- check collection page (ie Home, Components)
- check detail page (ie Button)

If you can't visually parse the difference between Jobber Pro and Poppins, remove Poppins from the fallback stack in your inspector and observe no change to the rendered font.

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
