### PR TITLE
feat(components): Co-Pilot Instructions First Pass

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,8 @@
 5. **Accessibility**:
 
    - Consider accessibility in all code.
-   - Use ARIA roles and properties where applicable.
+   - Prefer HTML-native roles and attributes, and use ARIA roles only as
+     necessary
 
 6. **Comments and Documentation**:
 


### PR DESCRIPTION
## Motivations

Github Copilot has rolled out some new functionality to leverage a set of instructions on every prompt while working within a repository.

https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot

This PR is a first-pass attempt at encoding some Atlantis-specific direction for Copilot to leverage.

I took a pass at high-level information as suggested by the documentation, then I worked with co-pilot a bit locally to format those steps into a format that it prefers (mainly added the bolding in the title, and formatting for the bullet points).

I then generated some changes along with the document to refine further (function over arrow definition, documentation for interface properties).

Very much open to feedback if you feel the instructions should include (or not include) any information.

### Added

1. Github Copilot instructions

## Testing

1. If you pull this branch down locally, and ask Copilot a question within vscode, it will automatically add the contents of copilot-instructions.md to your prompt.
1. There are instructions in the Github documentation above for enabling/disabling instructions within vscode, if you wanted to test toggling on and toggling off.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
