### PR TITLE
fix(docx): Jobber Pro not rendering properly within Heading + Typography coded examples.

### DIFF
--- a/packages/site/src/preview/useAtlantisPreviewSkeleton.tsx
+++ b/packages/site/src/preview/useAtlantisPreviewSkeleton.tsx
@@ -38,6 +38,7 @@ html,body,#root {
     padding: var(--space-smallest);
   }
 </style>
+<link rel="stylesheet" href="https://cdn.jobber.com/fonts/fonts.css">
 <link rel="stylesheet" href="/styles.css">
 <link rel="stylesheet" href="/foundation.css">
 <link rel="stylesheet" href="/dark.mode.css">


### PR DESCRIPTION

## Motivations

1. Reported issue where Heading + Typography were not rendering the Jobber Pro font (and instead Poppins or Inter).

## Changes

Added the font properly to the AtlantisPreview build.

## Testing

Viewing the Heading component now looks proper, and you can modify the Typography code (fontFamily='display') to render the Jobber Pro font.

If you want to show it on/off, you can remove the line added to the PR to disable/renable the font (in Chrome).

NOTE: This bug did not appear in Firefox, so swapping will have no effect there.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
