### PR TITLE
fix(docx): Fixing the double scroll bars on the Docs Site

### DIFF
--- a/packages/site/src/components/VisibleWhenFocused.module.css
+++ b/packages/site/src/components/VisibleWhenFocused.module.css
@@ -1,6 +1,5 @@
 .container {
-    width: 100%;
-    pointer-events: none; 
+    pointer-events: none;
     position: absolute;
     top: 0;
     opacity: 0;

--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -7,11 +7,11 @@
   flex-direction: column;
   padding: 36px 0 0 0;
   height: 100dvh;
-  width: var(--sideBarWidth);
+  min-width: var(--sideBarWidth);
   box-sizing: border-box;
 }
 
-.navMenuContainer > * {
+.navMenuContainer>* {
   padding-left: var(--space-base);
   padding-right: var(--space-base);
   padding-bottom: var(--space-base);


### PR DESCRIPTION
## Motivations

When we recently introduced some updates to the sidenav + 404page + DOM, we accidentally introduced some additional scrollbars where we didn't want them.

This PR removes the scrollbars (and ensures the nav is the correct width).

Before the changes: 

![image](https://github.com/user-attachments/assets/c4fa55b1-5a83-4e3d-83bd-21b7ac000e3e)

After the changes:
![image](https://github.com/user-attachments/assets/abacafde-91e5-4650-bdb2-d06f2b67c960)


## Changes

Removed the double scrollbars (the width of the skip nav combined with the padding on the inner nav elements was causing an overflow).



## Testing

When visiting the link below you should not see a horizontal scrollbar, and only a single vertical scrollbar.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
