### PR TITLE
docs: update HTML typography elements

### DIFF
--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -12,14 +12,39 @@ h1 {
   font-weight: 800;
 }
 
-h1,
+h1 {
+  font-family: var(--typography--fontFamily-display);
+}
+
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: var(--typography--fontFamily-display);
+  font-weight: 700;
 }
+
+h2 {
+  font-size: var(--typography--fontSize-largest);
+}
+
+h3 {
+  font-size: var(--typography--fontSize-larger);
+}
+
+h4 {
+  font-size: var(--typography--fontSize-large);
+}
+
+h5 {
+  font-size: var(--typography--fontSize-base);
+}
+
+h6 {
+  font-size: var(--typography--fontSize-small);
+  text-transform: uppercase;
+}
+
 
 a {
   margin: calc(-1 * var(--space-smallest));
@@ -42,6 +67,14 @@ a:focus-visible {
 
 a:visited {
   color: var(--color-interactive--hover);
+}
+
+blockquote {
+  background-color: var(--color-surface--background--subtle);
+  margin: 0;
+  padding: var(--space-large);
+  border-radius: var(--radius-base);
+  box-shadow: var(--shadow-low);
 }
 
 custom-elements,

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -74,7 +74,6 @@ blockquote {
   margin: 0;
   padding: var(--space-large);
   border-radius: var(--radius-base);
-  box-shadow: var(--shadow-low);
 }
 
 custom-elements,

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -72,7 +72,7 @@ a:visited {
 blockquote {
   background-color: var(--color-surface--background--subtle);
   margin: 0;
-  padding: var(--space-large);
+  padding: var(--space-base) var(--space-large);
   border-radius: var(--radius-base);
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Our docs headings were not using our Heading components, so I have copied over some core styling from the `Heading` component to ensure they match. Also, blockquotes were a little off, and I didn't want to get too into the weeds so I just put them in a box.

#### Before
![image](https://github.com/user-attachments/assets/c2126a51-0a94-4642-a934-ced45d90852f)
![image](https://github.com/user-attachments/assets/90a4733c-21c1-4ec7-8484-26c73e9d9987)

#### After
![image](https://github.com/user-attachments/assets/8b482248-5241-4778-b644-0c3f34671d9d)
![image](https://github.com/user-attachments/assets/882680e2-d996-43d6-95ec-202df2e6d561)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Styling of `h-` elements and blockquotes.

## Testing

Run docs site locally / CF

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
