### PR TITLE
docs: Make the site work better at the sub-1024px range

### DIFF
--- a/docs/guides/documentation-style.stories.mdx
+++ b/docs/guides/documentation-style.stories.mdx
@@ -2,9 +2,9 @@ import { Meta } from "@storybook/addon-docs";
 import showDo from "./assets/Atlantis_Docs_Show_Do.png";
 import showDont from "./assets/Atlantis_Docs_Show_Dont.png";
 
-<Meta title="Guides/Documentation styleguide" />
+<Meta title="Guides/Writing documentation" />
 
-# Documentation styleguide
+# Writing documentation
 
 <br />
 

--- a/packages/site/src/components/PropsList.tsx
+++ b/packages/site/src/components/PropsList.tsx
@@ -60,7 +60,7 @@ export const PropsList = ({
                 description: "Description",
                 component: "Type",
               }}
-              headerVisibility={{ xs: false, md: true }}
+              headerVisibility={{ xs: false, lg: true }}
             >
               <DataList.Layout size="md">
                 {(item: {
@@ -70,7 +70,7 @@ export const PropsList = ({
                   required: boolean;
                 }) => (
                   <Grid>
-                    <Grid.Cell size={{ xs: 2 }}>
+                    <Grid.Cell size={{ md: 6, lg: 3 }}>
                       <div
                         style={{
                           display: "flex",
@@ -82,8 +82,12 @@ export const PropsList = ({
                         {item.required && <InlineLabel>Required</InlineLabel>}
                       </div>
                     </Grid.Cell>
-                    <Grid.Cell size={{ xs: 3 }}>{item.component}</Grid.Cell>
-                    <Grid.Cell size={{ xs: 7 }}>{item.description}</Grid.Cell>
+                    <Grid.Cell size={{ md: 6, lg: 3 }}>
+                      {item.component}
+                    </Grid.Cell>
+                    <Grid.Cell size={{ md: 12, lg: 6 }}>
+                      {item.description}
+                    </Grid.Cell>
                   </Grid>
                 )}
               </DataList.Layout>
@@ -95,7 +99,7 @@ export const PropsList = ({
                   required: boolean;
                 }) => (
                   <Grid>
-                    <Grid.Cell size={{ xs: 6 }}>
+                    <Grid.Cell size={{ xs: 12 }}>
                       <div
                         style={{
                           display: "flex",
@@ -107,7 +111,7 @@ export const PropsList = ({
                         {item.required && <InlineLabel>Required</InlineLabel>}
                       </div>
                     </Grid.Cell>
-                    <Grid.Cell size={{ xs: 6 }}>{item.component}</Grid.Cell>
+                    <Grid.Cell size={{ xs: 12 }}>{item.component}</Grid.Cell>
                     <Grid.Cell size={{ xs: 12 }}>{item.description}</Grid.Cell>
                   </Grid>
                 )}

--- a/packages/site/src/components/PropsList.tsx
+++ b/packages/site/src/components/PropsList.tsx
@@ -70,7 +70,7 @@ export const PropsList = ({
                   required: boolean;
                 }) => (
                   <Grid>
-                    <Grid.Cell size={{ md: 6, lg: 3 }}>
+                    <Grid.Cell size={{ md: 5, lg: 3 }}>
                       <div
                         style={{
                           display: "flex",
@@ -82,7 +82,7 @@ export const PropsList = ({
                         {item.required && <InlineLabel>Required</InlineLabel>}
                       </div>
                     </Grid.Cell>
-                    <Grid.Cell size={{ md: 6, lg: 3 }}>
+                    <Grid.Cell size={{ md: 7, lg: 3 }}>
                       {item.component}
                     </Grid.Cell>
                     <Grid.Cell size={{ md: 12, lg: 6 }}>

--- a/packages/site/src/guidesList.ts
+++ b/packages/site/src/guidesList.ts
@@ -9,7 +9,7 @@ export const guidesList = [
     additionalMatches: ["Custom", "Composability"],
   },
   {
-    title: "Documentation styleguide",
+    title: "Writing documentation",
     to: "/guides/documentation-styleguide",
   },
   {

--- a/packages/site/src/layout/BaseView.tsx
+++ b/packages/site/src/layout/BaseView.tsx
@@ -20,7 +20,16 @@ BaseView.Main = function Main({
       }}
     >
       <Box alignItems="center">
-        <div style={{ width: "100%", maxWidth: "768px" }}>{children}</div>
+        <div
+          style={{
+            width: "100%",
+            maxWidth: "calc(768px + var(--space-large)",
+            padding: "0 var(--space-base)",
+            boxSizing: "border-box",
+          }}
+        >
+          {children}
+        </div>
       </Box>
     </main>
   );
@@ -37,20 +46,5 @@ BaseView.Siderail = function Siderail({
     return null;
   }
 
-  return (
-    <aside
-      style={{
-        width: "var(--sideBarWidth)",
-        padding: "36px var(--space-base)",
-        display: "flex",
-        flexDirection: "column",
-        flexShrink: "0",
-        boxSizing: "border-box",
-        overflowY: "auto",
-        height: "100%",
-      }}
-    >
-      {children}
-    </aside>
-  );
+  return <aside className="baseView-sideRail">{children}</aside>;
 };

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -1,5 +1,11 @@
 :root {
-  --sideBarWidth: 250px;
+  --sideBarWidth: 200px;
+}
+
+@media screen and (min-width: 1024px) {
+  :root {
+    --sideBarWidth: 220px;
+  }
 }
 
 body {
@@ -224,4 +230,21 @@ iframe {
   position: sticky;
   top: 0;
   z-index: 1;
+}
+
+.baseView-sideRail {
+  width: var(--sideBarWidth);
+  padding: 36px var(--space-base);
+  display: none;
+  flex-direction: column;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  overflow-y: auto;
+  height: 100%;
+}
+
+@media screen and (min-width: 1024px) {
+  .baseView-sideRail {
+    display: flex;
+  }
 }

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -4,7 +4,7 @@
 
 @media screen and (min-width: 1024px) {
   :root {
-    --sideBarWidth: 220px;
+    --sideBarWidth: 235px;
   }
 }
 

--- a/packages/site/src/maps/guidesContent.tsx
+++ b/packages/site/src/maps/guidesContent.tsx
@@ -18,8 +18,8 @@ export const guidesContentMap: ContentMapItems = {
     content: () => <CustomizingComponentsComponent />,
   },
   "documentation-styleguide": {
-    intro: "Documentation styleguide",
-    title: "Documentation styleguide",
+    intro: "Writing documentation",
+    title: "Writing documentation",
     content: () => <DocumentationStyleguideComponent />,
   },
   "frontend-styleguide": {

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -176,7 +176,7 @@ export const routes: Array<AtlantisRoute> = [
       },
       {
         path: "/guides/documentation-styleguide",
-        handle: "Documentation styleguide",
+        handle: "Writing documentation",
         exact: true,
       },
       {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

While our primary consumers are working on larger monitors, we should consider that they don't always have the docs site running at full width.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

### Changed

- Siderail hides on smaller viewports
  - this could be a bit controversial, but I think it's better to maximize usable docs space over quick navigation. Similar behaviour can be observed in other docs sites like [this one](https://polaris.shopify.com/components/actions/button).
![image](https://github.com/user-attachments/assets/93f1fbfd-a79f-4f61-98c5-4fd32321f0b7)

- siderail and nav are narrower on smaller-than-large viewports
![image](https://github.com/user-attachments/assets/2b6eadcf-1e3b-48c5-9baf-e3ff89cc20a4)

- Non-component "detail" pages have padding on the left and right when the "main" page region gets narrower than 768 px (future work: Make all "detail" pages use the Page component)
![image](https://github.com/user-attachments/assets/3633f323-16a0-487f-a842-7f0e8670b12a)

- Props Table reflows a bit earlier
![image](https://github.com/user-attachments/assets/151b6a48-5099-4f74-9953-8d1248d5f827)

## Testing

Run docs site locally/CF

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
