### PR TITLE
fix(docx): style sidenav correctly in Safari

### DIFF
--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -131,34 +131,36 @@
   align-items: stretch;
   justify-content: space-between;
   background-color: var(--color-surface--background);
-
-  &:hover {
-    background-color: var(--color-surface--background--hover);
-  }
-
-  a {
-    background-color: transparent;
-    display: flex;
-    align-items: center;
-    outline: transparent;
-    text-decoration: none;
-    flex-grow: 1;
-    min-height: var(--navItemHeight);
-
-    &:focus-visible {
-      box-shadow: var(--shadow-focus);
-      background-color: var(--color-surface--background--hover);
-    }
-  }
-
-  button {
-    border-radius: var(--radius-small);
-    mix-blend-mode: multiply;
-  }
 }
 
-:root[data-theme="dark"] .disclosureNavItem {
-  button {
-    mix-blend-mode: screen;
-  }
+.disclosureNavItem a {
+  background-color: transparent;
+  display: flex;
+  display: inline-flex;
+  align-self: stretch;
+  width: 100%;
+  align-items: center;
+  outline: transparent;
+  text-decoration: none;
+  flex-grow: 1;
+  min-height: var(--navItemHeight);
+  outline: transparent;
+}
+
+.disclosureNavItem:hover {
+  background-color: var(--color-surface--background--hover);
+}
+
+.disclosureNavItem a:focus-visible {
+  box-shadow: var(--shadow-focus);
+  background-color: var(--color-surface--background--hover);
+}
+
+.disclosureNavItem button {
+  border-radius: var(--radius-small);
+  mix-blend-mode: multiply;
+}
+
+:root[data-theme="dark"] .disclosureNavItem button {
+  mix-blend-mode: screen;
 }

--- a/packages/site/src/layout/NavMenu.tsx
+++ b/packages/site/src/layout/NavMenu.tsx
@@ -92,7 +92,9 @@ export const NavMenu = ({ mainContentRef }: NavMenuProps) => {
           >
             <Icon name="search" color="greyBlue" />
             <span className={styles.searchButtonText}>
-              <Typography textColor={"textSecondary"}>Search</Typography>
+              <Typography size={"base"} textColor={"textSecondary"}>
+                Search
+              </Typography>
             </span>
             <div className={styles.searchKeyIndicator}>/</div>
           </button>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Safari sidenav items were misaligned and not interacting as expected in [Safari 17.1 and older.](https://caniuse.com/css-nesting)

![image](https://github.com/user-attachments/assets/92ddd9e7-bd9c-4270-8783-17a7df96611b)

## Changes

### Changed

- Moved some nested selectors out of the "nested" CSS pattern and into standalone selectors for backwards compatibility. It might be worth doing this globally, or ensuring that our CSS compiles into backwards-compatible CSS automatically, but this PR just fixes the most egregious examples I found.

### Fixed

- Search, sidenav link and disclosure items look as expected
![image](https://github.com/user-attachments/assets/a362edff-cd20-4d49-bf96-c9a5d14cbff4)

## Testing

Run locally or in CF in Safari

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
