### PR TITLE
fix(docx): get component iframes rendering correctly

### DIFF
--- a/packages/site/src/preview/AtlantisPreviewViewer.tsx
+++ b/packages/site/src/preview/AtlantisPreviewViewer.tsx
@@ -14,6 +14,7 @@ export const AtlantisPreviewViewer = () => {
         style={{
           border: "none",
           display: type == "web" ? "block" : "none",
+          minHeight: "200px",
         }}
         ref={iframe}
       />
@@ -22,6 +23,7 @@ export const AtlantisPreviewViewer = () => {
           border: "none",
           display: type == "mobile" ? "block" : "none",
           borderRadius: "var(--radius-base)",
+          minHeight: "200px",
         }}
         ref={iframeMobile}
       />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Initially, I set the height of the iframes to have a min-height simply to avoid the internal scrolling area that was occuring, not intending to fix the components themselves not being visible, however this also seems to have fixed the components not being visible as well. 🎉 ?

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- add min-height to the iframes themselves
  - without the min-height, they seemed to just be collapsing in on themselves

### Fixed

- Components now render in Safari
![image](https://github.com/user-attachments/assets/4f83463f-b861-43fc-9096-861b9ef7e436)

## Testing

Run locally in Safari/Chrome/FF

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
