### PR TITLE
docs: Add a new route for Welcome Guide

### DIFF
--- a/packages/site/src/maps/designContent.tsx
+++ b/packages/site/src/maps/designContent.tsx
@@ -1,4 +1,3 @@
-import WelcomeGuide from "@atlantis/docs/README.md";
 import AnimationDocs from "@atlantis/docs/design/Animation.stories.mdx";
 import BorderDocs from "@atlantis/docs/design/Borders.stories.mdx";
 import ColorDocs from "@atlantis/docs/design/Colors.stories.mdx";
@@ -11,12 +10,6 @@ import TypographyDocs from "@atlantis/docs/design/Typography.stories.mdx";
 import { ContentMapItems } from "../types/maps";
 
 export const designContentMap: ContentMapItems = {
-  "welcome-guide": {
-    intro: "Welcome!",
-    title: "Welcome Guide!",
-    content: () => <WelcomeGuide />,
-  },
-
   animation: {
     intro: "Animation",
     title: "Animation",

--- a/packages/site/src/pages/GettingStartedPage.tsx
+++ b/packages/site/src/pages/GettingStartedPage.tsx
@@ -1,0 +1,12 @@
+import WelcomeGuide from "@atlantis/docs/README.md";
+import { BaseView } from "../layout/BaseView";
+
+export const GettingStartedPage = () => {
+  return (
+    <BaseView>
+      <BaseView.Main>
+        <WelcomeGuide />
+      </BaseView.Main>
+    </BaseView>
+  );
+};

--- a/packages/site/src/pages/GettingStartedPage.tsx
+++ b/packages/site/src/pages/GettingStartedPage.tsx
@@ -1,12 +1,12 @@
 import WelcomeGuide from "@atlantis/docs/README.md";
-import { BaseView } from "../layout/BaseView";
+import { ContentView } from "../layout/ContentView";
 
 export const GettingStartedPage = () => {
   return (
-    <BaseView>
-      <BaseView.Main>
-        <WelcomeGuide />
-      </BaseView.Main>
-    </BaseView>
+    <ContentView
+      title="Welcome Guide"
+      key="welcome-guide"
+      content={() => <WelcomeGuide />}
+    />
   );
 };

--- a/packages/site/src/pages/HomePage.tsx
+++ b/packages/site/src/pages/HomePage.tsx
@@ -8,7 +8,7 @@ export const HomePage = () => {
           title: "Home",
           body: "Jobber's toolkit for building consumer-grade experiences",
           ctaLabel: "Get Started",
-          to: "/design/welcome-guide",
+          to: "/welcome-guide",
           imageURL: "/img_collage.jpg",
         },
         body: {

--- a/packages/site/src/pages/WelcomeGuidePage.tsx
+++ b/packages/site/src/pages/WelcomeGuidePage.tsx
@@ -1,7 +1,7 @@
 import WelcomeGuide from "@atlantis/docs/README.md";
 import { ContentView } from "../layout/ContentView";
 
-export const GettingStartedPage = () => {
+export const WelcomeGuidePage = () => {
   return (
     <ContentView
       title="Welcome Guide"

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -12,7 +12,7 @@ import { hooksList } from "./hooksList";
 import { GuidesPage } from "./pages/GuidesPage";
 import { PackagesPage } from "./pages/PackagesPage";
 import { ComponentNotFound } from "./components/ComponentNotFound";
-import { GettingStartedPage } from "./pages/GettingStartedPage";
+import { WelcomeGuidePage } from "./pages/WelcomeGuidePage";
 
 export interface AtlantisRoute {
   path?: string;
@@ -341,7 +341,7 @@ export const routes: Array<AtlantisRoute> = [
   },
   {
     path: "/welcome-guide",
-    component: GettingStartedPage,
+    component: WelcomeGuidePage,
     handle: "WelcomeGuide",
     inNav: false,
     exact: true,

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -12,6 +12,7 @@ import { hooksList } from "./hooksList";
 import { GuidesPage } from "./pages/GuidesPage";
 import { PackagesPage } from "./pages/PackagesPage";
 import { ComponentNotFound } from "./components/ComponentNotFound";
+import { GettingStartedPage } from "./pages/GettingStartedPage";
 
 export interface AtlantisRoute {
   path?: string;
@@ -335,6 +336,13 @@ export const routes: Array<AtlantisRoute> = [
     path: "/component-not-found",
     component: ComponentNotFound,
     handle: "ComponentNotFound",
+    inNav: false,
+    exact: true,
+  },
+  {
+    path: "/welcome-guide",
+    component: GettingStartedPage,
+    handle: "WelcomeGuide",
     inNav: false,
     exact: true,
   },


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Clicking on the `Get Started` Button on the Home page, also opened up the Design side nav item.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

#### Before

https://github.com/user-attachments/assets/0a833771-d9b6-4ee5-b611-b40022b9e62f

#### After

https://github.com/user-attachments/assets/d6268b41-c31f-4c08-b81d-301004084b03


## Testing

- [ ] Click `Get Started` and make sure the Design side nav disclosure doesn't open
- [ ] The `Get Started` page is formatted as it was before (including siderail)

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
