### PR TITLE
docs: Update zIndex on ToggleThemeButton

### DIFF
--- a/packages/site/src/components/CategoryCardSection.tsx
+++ b/packages/site/src/components/CategoryCardSection.tsx
@@ -26,7 +26,7 @@ export const CategoryCardSection = ({
           padding:
             "var(--space-base) var(--space-minuscule) var(--space-smaller) 0px",
           marginLeft: "-1px",
-          display: "inline-block",
+          width: "100%",
         }}
       >
         <Heading level={2}>{category}</Heading>

--- a/packages/site/src/components/CategoryCardSection.tsx
+++ b/packages/site/src/components/CategoryCardSection.tsx
@@ -26,7 +26,7 @@ export const CategoryCardSection = ({
           padding:
             "var(--space-base) var(--space-minuscule) var(--space-smaller) 0px",
           marginLeft: "-1px",
-          width: "100%",
+          display: "inline-block",
         }}
       >
         <Heading level={2}>{category}</Heading>

--- a/packages/site/src/components/ToggleThemeButton.tsx
+++ b/packages/site/src/components/ToggleThemeButton.tsx
@@ -24,6 +24,7 @@ export const ToggleThemeButton = () => {
         right: "var(--space-base)",
         boxShadow: "var(--shadow-base)",
         borderRadius: "var(--radius-base)",
+        zIndex: 1,
       }}
       data-elevation="elevated"
     >


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

On smaller breakpoints, the `CategoryCardSection` that holds the headings would overlap the Dark Mode toggle on the bottom right of the page.

At first I adjusted `CategoryCardSection` but really, it should probably be the `ToggleThemeButton` that is adjusted to have a higher zIndex.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

#### Before

<img width="687" alt="Screenshot 2025-01-10 at 9 25 37 PM" src="https://github.com/user-attachments/assets/8592c53b-e8e9-4ce3-9a3e-818a443f7935" />


#### After

<img width="692" alt="Screenshot 2025-01-10 at 9 25 16 PM" src="https://github.com/user-attachments/assets/0934a40e-7552-4538-97c8-a2a459b9c364" />

## Testing

<!-- How to test your changes. -->
- [ ] make sure on smaller screens where the `CategoryCardSection` overlaps with the toggle theme button, the button remains completely visible

<img width="881" alt="Screenshot 2025-01-10 at 11 14 52 PM" src="https://github.com/user-attachments/assets/7c58083f-b531-4fbd-af05-6d59e1a8de14" />


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
