### PR TITLE
fix(components): DataListTotalCount results pluralization

### DIFF
--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -109,7 +109,7 @@ export interface DataListProps<T extends DataListObject> {
   /**
    * Total number of items in the DataList.
    *
-   * This renders an "N result" text with the DataList
+   * This renders an "N results" text with the DataList
    * that helps users know how many items they have
    * in the list
    */

--- a/packages/components/src/DataList/components/DataListTotalCount/DataListTotalCount.test.tsx
+++ b/packages/components/src/DataList/components/DataListTotalCount/DataListTotalCount.test.tsx
@@ -12,6 +12,11 @@ describe("DataListTotalCount", () => {
     expect(screen.getByText("(10 results)")).toBeInTheDocument();
   });
 
+  it("should render the proper pluralization for 1 result", () => {
+    render(<DataListTotalCount totalCount={1} loading={false} />);
+    expect(screen.getByText("(1 result)")).toBeInTheDocument();
+  });
+
   it("should render a Glimmer when loading and total count is null", () => {
     render(<DataListTotalCount totalCount={null} loading={true} />);
     const results = screen.getByTestId(DATALIST_TOTALCOUNT_TEST_ID);

--- a/packages/components/src/DataList/components/DataListTotalCount/DataListTotalCount.tsx
+++ b/packages/components/src/DataList/components/DataListTotalCount/DataListTotalCount.tsx
@@ -33,7 +33,10 @@ export function DataListTotalCount({
   if (typeof totalCount === "number") {
     return (
       <DataListTotalCountContainer>
-        <Text variation="subdued">({totalCount.toLocaleString()} results)</Text>
+        <Text variation="subdued">
+          ({totalCount.toLocaleString()}{" "}
+          {totalCount == 1 ? "result" : "results"})
+        </Text>
       </DataListTotalCountContainer>
     );
   }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
This fixes the `DataListTotalCount` results pluralization 

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- When there is a singular result we will show `(1 result)`
- before:
![Screenshot 2025-01-15 at 2 21 11 PM](https://github.com/user-attachments/assets/8d65f568-0f2c-4627-b3b5-315c2c5a15b8)
- after:
![Screenshot 2025-01-15 at 2 21 33 PM](https://github.com/user-attachments/assets/bf29b6fa-1724-49bd-b147-3ff9f2de00f9)




## Testing
- Hardcode the `totalCount` to 0,1,2 [here](https://github.com/GetJobber/atlantis/blob/eb21f8c427dd5d427275eb3856d9a2c4bd017019/docs/components/DataList/Web.stories.tsx#L77)
<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
