### PR TITLE
fix(components): Add transparent outline for DataList sort options 

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.module.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.module.css
@@ -37,4 +37,5 @@
 
 .option:focus-visible {
   box-shadow: var(--shadow-focus);
+  outline: transparent;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We are already adding a box shadow data list sorting options when focused so we don't need an additional outline. As you can see the current behaviour is quite busy:
![image](https://github.com/user-attachments/assets/68712b48-db99-4ec8-95cc-c8a4a2a88a22)

## Changes

Makes the outline on focused sorting options transparent

## Testing

Here is a video of the new behaviour when tested via the pre-release

https://github.com/user-attachments/assets/3433ca33-39f1-4029-bad4-b0920f82f887


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
