### PR TITLE
fix(components): Fix label issue with SegmentedControl on older versions of Safari [113267]

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.module.css
+++ b/packages/components/src/DataList/components/DataListHeaderTile/components/DataListSortingOptions.module.css
@@ -37,4 +37,5 @@
 
 .option:focus-visible {
   box-shadow: var(--shadow-focus);
+  outline: transparent;
 }

--- a/packages/components/src/SegmentedControl/SegmentedControl.module.css
+++ b/packages/components/src/SegmentedControl/SegmentedControl.module.css
@@ -29,7 +29,6 @@
 .container label {
   display: flex;
   z-index: 1;
-  height: 100%;
   padding: 0 calc(var(--space-base) - var(--space-smaller));
   overflow: hidden;
   font-size: var(--typography--fontSize-base);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

On old versions of Safari (before 18) the labels on SegmentedControl were displaying far off of where they belonged. 

![Screenshot 2025-01-16 at 3 19 04 PM](https://github.com/user-attachments/assets/b07dd8b7-7397-448c-b093-b77372d8ed4f)

This was only observed in our new docs site but could also present itself in other implementations. The reason that this was only impacting old versions of Safari is that in 18 they fixed the bug: 
> Fixed overlapping elements with flex box when height: 100% is applied on nested content.

As far as I can tell the height of 100% on the label container was providing no benefits so removing it should allow the labels to display as expected in all versions of Safari as well as other browsers.


### Removed

The height of 100% from the label container for SegmentedControl labels

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Ensure that SegmentedControl continues to behave the same and as expected on browsers other than Safari. If you have Safari 18 installed you can use Browser Stack's Local Testing feature to test out the changes with an older version of Safari.

![Screenshot 2025-01-16 at 3 26 33 PM](https://github.com/user-attachments/assets/be19e8af-6e07-4227-b95b-b6fe4471f519)

I tested with Safari 17.3 which was broken before the changes (leading to the screenshot in the Motivations section):

![Screenshot 2025-01-16 at 3 18 15 PM](https://github.com/user-attachments/assets/8b45f3be-9114-4bcc-92a9-684bad7658f9)



Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
