### PR TITLE
docs: Add Implementing customization page to Guides

### DIFF
--- a/docs/components/Popover/Popover.stories.mdx
+++ b/docs/components/Popover/Popover.stories.mdx
@@ -44,11 +44,13 @@ go.
 
 ### UNSAFE\_ props (advanced usage)
 
-General information for using `UNSAFE_` props can be found
-[here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+Popover has three elements that can be targeted with classes or styles:
 
-Popover has three elements that can be targeted with classes or styles. These
-are the container, the dismiss button container, and the arrow.
+| **Element**               | **`UNSAFE_` props** |
+| :------------------------ | :------------------ |
+| `.container`              | ✅                  |
+| `.dismissButtonContainer` | ✅                  |
+| `.arrow`                  | ✅                  |
 
 **Note**: Use of `UNSAFE_` props is **at your own risk** and should be
 considered a **last resort**. Future Popover updates may lead to unintended
@@ -60,14 +62,14 @@ Use `UNSAFE_className` to apply custom classes to the Popover. This can be
 useful for applying styles via CSS Modules.
 
 ```tsx
-// Popover.tsx
+// CustomPopover.tsx
   UNSAFE_className={{
     container: styles.customPopoverBackground,
     dismissButtonContainer: styles.customDismissButton,
     arrow: styles.customArrow,
   }}
 
-// Popover.module.css
+// CustomPopover.module.css
 .customPopoverBackground {
   background-color: var(--color-surface--background);
 }
@@ -99,6 +101,9 @@ Use `UNSAFE_style` to apply inline custom styles to the Popover.
     arrow: { paddingRight: "var(--space-extravagant)" },
   }}
 ```
+
+General information for using `UNSAFE_` props can be found
+[here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
 
 ## Related components
 

--- a/docs/guides/implementing-customization.stories.mdx
+++ b/docs/guides/implementing-customization.stories.mdx
@@ -7,7 +7,7 @@ import { Banner } from "@jobber/components/Banner";
 
 When adding `UNSAFE_` props to a component, follow these guidelines:
 
-#### 1. Components have both `UNSAFE_className` & `UNSAFE_style`
+#### Components have both `UNSAFE_className` & `UNSAFE_style`
 
 `UNSAFE_className` is for applying custom classes:
 
@@ -25,9 +25,9 @@ UNSAFE_className={{ container: "custom-container-class" }}
   }}
 ```
 
-#### 2. Each component has a `container` type for the parent element
+#### Each component has a `container` type for the parent element
 
-#### 3. Where necessary, components have types for sub-components
+#### Where necessary, components have types for sub-components
 
 Each element should be targeted via `UNSAFE_` props. For example, in Popover:
 
@@ -37,7 +37,7 @@ Each element should be targeted via `UNSAFE_` props. For example, in Popover:
 | `.dismissButtonContainer` | ✅                  |
 | `.arrow`                  | ✅                  |
 
-#### 4. Naming conventions for sub-components are carefully considered
+#### Naming conventions for sub-components are carefully considered
 
 Sub-components may be other Atlantis components that will eventually have their
 own classNames.

--- a/docs/guides/implementing-customization.stories.mdx
+++ b/docs/guides/implementing-customization.stories.mdx
@@ -1,0 +1,60 @@
+import { Meta } from "@storybook/addon-docs";
+import { Banner } from "@jobber/components/Banner";
+
+<Meta title="Guides/Implementing customization" />
+
+# Implementing customization
+
+## Pattern for implementing UNSAFE\_ props
+
+When adding `UNSAFE_` props to a component, follow these guidelines:
+
+#### 1. Components have both `UNSAFE_className` & `UNSAFE_style`
+
+`UNSAFE_className` is for applying custom classes:
+
+```tsx
+UNSAFE_className={{ container: "custom-container-class" }}
+```
+
+`UNSAFE_style` is for inline custom styles:
+
+```tsx
+  UNSAFE_style={{
+    container: { backgroundColor: "lightblue" },
+    dismissButtonContainer: { paddingRight: "var(--space-larger)" },
+    arrow: { paddingRight: "var(--space-extravagant)" },
+  }}
+```
+
+#### 2. Each component has a `container` type for the wrapping `<div>`
+
+#### 3. Where necessary, components have types for sub-components
+
+Each element should be targeted via `UNSAFE_` props. For example, in Popover:
+
+| **Element**               | **`UNSAFE_` props** |
+| :------------------------ | :------------------ |
+| `.container`              | ✅                  |
+| `.dismissButtonContainer` | ✅                  |
+| `.arrow`                  | ✅                  |
+
+#### 4. Naming conventions for sub-components are carefully considered
+
+Sub-components may be other Atlantis components that will eventually have their
+own classNames.
+
+For example, the `.dismissButtonContainer` in Popover contains a ButtonDismiss
+component.
+
+ButtonDismiss may eventually have it's own `UNSAFE_` props type, which would
+likely be called `dismissButton`. This can then be referenced in Popover:
+
+```tsx
+readonly UNSAFE_className?: {
+  container?: string;
+  dismissButtonContainer?: string;
+  dismissButton?: string;
+  arrow?: string;
+};
+```

--- a/docs/guides/implementing-customization.stories.mdx
+++ b/docs/guides/implementing-customization.stories.mdx
@@ -25,7 +25,7 @@ UNSAFE_className={{ container: "custom-container-class" }}
   }}
 ```
 
-#### 2. Each component has a `container` type for the wrapping `<div>`
+#### 2. Each component has a `container` type for the parent element
 
 #### 3. Where necessary, components have types for sub-components
 

--- a/docs/guides/implementing-customization.stories.mdx
+++ b/docs/guides/implementing-customization.stories.mdx
@@ -5,8 +5,6 @@ import { Banner } from "@jobber/components/Banner";
 
 # Implementing customization
 
-## Pattern for implementing UNSAFE\_ props
-
 When adding `UNSAFE_` props to a component, follow these guidelines:
 
 #### 1. Components have both `UNSAFE_className` & `UNSAFE_style`

--- a/packages/site/src/content/Popover/PopoverNotes.mdx
+++ b/packages/site/src/content/Popover/PopoverNotes.mdx
@@ -2,11 +2,13 @@
 
 ### UNSAFE\_ props (advanced usage)
 
-General information for using `UNSAFE_` props can be found
-[here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+Popover has three elements that can be targeted with classes or styles:
 
-Popover has three elements that can be targeted with classes or styles. These
-are the container, the dismiss button container, and the arrow.
+| **Element**               | **`UNSAFE_` props** |
+| :------------------------ | :------------------ |
+| `.container`              | ✅                  |
+| `.dismissButtonContainer` | ✅                  |
+| `.arrow`                  | ✅                  |
 
 **Note**: Use of `UNSAFE_` props is **at your own risk** and should be
 considered a **last resort**. Future Popover updates may lead to unintended
@@ -18,14 +20,14 @@ Use `UNSAFE_className` to apply custom classes to the Popover. This can be
 useful for applying styles via CSS Modules.
 
 ```tsx
-// Popover.tsx
+// CustomPopover.tsx
   UNSAFE_className={{
     container: styles.customPopoverBackground,
     dismissButtonContainer: styles.customDismissButton,
     arrow: styles.customArrow,
   }}
 
-// Popover.module.css
+// CustomPopover.module.css
 .customPopoverBackground {
   background-color: var(--color-surface--background);
 }
@@ -57,3 +59,6 @@ Use `UNSAFE_style` to apply inline custom styles to the Popover.
     arrow: { paddingRight: "var(--space-extravagant)" },
   }}
 ```
+
+General information for using `UNSAFE_` props can be found
+[here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).

--- a/packages/site/src/guidesList.ts
+++ b/packages/site/src/guidesList.ts
@@ -9,6 +9,11 @@ export const guidesList = [
     additionalMatches: ["Custom", "Composability"],
   },
   {
+    title: "Implementing customization",
+    to: "/guides/implementing-customization",
+    additionalMatches: ["Custom"],
+  },
+  {
     title: "Writing documentation",
     to: "/guides/documentation-styleguide",
   },

--- a/packages/site/src/maps/guidesContent.tsx
+++ b/packages/site/src/maps/guidesContent.tsx
@@ -4,6 +4,7 @@ import DocumentationStyleguideComponent from "@atlantis/docs/guides/documentatio
 import FrontendStyleguideComponenet from "@atlantis/docs/guides/frontend-style.stories.mdx";
 import GettingSatrtedWithReactComponent from "@atlantis/docs/getting-started-with-react/getting-started-with-react.stories.mdx";
 import PullRequestTitleGeneratorComponent from "@atlantis/docs/guides/pull-request-title-generator.stories.mdx";
+import ImplementingCustomizationComponent from "@atlantis/docs/guides/implementing-customization.stories.mdx";
 import { ContentMapItems } from "../types/maps";
 
 export const guidesContentMap: ContentMapItems = {
@@ -16,6 +17,11 @@ export const guidesContentMap: ContentMapItems = {
     intro: "Customizing components",
     title: "Customizing components",
     content: () => <CustomizingComponentsComponent />,
+  },
+  "implementing-customization": {
+    intro: "Implementing customization",
+    title: "Implementing customization",
+    content: () => <ImplementingCustomizationComponent />,
   },
   "documentation-styleguide": {
     intro: "Writing documentation",

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -176,6 +176,11 @@ export const routes: Array<AtlantisRoute> = [
         exact: true,
       },
       {
+        path: "/guides/implementing-customization",
+        handle: "Implementing customization",
+        exact: true,
+      },
+      {
         path: "/guides/documentation-styleguide",
         handle: "Writing documentation",
         exact: true,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
If anyone would like to add `UNSAFE_` props to a component, we've now added an _Implementing customization_ page in the Guides section of our docs. In the future this page can also contain others guidelines on adding customization to components.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

<!-- new features -->
- New page in Guides: _Implementing customization_

### Changed

<!-- changes in existing functionality -->
- updated a few things in Popover docs/notes, like adding a table for better readability on what `UNSAFE_` prop types are available in Popover

## Testing

<!-- How to test your changes. -->
You can view the new _Implementing customization_ page in the Guides section in New Docs Site and Storybook

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
