### PR TITLE
feat(components): Adding Quick Delete to FormatFile

### DIFF
--- a/docs/components/FormatFile/Web.stories.tsx
+++ b/docs/components/FormatFile/Web.stories.tsx
@@ -43,6 +43,22 @@ Collapsed.args = {
   onDelete: () => alert("Deleted"),
 };
 
+export const QuickDelete = BasicTemplate.bind({});
+QuickDelete.args = {
+  file: {
+    key: "abc",
+    name: "myballisbigandroundIamrollingitontheground.png",
+    type: "image/png",
+    size: 213402324,
+    progress: 1,
+    src: () => Promise.resolve("https://picsum.photos/250"),
+  },
+  display: "compact",
+  displaySize: "large",
+  quickDelete: true,
+  onDelete: () => alert("Deleted"),
+};
+
 export const ExpandedWithDelete = BasicTemplate.bind({});
 ExpandedWithDelete.args = {
   file: {

--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -37,6 +37,8 @@ interface FormatFileProps {
    * onDelete callback - this function will be called when the delete action is triggered
    */
   onDelete?(): void;
+
+  readonly quickDelete?: boolean;
 }
 
 export function FormatFile({
@@ -44,6 +46,7 @@ export function FormatFile({
   display = "expanded",
   displaySize = "base",
   onDelete,
+  quickDelete,
   onClick,
 }: FormatFileProps) {
   const isComplete = file.progress >= 1;
@@ -104,6 +107,7 @@ export function FormatFile({
       {isComplete && onDelete && (
         <div className={styles.deleteButton}>
           <FormatFileDeleteButton
+            quickDelete={quickDelete}
             size={display === "expanded" ? "large" : displaySize}
             onDelete={onDelete}
           />

--- a/packages/components/src/FormatFile/FormatFileDeleteButton.tsx
+++ b/packages/components/src/FormatFile/FormatFileDeleteButton.tsx
@@ -6,19 +6,32 @@ import { ConfirmationModal } from "../ConfirmationModal";
 interface DeleteButtonProps {
   readonly size?: "base" | "large";
   readonly onDelete?: () => void;
+  readonly quickDelete?: boolean;
 }
 
-export function FormatFileDeleteButton({ size, onDelete }: DeleteButtonProps) {
+export function FormatFileDeleteButton({
+  size,
+  onDelete,
+  quickDelete,
+}: DeleteButtonProps) {
   const buttonSize = size === "base" ? "small" : "base";
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+
+  const determineIfQuickDelete = () => {
+    if (!quickDelete) {
+      setDeleteConfirmationOpen(!deleteConfirmationOpen);
+    } else {
+      onDelete?.();
+    }
+  };
 
   return (
     <div className={styles.deleteButton}>
       <Button
-        onClick={() => setDeleteConfirmationOpen(true)}
+        onClick={() => determineIfQuickDelete()}
         variation="destructive"
         type="tertiary"
-        icon="trash"
+        icon={quickDelete ? "remove" : "trash"}
         ariaLabel="Delete File"
         size={buttonSize}
       />


### PR DESCRIPTION
## Motivations

1. Were curious about what it would take to update quick delete to add the ability to bypass the confirmation modal.

## Changes

1. Added a 'quickDelete' prop (name up for consideration) that allows you to bypass the confirmation modal, and immediate hit the onDelete callback on press.



## Testing

1. There is a new Quick Delete Story, if you hit the 'X' button on the Image thumbnail, it immediately calls the onDelete callback.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
