### PR TITLE
docs: style and content tweaks to feedback banner

### DIFF
--- a/packages/site/src/components/FeedbackBanner.tsx
+++ b/packages/site/src/components/FeedbackBanner.tsx
@@ -47,7 +47,7 @@ export const FeedbackBanner = () => {
     >
       <Disclosure
         title={
-          <Heading>
+          <Heading level={4}>
             Welcome to the <Emphasis variation="highlight">new</Emphasis>{" "}
             Atlantis docs site
           </Heading>

--- a/packages/site/src/components/FeedbackBanner.tsx
+++ b/packages/site/src/components/FeedbackBanner.tsx
@@ -1,5 +1,12 @@
-import { Box, Button, Heading } from "@jobber/components";
-import { useState } from "react";
+import {
+  Box,
+  Button,
+  Content,
+  Disclosure,
+  Emphasis,
+  Heading,
+  Text,
+} from "@jobber/components";
 
 /**
  * FeedbackBanner
@@ -10,7 +17,6 @@ import { useState } from "react";
  * @returns
  */
 export const FeedbackBanner = () => {
-  const [isExpanded, setIsExpanded] = useState(true);
   const hideFeedbackBanner = localStorage.getItem("hideFeedbackBanner");
 
   if (hideFeedbackBanner) {
@@ -19,12 +25,12 @@ export const FeedbackBanner = () => {
 
   return (
     <div
+      data-elevation="elevated"
       style={{
         position: "fixed",
         bottom: 0,
         width: "375px",
         backgroundColor: "var(--color-surface)",
-        color: "white",
         left: 0,
         right: 0,
         margin: "0 auto",
@@ -32,50 +38,47 @@ export const FeedbackBanner = () => {
         display: "flex",
         flexDirection: "column",
         border: "1px solid var(--color-border)",
+        borderBottom: "none",
         borderTopLeftRadius: "var(--radius-base)",
         borderTopRightRadius: "var(--radius-base)",
         boxShadow: "var(--shadow-base)",
         padding: "var(--space-small)",
-        transition: "transform var(--timing-base) ease-in-out",
-        transform: isExpanded
-          ? "translateY(0px)"
-          : "translateY(calc(100% - 40px))",
       }}
     >
-      <Box
-        direction="row"
-        justifyContent="space-between"
-        width="100%"
-        alignItems="center"
+      <Disclosure
+        title={
+          <Heading>
+            Welcome to the <Emphasis variation="highlight">new</Emphasis>{" "}
+            Atlantis docs site
+          </Heading>
+        }
       >
-        <Heading level={4}>Welcome to the new site</Heading>
-        <Button
-          icon={isExpanded ? "arrowDown" : "arrowUp"}
-          ariaLabel={isExpanded ? "Collapse" : "Expand"}
-          variation="subtle"
-          type="secondary"
-          onClick={() => setIsExpanded(!isExpanded)}
-        />
-      </Box>
-      {isExpanded && (
-        <Box direction="row" alignItems="center" margin={{ top: "base" }}>
-          <Button
-            type="secondary"
-            url="https://docs.google.com/forms/d/e/1FAIpQLSdP0Gx84AT9rD5Y2Snm4x-COzavhE4pjNyOfOjjbdEmycdsAQ/viewform?usp=sharing"
-            label="Give feedback"
-          />
-          <Button
-            type="tertiary"
-            variation="subtle"
-            onClick={() => {
-              localStorage.setItem("nolikeynewsite", "true");
-              window.location.href =
-                "/storybook/?path=/docs/introduction--docs";
-            }}
-            label="Back to old site"
-          />
-        </Box>
-      )}
+        <Content spacing="small">
+          <Text size="small">
+            We&apos;re excited to share our new docs site with you! Please take
+            a moment to give us feedback so we can make it even better.
+          </Text>
+          <Box direction="row" alignItems="center" gap="small">
+            <Button
+              type="secondary"
+              size="small"
+              url="https://docs.google.com/forms/d/e/1FAIpQLSdP0Gx84AT9rD5Y2Snm4x-COzavhE4pjNyOfOjjbdEmycdsAQ/viewform?usp=sharing"
+              label="Give feedback"
+            />
+            <Button
+              type="tertiary"
+              variation="subtle"
+              size="small"
+              onClick={() => {
+                localStorage.setItem("nolikeynewsite", "true");
+                window.location.href =
+                  "/storybook/?path=/docs/introduction--docs";
+              }}
+              label="Back to old site"
+            />
+          </Box>
+        </Content>
+      </Disclosure>
     </div>
   );
 };


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Some styling cleanups to the feedback prompt, as well as some text content to be more explicit with our feedback ask.

Also addresses an issue where the "is expanded" state was resetting to open on subsequent visits.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- elevation for dark mode
- a small blurb before the buttons
![image](https://github.com/user-attachments/assets/8d2c1f83-866d-4487-9b88-fff4a71dc2d9)

### Changed

- header uses Disclosure
- used Emphasis to highlight the "new"
- Buttons are small now

## Testing

Run the site locally or on CF!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
