### PR TITLE
fix(docx): use a correct link for star wars graphQL API (useCollectionQuery hook)

### DIFF
--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -499,7 +499,7 @@ export const ClearAllFilters: StoryFn<typeof DataList> = args => {
   const apolloClient1 = useMemo(
     () =>
       new ApolloClient({
-        uri: "https://swapi-graphql.netlify.app/.netlify/functions/index",
+        uri: "https://swapi-graphql.netlify.app/graphql",
         cache: new InMemoryCache(),
       }),
     [],

--- a/docs/components/DataList/storyUtils.ts
+++ b/docs/components/DataList/storyUtils.ts
@@ -74,6 +74,6 @@ export const LIST_QUERY = gql`
 `;
 
 export const apolloClient = new ApolloClient({
-  uri: "https://swapi-graphql.netlify.app/.netlify/functions/index",
+  uri: "https://swapi-graphql.netlify.app/graphql",
   cache: new InMemoryCache(),
 });

--- a/packages/hooks/src/useCollectionQuery/mdxUtils.ts
+++ b/packages/hooks/src/useCollectionQuery/mdxUtils.ts
@@ -39,7 +39,7 @@ export const LIST_QUERY = gql`
 `;
 
 export const apolloClient = new ApolloClient({
-  uri: "https://swapi-graphql.netlify.app/.netlify/functions/index",
+  uri: "https://swapi-graphql.netlify.app/graphql",
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
There were a bunch of console errors when trying to check the docs for `useCollectionQuery` hook, since the star wars API link specified no longer worked.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Changed the graphQL API link to the one 

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->
1. Navigate to https://atlantis.getjobber.com/hooks/useCollectionQuery
2. Observe CORS error in the console (and network tab) and no returned results in the UI (no list of Star Wars planets)
3. Pull the branch locally or open a preview website
4. Notice the graph request is now successful (200 OK) as well as now you can see the list of planets in the UI.
  4.1. CORS error is no longer present in Chrome console.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
