### PR TITLE
feat(components-native): Adds styleOverrides for CommonButton borderColor and Text color. [JOB-112128]

### DIFF
--- a/packages/components-native/src/Button/Button.test.tsx
+++ b/packages/components-native/src/Button/Button.test.tsx
@@ -298,4 +298,40 @@ describe("Button", () => {
       expect(handlePress).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("styleOverrides", () => {
+    describe("borderColor", () => {
+      it("should apply the borderColor style override", () => {
+        const borderColor = "color-base-grey--100";
+        const { buttonStyle } = renderButton(
+          <Button
+            label="Override"
+            onPress={jest.fn()}
+            styleOverrides={{ borderColor }}
+          />,
+        );
+
+        expect(buttonStyle).toMatchObject({
+          borderColor: tokens[borderColor],
+        });
+      });
+
+      it("should throw an error if the colour is not a valid token key", () => {
+        const borderColor = "red";
+
+        const renderButtonWithInvalidStyleOverride = () =>
+          renderButton(
+            <Button
+              label="Override"
+              onPress={jest.fn()}
+              styleOverrides={{ borderColor }}
+            />,
+          );
+
+        expect(renderButtonWithInvalidStyleOverride).toThrow(
+          "Invalid borderColor key: red",
+        );
+      });
+    });
+  });
 });

--- a/packages/components-native/src/Button/Button.test.tsx
+++ b/packages/components-native/src/Button/Button.test.tsx
@@ -302,7 +302,7 @@ describe("Button", () => {
   describe("styleOverrides", () => {
     describe("borderColor", () => {
       it("should apply the borderColor style override", () => {
-        const borderColor = tokens["color-base-grey--100"];
+        const borderColor = "color-base-grey--100";
 
         const { buttonStyle } = renderButton(
           <Button
@@ -313,7 +313,7 @@ describe("Button", () => {
         );
 
         expect(buttonStyle).toMatchObject({
-          borderColor,
+          borderColor: tokens[borderColor],
         });
       });
     });

--- a/packages/components-native/src/Button/Button.test.tsx
+++ b/packages/components-native/src/Button/Button.test.tsx
@@ -302,7 +302,8 @@ describe("Button", () => {
   describe("styleOverrides", () => {
     describe("borderColor", () => {
       it("should apply the borderColor style override", () => {
-        const borderColor = "color-base-grey--100";
+        const borderColor = tokens["color-base-grey--100"];
+
         const { buttonStyle } = renderButton(
           <Button
             label="Override"
@@ -312,25 +313,8 @@ describe("Button", () => {
         );
 
         expect(buttonStyle).toMatchObject({
-          borderColor: tokens[borderColor],
+          borderColor,
         });
-      });
-
-      it("should throw an error if the colour is not a valid token key", () => {
-        const borderColor = "red";
-
-        const renderButtonWithInvalidStyleOverride = () =>
-          renderButton(
-            <Button
-              label="Override"
-              onPress={jest.fn()}
-              styleOverrides={{ borderColor }}
-            />,
-          );
-
-        expect(renderButtonWithInvalidStyleOverride).toThrow(
-          "Invalid borderColor key: red",
-        );
       });
     });
   });

--- a/packages/components-native/src/Button/Button.tsx
+++ b/packages/components-native/src/Button/Button.tsx
@@ -85,7 +85,7 @@ interface CommonButtonProps {
 }
 
 export interface CommonButtonStyleOverride {
-  readonly borderColor?: string; // TODO: get proper type
+  readonly borderColor?: typeof tokens;
 }
 
 interface LabelButton extends CommonButtonProps {
@@ -129,17 +129,10 @@ export function Button({
     fullHeight && styles.fullHeight,
   ];
 
-  console.log("tokens", tokens);
-
   if (styleOverrides?.borderColor) {
-    if (styleOverrides.borderColor in tokens) {
-      const borderColor =
-        tokens[styleOverrides.borderColor as keyof typeof tokens];
-      buttonStyle.push({ borderColor: borderColor });
-    } else {
-      throw new Error(`Invalid borderColor key: ${styleOverrides.borderColor}`);
-    }
+    buttonStyle.push({ borderColor: styleOverrides.borderColor });
   }
+
   // attempts to use Pressable caused problems.  When a ScrollView contained
   // an InputText that was focused, it required two presses to activate the
   // Pressable.  Using a TouchableHighlight made things register correctly

--- a/packages/components-native/src/Button/Button.tsx
+++ b/packages/components-native/src/Button/Button.tsx
@@ -77,6 +77,15 @@ interface CommonButtonProps {
    * Used to locate this view in end-to-end tests.
    */
   readonly testID?: string;
+
+  /**
+   * Styles to override the default styles
+   */
+  readonly styleOverrides?: CommonButtonStyleOverride;
+}
+
+export interface CommonButtonStyleOverride {
+  readonly borderColor?: string; // TODO: get proper type
 }
 
 interface LabelButton extends CommonButtonProps {
@@ -107,6 +116,7 @@ export function Button({
   accessibilityHint,
   icon,
   testID,
+  styleOverrides,
 }: ButtonProps): JSX.Element {
   const buttonStyle = [
     styles.button,
@@ -119,6 +129,17 @@ export function Button({
     fullHeight && styles.fullHeight,
   ];
 
+  console.log("tokens", tokens);
+
+  if (styleOverrides?.borderColor) {
+    if (styleOverrides.borderColor in tokens) {
+      const borderColor =
+        tokens[styleOverrides.borderColor as keyof typeof tokens];
+      buttonStyle.push({ borderColor: borderColor });
+    } else {
+      throw new Error(`Invalid borderColor key: ${styleOverrides.borderColor}`);
+    }
+  }
   // attempts to use Pressable caused problems.  When a ScrollView contained
   // an InputText that was focused, it required two presses to activate the
   // Pressable.  Using a TouchableHighlight made things register correctly

--- a/packages/components-native/src/Button/Button.tsx
+++ b/packages/components-native/src/Button/Button.tsx
@@ -4,7 +4,12 @@ import { IconColorNames, IconNames } from "@jobber/design";
 import { XOR } from "ts-xor";
 import { styles } from "./Button.style";
 import { InternalButtonLoading } from "./components/InternalButtonLoading";
-import { ButtonSize, ButtonType, ButtonVariation } from "./types";
+import {
+  ButtonSize,
+  ButtonType,
+  ButtonVariation,
+  CommonButtonBorderColor,
+} from "./types";
 import { ActionLabel, ActionLabelVariation } from "../ActionLabel";
 import { Icon } from "../Icon";
 import { tokens } from "../utils/design";
@@ -85,7 +90,7 @@ interface CommonButtonProps {
 }
 
 export interface CommonButtonStyleOverride {
-  readonly borderColor?: typeof tokens;
+  readonly borderColor?: CommonButtonBorderColor;
 }
 
 interface LabelButton extends CommonButtonProps {
@@ -130,7 +135,7 @@ export function Button({
   ];
 
   if (styleOverrides?.borderColor) {
-    buttonStyle.push({ borderColor: styleOverrides.borderColor });
+    buttonStyle.push({ borderColor: tokens[styleOverrides.borderColor] });
   }
 
   // attempts to use Pressable caused problems.  When a ScrollView contained

--- a/packages/components-native/src/Button/index.ts
+++ b/packages/components-native/src/Button/index.ts
@@ -1,2 +1,2 @@
-export { Button } from "./Button";
+export { Button, CommonButtonStyleOverride } from "./Button";
 export type { ButtonVariation, ButtonType } from "./types";

--- a/packages/components-native/src/Button/index.ts
+++ b/packages/components-native/src/Button/index.ts
@@ -1,2 +1,6 @@
 export { Button, CommonButtonStyleOverride } from "./Button";
-export type { ButtonVariation, ButtonType } from "./types";
+export type {
+  ButtonVariation,
+  ButtonType,
+  CommonButtonBorderColor,
+} from "./types";

--- a/packages/components-native/src/Button/types.ts
+++ b/packages/components-native/src/Button/types.ts
@@ -1,3 +1,6 @@
+import { tokens } from "@jobber/design";
+
 export type ButtonVariation = "work" | "cancel" | "destructive" | "learning";
 export type ButtonType = "primary" | "secondary" | "tertiary";
 export type ButtonSize = "small" | "base";
+export type CommonButtonBorderColor = keyof typeof tokens;

--- a/packages/components-native/src/Text/Text.test.tsx
+++ b/packages/components-native/src/Text/Text.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react-native";
+import { tokens } from "@jobber/design";
 import { Text } from ".";
 
 it("renders text with no additional props", () => {
@@ -147,4 +148,36 @@ it("renders text with underline styling", () => {
   const text = render(<Text underline="dashed">Test Text</Text>);
 
   expect(text.toJSON()).toMatchSnapshot();
+});
+
+describe("styleOverride", () => {
+  describe("color", () => {
+    describe("when color is not provided", () => {
+      it("does not override the color", () => {
+        const text = render(<Text>Test Text</Text>);
+
+        // eslint-disable-next-line dot-notation
+        expect(text.toJSON()?.["props"]["style"]).toEqual(
+          expect.arrayContaining([
+            expect.not.objectContaining({
+              color: tokens["color-orange--dark"],
+            }),
+          ]),
+        );
+      });
+    });
+
+    it("renders text with color override", () => {
+      const text = render(
+        <Text styleOverride={{ color: "orangeDark" }}>Test Text</Text>,
+      );
+
+      // eslint-disable-next-line dot-notation
+      expect(text.toJSON()?.["props"]["style"]).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ color: tokens["color-orange--dark"] }),
+        ]),
+      );
+    });
+  });
 });

--- a/packages/components-native/src/Text/Text.tsx
+++ b/packages/components-native/src/Text/Text.tsx
@@ -4,6 +4,7 @@ import {
   LineHeight,
   TextAccessibilityRole,
   TextAlign,
+  TextColor,
   TextSize,
   TextVariation,
   TruncateLength,
@@ -85,6 +86,11 @@ interface TextProps
    * of the TextInput
    */
   readonly hideFromScreenReader?: boolean;
+
+  /**
+   * Style override for text
+   */
+  readonly styleOverride?: TextStyleOverride;
 }
 
 export type TextLevel = "text" | "textSupporting";
@@ -92,6 +98,10 @@ export type TextLevel = "text" | "textSupporting";
 interface LevelStyle {
   readonly size: TextSize;
   readonly lineHeight: LineHeight;
+}
+
+export interface TextStyleOverride {
+  readonly color: TextColor | undefined;
 }
 
 const levelStyles: Record<TextLevel, LevelStyle> = {
@@ -125,14 +135,21 @@ export function Text({
   italic = false,
   hideFromScreenReader = false,
   maxFontScaleSize,
+  styleOverride,
   underline,
   selectable,
 }: TextProps): JSX.Element {
   const accessibilityRole: TextAccessibilityRole = "text";
 
+  let color: TextColor = variation;
+
+  if (styleOverride?.color) {
+    color = styleOverride.color;
+  }
+
   return (
     <Typography
-      color={variation}
+      color={color}
       fontFamily="base"
       fontStyle={italic ? "italic" : "regular"}
       fontWeight={getFontWeight({ level, emphasis })}

--- a/packages/components-native/src/Text/index.ts
+++ b/packages/components-native/src/Text/index.ts
@@ -1,1 +1,6 @@
-export { Text, TextLevel, TEXT_MAX_SCALED_FONT_SIZES } from "./Text";
+export {
+  Text,
+  TextLevel,
+  TEXT_MAX_SCALED_FONT_SIZES,
+  TextStyleOverride,
+} from "./Text";

--- a/packages/components-native/src/Typography/Typography.style.ts
+++ b/packages/components-native/src/Typography/Typography.style.ts
@@ -171,6 +171,14 @@ export const typographyTokens: { [index: string]: TextStyle } = {
     color: tokens["color-yellow"],
   },
 
+  purple400: {
+    color: tokens["color-base-purple--400"],
+  },
+
+  purple600: {
+    color: tokens["color-base-purple--600"],
+  },
+
   yellowDark: {
     color: tokens["color-yellow--dark"],
   },

--- a/packages/components-native/src/Typography/Typography.tsx
+++ b/packages/components-native/src/Typography/Typography.tsx
@@ -329,6 +329,8 @@ export type TextColor =
   | "orangeDark"
   | "navyDark"
   | "limeDark"
+  | "purple400"
+  | "purple600"
   | "purpleDark"
   | "pinkDark"
   | "tealDark"


### PR DESCRIPTION

## Motivations

For Jobber Copilot, we have some unique styling needs. So I [asked in the #team-atlantis](https://getjobber.slack.com/archives/C03BJHV3PMG/p1735848962205089) channel about a good way to approach this.
Style overrides were recommended as a good intermediate solution

## Changes

### Added

- <Text styleOverrides={"color": TextColor}/>`
- <Button styleOverrides={"borderColor": CommonButtonBorderColor} />

## Testing

- Unit testing
- By installing the packages and overriding in the mobile app

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
