### PR TITLE
docs: reduce min size of contentCards in wrapper grid

### DIFF
--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -215,7 +215,7 @@ iframe {
 .contentCardWrapper {
   display: grid;
   width: 100%;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   grid-template-rows: auto;
   gap: var(--space-base);
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Early users indicated seeing slightly more results in the search box could be useful
![image](https://github.com/user-attachments/assets/4d7be4cd-0a03-4ce4-9926-3a07eaa62f04)
![image](https://github.com/user-attachments/assets/03902368-a59d-4f0f-a1df-e075408de5c5)

## Changes

### Changed

- min size of the grid items in ContentCardWrapper so search now reveals 4 cards per row at larger breakpoints
- this has minimal impact on the "Collection" page layouts but at some edge case breakpoints you can see 4 earlier than before
![image](https://github.com/user-attachments/assets/df9d85a2-bea6-44ff-8ff0-42eb3bffe9e2)

## Testing

Run docs site locally / CF

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
