### PR TITLE
fix(components-native): Add missing onPress prop type to InputPressable suffix (it's already accepted)

### DIFF
--- a/docs/components/InputPressable/Mobile.stories.tsx
+++ b/docs/components/InputPressable/Mobile.stories.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { ComponentStory } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { InputPressable } from "@jobber/components-native";
 
-export default {
+const meta: Meta<typeof InputPressable> = {
   title: "Components/Forms and Inputs/InputPressable/Mobile",
   component: InputPressable,
   parameters: {
@@ -10,7 +11,10 @@ export default {
     previewTabs: { code: { hidden: false } },
     viewport: { defaultViewport: "mobile1" },
   },
-} as ComponentMeta<typeof InputPressable>;
+};
+
+export default meta;
+type Story = StoryObj<typeof InputPressable>;
 
 const BasicTemplate: ComponentStory<typeof InputPressable> = args => (
   <InputPressable {...args} />
@@ -39,6 +43,17 @@ PrefixOrSuffix.args = {
   value: "2021-01-01",
   prefix: { icon: "calendar" },
   onPress: () => alert("📅"),
+};
+
+export const ClickableSuffix: Story = {
+  render: () => (
+    <InputPressable
+      placeholder="Placeholder"
+      value="input value"
+      onPress={() => alert("👍")}
+      suffix={{ icon: "dropdown", onPress: () => alert("👍") }}
+    />
+  ),
 };
 
 export const Disabled = BasicTemplate.bind({});

--- a/packages/components-native/src/InputPressable/InputPressable.tsx
+++ b/packages/components-native/src/InputPressable/InputPressable.tsx
@@ -64,11 +64,16 @@ export interface InputPressableProps {
   /**
    * Symbol to display after the text input
    */
-  readonly suffix?: {
-    icon?: IconNames;
-    label?: string;
-    onPress?: () => void;
-  };
+  readonly suffix?:
+    | {
+        icon?: IconNames;
+        label?: string;
+      }
+    | {
+        icon: IconNames; // Required when onPress is present
+        label?: string;
+        onPress: () => void;
+      };
   /**
    * Add a clear action on the input that clears the value.
    *

--- a/packages/components-native/src/InputPressable/InputPressable.tsx
+++ b/packages/components-native/src/InputPressable/InputPressable.tsx
@@ -3,8 +3,20 @@ import { IconNames } from "@jobber/design";
 import { FieldError } from "react-hook-form";
 import { Text as NativeText, Pressable } from "react-native";
 import { Clearable, useShowClear } from "@jobber/hooks";
+import { XOR } from "ts-xor";
 import { styles } from "./InputPressable.style";
 import { InputFieldWrapper, commonInputStyles } from "../InputFieldWrapper";
+
+interface BasicSuffix {
+  icon?: IconNames;
+  label?: string;
+}
+
+interface InteractiveSuffix {
+  icon: IconNames;
+  label?: string;
+  onPress: () => void;
+}
 
 export interface InputPressableProps {
   /**
@@ -64,16 +76,8 @@ export interface InputPressableProps {
   /**
    * Symbol to display after the text input
    */
-  readonly suffix?:
-    | {
-        icon?: IconNames;
-        label?: string;
-      }
-    | {
-        icon: IconNames; // Required when onPress is present
-        label?: string;
-        onPress: () => void;
-      };
+  readonly suffix?: XOR<BasicSuffix, InteractiveSuffix>;
+
   /**
    * Add a clear action on the input that clears the value.
    *

--- a/packages/components-native/src/InputPressable/InputPressable.tsx
+++ b/packages/components-native/src/InputPressable/InputPressable.tsx
@@ -67,6 +67,7 @@ export interface InputPressableProps {
   readonly suffix?: {
     icon?: IconNames;
     label?: string;
+    onPress?: () => void;
   };
   /**
    * Add a clear action on the input that clears the value.


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`InputPressable` uses `InputFieldWrapper` internally, which accepts a `suffix` prop. While `InputFieldWrapper`'s `suffix` accepts `icon`, `label` and `onPress`, `InputPressable` was missing `onPress` from type definitions. Passing that property still worked, but TS was throwing an error due to missing prop.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `onPress` prop as a part of `suffix` type in `InputPressable`.

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
