### PR TITLE
feat(components): Allow Gallery to take a promise source [JOB-113953]

### DIFF
--- a/docs/components/Gallery/Web.stories.tsx
+++ b/docs/components/Gallery/Web.stories.tsx
@@ -104,7 +104,8 @@ const files: GalleryFile[] = [
 function convertFileSrcToPromises(fileToConvert: GalleryFile[]) {
   return fileToConvert.map(file => ({
     ...file,
-    src: () => Promise.resolve(file.src),
+    src: () =>
+      typeof file.src === "string" ? Promise.resolve(file.src) : file.src(),
   }));
 }
 

--- a/docs/components/Gallery/Web.stories.tsx
+++ b/docs/components/Gallery/Web.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Gallery } from "@jobber/components/Gallery";
+import { Gallery, GalleryFile } from "@jobber/components/Gallery";
 
 export default {
   title: "Components/Images and Icons/Gallery/Web",
@@ -15,7 +15,7 @@ const BasicTemplate: ComponentStory<typeof Gallery> = args => (
   <Gallery {...args} />
 );
 
-const files = [
+const files: GalleryFile[] = [
   {
     key: "abc",
     name: "myballisbigandroundIamrollingitontheground.png",
@@ -101,11 +101,10 @@ const files = [
 
 // This is just a bit of a smoke test to confirm that the Gallery component still
 // functions as expected when it receives a promise for the src.
-function convertFileSrcToPromises(fileToConvert) {
+function convertFileSrcToPromises(fileToConvert: GalleryFile[]) {
   return fileToConvert.map(file => ({
     ...file,
-    src: () =>
-      Promise.resolve(typeof file.src === "string" ? file.src : file.src()),
+    src: () => Promise.resolve(file.src),
   }));
 }
 

--- a/docs/components/Gallery/Web.stories.tsx
+++ b/docs/components/Gallery/Web.stories.tsx
@@ -99,6 +99,16 @@ const files = [
   },
 ];
 
+// This is just a bit of a smoke test to confirm that the Gallery component still
+// functions as expected when it receives a promise for the src.
+function convertFileSrcToPromises(fileToConvert) {
+  return fileToConvert.map(file => ({
+    ...file,
+    src: () =>
+      Promise.resolve(typeof file.src === "string" ? file.src : file.src()),
+  }));
+}
+
 export const Basic = BasicTemplate.bind({});
 Basic.args = {
   files,
@@ -106,6 +116,6 @@ Basic.args = {
 
 export const MaxFiles = BasicTemplate.bind({});
 MaxFiles.args = {
-  files,
+  files: convertFileSrcToPromises(files),
   max: 3,
 };

--- a/packages/components/src/Gallery/Gallery.tsx
+++ b/packages/components/src/Gallery/Gallery.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import classNames from "classnames";
 import styles from "./Gallery.module.css";
-import { File, GalleryProps } from "./GalleryTypes";
+import { GalleryFile, GalleryProps } from "./GalleryTypes";
 import { LightBox } from "../LightBox";
 import { FormatFile } from "../FormatFile";
 import { Button } from "../Button";
@@ -101,11 +101,11 @@ export function Gallery({ files, size = "base", max, onDelete }: GalleryProps) {
   }
 }
 
-async function getFileSrc(file: File) {
+async function getFileSrc(file: GalleryFile) {
   return typeof file.src === "string" ? file.src : file.src();
 }
 
-function isSupportedImageType(file: File) {
+function isSupportedImageType(file: GalleryFile) {
   const userAgent =
     typeof document === "undefined" ? "" : window.navigator.userAgent;
   const nonHeicImage = !file.type.startsWith("image/heic");
@@ -114,7 +114,7 @@ function isSupportedImageType(file: File) {
   return (nonHeicImage || isSafari(userAgent)) && nonSVGImage;
 }
 
-async function generateImagesArray(files: File[]) {
+async function generateImagesArray(files: GalleryFile[]) {
   const images = [];
   const filesToImageIndex = [];
   let imageIndex = 0;

--- a/packages/components/src/Gallery/GalleryTypes.ts
+++ b/packages/components/src/Gallery/GalleryTypes.ts
@@ -18,7 +18,7 @@ export interface GalleryProps {
   /**
    * The files for the Gallery to display
    */
-  files: File[];
+  files: GalleryFile[];
 
   /**
    * The max number of thumbnails before no more thumbnails are displayed
@@ -30,10 +30,10 @@ export interface GalleryProps {
    * onDelete callback - this function will be called when the delete action is
    * triggered on a Gallery image
    */
-  onDelete?(file: File): void;
+  onDelete?(file: GalleryFile): void;
 }
 
-export interface File
+export interface GalleryFile
   extends Pick<FileUpload, "key" | "name" | "type" | "size" | "progress"> {
   /**
    * The thumbnail url of the file.

--- a/packages/components/src/Gallery/GalleryTypes.ts
+++ b/packages/components/src/Gallery/GalleryTypes.ts
@@ -43,5 +43,5 @@ export interface File
   /**
    * The data url of the file.
    */
-  readonly src: string;
+  readonly src: string | (() => Promise<string>);
 }

--- a/packages/components/src/Gallery/index.ts
+++ b/packages/components/src/Gallery/index.ts
@@ -1,1 +1,2 @@
 export { Gallery } from "./Gallery";
+export type { GalleryFile, GalleryProps } from "./GalleryTypes";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Currently our `InputFile` returns a list of `FileUpload` objects but those objects can't be plugged directly into the Gallery component. This is because Gallery expects files to be of type `File` whose src field is of type `string` instead of `FileUpload` which has a src of type `() => Promise<string>`

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

The file type that Gallery accepts now allows for a src field of either `string` or `() => Promise<string>` so users can now plug the files that come from InputFile directly into Gallery

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

The Max Files storybook example now uses files whose src value is `() => Promise<string>`. You can also test existing instances of Gallery using the pre-release version to ensure that its functionality hasn't been modified

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
