### PR TITLE
refactor(components): update menu hover state animation curve and transition state guidance

### DIFF
--- a/docs/patterns/interaction.stories.mdx
+++ b/docs/patterns/interaction.stories.mdx
@@ -50,7 +50,7 @@ An interactive element is... being interacted with.
         - a custom focus ring is applied
 
         #### Timing
-        Most state transitions use `var(--timing-base) ease-in` for a pleasant
+        Most state transitions use `var(--timing-base) ease-out` for a pleasant
         transition.
 
         #### CSS implementation
@@ -62,7 +62,7 @@ An interactive element is... being interacted with.
             .myElement {
                 background-color: var(--color-surface);
                 /* apply consistent transitions to background and box-shadow */
-                transition: all var(--timing-base) ease-in;
+                transition: all var(--timing-base) ease-out;
                 cursor: pointer;
                 /* hide the default focus ring, but still support "high contrast" modes */
                 outline: transparent;

--- a/packages/components/src/Menu/Menu.module.css
+++ b/packages/components/src/Menu/Menu.module.css
@@ -76,8 +76,8 @@
   gap: var(--menu-space);
   align-items: center;
   transition:
-    background-color var(--timing-base) ease-in,
-    box-shadow var(--timing-base) ease-in;
+    background-color var(--timing-base) ease-out,
+    box-shadow var(--timing-base) ease-out;
 }
 
 .action:hover,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Make Menu hover feel more cohesive with the rest of Atlantis

Make our interaction guide more reflective of how we build hover states

## Changes

### Changed

- Menu hover to `ease-out`
- Updated guide content

## Testing

Locally or via prerelease

Test Menu

Read the docs!

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
