### PR TITLE
build: Ignore public directory to prevent eslint from hanging

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,11 +1,13 @@
 node_modules
 dist
+.rollup.cache
 .rpt2_cache
 packages/design/colors.js
 packages/design/src/assets/**
 packages/design/src/icons/iconStyles.*
 packages/design/icons
 packages/generators/templates
+public
 storybook-static
 
 *.css.d.ts


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Eslint was hanging while parsing the `packages/site/public` directory.

Ignoring this directory solves the problem.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->


### Fixed

- Ignored `public` directories to prevent eslint from parsing them unneccesarily


## Testing

<!-- How to test your changes. -->

Try to run eslint locally, it should no longer hang!
