### PR TITLE
fix(components): Put Popover inside a portal 

### DIFF
--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -107,11 +107,7 @@ export function Popover({
     </div>
   );
 
-  return <>{open && <PopoverPortal>{popoverContent}</PopoverPortal>}</>;
-}
-
-function PopoverPortal({ children }: { children: React.ReactNode }) {
-  return ReactDOM.createPortal(children, document.body);
+  return <>{open && ReactDOM.createPortal(popoverContent, document.body)}</>;
 }
 
 function buildModifiers(arrowElement: HTMLElement | undefined | null) {

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -77,6 +77,7 @@ export function Popover({
     },
   );
   useRefocusOnActivator(open);
+
   const popoverClassNames = classnames(
     classes.popover,
     UNSAFE_className.container,

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -12,23 +12,28 @@ export interface PopoverProps {
    * and passed as an attachTo prop in order for the Popover to function properly
    */
   readonly attachTo: Element | React.RefObject<Element | null>;
+
   /**
    * Popover content.
    */
   readonly children: React.ReactNode;
+
   /**
    * Control Popover visibility.
    */
   readonly open: boolean;
+
   /**
    * Callback executed when the user wants to close/dismiss the Popover
    */
   readonly onRequestClose?: () => void;
+
   /**
    * Describes the preferred placement of the Popover.
    * @default 'auto'
    */
   readonly preferredPlacement?: "top" | "bottom" | "left" | "right" | "auto";
+
   /**
    * **Use at your own risk:** Custom class names for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
@@ -39,6 +44,7 @@ export interface PopoverProps {
     dismissButtonContainer?: string;
     arrow?: string;
   };
+
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties, useState } from "react";
 import { usePopper } from "react-popper";
 import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
 import classnames from "classnames";
+import ReactDOM from "react-dom";
 import classes from "./Popover.module.css";
 import { ButtonDismiss } from "../ButtonDismiss";
 
@@ -11,28 +12,23 @@ export interface PopoverProps {
    * and passed as an attachTo prop in order for the Popover to function properly
    */
   readonly attachTo: Element | React.RefObject<Element | null>;
-
   /**
    * Popover content.
    */
   readonly children: React.ReactNode;
-
   /**
    * Control Popover visibility.
    */
   readonly open: boolean;
-
   /**
    * Callback executed when the user wants to close/dismiss the Popover
    */
   readonly onRequestClose?: () => void;
-
   /**
    * Describes the preferred placement of the Popover.
    * @default 'auto'
    */
   readonly preferredPlacement?: "top" | "bottom" | "left" | "right" | "auto";
-
   /**
    * **Use at your own risk:** Custom class names for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
@@ -43,7 +39,6 @@ export interface PopoverProps {
     dismissButtonContainer?: string;
     arrow?: string;
   };
-
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
@@ -76,7 +71,6 @@ export function Popover({
     },
   );
   useRefocusOnActivator(open);
-
   const popoverClassNames = classnames(
     classes.popover,
     UNSAFE_className.container,
@@ -86,37 +80,38 @@ export function Popover({
     UNSAFE_className.dismissButtonContainer,
   );
   const arrowClassNames = classnames(classes.arrow, UNSAFE_className.arrow);
-
-  return (
-    <>
-      {open && (
-        <div
-          role="dialog"
-          data-elevation={"elevated"}
-          ref={setPopperElement}
-          style={{ ...popperStyles.popper, ...(UNSAFE_style.container ?? {}) }}
-          className={popoverClassNames}
-          {...attributes.popper}
-          data-testid="popover-container"
-        >
-          <div
-            className={dismissButtonClassNames}
-            style={UNSAFE_style.dismissButtonContainer ?? {}}
-            data-testid="popover-dismiss-button-container"
-          >
-            <ButtonDismiss onClick={onRequestClose} ariaLabel="Close dialog" />
-          </div>
-          {children}
-          <div
-            ref={setArrowElement}
-            className={arrowClassNames}
-            style={{ ...popperStyles.arrow, ...(UNSAFE_style.arrow ?? {}) }}
-            data-testid="popover-arrow"
-          />
-        </div>
-      )}
-    </>
+  const popoverContent = (
+    <div
+      role="dialog"
+      data-elevation={"elevated"}
+      ref={setPopperElement}
+      style={{ ...popperStyles.popper, ...(UNSAFE_style.container ?? {}) }}
+      className={popoverClassNames}
+      {...attributes.popper}
+      data-testid="popover-container"
+    >
+      <div
+        className={dismissButtonClassNames}
+        style={UNSAFE_style.dismissButtonContainer ?? {}}
+        data-testid="popover-dismiss-button-container"
+      >
+        <ButtonDismiss onClick={onRequestClose} ariaLabel="Close dialog" />
+      </div>
+      {children}
+      <div
+        ref={setArrowElement}
+        className={arrowClassNames}
+        style={{ ...popperStyles.arrow, ...(UNSAFE_style.arrow ?? {}) }}
+        data-testid="popover-arrow"
+      />
+    </div>
   );
+
+  return <>{open && <PopoverPortal>{popoverContent}</PopoverPortal>}</>;
+}
+
+function PopoverPortal({ children }: { children: React.ReactNode }) {
+  return ReactDOM.createPortal(children, document.body);
 }
 
 function buildModifiers(arrowElement: HTMLElement | undefined | null) {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

A user of Atlantis [pointed out](https://getjobber.slack.com/archives/C03BJHV3PMG/p1738701498519799) that when they use Popover inside a container that has overflow: hidden their popover is cut off. This is because the popover is not inside a portal.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
A portal wrapping Popover

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

![Screenshot 2025-02-04 at 4 57 59 PM](https://github.com/user-attachments/assets/c505a38a-270e-4c70-b453-23577634eef5)


### Security

- <!-- in case of vulnerabilities -->

## Testing

Verify that a couple of other portals are behaving as expected and have not been modified. You can grab the pre-release and test out [the endpoint](http://localhost.test:3000/business_health) where the problem was reported. Kyle said I would need a feature flag turned on to view this but I didn't end up needing to. Mentioning in case the reviewer runs into an error on that endpoint.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
