### PR TITLE
fix(components): Prevent Stretching Small Images in Lightbox

### DIFF
--- a/packages/components/src/LightBox/LightBox.module.css
+++ b/packages/components/src/LightBox/LightBox.module.css
@@ -102,7 +102,7 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: none;
 }
 
 .imageArea {

--- a/packages/components/src/LightBox/LightBox.module.css
+++ b/packages/components/src/LightBox/LightBox.module.css
@@ -102,7 +102,7 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  object-fit: none;
+  object-fit: scale-down;
 }
 
 .imageArea {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

when you view a small image with the new Lightbox changes, it gets stretched out and doesn't look excellent

rather than stretching the image, lets let it be as big as it is and then it doesn't look so bad for small images

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

we were using `object-fit: contain`

>[contain](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit#contain)
>The replaced content is scaled to maintain its [aspect ratio](https://developer.mozilla.org/en-US/docs/Glossary/Aspect_ratio) while fitting within the element's content box. The entire object is made to fill the box, while preserving its aspect ratio, so the object will be ["letterboxed"](https://en.wikipedia.org/wiki/Letterboxing_(filming)) or ["pillarboxed"](https://en.wikipedia.org/wiki/Pillarbox) if its aspect ratio does not match the aspect ratio of the box.


and instead we'll now use

>[scale-down](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit#scale-down)
>The content is sized as if none or contain were specified, whichever would result in a smaller concrete object size.

which will never stretch the image to be bigger than it is

![image](https://github.com/user-attachments/assets/7fb41f31-ac4d-49e1-9a6f-ff6f856b3510)

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
