### PR TITLE
feat(components): Checkbox v2

### DIFF
--- a/docs/components/Checkbox/Web.stories.tsx
+++ b/docs/components/Checkbox/Web.stories.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Checkbox } from "@jobber/components/Checkbox";
 import { Text } from "@jobber/components/Text";
 import { Link } from "@jobber/components/Link";
+import { Checkbox } from "@jobber/components/Checkbox";
 
 export default {
   title: "Components/Selections/Checkbox/Web",
@@ -15,8 +15,14 @@ export default {
 
 const BasicTemplate: ComponentStory<typeof Checkbox> = args => {
   const [checked, setChecked] = useState(true);
+  const myRef = useRef<HTMLInputElement>(null);
 
-  return <Checkbox {...args} checked={checked} onChange={setChecked} />;
+  console.log(args);
+
+  // return <Checkbox {...args} checked={checked} onChange={setChecked} />;
+  return (
+    <Checkbox version={2} checked={checked} onChange={setChecked} ref={myRef} />
+  );
 };
 
 export const Basic = BasicTemplate.bind({});

--- a/docs/components/Checkbox/Web.stories.tsx
+++ b/docs/components/Checkbox/Web.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Text } from "@jobber/components/Text";
 import { Link } from "@jobber/components/Link";
@@ -15,14 +15,8 @@ export default {
 
 const BasicTemplate: ComponentStory<typeof Checkbox> = args => {
   const [checked, setChecked] = useState(true);
-  const myRef = useRef<HTMLInputElement>(null);
 
-  console.log(args);
-
-  // return <Checkbox {...args} checked={checked} onChange={setChecked} />;
-  return (
-    <Checkbox version={2} checked={checked} onChange={setChecked} ref={myRef} />
-  );
+  return <Checkbox {...args} checked={checked} onChange={setChecked} />;
 };
 
 export const Basic = BasicTemplate.bind({});

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
-import { Checkbox } from "./Checkbox.rebuilt";
+import { Checkbox } from ".";
 import { Text } from "../Text";
 
 describe("Checkbox", () => {

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
@@ -93,6 +93,7 @@ describe("Checkbox", () => {
 
       fireEvent.click(getByRole("checkbox"));
       expect(handleChange).toHaveBeenCalledWith(true);
+      expect(handleChange).toHaveBeenCalledTimes(1);
     });
 
     it("calls onChange with false when checked checkbox is clicked", () => {
@@ -108,6 +109,7 @@ describe("Checkbox", () => {
 
       fireEvent.click(getByRole("checkbox"));
       expect(handleChange).toHaveBeenCalledWith(false);
+      expect(handleChange).toHaveBeenCalledTimes(1);
     });
 
     it("calls onFocus when checkbox receives focus", () => {

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
@@ -25,7 +25,15 @@ describe("Checkbox", () => {
     expect(checkbox).toBeDisabled();
   });
 
-  it("renders a description when provided", () => {
+  it("renders a description when provided string", () => {
+    const { getByText } = render(
+      <Checkbox version={2} label="Label" description="Additional info" />,
+    );
+    const description = getByText("Additional info");
+    expect(description).toBeInTheDocument();
+  });
+
+  it("renders a description when provided markup", () => {
     const { getByText } = render(
       <Checkbox version={2} label="Label" description="Additional info" />,
     );
@@ -39,11 +47,9 @@ describe("Checkbox", () => {
       expect(getByText("Click me")).toBeInTheDocument();
     });
 
-    it("renders with children as label", () => {
+    it("renders with markup as label", () => {
       const { getByText } = render(
-        <Checkbox version={2}>
-          <Text>Custom label content</Text>
-        </Checkbox>,
+        <Checkbox version={2} label={<Text>Custom label content</Text>} />,
       );
       expect(getByText("Custom label content")).toBeInTheDocument();
     });

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
@@ -119,5 +119,15 @@ describe("Checkbox", () => {
       fireEvent.focus(getByRole("checkbox"));
       expect(handleFocus).toHaveBeenCalled();
     });
+
+    it("calls onBlur when checkbox loses focus", () => {
+      const handleBlur = jest.fn();
+      const { getByRole } = render(
+        <Checkbox version={2} label="Blur me" onBlur={handleBlur} />,
+      );
+
+      fireEvent.blur(getByRole("checkbox"));
+      expect(handleBlur).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { Checkbox } from "./Checkbox.rebuilt";
+import { Text } from "../Text";
+
+describe("Checkbox", () => {
+  it("renders a basic checkbox", () => {
+    const { getByRole } = render(
+      <Checkbox
+        version={2}
+        label="Send me spam?"
+        name="send_me_spam"
+        value="spam"
+      />,
+    );
+    const checkbox = getByRole("checkbox");
+    expect(checkbox).toBeInTheDocument();
+  });
+
+  it("renders a disabled checkbox", () => {
+    const { getByRole } = render(
+      <Checkbox version={2} label="Dont click me" disabled={true} />,
+    );
+    const checkbox = getByRole("checkbox");
+    expect(checkbox).toBeDisabled();
+  });
+
+  it("renders a description when provided", () => {
+    const { getByText } = render(
+      <Checkbox version={2} label="Label" description="Additional info" />,
+    );
+    const description = getByText("Additional info");
+    expect(description).toBeInTheDocument();
+  });
+
+  describe("Label rendering", () => {
+    it("renders with string label", () => {
+      const { getByText } = render(<Checkbox version={2} label="Click me" />);
+      expect(getByText("Click me")).toBeInTheDocument();
+    });
+
+    it("renders with children as label", () => {
+      const { getByText } = render(
+        <Checkbox version={2}>
+          <Text>Custom label content</Text>
+        </Checkbox>,
+      );
+      expect(getByText("Custom label content")).toBeInTheDocument();
+    });
+  });
+
+  describe("Checkbox states", () => {
+    it("handles indeterminate state", () => {
+      const { getByTestId } = render(
+        <Checkbox version={2} label="Parent" indeterminate={true} />,
+      );
+      expect(getByTestId("minus2")).toBeInTheDocument();
+    });
+
+    it("shows checkmark when checked", () => {
+      const { getByTestId } = render(
+        <Checkbox version={2} label="Option" checked={true} />,
+      );
+      expect(getByTestId("checkmark")).toBeInTheDocument();
+    });
+
+    it("respects defaultChecked prop", () => {
+      const { getByRole } = render(
+        <Checkbox version={2} label="Default On" defaultChecked={true} />,
+      );
+      const checkbox = getByRole("checkbox");
+      expect(checkbox).toHaveProperty("defaultChecked", true);
+    });
+  });
+
+  describe("Event handling", () => {
+    it("calls onChange with true when unchecked checkbox is clicked", () => {
+      const handleChange = jest.fn();
+      const { getByRole } = render(
+        <Checkbox
+          version={2}
+          label="Click me"
+          checked={false}
+          onChange={handleChange}
+        />,
+      );
+
+      fireEvent.click(getByRole("checkbox"));
+      expect(handleChange).toHaveBeenCalledWith(true);
+    });
+
+    it("calls onChange with false when checked checkbox is clicked", () => {
+      const handleChange = jest.fn();
+      const { getByRole } = render(
+        <Checkbox
+          version={2}
+          label="Click me"
+          checked={true}
+          onChange={handleChange}
+        />,
+      );
+
+      fireEvent.click(getByRole("checkbox"));
+      expect(handleChange).toHaveBeenCalledWith(false);
+    });
+
+    it("calls onFocus when checkbox receives focus", () => {
+      const handleFocus = jest.fn();
+      const { getByRole } = render(
+        <Checkbox version={2} label="Focus me" onFocus={handleFocus} />,
+      );
+
+      fireEvent.focus(getByRole("checkbox"));
+      expect(handleFocus).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.test.tsx
@@ -92,7 +92,7 @@ describe("Checkbox", () => {
       );
 
       fireEvent.click(getByRole("checkbox"));
-      expect(handleChange).toHaveBeenCalledWith(true);
+      expect(handleChange).toHaveBeenCalledWith(true, expect.any(Object));
       expect(handleChange).toHaveBeenCalledTimes(1);
     });
 
@@ -108,7 +108,7 @@ describe("Checkbox", () => {
       );
 
       fireEvent.click(getByRole("checkbox"));
-      expect(handleChange).toHaveBeenCalledWith(false);
+      expect(handleChange).toHaveBeenCalledWith(false, expect.any(Object));
       expect(handleChange).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -66,7 +66,6 @@ export function CheckboxRebuilt({
             value={value}
             defaultChecked={defaultChecked}
             disabled={disabled}
-            aria-checked={indeterminate ? "mixed" : effectiveChecked}
             onChange={handleChange}
             onFocus={onFocus}
             onBlur={onBlur}

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -14,7 +14,6 @@ export function CheckboxRebuilt({
   value,
   indeterminate = false,
   description,
-  children,
   id,
   onBlur,
   onChange,
@@ -28,7 +27,15 @@ export function CheckboxRebuilt({
     [styles.indeterminate]: indeterminate,
   });
   const iconName = indeterminate ? "minus2" : "checkmark";
-  const labelText = label ? <Text>{label}</Text> : children;
+  const labelText = typeof label === "string" ? <Text>{label}</Text> : label;
+  const descriptionText =
+    typeof description === "string" ? (
+      <Text size="small" variation="subdued">
+        {description}
+      </Text>
+    ) : (
+      description
+    );
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const newChecked = event.currentTarget.checked;
@@ -48,7 +55,7 @@ export function CheckboxRebuilt({
             defaultChecked={defaultChecked}
             value={value}
             disabled={disabled}
-            aria-label={label}
+            aria-checked={checked}
             onChange={handleChange}
             onFocus={onFocus}
             onBlur={onBlur}
@@ -61,11 +68,7 @@ export function CheckboxRebuilt({
         {labelText && <span className={styles.label}>{labelText}</span>}
       </label>
       {description && (
-        <div className={styles.description}>
-          <Text variation="subdued" size="small">
-            {description}
-          </Text>
-        </div>
+        <div className={styles.description}>{descriptionText}</div>
       )}
     </div>
   );

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from "react";
+import React, { ChangeEvent } from "react";
 import classnames from "classnames";
 import styles from "./Checkbox.module.css";
 import { CheckboxRebuiltProps } from "./Checkbox.types";
@@ -19,12 +19,6 @@ export function CheckboxRebuilt({
   onChange,
   onFocus,
 }: CheckboxRebuiltProps) {
-  const [internalChecked, setInternalChecked] = useState(
-    defaultChecked ?? false,
-  );
-  const isControlled = checked !== undefined;
-  const effectiveChecked = isControlled ? checked : internalChecked;
-
   const wrapperClassName = classnames(
     styles.wrapper,
     disabled && styles.disabled,
@@ -47,9 +41,6 @@ export function CheckboxRebuilt({
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const newChecked = event.currentTarget.checked;
 
-    if (!isControlled) {
-      setInternalChecked(newChecked);
-    }
     onChange?.(newChecked);
   }
 
@@ -62,7 +53,7 @@ export function CheckboxRebuilt({
             id={id}
             className={inputClassName}
             name={name}
-            checked={effectiveChecked}
+            checked={checked}
             value={value}
             defaultChecked={defaultChecked}
             disabled={disabled}

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -1,28 +1,25 @@
-import React, { ChangeEvent, ForwardedRef, forwardRef } from "react";
+import React, { ChangeEvent } from "react";
 import classnames from "classnames";
 import styles from "./Checkbox.module.css";
 import { CheckboxRebuiltProps } from "./Checkbox.types";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
 
-export const Checkbox = forwardRef(function CheckboxRebuilt(
-  {
-    checked,
-    defaultChecked,
-    disabled,
-    label,
-    name,
-    value,
-    indeterminate = false,
-    description,
-    children,
-    id,
-    onBlur,
-    onChange,
-    onFocus,
-  }: CheckboxRebuiltProps,
-  ref: ForwardedRef<HTMLInputElement>,
-) {
+export function CheckboxRebuilt({
+  checked,
+  defaultChecked,
+  disabled,
+  label,
+  name,
+  value,
+  indeterminate = false,
+  description,
+  children,
+  id,
+  onBlur,
+  onChange,
+  onFocus,
+}: CheckboxRebuiltProps) {
   const wrapperClassName = classnames(
     styles.wrapper,
     disabled && styles.disabled,
@@ -43,7 +40,6 @@ export const Checkbox = forwardRef(function CheckboxRebuilt(
       <label className={wrapperClassName}>
         <span className={styles.checkHolder}>
           <input
-            ref={ref}
             type="checkbox"
             id={id}
             className={inputClassName}
@@ -73,4 +69,4 @@ export const Checkbox = forwardRef(function CheckboxRebuilt(
       )}
     </div>
   );
-});
+}

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -1,0 +1,150 @@
+import React, {
+  ChangeEvent,
+  ForwardedRef,
+  ReactElement,
+  forwardRef,
+} from "react";
+import classnames from "classnames";
+import { XOR } from "ts-xor";
+import styles from "./Checkbox.module.css";
+import { Icon } from "../Icon";
+import { Text } from "../Text";
+
+interface BaseCheckboxProps {
+  /**
+   * Determines if the checkbox is checked or not.
+   */
+  readonly checked?: boolean;
+
+  /**
+   * Initial checked value of the checkbox. Only use this when you need to
+   * pre-populate the checked attribute that is not controlled by the component's
+   * state. If a state is controlling it, use the `checked` prop instead.
+   */
+  readonly defaultChecked?: boolean;
+
+  /**
+   * Disables the checkbox.
+   */
+  readonly disabled?: boolean;
+
+  /**
+   * When `true` the checkbox to appears in indeterminate.
+   *
+   * @default false
+   */
+  readonly indeterminate?: boolean;
+
+  /**
+   * Checkbox input name
+   */
+  readonly name?: string;
+
+  /**
+   * Value of the checkbox.
+   */
+  readonly value?: string;
+
+  /**
+   * Further description of the label
+   */
+  readonly description?: string;
+
+  /**
+   * ID for the checkbox input
+   */
+  readonly id?: string;
+
+  readonly version: 2;
+
+  onChange?(newValue: boolean): void;
+
+  onFocus?(): void;
+}
+
+interface CheckboxLabelProps extends BaseCheckboxProps {
+  /**
+   * Label that shows up beside the checkbox.
+   */
+  readonly label?: string;
+}
+
+interface CheckboxChildrenProps extends BaseCheckboxProps {
+  /**
+   * Component children, which shows up as a label
+   */
+  readonly children?: ReactElement;
+}
+
+export type CheckboxRebuiltProps = XOR<
+  CheckboxLabelProps,
+  CheckboxChildrenProps
+>;
+
+export const Checkbox = forwardRef(function CheckboxRebuilt(
+  {
+    checked,
+    defaultChecked,
+    disabled,
+    label,
+    name,
+    value,
+    indeterminate = false,
+    description,
+    children,
+    id,
+    onChange,
+    onFocus,
+  }: CheckboxRebuiltProps,
+  ref: ForwardedRef<HTMLInputElement>,
+) {
+  const wrapperClassName = classnames(
+    styles.wrapper,
+    disabled && styles.disabled,
+  );
+  const inputClassName = classnames(styles.input, {
+    [styles.indeterminate]: indeterminate,
+  });
+  const iconName = indeterminate ? "minus2" : "checkmark";
+  const labelText = label ? <Text>{label}</Text> : children;
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    const newChecked = event.currentTarget.checked;
+    onChange?.(newChecked);
+  }
+
+  return (
+    <div className={styles.checkBoxParent}>
+      <label className={wrapperClassName}>
+        <span className={styles.checkHolder}>
+          <input
+            ref={ref}
+            type="checkbox"
+            id={id}
+            className={inputClassName}
+            name={name}
+            checked={checked}
+            defaultChecked={defaultChecked}
+            value={value}
+            disabled={disabled}
+            aria-label={label}
+            onChange={handleChange}
+            onFocus={onFocus}
+          />
+          <span className={styles.checkBox}>
+            <Icon name={iconName} color="surface" />
+          </span>
+        </span>
+
+        {labelText && <span className={styles.label}>{labelText}</span>}
+      </label>
+      {description && (
+        <div className={styles.description}>
+          <Text variation="subdued" size="small">
+            {description}
+          </Text>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import classnames from "classnames";
 import styles from "./Checkbox.module.css";
 import { CheckboxRebuiltProps } from "./Checkbox.types";
@@ -19,6 +19,18 @@ export function CheckboxRebuilt({
   onChange,
   onFocus,
 }: CheckboxRebuiltProps) {
+  const [internalChecked, setInternalChecked] = useState(
+    defaultChecked ?? false,
+  );
+  const isControlled = checked !== undefined;
+  const effectiveChecked = isControlled ? checked : internalChecked;
+
+  useEffect(() => {
+    if (defaultChecked !== undefined) {
+      setInternalChecked(defaultChecked);
+    }
+  }, [defaultChecked]);
+
   const wrapperClassName = classnames(
     styles.wrapper,
     disabled && styles.disabled,
@@ -39,6 +51,10 @@ export function CheckboxRebuilt({
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const newChecked = event.currentTarget.checked;
+
+    if (!isControlled) {
+      setInternalChecked(newChecked);
+    }
     onChange?.(newChecked);
   }
 
@@ -51,11 +67,10 @@ export function CheckboxRebuilt({
             id={id}
             className={inputClassName}
             name={name}
-            checked={checked}
-            defaultChecked={defaultChecked}
+            checked={effectiveChecked}
             value={value}
             disabled={disabled}
-            aria-checked={checked}
+            aria-checked={indeterminate ? "mixed" : effectiveChecked}
             onChange={handleChange}
             onFocus={onFocus}
             onBlur={onBlur}

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -17,6 +17,7 @@ export const Checkbox = forwardRef(function CheckboxRebuilt(
     description,
     children,
     id,
+    onBlur,
     onChange,
     onFocus,
   }: CheckboxRebuiltProps,
@@ -54,6 +55,7 @@ export const Checkbox = forwardRef(function CheckboxRebuilt(
             aria-label={label}
             onChange={handleChange}
             onFocus={onFocus}
+            onBlur={onBlur}
           />
           <span className={styles.checkBox}>
             <Icon name={iconName} color="surface" />

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -60,6 +60,8 @@ interface BaseCheckboxProps {
   onChange?(newValue: boolean): void;
 
   onFocus?(): void;
+
+  onBlur?(): void;
 }
 
 interface CheckboxLabelProps extends BaseCheckboxProps {

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -39,8 +39,8 @@ export function CheckboxRebuilt({
     [styles.indeterminate]: indeterminate,
   });
   const iconName = indeterminate ? "minus2" : "checkmark";
-  const labelText = typeof label === "string" ? <Text>{label}</Text> : label;
-  const descriptionText =
+  const labelContent = typeof label === "string" ? <Text>{label}</Text> : label;
+  const descriptionContent =
     typeof description === "string" ? (
       <Text size="small" variation="subdued">
         {description}
@@ -80,10 +80,10 @@ export function CheckboxRebuilt({
           </span>
         </span>
 
-        {labelText && <span className={styles.label}>{labelText}</span>}
+        {labelContent && <span className={styles.label}>{labelContent}</span>}
       </label>
       {description && (
-        <div className={styles.description}>{descriptionText}</div>
+        <div className={styles.description}>{descriptionContent}</div>
       )}
     </div>
   );

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useEffect, useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import classnames from "classnames";
 import styles from "./Checkbox.module.css";
 import { CheckboxRebuiltProps } from "./Checkbox.types";
@@ -44,12 +44,6 @@ export function CheckboxRebuilt({
       description
     );
 
-  useEffect(() => {
-    if (defaultChecked !== undefined && !isControlled) {
-      setInternalChecked(defaultChecked);
-    }
-  }, [defaultChecked, isControlled]);
-
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const newChecked = event.currentTarget.checked;
 
@@ -70,6 +64,7 @@ export function CheckboxRebuilt({
             name={name}
             checked={effectiveChecked}
             value={value}
+            defaultChecked={defaultChecked}
             disabled={disabled}
             aria-checked={indeterminate ? "mixed" : effectiveChecked}
             onChange={handleChange}

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -40,8 +40,7 @@ export function CheckboxRebuilt({
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const newChecked = event.currentTarget.checked;
-
-    onChange?.(newChecked);
+    onChange?.(newChecked, event);
   }
 
   return (

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -25,12 +25,6 @@ export function CheckboxRebuilt({
   const isControlled = checked !== undefined;
   const effectiveChecked = isControlled ? checked : internalChecked;
 
-  useEffect(() => {
-    if (defaultChecked !== undefined) {
-      setInternalChecked(defaultChecked);
-    }
-  }, [defaultChecked]);
-
   const wrapperClassName = classnames(
     styles.wrapper,
     disabled && styles.disabled,
@@ -38,6 +32,7 @@ export function CheckboxRebuilt({
   const inputClassName = classnames(styles.input, {
     [styles.indeterminate]: indeterminate,
   });
+
   const iconName = indeterminate ? "minus2" : "checkmark";
   const labelContent = typeof label === "string" ? <Text>{label}</Text> : label;
   const descriptionContent =
@@ -48,6 +43,12 @@ export function CheckboxRebuilt({
     ) : (
       description
     );
+
+  useEffect(() => {
+    if (defaultChecked !== undefined && !isControlled) {
+      setInternalChecked(defaultChecked);
+    }
+  }, [defaultChecked, isControlled]);
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const newChecked = event.currentTarget.checked;

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -1,87 +1,9 @@
-import React, {
-  ChangeEvent,
-  ForwardedRef,
-  ReactElement,
-  forwardRef,
-} from "react";
+import React, { ChangeEvent, ForwardedRef, forwardRef } from "react";
 import classnames from "classnames";
-import { XOR } from "ts-xor";
 import styles from "./Checkbox.module.css";
+import { CheckboxRebuiltProps } from "./Checkbox.types";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
-
-interface BaseCheckboxProps {
-  /**
-   * Determines if the checkbox is checked or not.
-   */
-  readonly checked?: boolean;
-
-  /**
-   * Initial checked value of the checkbox. Only use this when you need to
-   * pre-populate the checked attribute that is not controlled by the component's
-   * state. If a state is controlling it, use the `checked` prop instead.
-   */
-  readonly defaultChecked?: boolean;
-
-  /**
-   * Disables the checkbox.
-   */
-  readonly disabled?: boolean;
-
-  /**
-   * When `true` the checkbox to appears in indeterminate.
-   *
-   * @default false
-   */
-  readonly indeterminate?: boolean;
-
-  /**
-   * Checkbox input name
-   */
-  readonly name?: string;
-
-  /**
-   * Value of the checkbox.
-   */
-  readonly value?: string;
-
-  /**
-   * Further description of the label
-   */
-  readonly description?: string;
-
-  /**
-   * ID for the checkbox input
-   */
-  readonly id?: string;
-
-  readonly version: 2;
-
-  onChange?(newValue: boolean): void;
-
-  onFocus?(): void;
-
-  onBlur?(): void;
-}
-
-interface CheckboxLabelProps extends BaseCheckboxProps {
-  /**
-   * Label that shows up beside the checkbox.
-   */
-  readonly label?: string;
-}
-
-interface CheckboxChildrenProps extends BaseCheckboxProps {
-  /**
-   * Component children, which shows up as a label
-   */
-  readonly children?: ReactElement;
-}
-
-export type CheckboxRebuiltProps = XOR<
-  CheckboxLabelProps,
-  CheckboxChildrenProps
->;
 
 export const Checkbox = forwardRef(function CheckboxRebuilt(
   {

--- a/packages/components/src/Checkbox/Checkbox.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.test.tsx
@@ -89,3 +89,49 @@ describe("Clicking the checkbox it should call the handler", () => {
     expect(clickHandler).toHaveBeenCalledWith(false);
   });
 });
+
+describe("Checkbox", () => {
+  describe("focus handling", () => {
+    it("calls onFocus when the checkbox receives focus", () => {
+      const onFocus = jest.fn();
+      const { getByRole } = render(
+        <Checkbox version={2} label="Test" onFocus={onFocus} />,
+      );
+
+      const checkbox = getByRole("checkbox");
+      checkbox.focus();
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onBlur when the checkbox loses focus", () => {
+      const onBlur = jest.fn();
+      const { getByRole } = render(
+        <Checkbox version={2} label="Test" onBlur={onBlur} />,
+      );
+
+      const checkbox = getByRole("checkbox");
+      checkbox.focus();
+      checkbox.blur();
+
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles both focus and blur events", () => {
+      const onFocus = jest.fn();
+      const onBlur = jest.fn();
+      const { getByRole } = render(
+        <Checkbox version={2} label="Test" onFocus={onFocus} onBlur={onBlur} />,
+      );
+
+      const checkbox = getByRole("checkbox");
+      checkbox.focus();
+      expect(onFocus).toHaveBeenCalledTimes(1);
+      expect(onBlur).not.toHaveBeenCalled();
+
+      checkbox.blur();
+      expect(onFocus).toHaveBeenCalledTimes(1);
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -1,81 +1,10 @@
-import React, {
-  ChangeEvent,
-  ReactElement,
-  useEffect,
-  useId,
-  useState,
-} from "react";
+import React, { ChangeEvent, useEffect, useId, useState } from "react";
 import classnames from "classnames";
-import { XOR } from "ts-xor";
 import { Controller, useForm, useFormContext } from "react-hook-form";
 import styles from "./Checkbox.module.css";
+import { CheckboxProps } from "./Checkbox.types";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
-
-interface BaseCheckboxProps {
-  /**
-   * Determines if the checkbox is checked or not.
-   */
-  readonly checked?: boolean;
-
-  /**
-   * Initial checked value of the checkbox. Only use this when you need to
-   * pre-populate the checked attribute that is not controlled by the component's
-   * state. If a state is controlling it, use the `checked` prop instead.
-   */
-  readonly defaultChecked?: boolean;
-
-  /**
-   * Disables the checkbox.
-   */
-  readonly disabled?: boolean;
-
-  /**
-   * When `true` the checkbox to appears in indeterminate.
-   *
-   * @default false
-   */
-  readonly indeterminate?: boolean;
-
-  /**
-   * Checkbox input name
-   */
-  readonly name?: string;
-
-  /**
-   * Value of the checkbox.
-   */
-  readonly value?: string;
-
-  /**
-   * Further description of the label
-   */
-  readonly description?: string;
-
-  readonly version?: 1;
-
-  onChange?(newValue: boolean): void;
-
-  onFocus?(): void;
-
-  onBlur?(): void;
-}
-
-interface CheckboxLabelProps extends BaseCheckboxProps {
-  /**
-   * Label that shows up beside the checkbox.
-   */
-  readonly label?: string;
-}
-
-interface CheckboxChildrenProps extends BaseCheckboxProps {
-  /**
-   * Component children, which shows up as a label
-   */
-  readonly children?: ReactElement;
-}
-
-export type CheckboxProps = XOR<CheckboxLabelProps, CheckboxChildrenProps>;
 
 export function Checkbox({
   checked,

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, useEffect, useId, useState } from "react";
 import classnames from "classnames";
 import { Controller, useForm, useFormContext } from "react-hook-form";
 import styles from "./Checkbox.module.css";
-import { CheckboxProps } from "./Checkbox.types";
+import { CheckboxLegacyProps } from "./Checkbox.types";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
 
@@ -19,7 +19,7 @@ export function CheckboxLegacy({
   onBlur,
   onChange,
   onFocus,
-}: CheckboxProps) {
+}: CheckboxLegacyProps) {
   const { control, setValue, watch } =
     useFormContext() != undefined
       ? useFormContext()

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -16,6 +16,7 @@ export function Checkbox({
   indeterminate = false,
   description,
   children,
+  onBlur,
   onChange,
   onFocus,
 }: CheckboxProps) {
@@ -81,6 +82,7 @@ export function Checkbox({
                   aria-label={label}
                   onChange={handleChange}
                   onFocus={onFocus}
+                  onBlur={onBlur}
                 />
                 <span className={styles.checkBox}>
                   <Icon name={iconName} color="surface" />

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -52,9 +52,13 @@ interface BaseCheckboxProps {
    */
   readonly description?: string;
 
+  readonly version?: 1;
+
   onChange?(newValue: boolean): void;
 
   onFocus?(): void;
+
+  onBlur?(): void;
 }
 
 interface CheckboxLabelProps extends BaseCheckboxProps {
@@ -71,7 +75,7 @@ interface CheckboxChildrenProps extends BaseCheckboxProps {
   readonly children?: ReactElement;
 }
 
-type CheckboxProps = XOR<CheckboxLabelProps, CheckboxChildrenProps>;
+export type CheckboxProps = XOR<CheckboxLabelProps, CheckboxChildrenProps>;
 
 export function Checkbox({
   checked,

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import { CheckboxProps } from "./Checkbox.types";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
 
-export function Checkbox({
+export function CheckboxLegacy({
   checked,
   defaultChecked,
   disabled,

--- a/packages/components/src/Checkbox/Checkbox.types.ts
+++ b/packages/components/src/Checkbox/Checkbox.types.ts
@@ -1,0 +1,79 @@
+import { ReactElement } from "react";
+import { XOR } from "ts-xor";
+
+export interface BaseCheckboxProps {
+  /**
+   * Determines if the checkbox is checked or not.
+   */
+  readonly checked?: boolean;
+
+  /**
+   * Initial checked value of the checkbox. Only use this when you need to
+   * pre-populate the checked attribute that is not controlled by the component's
+   * state. If a state is controlling it, use the `checked` prop instead.
+   */
+  readonly defaultChecked?: boolean;
+
+  /**
+   * Disables the checkbox.
+   */
+  readonly disabled?: boolean;
+
+  /**
+   * When `true` the checkbox to appears in indeterminate.
+   *
+   * @default false
+   */
+  readonly indeterminate?: boolean;
+
+  /**
+   * Checkbox input name
+   */
+  readonly name?: string;
+
+  /**
+   * Value of the checkbox.
+   */
+  readonly value?: string;
+
+  /**
+   * Further description of the label
+   */
+  readonly description?: string;
+
+  /**
+   * ID for the checkbox input
+   */
+  readonly id?: string;
+
+  onChange?(newValue: boolean): void;
+
+  onFocus?(): void;
+
+  onBlur?(): void;
+}
+
+interface CheckboxLabelProps extends BaseCheckboxProps {
+  /**
+   * Label that shows up beside the checkbox.
+   */
+  readonly label?: string;
+}
+
+interface CheckboxChildrenProps extends BaseCheckboxProps {
+  /**
+   * Component children, which shows up as a label
+   */
+  readonly children?: ReactElement;
+}
+
+export type CheckboxRebuiltProps = XOR<
+  CheckboxLabelProps,
+  CheckboxChildrenProps
+> & {
+  version: 2;
+};
+
+export type CheckboxProps = XOR<CheckboxLabelProps, CheckboxChildrenProps> & {
+  version?: 1;
+};

--- a/packages/components/src/Checkbox/Checkbox.types.ts
+++ b/packages/components/src/Checkbox/Checkbox.types.ts
@@ -46,10 +46,19 @@ export interface BaseCheckboxProps {
    */
   readonly id?: string;
 
+  /**
+   * Called when the checkbox value changes
+   */
   onChange?(newValue: boolean): void;
 
+  /**
+   * Called when the checkbox is focused
+   */
   onFocus?(): void;
 
+  /**
+   * Called when the checkbox loses focus
+   */
   onBlur?(): void;
 }
 
@@ -71,8 +80,23 @@ export type CheckboxRebuiltProps = Omit<
   BaseCheckboxProps,
   "label" | "description" | "children"
 > & {
+  /**
+   * Label that shows up beside the checkbox.
+   * String will be rendered with the default markup.
+   * ReactElement will be rendered with provided positionining.
+   */
   label?: string | ReactElement;
+
+  /**
+   * Additional description of the checkbox.
+   * String will be rendered with the default markup.
+   * ReactElement will be rendered with provided positioning.
+   */
   description?: string | ReactElement;
+
+  /**
+   * Version 2 is highly experimental, avoid using it unless you have talked with Atlantis first.
+   */
   version: 2;
 };
 

--- a/packages/components/src/Checkbox/Checkbox.types.ts
+++ b/packages/components/src/Checkbox/Checkbox.types.ts
@@ -78,7 +78,7 @@ interface CheckboxChildrenProps extends BaseCheckboxProps {
 
 export type CheckboxRebuiltProps = Omit<
   BaseCheckboxProps,
-  "label" | "description" | "children"
+  "label" | "description" | "children" | "onChange"
 > & {
   /**
    * Label that shows up beside the checkbox.
@@ -93,6 +93,15 @@ export type CheckboxRebuiltProps = Omit<
    * ReactElement will be rendered with provided positioning.
    */
   description?: string | ReactElement;
+
+  /**
+   * Called when the checkbox value changes.
+   * Includes the change event as a second argument.
+   */
+  onChange?(
+    newValue: boolean,
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void;
 
   /**
    * Version 2 is highly experimental, avoid using it unless you have talked with Atlantis first.

--- a/packages/components/src/Checkbox/Checkbox.types.ts
+++ b/packages/components/src/Checkbox/Checkbox.types.ts
@@ -100,6 +100,9 @@ export type CheckboxRebuiltProps = Omit<
   version: 2;
 };
 
-export type CheckboxProps = XOR<CheckboxLabelProps, CheckboxChildrenProps> & {
+export type CheckboxLegacyProps = XOR<
+  CheckboxLabelProps,
+  CheckboxChildrenProps
+> & {
   version?: 1;
 };

--- a/packages/components/src/Checkbox/Checkbox.types.ts
+++ b/packages/components/src/Checkbox/Checkbox.types.ts
@@ -67,10 +67,12 @@ interface CheckboxChildrenProps extends BaseCheckboxProps {
   readonly children?: ReactElement;
 }
 
-export type CheckboxRebuiltProps = XOR<
-  CheckboxLabelProps,
-  CheckboxChildrenProps
+export type CheckboxRebuiltProps = Omit<
+  BaseCheckboxProps,
+  "label" | "description" | "children"
 > & {
+  label?: string | ReactElement;
+  description?: string | ReactElement;
   version: 2;
 };
 

--- a/packages/components/src/Checkbox/Checkbox.types.ts
+++ b/packages/components/src/Checkbox/Checkbox.types.ts
@@ -54,12 +54,12 @@ export interface BaseCheckboxProps {
   /**
    * Called when the checkbox is focused
    */
-  onFocus?(): void;
+  onFocus?(event: React.FocusEvent<HTMLInputElement>): void;
 
   /**
    * Called when the checkbox loses focus
    */
-  onBlur?(): void;
+  onBlur?(event: React.FocusEvent<HTMLInputElement>): void;
 }
 
 interface CheckboxLabelProps extends BaseCheckboxProps {

--- a/packages/components/src/Checkbox/index.ts
+++ b/packages/components/src/Checkbox/index.ts
@@ -1,1 +1,0 @@
-export { Checkbox } from "./Checkbox";

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -1,9 +1,9 @@
-import React, { ForwardedRef, forwardRef } from "react";
+import React from "react";
 import { Checkbox as CheckboxLegacy } from "./Checkbox";
 import { Checkbox as CheckboxRebuilt } from "./Checkbox.rebuilt";
 import { CheckboxProps, CheckboxRebuiltProps } from "./Checkbox.types";
 
-export type CheckboxShimProps = CheckboxProps | CheckboxRebuiltProps;
+type CheckboxShimProps = CheckboxProps | CheckboxRebuiltProps;
 
 function isNewCheckboxProps(
   props: CheckboxShimProps,
@@ -11,15 +11,12 @@ function isNewCheckboxProps(
   return props.version === 2;
 }
 
-export const Checkbox = forwardRef(function CheckboxShim(
-  props: CheckboxShimProps,
-  ref: ForwardedRef<HTMLInputElement>,
-) {
+export function Checkbox(props: CheckboxShimProps) {
   if (isNewCheckboxProps(props)) {
-    return <CheckboxRebuilt {...props} ref={ref} />;
+    return <CheckboxRebuilt {...props} />;
   }
 
   return <CheckboxLegacy {...props} />;
-});
+}
 
 export type { CheckboxProps, CheckboxRebuiltProps };

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CheckboxLegacy } from "./Checkbox";
 import { CheckboxRebuilt } from "./Checkbox.rebuilt";
-import { CheckboxProps, CheckboxRebuiltProps } from "./Checkbox.types";
+import { CheckboxLegacyProps, CheckboxRebuiltProps } from "./Checkbox.types";
 
-type CheckboxShimProps = CheckboxProps | CheckboxRebuiltProps;
+type CheckboxShimProps = CheckboxLegacyProps | CheckboxRebuiltProps;
 
 function isNewCheckboxProps(
   props: CheckboxShimProps,
@@ -19,4 +19,4 @@ export function Checkbox(props: CheckboxShimProps) {
   return <CheckboxLegacy {...props} />;
 }
 
-export type { CheckboxProps, CheckboxRebuiltProps };
+export type { CheckboxLegacyProps, CheckboxRebuiltProps };

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -1,9 +1,7 @@
 import React, { ForwardedRef, forwardRef } from "react";
-import { Checkbox as CheckboxLegacy, CheckboxProps } from "./Checkbox";
-import {
-  Checkbox as CheckboxRebuilt,
-  CheckboxRebuiltProps,
-} from "./Checkbox.rebuilt";
+import { Checkbox as CheckboxLegacy } from "./Checkbox";
+import { Checkbox as CheckboxRebuilt } from "./Checkbox.rebuilt";
+import { CheckboxProps, CheckboxRebuiltProps } from "./Checkbox.types";
 
 export type CheckboxShimProps = CheckboxProps | CheckboxRebuiltProps;
 

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -1,0 +1,27 @@
+import React, { ForwardedRef, forwardRef } from "react";
+import { Checkbox as CheckboxLegacy, CheckboxProps } from "./Checkbox";
+import {
+  Checkbox as CheckboxRebuilt,
+  CheckboxRebuiltProps,
+} from "./Checkbox.rebuilt";
+
+export type CheckboxShimProps = CheckboxProps | CheckboxRebuiltProps;
+
+function isNewCheckboxProps(
+  props: CheckboxShimProps,
+): props is CheckboxRebuiltProps {
+  return props.version === 2;
+}
+
+export const Checkbox = forwardRef(function CheckboxShim(
+  props: CheckboxShimProps,
+  ref: ForwardedRef<HTMLInputElement>,
+) {
+  if (isNewCheckboxProps(props)) {
+    return <CheckboxRebuilt {...props} ref={ref} />;
+  }
+
+  return <CheckboxLegacy {...props} />;
+});
+
+export type { CheckboxProps, CheckboxRebuiltProps };

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Checkbox as CheckboxLegacy } from "./Checkbox";
-import { Checkbox as CheckboxRebuilt } from "./Checkbox.rebuilt";
+import { CheckboxLegacy } from "./Checkbox";
+import { CheckboxRebuilt } from "./Checkbox.rebuilt";
 import { CheckboxProps, CheckboxRebuiltProps } from "./Checkbox.types";
 
 type CheckboxShimProps = CheckboxProps | CheckboxRebuiltProps;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We want to have a version of Checkbox that isn't coupled with RHF internally. The hidden connection that generates its own names isn't desirable when we want to use a Checkbox with RHF on a form. Additionally, we would like to be less tied to a single form library.

We can't just remove the coupling in our existing component because too much relies on that, and so to offer a de-coupled version we're going to offer a v2 that doesn't include the same setup.

unlike some of the other v2 inputs we've made recently I've opted to not add `ref` as a prop. I can't think of a compelling reason you'd need access to the ref. I haven't heard of anyone requesting it in all the time Checkbox has existed. not strictly opposed to it though, just don't see a reason currently.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

A "rebuilt" Checkbox that has no RHF included



### Changed

no longer using XOR within types to determine if label is a string or child. instead, `label` accepts a string to use the default Text element and positions, or if more customization is needed markup can be passed in.

similarly, `description` also accepts a string or markup.



### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
