### PR TITLE
feat: Allow DataList.ItemAction to avoid nesting

### DIFF
--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -367,7 +367,7 @@ export interface DataListActionProps<T extends DataListObject> {
   readonly actionUrl?: string;
 
   /**
-   * Determine if the action is always visible.
+   * Determine if the action is always visible. It is not recommended to set this to true on more then one action.
    */
   readonly alwaysVisible?: boolean;
 }

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -365,6 +365,11 @@ export interface DataListActionProps<T extends DataListObject> {
    * The URL to navigate to when the action is clicked.
    */
   readonly actionUrl?: string;
+
+  /**
+   * Determine if the action is always visible.
+   */
+  readonly alwaysVisible?: boolean;
 }
 
 export interface DataListActionsProps<T extends DataListObject> {

--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -109,8 +109,9 @@ export function getExposedActions(
 
   return firstNChildren.reduce((result: typeof childrenArray, child, i) => {
     const hasIcon = Boolean(child.props.icon);
+    const isAlwaysVisible = child.props.alwaysVisible; // If true, the child will always be visible and not nested in the dropdown.
 
-    if (!hasIcon) return result; // If the child does not have an icon, continue.
+    if (!hasIcon || !isAlwaysVisible) return result; // If the child does not have an icon, continue.
 
     const isLastChildAdded = result.length === i;
 

--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -111,7 +111,10 @@ export function getExposedActions(
     const hasIcon = Boolean(child.props.icon);
     const isAlwaysVisible = child.props.alwaysVisible; // If true, the child action will always be visible and not nested in the dropdown.
 
-    if (isAlwaysVisible === false || (isAlwaysVisible === undefined && !hasIcon)) {
+    if (
+      isAlwaysVisible === false ||
+      (isAlwaysVisible === undefined && !hasIcon)
+    ) {
       return result;
     }
 

--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -109,9 +109,11 @@ export function getExposedActions(
 
   return firstNChildren.reduce((result: typeof childrenArray, child, i) => {
     const hasIcon = Boolean(child.props.icon);
-    const isAlwaysVisible = child.props.alwaysVisible; // If true, the child will always be visible and not nested in the dropdown.
+    const isAlwaysVisible = child.props.alwaysVisible; // If true, the child action will always be visible and not nested in the dropdown.
 
-    if (!hasIcon || !isAlwaysVisible) return result; // If the child does not have an icon, continue.
+    if (!isAlwaysVisible && (isAlwaysVisible !== undefined || !hasIcon)) {
+      return result;
+    }
 
     const isLastChildAdded = result.length === i;
 

--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -111,7 +111,7 @@ export function getExposedActions(
     const hasIcon = Boolean(child.props.icon);
     const isAlwaysVisible = child.props.alwaysVisible; // If true, the child action will always be visible and not nested in the dropdown.
 
-    if (!isAlwaysVisible && (isAlwaysVisible !== undefined || !hasIcon)) {
+    if (isAlwaysVisible === false || (isAlwaysVisible === undefined && !hasIcon)) {
       return result;
     }
 

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.test.tsx
@@ -131,6 +131,54 @@ describe("DataListActions", () => {
       expect(screen.queryByLabelText("Edit")).not.toBeInTheDocument();
     });
   });
+
+  describe("alwaysVisible prop", () => {
+    const label = "Foo";
+    const moreLabel = "More actions";
+
+    describe("is true", () => {
+      it("should not render the more actions icon", () => {
+        render(
+          <DataListActions>
+            <DataListAction
+              alwaysVisible
+              icon="edit"
+              label={label}
+              visible={() => true}
+            />
+          </DataListActions>,
+        );
+
+        expect(screen.queryByLabelText(moreLabel)).not.toBeInTheDocument();
+        expect(screen.getByLabelText(label)).toBeInTheDocument();
+      });
+    });
+
+    describe("is false", () => {
+      it("should render the more actions icon", () => {
+        render(
+          <DataListActions>
+            <DataListAction
+              alwaysVisible={false}
+              icon="edit"
+              label={label}
+              visible={() => true}
+            />
+          </DataListActions>,
+        );
+
+        expect(screen.getByLabelText(moreLabel)).toBeInTheDocument();
+      });
+    });
+
+    describe("is undefined", () => {
+      it("should render the more actions icon", () => {
+        renderComponent();
+
+        expect(screen.getByLabelText("More actions")).toBeInTheDocument();
+      });
+    });
+  });
 });
 
 function renderComponent(itemsToExpose = 3) {

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
@@ -26,8 +26,13 @@ export function DataListActions<T extends DataListObject>({
   return (
     <>
       {exposedActions.map(({ props }) => {
-        if (props.visible && !props.visible(activeItem)) return null;
-        if (!props.icon) return null;
+        const shouldHide =
+          (props.visible && !props.visible(activeItem)) ||
+          !(props.icon || props.alwaysVisible);
+
+        if (shouldHide) {
+          return null;
+        }
 
         function getActionLabel() {
           if (typeof props.label === "string") {
@@ -40,6 +45,21 @@ export function DataListActions<T extends DataListObject>({
         }
 
         const actionLabel = getActionLabel();
+
+        // If the action is always visible, we don't need a tooltip.
+        if (props.alwaysVisible) {
+          return (
+            <Button
+              key={props.label}
+              label={actionLabel}
+              onClick={() => {
+                props.onClick?.(activeItem);
+              }}
+              type="tertiary"
+              variation="subtle"
+            />
+          );
+        }
 
         return (
           <Tooltip key={actionLabel} message={actionLabel}>

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
@@ -46,8 +46,7 @@ export function DataListActions<T extends DataListObject>({
         const actionLabel = getActionLabel();
 
         // If the action is always visible, we don't want a tooltip.
-
-        if (props.alwaysVisible !== undefined && props.alwaysVisible) {
+        if (props.alwaysVisibled) {
           return (
             <Button
               ariaLabel={actionLabel}

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
@@ -46,16 +46,19 @@ export function DataListActions<T extends DataListObject>({
 
         const actionLabel = getActionLabel();
 
-        // If the action is always visible, we don't need a tooltip.
-        if (props.alwaysVisible) {
+        // If the action is always visible, we don't want a tooltip.
+
+        if (props.alwaysVisible !== undefined && props.alwaysVisible) {
           return (
             <Button
+              ariaLabel={actionLabel}
               key={props.label}
+              icon={props.icon}
               label={actionLabel}
               onClick={() => {
                 props.onClick?.(activeItem);
               }}
-              type="tertiary"
+              type="secondary"
               variation="subtle"
             />
           );

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
@@ -26,11 +26,10 @@ export function DataListActions<T extends DataListObject>({
   return (
     <>
       {exposedActions.map(({ props }) => {
-        const shouldHide =
-          (props.visible && !props.visible(activeItem)) ||
-          !(props.icon || props.alwaysVisible);
+        const isVisible = props.visible ? props.visible(activeItem) : true;
+        const hasIconOrAlwaysVisible = props.icon || props.alwaysVisible;
 
-        if (shouldHide) {
+        if (!isVisible || !hasIconOrAlwaysVisible) {
           return null;
         }
 


### PR DESCRIPTION
## Motivations

SCE wants to introduce a persistent `DataList.ItemAction` for our review dashboard client attributions. [See original PR.](https://jobber.atlassian.net/browse/JOB-114615)

## Changes and Additions

- Until the `DataList.ItemAction` UI becomes completely customizable/composable by JO facing teams, this prop allows us to force a single action item to render un-nested (no longer hidden behind the `more` icon)
  - Please see the video below for usage of the prop.


https://github.com/user-attachments/assets/04dd4887-0020-45f2-ad08-8b81047a7704


## Testing
_You can follow the steps in the video above or follow along below_
1. Deploy storybook locally
2. Verify DataList remains unbroken
3. Open `docs/components/DataList/Web.stories.tsx` and set one of the item actions to `alwaysVisible={true}`, delete the other item actions
4. Navigate to your local story book and verify you no longer see the 'more' icon and instead see your item actions label on hover of the row.


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

----
<p align="center">
  <img src="https://user-images.githubusercontent.com/61296534/224802440-8aae64a9-c41c-47e8-935a-ff78607ce659.png" width="100"/>
</p>
