### PR TITLE
fix(components): InputChipDismissibleInput clearing options in chip on initial render

### DIFF
--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import debounce from "lodash/debounce";
 import classNames from "classnames";
+import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
 import styles from "./InternalChipDismissible.module.css";
 import { ChipDismissibleInputProps } from "./InternalChipDismissibleTypes";
 import {
@@ -19,6 +20,7 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     attachTo,
     isLoadingMore = false,
     onLoadMore,
+    options,
   } = props;
 
   const {
@@ -50,16 +52,15 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     update,
     setPositionedElementRef,
   } = useRepositionMenu(attachTo);
+  useSafeLayoutEffect(() => {
+    update?.();
+  }, [allOptions, menuOpen, update, options]);
 
   useEffect(() => {
-    if (menuOpen && update) update();
-  }, [allOptions]);
-
-  useEffect(() => {
-    handleDebouncedSearch();
+    handleDebouncedSearch(searchValue, options);
 
     return handleDebouncedSearch.cancel;
-  }, [searchValue]);
+  }, [searchValue, options]);
 
   useEffect(() => {
     isInView && onLoadMore && onLoadMore(searchValue);

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -51,6 +51,16 @@ export function useInternalChipDismissibleInput({
     previousOptionIndex: activeIndex > 0 ? activeIndex - 1 : maxOptionIndex,
   };
 
+  function handleSearch(newSearchValue: string, newOptions: ChipProps[] = []) {
+    onSearch && onSearch(newSearchValue);
+
+    setAllOptions(
+      generateOptions(newOptions, newSearchValue, canAddCustomOption),
+    );
+    setShouldCancelEnter(false);
+  }
+
+  const handleDebouncedSearch = debounce(handleSearch, 300);
   const actions = {
     generateDescendantId: (index: number) => `${computed.menuId}-${index}`,
 
@@ -130,11 +140,7 @@ export function useInternalChipDismissibleInput({
       handleKeydownEvents(callbacks, event);
     },
 
-    handleDebouncedSearch: debounce(() => {
-      onSearch && onSearch(searchValue);
-      setAllOptions(generateOptions(options, searchValue, canAddCustomOption));
-      setShouldCancelEnter(false);
-    }, 300),
+    handleDebouncedSearch,
   };
 
   return {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

On the initial render of dismissive chips with a custom activator the options would be empty when they were passed in as props

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
 - Updated the Popper for the `Chips` typeahead to update when the options change to make sure it renders correctly
 - Made the debounced search function take parameters instead of using stale values in the closure

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- fixed initial render of dismissible chips having an empty options list when data is present

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
