### PR TITLE
fix(components): Allow Chip to be used as an activator in Menu 

### DIFF
--- a/packages/components/src/Menu/Menu.module.css
+++ b/packages/components/src/Menu/Menu.module.css
@@ -10,10 +10,6 @@
   z-index: var(--elevation-modal);
 }
 
-.shadowRef {
-  display: none;
-}
-
 .menu {
   --menu-space: var(--space-small);
   --menu-offset: var(--space-smallest);

--- a/packages/components/src/Menu/Menu.module.css.d.ts
+++ b/packages/components/src/Menu/Menu.module.css.d.ts
@@ -1,7 +1,6 @@
 declare const styles: {
   readonly "wrapper": string;
   readonly "popperContainer": string;
-  readonly "shadowRef": string;
   readonly "menu": string;
   readonly "section": string;
   readonly "sectionHeader": string;

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -64,7 +64,7 @@ export interface SectionProps {
 // eslint-disable-next-line max-statements
 export function Menu({ activator, items }: MenuProps) {
   const [visible, setVisible] = useState(false);
-  const shadowRef = useRef<HTMLSpanElement>(null);
+  const popperRef = useRef<HTMLDivElement>(null);
 
   const { width } = useWindowDimensions();
 
@@ -88,7 +88,7 @@ export function Menu({ activator, items }: MenuProps) {
     styles: popperStyles,
     attributes,
     state,
-  } = usePopper(shadowRef.current?.nextElementSibling, popperElement, {
+  } = usePopper(popperRef.current, popperElement, {
     placement: "bottom-start",
     strategy: "fixed",
     modifiers: [
@@ -127,14 +127,15 @@ export function Menu({ activator, items }: MenuProps) {
 
   return (
     <div className={wrapperClasses} onClick={handleParentClick}>
-      <span ref={shadowRef} className={styles.shadowRef} />
-      {React.cloneElement(activator, {
-        onClick: toggle(activator.props.onClick),
-        id: buttonID,
-        ariaControls: menuID,
-        ariaExpanded: visible,
-        ariaHaspopup: true,
-      })}
+      <div ref={popperRef}>
+        {React.cloneElement(activator, {
+          onClick: toggle(activator.props.onClick),
+          id: buttonID,
+          ariaControls: menuID,
+          ariaExpanded: visible,
+          ariaHaspopup: true,
+        })}
+      </div>
       <MenuPortal>
         <AnimatePresence>
           {visible && (

--- a/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/packages/components/src/Menu/__snapshots__/Menu.test.tsx.snap
@@ -5,33 +5,32 @@ exports[`Menu renders 1`] = `
   <div
     class="wrapper"
   >
-    <span
-      class="shadowRef"
-    />
-    <button
-      aria-controls=":r1:"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="button base hasIconAndLabel work secondary fullWidth"
-      id=":r0:"
-      type="button"
-    >
-      <svg
-        data-testid="more"
-        style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+    <div>
+      <button
+        aria-controls=":r1:"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="button base hasIconAndLabel work secondary fullWidth"
+        id=":r0:"
+        type="button"
       >
-        <path
-          d="M4 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm8-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
-        />
-      </svg>
-      <span
-        class="base semiBold base base"
-      >
-        More Actions
-      </span>
-    </button>
+        <svg
+          data-testid="more"
+          style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm8-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
+          />
+        </svg>
+        <span
+          class="base semiBold base base"
+        >
+          More Actions
+        </span>
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -41,23 +40,22 @@ exports[`Menu with custom activator renders 1`] = `
   <div
     class="wrapper"
   >
-    <span
-      class="shadowRef"
-    />
-    <button
-      aria-controls=":rc:"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="button base work primary"
-      id=":rb:"
-      type="button"
-    >
-      <span
-        class="base semiBold base base"
+    <div>
+      <button
+        aria-controls=":rc:"
+        aria-expanded="false"
+        aria-haspopup="true"
+        class="button base work primary"
+        id=":rb:"
+        type="button"
       >
-        Menu
-      </span>
-    </button>
+        <span
+          class="base semiBold base base"
+        >
+          Menu
+        </span>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/components/src/Page/__snapshots__/Page.test.tsx.snap
@@ -58,33 +58,32 @@ exports[`When actions are provided renders a Page with action buttons and a menu
               <div
                 class="wrapper"
               >
-                <span
-                  class="shadowRef"
-                />
-                <button
-                  aria-controls=":r1:"
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="button base hasIconAndLabel work secondary fullWidth"
-                  id=":r0:"
-                  type="button"
-                >
-                  <svg
-                    data-testid="more"
-                    style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
+                <div>
+                  <button
+                    aria-controls=":r1:"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    class="button base hasIconAndLabel work secondary fullWidth"
+                    id=":r0:"
+                    type="button"
                   >
-                    <path
-                      d="M4 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm8-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
-                    />
-                  </svg>
-                  <span
-                    class="base semiBold base base"
-                  >
-                    More Actions
-                  </span>
-                </button>
+                    <svg
+                      data-testid="more"
+                      style="fill: var(--color-icon); display: inline-block; vertical-align: middle; width: 24px; height: 24px;"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M4 12a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm6 0a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm8-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
+                      />
+                    </svg>
+                    <span
+                      class="base semiBold base base"
+                    >
+                      More Actions
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Gui pointed out [here](https://getjobber.slack.com/archives/C03BJHV3PMG/p1739480113250269) that a `Chip` could not be used as an activator for a `Menu`. The reason Chip doesn't work is:
- Chip is essentially a Button wrapped in a Toolbar which leads to code like this:
```
<span class="Tooltip-module__shadowActivator--G4n8v"></span>
<button class="Chip-module__chip--Ob7Ns Chip-module__base--Gz7fH" tabindex="0" role="button" type="button" aria-description="description">
```
- Before these changes we were adding a shadow ref as a sibling to the activator and then using `shadowRef.current?.nextElementSibling` to access the activator
- When a button was used as an activator this would work since the button would be the sibling of the shadow ref. Unfortunately, this was broken for a Chip since the first sibling would be the tooltip span

## Changes

- Instead of using a span with a shadow ref and grabbing the next sibling, the activator is wrapped in a div which is used to reference the activator. 

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Test out the menu functionality with an activator of a Button or a Chip (by modifying `docs/components/Menu/Web.stories.tsx`). You can also test out various menus in JO/JF by using the pre-release.

I also tested that parent click actions are handled as expected and as a more out there case I tested when a Menu is used as a toolbar to ensure none of the current functionality breaks. 

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
