### PR TITLE
fix(design): Ensure dark mode surfaces match existing in JO

### DIFF
--- a/packages/design/src/tokens/dark.tokens.json
+++ b/packages/design/src/tokens/dark.tokens.json
@@ -166,20 +166,20 @@
             "$value": "{color.base.blue-.200}"
         },
         "surface": {
-            "$value": "{color.base.blue-.900}",
+            "$value": "{color.base.blue-.800}",
             "$description": "The primary color of the application surface (background). If interactive, surfaces have a hover and active color."
         },
         "surface-": {
             "hover": {
-                "$value": "{color.base.blue-.800}",
+                "$value": "{color.base.blue-.700}",
                 "$description": "Hover state for surface."
             },
             "active": {
-                "$value": "{color.base.blue-.700}",
+                "$value": "{color.base.blue-.600}",
                 "$description": "Active state for surface."
             },
             "background": {
-                "$value": "{color.base.blue-.1000}",
+                "$value": "{color.base.blue-.900}",
                 "$description": "A slightly darker surface gives a receded appearance relative to main surfaces."
             },
             "background-": {
@@ -188,7 +188,7 @@
                     "$description": "Hover state for surface--background."
                 },
                 "subtle": {
-                    "$value": "{color.base.blue-.800}",
+                    "$value": "{color.base.blue-.700}",
                     "$description": "Use when a subtler distinction than the standard surface--background is needed."
                 }
             },


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- Wanted to ensure parity between jobber-frontend and JO

### Fixed

- Make sure that surface values are correct in dark mode:

JO:
<img width="291" alt="image" src="https://github.com/user-attachments/assets/882447f7-b94e-4f27-adb0-3d7aff39d3ad" />

jobber-frontend:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f074fe75-8a96-4a2e-9376-643bd40efb4d" />


## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
