### PR TITLE
docs: update documentation links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
   Atlantis uses Conventional Commits to track versions.
   Pull request titles should follow the following format.
 
-  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/?path=/story/guides-pull-request-title-generator--docs)
+  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)
 
   <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -150,7 +150,7 @@ follow the following format.
 `<TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>`
 
 Want help with your pull request title? We have a
-[tool to help](../?path=/docs/guides-pull-request-title-generator--docs).
+[tool to help](/guides/pull-request-title-generator).
 
 ##### Requesting review
 
@@ -195,11 +195,10 @@ changes._
 
 ### Code and sandbox
 
-Some components, like
-[Card](../?path=/story/components-layouts-and-structure-card-web--basic),
-includes a "Code" tab on the top right of the screen. This is turned off by
-default. To turn this feature on, add a `parameter` of `previewTabs.code.hidden`
-and set it to `false` on your stories meta.
+Some components, like [Card](/components/Card), includes a "Code" tab on the top
+right of the screen. This is turned off by default. To turn this feature on, add
+a `parameter` of `previewTabs.code.hidden` and set it to `false` on your stories
+meta.
 
 ```ts
 export default {

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,9 +69,9 @@ This following list has installation links for each package:
 
 These are the core packages you'll need to build with Atlantis:
 
-- [Components](https://atlantis.getjobber.com/?path=/docs/packages-components--docs)
-- [Design](https://atlantis.getjobber.com/?path=/docs/packages-design--docs)
-- [Hooks](https://atlantis.getjobber.com/?path=/docs/packages-hooks--docs)
+- [Components](https://atlantis.getjobber.com/components)
+- [Design](https://atlantis.getjobber.com/design)
+- [Hooks](https://atlantis.getjobber.com/hooks)
 
 #### Installing specific versions
 
@@ -93,8 +93,8 @@ npm install @jobber/{package}@{version}
 If you're looking to build documentation and tooling using Atlantis' development
 standards, these packages will be useful:
 
-- [EsLint configuration](https://atlantis.getjobber.com/?path=/docs/packages-eslint-config--docs)
-- [StyleLint configuration](https://atlantis.getjobber.com/?path=/docs/packages-stylelint-config--docs)
+- [EsLint configuration](https://atlantis.getjobber.com/packages/eslint-config)
+- [StyleLint configuration](https://atlantis.getjobber.com/packages/stylelint-config)
 
 ## Generating a component
 
@@ -192,7 +192,8 @@ For more information on how the packages are bootstrapped, check out
 ## Contributing
 
 Everyone is a friend of Atlantis and we welcome pull requests. See the
-[contribution guidelines](https://atlantis.getjobber.com/?path=/docs/contributing--docs) to learn how.
+[contribution guidelines](https://atlantis.getjobber.com/?path=/docs/contributing--docs)
+to learn how.
 
 ## Publishing
 
@@ -210,9 +211,9 @@ npm run release-the-kraken
 ### Publishing a failed release to NPM
 
 In some cases, the automatic release may successfully bump the version and add a
-[changelog](https://atlantis.getjobber.com/?path=/docs/changelog-components--docs) but fail to publish to
-NPM. If this happens and you're one of the Atlantis NPM collaborators, run the
-code below to send unpublished versions to NPM.
+[changelog](https://atlantis.getjobber.com/changelog/components) but fail to
+publish to NPM. If this happens and you're one of the Atlantis NPM
+collaborators, run the code below to send unpublished versions to NPM.
 
 ```sh
 npm run release:unpublished-package

--- a/docs/components/ActionItem/ActionItem.stories.mdx
+++ b/docs/components/ActionItem/ActionItem.stories.mdx
@@ -14,9 +14,8 @@ text content.
 The ActionItem will provide a familiar pattern for enhancing text content with
 icons and providing actions.
 
-ActionItem is commonly used
-[in a Card](../?path=/story/components-layouts-and-structure-actionitem-mobile--in-a-card),
-where it can be grouped with other ActionItems or other elements as needed.
+ActionItem is commonly used [in a Card](/components/Card), where it can be
+grouped with other ActionItems or other elements as needed.
 
 If the action appears directly related to the title, or otherwise is not
 well-suited to be centered in the ActionItem, you can
@@ -36,17 +35,15 @@ interactivity. If a child of the ActionItem has an `onPress`, tapping directly
 on that child will trigger the child item's `onPress`.
 
 Child content can be whatever you need but typically consists of
-[Text](../?path=/docs/components-text-and-typography-text--docs).
+[Text](/components/Text).
 
 ## Related components
 
 To group multiple ActionItems together with dividers between them, use
-[ActionItemGroup](../?path=/docs/components-layouts-and-structure-actionitemgroup--docs).
+[ActionItemGroup](/components/ActionItemGroup).
 
-ActionItem is commonly consumed by
-[Card](../?path=/docs/components-layouts-and-structure-card--docs). In most
-cases, it will also render at least one
-[Icon](../?path=/docs/components-images-and-icons-icon--docs).
+ActionItem is commonly consumed by [Card](/components/Card). In most cases, it
+will also render at least one [Icon](/components/Icon).
 
 ## Accessibility
 

--- a/docs/components/ActionItemGroup/ActionItemGroup.stories.mdx
+++ b/docs/components/ActionItemGroup/ActionItemGroup.stories.mdx
@@ -5,8 +5,8 @@ import { Meta } from "@storybook/addon-docs";
 # Action Item Group
 
 ActionItemGroup is a layout wrapper allowing for quick and easy grouping of
-[ActionItems](../?path=/docs/components-layouts-and-structure-actionitem--docs).
-It can also house other content alongside an ActionItem if needed.
+[ActionItems](/components/ActionItem). It can also house other content alongside
+an ActionItem if needed.
 
 ## Design & usage guidelines
 
@@ -19,21 +19,17 @@ You'll mostly be passing ActionItems into ActionItemGroup, but as shown it can
 handle other content types if needed.
 
 In forms in particular, you may find the need to add other elements into the
-group. You may need to use
-[Content](../?path=/docs/components-layouts-and-structure-content--docs) or
-write some styling to get things aligned. In the Mixed Components
+group. You may need to use [Content](/components/Content) or write some styling
+to get things aligned. In the Mixed Components
 [example](../?path=/story/components-layouts-and-structure-actionitemgroup-mobile--mixed-components)
-you can see Content being used to layout
-[Text](../?path=/docs/components-text-and-typography-text--docs) and
-[Typography](../?path=/docs/components-text-and-typography-typography--docs)
-alongside some
-[ActionItems](../?path=/docs/components-layouts-and-structure-actionitem--docs).
+you can see Content being used to layout [Text](/components/Text) and
+[Typography](/components/Typography) alongside some
+[ActionItems](/components/ActionItem).
 
 ## Related components
 
-If you only need one
-[ActionItem](../?path=/docs/components-layouts-and-structure-actionitem--docs),
-you can use that on its own without this wrapper.
+If you only need one [ActionItem](/components/ActionItem), you can use that on
+its own without this wrapper.
 
 ## Accessibility
 

--- a/docs/components/ActivityIndicator/ActivityIndicator.stories.mdx
+++ b/docs/components/ActivityIndicator/ActivityIndicator.stories.mdx
@@ -11,7 +11,7 @@ amount of loading time or progress is unknown.
 ## Related components
 
 To indicate loading content in web applications, refer to
-[Spinner](../?path=/docs/components-status-and-feedback-spinner--docs).
+[Spinner](/components/Spinner).
 
 ActivityIndicator uses the core component
 [ActivityIndicator](https://reactnative.dev/docs/activityIndicator) from

--- a/docs/components/Autocomplete/Autocomplete.stories.mdx
+++ b/docs/components/Autocomplete/Autocomplete.stories.mdx
@@ -42,7 +42,6 @@ or `await`.
 ## Related components
 
 - If you want to present a list of predefined options without text input, or the
-  number of options is smaller, use a
-  [Select](../?path=/docs/components-selections-select--docs)
+  number of options is smaller, use a [Select](/components/Select)
 - If autocompleted results are not required for the text input, use
-  [InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs)
+  [InputText](/components/InputText)

--- a/docs/components/Banner/Banner.stories.mdx
+++ b/docs/components/Banner/Banner.stories.mdx
@@ -18,8 +18,8 @@ Banner should align to the left and right of the content it is related to.
 
 When using a Banner within a modal or a page layout, this means Banner should
 align with the text, inputs or other UI elements beneath it. For best results,
-use [Content](../?path=/docs/components-layouts-and-structure-content--docs) to
-ensure consistent vertical spacing between Banner and adjacent elements.
+use [Content](/components/Content) to ensure consistent vertical spacing between
+Banner and adjacent elements.
 
 #### "Global" Banner (web)
 
@@ -56,15 +56,11 @@ Success banners are appropriate when:
   <li>success feedback is delayed</li>
 </ul>
 
-Otherwise, use
-[Toast](../?path=/docs/components-status-and-feedback-toast--docs) as the
-default for success messages.
+Otherwise, use [Toast](/components/Toast) as the default for success messages.
 
 #### Success messages (mobile)
 
-On mobile, use
-[Toast](../?path=/docs/components-status-and-feedback-toast--docs) for a success
-message.
+On mobile, use [Toast](/components/Toast) for a success message.
 
 ### Notice message
 
@@ -100,12 +96,11 @@ Use warning banners when:
 </ul>
 
 Warning messages should be one to two short sentences that describe the possibly
-unknown impact a user’s changes or actions will have. They should not begin with
+unknown impact a user's changes or actions will have. They should not begin with
 "Warning:" and should not be used as a way to block or redirect a workflow.
 
-On web, you should use
-[ConfirmationModal](../?path=/docs/components-overlays-confirmationmodal--docs)
-when you need to get explicit confirmation from the user before they complete an
+On web, you should use [ConfirmationModal](/components/ConfirmationModal) when
+you need to get explicit confirmation from the user before they complete an
 action that is difficult to reverse.
 
 ### Error message
@@ -137,8 +132,7 @@ context to the user.
 
 If an error is directly related to an input, don't use a banner. Use the
 [InputText validation message](../?path=/docs/components-forms-and-inputs-inputtext--docs#validation-message)
-component or, if unavailable,
-[InputValidation](../?path=/docs/components-forms-and-inputs-inputvalidation--docs).
+component or, if unavailable, [InputValidation](/components/InputValidation).
 Scroll to the first affected field on submission.
 
 #### Errors in forms (mobile)
@@ -165,17 +159,12 @@ Content in Banner should:
 
 - Be concise and kept to only 1 to 2 sentences where possible
 - Avoid exceeding 200 characters
-- Follow the
-  [Product Vocabulary](../?path=/docs/content-product-vocabulary--docs) where
-  applicable
+- Follow the [Product Vocabulary](/content/product-vocabulary) where applicable
 - In the case of warning or error banners, explain how to resolve the issue
 
 ## Related components
 
 - To provide low-priority, temporary feedback on the outcome of a user action,
-  use [Toast](../?path=/docs/components-status-and-feedback-toast--docs)
-  instead.
-- Use
-  [ConfirmationModal](../?path=/docs/components-overlays-confirmationmodal--docs)
-  when you need to get explicit confirmation from the user before they complete
-  an action.
+  use [Toast](/components/Toast) instead.
+- Use [ConfirmationModal](/components/ConfirmationModal) when you need to get
+  explicit confirmation from the user before they complete an action.

--- a/docs/components/Banner/Banner.stories.mdx
+++ b/docs/components/Banner/Banner.stories.mdx
@@ -36,12 +36,8 @@ be flush with the edges of the screen.
 
 ### Types of Banner
 
-There are four types of Banner, each with guidelines for their usage:
-
-- `success` (web only) [<Icon name="link" />](#success-message)
-- `notice` [<Icon name="link" />](#notice-message)
-- `warning`[<Icon name="link" />](#warning-message)
-- `error` [<Icon name="link" />](#error-message)
+Banners come in four types; `success`, `notice`, `warning` and `error`. Each
+type has guidelines for usage:
 
 ### Success message (Web only)
 

--- a/docs/components/Box/Box.stories.mdx
+++ b/docs/components/Box/Box.stories.mdx
@@ -31,11 +31,10 @@ example via the left-hand navigation.
 
 ## Related components
 
-[Card](https://atlantis.getjobber.com/?path=/docs/components-layouts-and-structure-card--docs)
-is a more opionated layout container, with a set background, border, radius, and
-an optional preset header. It is the preferred way to group related information
-and tasks so that users can consistently scan and prioritize information more
-easily.
+[Card](/components/Card) is a more opionated layout container, with a set
+background, border, radius, and an optional preset header. It is the preferred
+way to group related information and tasks so that users can consistently scan
+and prioritize information more easily.
 
 ### No Props
 

--- a/docs/components/Button/Button.stories.mdx
+++ b/docs/components/Button/Button.stories.mdx
@@ -103,8 +103,7 @@ Actions for all three levels.
 
 A Primary destructive action will permanently destroy an object carrying
 significant data, such as a job, quote, or client. This destructive action
-should be contained in a
-[ConfirmationModal](../?path=/docs/components-overlays-confirmationmodal--docs)
+should be contained in a [ConfirmationModal](/components/ConfirmationModal)
 triggered by clicking a secondary or tertiary destructive button.
 
 #### Secondary or Tertiary

--- a/docs/components/ButtonDismiss/ButtonDismiss.stories.mdx
+++ b/docs/components/ButtonDismiss/ButtonDismiss.stories.mdx
@@ -14,8 +14,7 @@ design patterns of Atlantis.
 
 ## Related components
 
-ButtonDismiss is built with
-[Button](../?path=/docs/components-actions-button--docs).
+ButtonDismiss is built with [Button](/components/Button).
 
 ## Accessibility
 

--- a/docs/components/Card/Card.stories.mdx
+++ b/docs/components/Card/Card.stories.mdx
@@ -40,15 +40,12 @@ for an example.
 
 ## Related components
 
-[Content](https://atlantis.getjobber.com/?path=/docs/components-layouts-and-structure-content--docs)
-and
-[Flex](https://atlantis.getjobber.com/?path=/docs/components-layouts-and-structure-flex--docs)
-are the most common layout tools for managing the Card's children. Generally,
-Card is un-opinionated about what goes inside of it.
+[Content](/components/Content) and [Flex](/components/Flex) are the most common
+layout tools for managing the Card's children. Generally, Card is un-opinionated
+about what goes inside of it.
 
 If you require more customization over the appearance of your container,
-[Box](https://atlantis.getjobber.com/?path=/docs/components-layouts-and-structure-box--docs)
-is the preferred way to achieve this without writing CSS.
+[Box](/components/Box) is the preferred way to achieve this without writing CSS.
 
 ## Content guidelines
 

--- a/docs/components/Checkbox/Checkbox.stories.mdx
+++ b/docs/components/Checkbox/Checkbox.stories.mdx
@@ -14,14 +14,13 @@ options, or opt in to a single choice. It allows a user to provide boolean
 input. It can also be in an indeterminate state when we don't know if the
 checkbox is considered checked or not.
 
-A single checkbox, a
-[Switch](../?path=/docs/components-selections-switch--docs), and a pair of
-[radio buttons](../?path=/docs/components-forms-and-inputs-radiogroup--docs) can
-seem similar in theory, as all can represent an either/or decision for the user.
-Use a switch when the user must make a decision to turn something on or off, and
-a single checkbox when a user is opting in to a choice. A pair of radio buttons
-can be used to help the user decide between two discrete options, such as “fixed
-price” and “per visit” invoicing options.
+A single checkbox, a [Switch](/components/Switch), and a pair of
+[radio buttons](/components/RadioGroup) can seem similar in theory, as all can
+represent an either/or decision for the user. Use a switch when the user must
+make a decision to turn something on or off, and a single checkbox when a user
+is opting in to a choice. A pair of radio buttons can be used to help the user
+decide between two discrete options, such as “fixed price” and “per visit”
+invoicing options.
 
 Of note: when a single selection is to be made, a Switch should be used rather
 than a single Checkbox. Use a Checkbox only when there are multiple selection
@@ -32,9 +31,9 @@ labels on a set of Radio options are consistently small (1–2 words), use Chip.
 ## Related components
 
 - To let people turn a setting on or off instantly, use a
-  [Switch](../?path=/docs/components-selections-switch--docs).
+  [Switch](/components/Switch).
 - To present a set of options where people can only make a single choice, use a
-  [RadioGroup](../?path=/docs/components-forms-and-inputs-radiogroup--docs).
+  [RadioGroup](/components/RadioGroup).
 
 ## Mockup
 

--- a/docs/components/Chip/Chip.stories.mdx
+++ b/docs/components/Chip/Chip.stories.mdx
@@ -12,7 +12,7 @@ Chip is a flexible component that can be used for
 
 - inline single- or multi-selection of items
 - triggering filtering and selection components like
-  [Combobox](../?path=/docs/components-selections-combobox--docs)
+  [Combobox](/components/Combobox)
 - presenting grouped items that can be added or removed
 
 <Canvas>
@@ -62,9 +62,8 @@ will allow the user to choose one of those items.
 This preserves vertical space while allowing the user to clearly identify which
 item they have selected.
 
-Unlike [Radio](../?path=/docs/components-forms-and-inputs-radiogroup--docs), the
-selected single-select Chip can be de-selected by the user, leaving all
-selections blank.
+Unlike [Radio](/components/RadioGroup), the selected single-select Chip can be
+de-selected by the user, leaving all selections blank.
 
 <Canvas>
   <Flex
@@ -92,7 +91,7 @@ Chips will allow the user to choose as many items from the group as they wish.
 This preserves vertical space while allowing the user to clearly identify which
 items they have selected. To signify to the user that multiple selections are
 possible, a checkmark icon is present to reinforce the conceptual similarity to
-a [Checkbox](../?path=/docs/components-selections-checkbox--docs).
+a [Checkbox](/components/Checkbox).
 
 Similar to Checkbox, a selected multi-select Chip can be de-selected by the
 user, leaving all selections blank.
@@ -185,23 +184,20 @@ invalid state.
 
 ## Related components
 
-- [Chips](../?path=/docs/components-selections-chips--docs) is a convenience
-  wrapper that offers the single-select, multi-select, and add/dismiss
-  functionality "out of the box"
-- [Combobox](../?path=/docs/components-selections-combobox--docs) is most
-  commonly triggered by a Chip, but is a separate component
-- [Select](../?path=/docs/components-selections-select--docs) is a simpler
-  single-select "dropdown" that presents as a form element and should be
-  preferred in forms
-- [RadioGroup](../?path=/docs/components-forms-and-inputs-radiogroup--docs)
-  should be used to allow the user to select "one-of-many" items (single-select)
-  and the labels for the items are longer than 1 or 2 words.
-- [Checkbox](../?path=/docs/components-selections-checkbox--docs) should be used
-  to allow the user to select "one-or-more-of-many" items (multi-select) and the
-  labels for the items are longer than 1 or 2 words.
-- [InlineLabel](../?path=/docs/components-status-and-feedback-inlinelabel--docs)
-  should be used when you just need a rounded-rectangular element that displays
-  metadata about an element
+- [Chips](/components/Chips) is a convenience wrapper that offers the
+  single-select, multi-select, and add/dismiss functionality "out of the box"
+- [Combobox](/components/Combobox) is most commonly triggered by a Chip, but is
+  a separate component
+- [Select](/components/Select) is a simpler single-select "dropdown" that
+  presents as a form element and should be preferred in forms
+- [RadioGroup](/components/RadioGroup) should be used to allow the user to
+  select "one-of-many" items (single-select) and the labels for the items are
+  longer than 1 or 2 words.
+- [Checkbox](/components/Checkbox) should be used to allow the user to select
+  "one-or-more-of-many" items (multi-select) and the labels for the items are
+  longer than 1 or 2 words.
+- [InlineLabel](/components/InlineLabel) should be used when you just need a
+  rounded-rectangular element that displays metadata about an element
 
 ## Content guidelines
 

--- a/docs/components/Chips/Chips.stories.mdx
+++ b/docs/components/Chips/Chips.stories.mdx
@@ -26,9 +26,8 @@ will allow the user to choose one of those items.
 This preserves vertical space while allowing the user to clearly identify which
 item they have selected.
 
-Unlike [Radio](../?path=/docs/components-forms-and-inputs-radiogroup--docs), the
-selected single-select Chip can be de-selected by the user, leaving all
-selections blank.
+Unlike [Radio](/components/RadioGroup), the selected single-select Chip can be
+de-selected by the user, leaving all selections blank.
 
 ### Multi-select
 
@@ -39,7 +38,7 @@ Chips will allow the user to choose as many items from the group as they wish.
 This preserves vertical space while allowing the user to clearly identify which
 items they have selected. To signify to the user that multiple selections are
 possible, a checkmark icon is present to reinforce the conceptual similarity to
-a [Checkbox](../?path=/docs/components-selections-checkbox--docs).
+a [Checkbox](/components/Checkbox).
 
 Similar to Checkbox, a selected multi-select Chip can be de-selected by the
 user, leaving all selections blank.
@@ -83,18 +82,16 @@ In cases where the Chip is on an area whose background is
 
 ## Related components
 
-- [Chip](../?path=/docs/components-selections-chip--docs) is the building block
-  that Chips is built on top of, and has more flexibility to be used in
-  isolation.
-- [RadioGroup](../?path=/docs/components-forms-and-inputs-radiogroup--docs)
-  should be used to allow the user to select "one-of-many" items (single-select)
-  and the labels for the items are longer than 1 or 2 words.
-- [Checkbox](../?path=/docs/components-selections-checkbox--docs) should be used
-  to allow the user to select "one-or-more-of-many" items (multi-select) and the
-  labels for the items are longer than 1 or 2 words.
-- [InlineLabel](../?path=/docs/components-status-and-feedback-inlinelabel--docs)
-  should be used when you just need a rectangular element that displays the
-  status of another element.
+- [Chip](/components/Chip) is the building block that Chips is built on top of,
+  and has more flexibility to be used in isolation.
+- [RadioGroup](/components/RadioGroup) should be used to allow the user to
+  select "one-of-many" items (single-select) and the labels for the items are
+  longer than 1 or 2 words.
+- [Checkbox](/components/Checkbox) should be used to allow the user to select
+  "one-or-more-of-many" items (multi-select) and the labels for the items are
+  longer than 1 or 2 words.
+- [InlineLabel](/components/InlineLabel) should be used when you just need a
+  rectangular element that displays the status of another element.
 
 ## Content guidelines
 

--- a/docs/components/Combobox/Combobox.stories.mdx
+++ b/docs/components/Combobox/Combobox.stories.mdx
@@ -31,8 +31,8 @@ Combobox is designed to handle lists of selectable options, so the component is
 text based.
 
 You may customize the activator and action `label`. Refer to the
-[Product Vocabulary](../?path=/docs/content-product-vocabulary--docs) for
-consistency in terminology and naming conventions when setting these values.
+[Product Vocabulary](/content/product-vocabulary) for consistency in consistency
+in terminology and naming conventions when setting these values.
 
 You may also set an optional `subjectNoun` for the Combobox content. This will
 be used in the
@@ -40,10 +40,8 @@ be used in the
 of the Combobox, as well as the noun within the search placeholder.
 
 You may include a prefix element to any ComboBox.Option by setting its `prefix`
-prop. This could be a
-[StatusIndicator](../?path=/docs/components-status-and-feedback-statusindicator--docs)
-or [Icon](../?path=/docs/components-images-and-icons-icon--docs) to provide
-additional context to the option.
+prop. This could be a [StatusIndicator](/components/StatusIndicator) or
+[Icon](/components/Icon) to provide additional context to the option.
 
 ### Empty states
 

--- a/docs/components/ConfirmationModal/ConfirmationModal.stories.mdx
+++ b/docs/components/ConfirmationModal/ConfirmationModal.stories.mdx
@@ -56,7 +56,6 @@ Avoid using generic or verbose titles.
 ## Related components
 
 - To present non-blocking, contextual, text-only content, use a
-  [Tooltip](../?path=/docs/components-overlays-tooltip--docs)
+  [Tooltip](/components/Tooltip)
 - To simply present information for users to view, edit, or for a temporary
-  change of context, use a regular
-  [Modal](../?path=/docs/components-overlays-modal--docs)
+  change of context, use a regular [Modal](/components/Modal)

--- a/docs/components/Content/Content.stories.mdx
+++ b/docs/components/Content/Content.stories.mdx
@@ -9,9 +9,8 @@ Content is a container component that provides it's child elements with
 consistent vertical or horizontal spacing and padding.
 
 This is useful for when you want to include internal details like text within a
-parent component, such as a
-[Card,](../?path=/docs/components-layouts-and-structure-card--docs) while
-maintaining consistent spacing between the elements.
+parent component, such as a [Card](/components/Card), while maintaining
+consistent spacing between the elements.
 
 ## Design & usage guidelines
 
@@ -20,9 +19,8 @@ consistent spacing between the elements.
 
 ## Related components
 
-Use [Flex](../?path=/docs/components-layouts-and-structure-flex--docs) and
-[Grid](../?path=/docs/components-layouts-and-structure-grid--docs) to create
-more complex layouts.
+Use [Flex](/components/Flex) and [Grid](/components/Grid) to create more complex
+layouts.
 
 ## Accessibility
 

--- a/docs/components/Countdown/Countdown.stories.mdx
+++ b/docs/components/Countdown/Countdown.stories.mdx
@@ -36,6 +36,5 @@ decision on whether to show or hide the units.
 ## Related components
 
 - To display a unit of time that has already passed, use
-  [FormatRelativeDateTime](../?path=/docs/components-utilities-formatrelativedatetime--docs)
-- To display time as a static unit, use
-  [FormatTime](../?path=/docs/components-utilities-formattime--docs)
+  [FormatRelativeDateTime](/components/FormatRelativeDateTime)
+- To display time as a static unit, use [FormatTime](/components/FormatTime)

--- a/docs/components/DataList/DataList.stories.mdx
+++ b/docs/components/DataList/DataList.stories.mdx
@@ -11,7 +11,7 @@ import { Flex } from "@jobber/components/Flex";
 # DataList
 
 DataList is used to show a collection list of similar items in a simpler manner
-than [DataTable](../?path=/docs/components-lists-and-tables-datatable--docs).
+than [DataTable](/components/DataTable).
 
 It allows more control over the layout of the list items. It can also add
 different layouts depending on the size of the screen that we support.
@@ -24,5 +24,4 @@ list of important items. We recommend not going over more than 5 data points per
 item.
 
 If you need to add more information, consider using the
-[DataTable](../?path=/docs/components-lists-and-tables-datatable--docs)
-component instead.
+[DataTable](/components/DataTable) component instead.

--- a/docs/components/DataTable/DataTable.stories.mdx
+++ b/docs/components/DataTable/DataTable.stories.mdx
@@ -25,10 +25,9 @@ distinctions in dollar amounts, inventory counts, and other key business data.
 
 To list more complex collections of information (such as multi-line content like
 a detailed property address), you may want to consider the
-[List](../?path=/docs/components-lists-and-tables-list--docs) component. If you
-have a small list of information with a 1:1 label-to-data relationship (for
-example, the issued and due dates on an invoice), consider using
-[DescriptionList](../?path=/docs/components-lists-and-tables-descriptionlist--docs).
+[List](/components/List) component. If you have a small list of information with
+a 1:1 label-to-data relationship (for example, the issued and due dates on an
+invoice), consider using [DescriptionList](/components/DescriptionList).
 
 ## Responsiveness
 

--- a/docs/components/Datepicker/Datepicker.stories.mdx
+++ b/docs/components/Datepicker/Datepicker.stories.mdx
@@ -55,11 +55,9 @@ If using a custom activator, ensure that the activator is keyboard-operable.
 ## Related components
 
 - If you are looking to use the `DatePicker` in a `Form`, consider the
-  [InputDate](../?path=/docs/components-forms-and-inputs-inputdate--docs)
-  component.
-- For a time input, use
-  [InputTime](../?path=/docs/components-forms-and-inputs-inputtime--docs)
+  [InputDate](/components/InputDate) component.
+- For a time input, use [InputTime](/components/InputTime)
 - To present dates that have already been selected in a consistent format, use
-  [FormatDate](../?path=/docs/components-utilities-formatdate--docs)
+  [FormatDate](/components/FormatDate)
 - To represent past or future dates and times, use
-  [FormatRelativeDateTime](../?path=/docs/components-utilities-formatrelativedatetime--docs)
+  [FormatRelativeDateTime](/components/FormatRelativeDateTime)

--- a/docs/components/DescriptionList/DescriptionList.stories.mdx
+++ b/docs/components/DescriptionList/DescriptionList.stories.mdx
@@ -15,6 +15,6 @@ due dates on an invoice, or the job type, billing type and duration of a job.
 ## Related components
 
 - To list more complex collections of related information, consider using a
-  [List](../?path=/docs/components-lists-and-tables-list--docs).
+  [List](/components/List).
 - To display structured data for comparison, consider using a
-  [Table](../?path=/docs/components-lists-and-tables-table--docs).
+  [Table](/components/Table).

--- a/docs/components/Disclosure/Disclosure.stories.mdx
+++ b/docs/components/Disclosure/Disclosure.stories.mdx
@@ -47,9 +47,8 @@ to change but is not required to.
 - `children` should be actionable and clear. The contents of a Disclosure can
   be:
   - plain text
-  - any React component (except
-    [Page](../?path=/docs/components-layouts-and-structure-page--docs) and
-    [Table](../?path=/docs/components-lists-and-tables-table--docs))
+  - any React component (except [Page](/components/Page) and
+    [Table](/components/Table))
 
 ## Accessibility
 

--- a/docs/components/Divider/Divider.stories.mdx
+++ b/docs/components/Divider/Divider.stories.mdx
@@ -9,9 +9,7 @@ The Divider component is used to separate content into different sections.
 ## Design & usage guidelines
 
 Divider comes with no spacing around it. This means that it should be used
-within a
-[Content](../?path=/docs/components-layouts-and-structure-content--docs)
-component.
+within a [Content](/components/Content) component.
 
 ### Size
 
@@ -21,7 +19,5 @@ impact of their additional weight.
 
 ## Related components
 
-- To segment different groups of content, use
-  [Card](../?path=/docs/components-layouts-and-structure-card--docs)
-- For guidance on borders in general, see our
-  [Borders guide](../?path=/docs/design-borders--docs)
+- To segment different groups of content, use [Card](/components/Card)
+- For guidance on borders in general, see our [Borders guide](/design/borders)

--- a/docs/components/Drawer/Drawer.stories.mdx
+++ b/docs/components/Drawer/Drawer.stories.mdx
@@ -10,16 +10,16 @@ Users can interact with the main content while the drawer is visible.
 
 ## Related components
 
-Use [SideDrawer](../?path=/docs/components-overlays-sidedrawer--docs) if you
-need to overlay the page's content and block user interaction with the page,
-while still maintaining visibilty of the page's primary contents.
+Use [SideDrawer](/components/SideDrawer) if you need to overlay the page's
+content and block user interaction with the page, while still maintaining
+visibilty of the page's primary contents.
 
-Use [Modal](../?path=/docs/components-overlays-Modal--docs) if you need to
-overlay the page's content and block user interaction with the page, and do not
-need the user to have visibilty of the page's primary contents.
+Use [Modal](/components/Modal) if you need to overlay the page's content and
+block user interaction with the page, and do not need the user to have visibilty
+of the page's primary contents.
 
-Use [Card](../?path=/docs/components-layouts-and-structure-card--docs) to group
-content inline, within the main view, in a non-dismissible way.
+Use [Card](/components/Card) to group content inline, within the main view, in a
+non-dismissible way.
 
 ## Accessibility
 

--- a/docs/components/FeatureSwitch/FeatureSwitch.stories.mdx
+++ b/docs/components/FeatureSwitch/FeatureSwitch.stories.mdx
@@ -18,5 +18,4 @@ message, what the message template might be, and when the message should be
 sent.
 
 If the user is making a per-use-case on/off decision, such as enabling automatic
-payments for a single invoice, use the
-[Switch](../?path=/story/components-selections-switch-web--basic) component.
+payments for a single invoice, use the [Switch](/components/Switch) component.

--- a/docs/components/Flex/Flex.stories.mdx
+++ b/docs/components/Flex/Flex.stories.mdx
@@ -22,9 +22,9 @@ further control the layout of the children.
 
 ## Related components
 
-Use [Grid](../?path=/docs/components-layouts-and-structure-grid--docs) to create
-grid layouts. Using Flex inside of Grid gives you the ability to achieve complex
-layouts without needing custom wrappers.
+Use [Grid](/components/Grid) to create grid layouts. Using Flex inside of Grid
+gives you the ability to achieve complex layouts without needing custom
+wrappers.
 
-Use [Content](../?path=/docs/components-layouts-and-structure-content--docs) to
-evenly space elements in a simple one-directional layout.
+Use [Content](/components/Content) to evenly space elements in a simple
+one-directional layout.

--- a/docs/components/Form/Form.stories.mdx
+++ b/docs/components/Form/Form.stories.mdx
@@ -25,12 +25,9 @@ have a `value` and `onChange` prop.
 ### Inputs
 
 Form can accept various inputs and selection elements such as (but not limited
-to) [InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs),
-[ Select](../?path=/docs/components-selections-select--docs),
-[ Switch](../?path=/docs/components-selections-switch--docs),
-[ Checkbox](../?path=/docs/components-selections-checkbox--docs), and
-[ Chips](../?path=/docs/components-selections-chips--docs). They should be
-placed [Cards](../?path=/docs/components-layouts-and-structure-card--docs) to
+to) [InputText](/components/InputText), [Select](/components/Select),
+[Switch](/components/Switch), [Checkbox](/components/Checkbox), and
+[Chips](/components/Chips). They should be placed [Cards](/components/Card) to
 indicate grouping when relevant, and groups of Cards can be spaced appropriately
 using ContentSection.
 
@@ -44,7 +41,7 @@ saving the single input they are editing, but the entire object.
 ### Form errors
 
 All error messaging should follow our
-[Product Vocabulary.](../?path=/docs/content-product-vocabulary--docs)
+[Product Vocabulary.](/content/product-vocabulary)
 
 ## Accessibility (mobile)
 

--- a/docs/components/FormField/FormField.stories.mdx
+++ b/docs/components/FormField/FormField.stories.mdx
@@ -10,5 +10,5 @@ the form value for the field used by the component.
 
 ## Related components
 
-Refer to the [Form](../?path=/docs/components-forms-and-inputs-form--docs)
-documentation to learn more about inputs within a form.
+Refer to the [Form](/components/Form) documentation to learn more about inputs
+within a form.

--- a/docs/components/FormatDate/FormatDate.stories.mdx
+++ b/docs/components/FormatDate/FormatDate.stories.mdx
@@ -29,10 +29,9 @@ import { strFormatDate } from "@jobber/components/FormatDate";
 Use FormatDate to ensure that a date is represented as expected.
 
 If there are additional text styling concerns, wrap FormatDate in a
-[Text](../?path=/docs/components-text-and-typography-text--docs) component.
+[Text](/components/Text) component.
 
 If the formatted date is intended to be part of a heading, wrap FormatDate in a
-[Heading](../?path=/docs/components-text-and-typography-heading--docs)
-component.
+[Heading](/components/Heading) component.
 
 If you require a string instead of a component use strFormatDate.

--- a/docs/components/FormatFile/FormatFile.stories.mdx
+++ b/docs/components/FormatFile/FormatFile.stories.mdx
@@ -24,5 +24,4 @@ image, while expanded is used to display a file alongside its metadata.
 
 ## Related components
 
-- For a thumbnail representation of a user, use
-  [Avatar](../?path=/docs/components-images-and-icons-avatar--docs).
+- For a thumbnail representation of a user, use [Avatar](/components/Avatar).

--- a/docs/components/Glimmer/Glimmer.stories.mdx
+++ b/docs/components/Glimmer/Glimmer.stories.mdx
@@ -8,7 +8,7 @@ import { Glimmer } from "@jobber/components/Glimmer";
 
 Glimmer is a foundational component that is used to build Skeleton (_coming
 soon_) or other components that invoke loading such as an image waiting to load
-on [FormatFile](../?path=/docs/components-images-and-icons-formatfile--docs).
+on [FormatFile](/components/FormatFile).
 
 ## Colors
 

--- a/docs/components/Grid/Grid.stories.mdx
+++ b/docs/components/Grid/Grid.stories.mdx
@@ -12,7 +12,7 @@ Helps create a layout that conforms to a 12-point grid system.
 The Grid is divided up into 12 columns. The `Grid.Cell` child sets how many of
 the 12 columns it takes as a width via `size`. The `Grid.Cell` also includes
 breakpoints of `xs`, `sm`, `md`, `lg`, and `xl`. Those sizes strictly follow our
-[Design Breakpoints](../?path=/docs/design-breakpoints--docs).
+[Design Breakpoints](/design/breakpoints).
 
 As an example, let's say you have a
 [three column grid](../?path=/story/components-layouts-and-structure-grid-web--three-columns)
@@ -35,11 +35,11 @@ The way you'd achieve that is to:
 
 ## Related components
 
-Use [Flex](../?path=/docs/components-layouts-and-structure-flex--docs) inside of
-Grid to create complex layouts without needing custom wrappers.
+Use [Flex](/components/Flex) inside of Grid to create complex layouts without
+needing custom wrappers.
 
-Use [Content](../?path=/docs/components-layouts-and-structure-content--docs) to
-evenly space elements in a simple one-directional layout.
+Use [Content](/components/Content) to evenly space elements in a simple
+one-directional layout.
 
 ### Visualizing the grid lines
 

--- a/docs/components/Heading/Heading.stories.mdx
+++ b/docs/components/Heading/Heading.stories.mdx
@@ -53,7 +53,7 @@ as a stylistic reference to the
 ## Related components
 
 For introductory text after a page title, or paragraph text for body copy, use
-[Text](../?path=/docs/components-text-and-typography-text--docs).
+[Text](/components/Text).
 
 ## Accessibility
 

--- a/docs/components/IconButton/IconButton.stories.mdx
+++ b/docs/components/IconButton/IconButton.stories.mdx
@@ -14,8 +14,8 @@ IconButtons are used to create pressable components (buttons) that render an
 Icon. IconButtons are used for navigation between different screens or
 performing core actions.
 
-Please read the [Icon](../?path=/docs/components-images-and-icons-icon--docs)
-documentation for more information regarding which icons to use.
+Please read the [Icon](/components/Icon) documentation for more information
+regarding which icons to use.
 
 ## Mockup
 

--- a/docs/components/InlineLabel/InlineLabel.stories.mdx
+++ b/docs/components/InlineLabel/InlineLabel.stories.mdx
@@ -14,9 +14,8 @@ labeling element from other typographic content.
 ## Design & usage guidelines
 
 Inline labels can be used fairly broadly, but the application of
-[color](../?path=/docs/design-colors--docs) should be handled with intent. Use
-of color along with a descriptive label can help the user understand the meaning
-of an item.
+[color](/design/colors) should be handled with intent. Use of color along with a
+descriptive label can help the user understand the meaning of an item.
 
 ### Counts
 
@@ -57,8 +56,8 @@ of an item.
 
 ## Related components
 
-[StatusLabel](../?path=/docs/components-status-and-feedback-statuslabel--docs)
-should be used when you're conveying the "status" of something.
+[StatusLabel](/components/StatusLabel) should be used when you're conveying the
+"status" of something.
 
 ## Variants
 

--- a/docs/components/InputDate/InputDate.stories.mdx
+++ b/docs/components/InputDate/InputDate.stories.mdx
@@ -46,19 +46,16 @@ When the InputDate is near the top or bottom of the viewport, the Datepicker
 will adjust its position to remain in view.
 
 The FormField for InputDate will take up the full available width of its parent.
-If used in an
-[InputGroup](../?path=/docs/components-forms-and-inputs-inputgroup--docs), it
-will take up the available amount of space left by any other inputs in the
-group.
+If used in an [InputGroup](/components/InputGroup), it will take up the
+available amount of space left by any other inputs in the group.
 
 ## Related components
 
 - On web if you do not need an accompanying form field, you can use the
-  [Datepicker](../?path=/docs/components-selections-datepicker--docs) on its own
+  [Datepicker](/components/Datepicker) on its own
 - If you need to allow the user to enter time, use
-  [InputTime](../?path=/docs/components-forms-and-inputs-inputtime--docs)
-- If you just need a text input, use
-  [InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs)
+  [InputTime](/components/InputTime)
+- If you just need a text input, use [InputText](/components/InputText)
 
 ## Accessibility
 

--- a/docs/components/InputEmail/InputEmail.stories.mdx
+++ b/docs/components/InputEmail/InputEmail.stories.mdx
@@ -18,4 +18,4 @@ available on mobile.
 ## Related components
 
 If you are not worried about email address validation, consider using
-[InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs).
+[InputText](/components/InputText).

--- a/docs/components/InputFieldWrapper/InputFieldWrapper.stories.mdx
+++ b/docs/components/InputFieldWrapper/InputFieldWrapper.stories.mdx
@@ -5,10 +5,10 @@ import { Meta } from "@storybook/addon-docs";
 # InputFieldWrapper
 
 This component is used to wrap input fields such as
-[InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs) and
-[InputPressable](..?path=/docs/components-forms-and-inputs-inputpressable--docs)
-to provide common patterns and functionality present in our input designs, such
-as suffix/prefix icons, placeholders, etc.
+[InputText](/components/InputText) and
+[InputPressable](/components/InputPressable) to provide common patterns and
+functionality present in our input designs, such as suffix/prefix icons,
+placeholders, etc.
 
 ## Design & usage guidelines
 
@@ -17,8 +17,8 @@ as suffix/prefix icons, placeholders, etc.
 Use a prefix or suffix when additional visual cues about an input's function may
 be helpful.
 
-Some fields have common visual patterns such as “search” having a magnifying
-glass icon, “Select” having a downwards arrow, or currency inputs having a
+Some fields have common visual patterns such as "search" having a magnifying
+glass icon, "Select" having a downwards arrow, or currency inputs having a
 currency symbol. These signifiers reinforce the purpose of the input to increase
 [Recognition over Recall](https://www.nngroup.com/articles/ten-usability-heuristics/)
 and align the input with
@@ -29,7 +29,6 @@ focus on the task at hand. See
 
 ## Related components
 
-Refer to [InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs)
-and
-[InputPressable](../?path=/docs/components-forms-and-inputs-inputpressable--docs)
-to see implementation examples using InputFieldWrapper.
+Refer to [InputText](/components/InputText) and
+[InputPressable](/components/InputPressable) to see implementation examples
+using InputFieldWrapper.

--- a/docs/components/InputGroup/InputGroup.stories.mdx
+++ b/docs/components/InputGroup/InputGroup.stories.mdx
@@ -21,6 +21,5 @@ issues caused by nesting. Any non-horizontal nested groups will log an error to
 the console and not be rendered.
 
 If one of the InputGroup fields has a preset value from a larger list of
-options, it is possible to use
-[Autocomplete](../?path=/docs/components-forms-and-inputs-autocomplete--docs)
-within InputGroup.
+options, it is possible to use [Autocomplete](/components/Autocomplete) within
+InputGroup.

--- a/docs/components/InputText/InputText.stories.mdx
+++ b/docs/components/InputText/InputText.stories.mdx
@@ -66,8 +66,8 @@ For web, you can set a minimum and maximum number of rows. See:
 Use a prefix or suffix when additional visual cues about an input's function may
 be helpful.
 
-Some fields have common visual patterns such as “search” having a magnifying
-glass icon, “Select” having a downwards arrow, or currency inputs having a
+Some fields have common visual patterns such as "search" having a magnifying
+glass icon, "Select" having a downwards arrow, or currency inputs having a
 currency symbol. These signifiers reinforce the purpose of the input to increase
 [Recognition over Recall](https://www.nngroup.com/articles/ten-usability-heuristics/)
 and align the input with

--- a/docs/components/Link/Link.stories.mdx
+++ b/docs/components/Link/Link.stories.mdx
@@ -14,17 +14,16 @@ from Jobber or to other applications or sites across Jobber where this behaviour
 is appropriate (e.g. linking from Jobber Online to the Jobber Help Center).
 
 Link should not be used to submit form data, trigger actions, or alter the state
-of the page. Use a [Button](../?path=/docs/components-actions-button--docs) for
-these purposes.
+of the page. Use a [Button](/components/Button) for these purposes.
 
 ## Content guidelines
 
 Contents of the link should be textual, and may include some formatting features
 (e.g. italic text for emphasis may be appropriate, changing the inherited
 underline probably isn't). The text can be plain, from a
-[Typography](../?path=/docs/components-text-and-typography-typography--docs)
-component, a `format`(`Date|Time|Email`) component or similar. Don't use this
-component to wrap other kinds of UI elements to make them clickable.
+[Typography](/components/Typography) component, a `format`(`Date|Time|Email`)
+component or similar. Don't use this component to wrap other kinds of UI
+elements to make them clickable.
 
 ## Accessibility
 

--- a/docs/components/Menu/Menu.stories.mdx
+++ b/docs/components/Menu/Menu.stories.mdx
@@ -15,7 +15,7 @@ only the first letter of the label unless there is a proper noun (such as a
 person's name) in the label.
 
 Jobber features, such as jobs, quotes, and invoices, are not proper nouns and
-[should not be capitalized.](../?path=/docs/content-product-vocabulary--docs#concepts-and-items)
+[should not be capitalized.](/content/product-vocabulary)
 
 | ✅ Do                            | ❌ Don't                         |
 | -------------------------------- | -------------------------------- |

--- a/docs/components/Modal/Modal.stories.mdx
+++ b/docs/components/Modal/Modal.stories.mdx
@@ -10,10 +10,9 @@ the rest of the application until a specific action is taken.
 
 ## Related components
 
-Use [SideDrawer](../?path=/docs/components-overlays-sidedrawer--docs) if you
-need to overlay the page's content and block user interaction with the page,
-while still maintaining visibilty of the page's primary contents.
+Use [SideDrawer](/components/SideDrawer) if you need to overlay the page's
+content and block user interaction with the page, while still maintaining
+visibilty of the page's primary contents.
 
-Use
-[ConfirmationModal](../?path=/docs/components-overlays-confirmationmodal--docs)
-to allow users to confirm or cancel actions that they are performing.
+Use [ConfirmationModal](/components/ConfirmationModal) to allow users to confirm
+or cancel actions that they are performing.

--- a/docs/components/MultiSelect/MultiSelect.stories.mdx
+++ b/docs/components/MultiSelect/MultiSelect.stories.mdx
@@ -22,8 +22,7 @@ the `onOptionsChange` prop.
 Adjusting the
 [size](../?path=/story/components-selections-multiselect-web--sizes) of the
 MultiSelect can be used to help align with common adjacent elements such as
-[InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs) or
-[Select](../?path=/docs/components-selections-select--docs).
+[InputText](/components/InputText) or [Select](/components/Select).
 
 ## Accessibility
 

--- a/docs/components/Popover/Popover.stories.mdx
+++ b/docs/components/Popover/Popover.stories.mdx
@@ -21,8 +21,7 @@ experience, Popover can be an excellent choice to highlight a specific piece of
 the experience.
 
 If there is an "acknowledgement" CTA for the user to confirm that they
-understand the change, use a `learning`
-[Button](../?path=/docs/components-actions-button--docs).
+understand the change, use a `learning` [Button](/components/Button).
 
 See
 [Popover/Informational](../?path=/story/components-overlays-popover-web--informational)
@@ -36,22 +35,19 @@ See
 Reveal a list of available actions to the user. For example, if the user clicks
 on an element and there are four potential actions they might take, Popover is a
 great way to present those actions. If you're looking to provide a menu of
-actions that comes complete with a trigger button,
-[Menu](../?path=/docs/components-navigation-menu--docs) has that bundle ready to
-go.
+actions that comes complete with a trigger button, [Menu](/components/Menu) has
+that bundle ready to go.
 
 ## Related components
 
 To add a menu button that presents multiple actions to the user, use
-[Menu](../?path=/docs/components-navigation-menu--docs).
+[Menu](/components/Menu).
 
 To add a hint about a UI element's function in a permanent fashion (ie revealing
-a Button's label on hover), use
-[Tooltip](../?path=/docs/components-overlays-tooltip--docs).
+a Button's label on hover), use [Tooltip](/components/Tooltip).
 
 To add an inline informational element that the user can dismiss, consider if
-[Banner](../?path=/docs/components-status-and-feedback-banner--docs) is the
-right fit for your use case.
+[Banner](/components/Banner) is the right fit for your use case.
 
 ## Content guidelines
 

--- a/docs/components/ProgressBar/ProgressBar.stories.mdx
+++ b/docs/components/ProgressBar/ProgressBar.stories.mdx
@@ -11,7 +11,7 @@ A ProgressBar is a visual indicator of how close something is to completion.
 The ProgressBar should be used to show "definite" progress; we know exactly how
 close the process is to completion. For "indefinite" progress, where we may not
 know exactly how much longer something might take, use a
-[Spinner](..?path=/docs/components-status-and-feedback-spinner--docs).
+[Spinner](/components/Spinner).
 
 Some great use cases for a ProgressBar include:
 

--- a/docs/components/RecurringSelect/RecurringSelect.stories.mdx
+++ b/docs/components/RecurringSelect/RecurringSelect.stories.mdx
@@ -45,5 +45,4 @@ the type of selection they are making.
 ## Related components
 
 To allow the user to select specific dates, use
-[Datepicker](../?path=/docs/components-selections-datepicker--docs) or
-[InputDate](../?path=/docs/components-forms-and-inputs-inputdate--docs).
+[Datepicker](/components/Datepicker) or [InputDate](/components/InputDate).

--- a/docs/components/SegmentedControl/SegmentedControl.stories.mdx
+++ b/docs/components/SegmentedControl/SegmentedControl.stories.mdx
@@ -23,8 +23,8 @@ parent container with a fixed width. Be sure to avoid truncating the labels.
 
 ## Content guidelines
 
-Concise [Text](../?path=/docs/components-text-and-typography-text--docs) should
-be used as the primary format for option labels.
+Concise [Text](/components/Text) should be used as the primary format for option
+labels.
 
 <Canvas>
   <SegmentedControl defaultOption="option1">
@@ -36,8 +36,8 @@ be used as the primary format for option labels.
   </SegmentedControl>
 </Canvas>
 
-Using [Icons](../?path=/docs/components-images-and-icons-icon--docs) as labels
-should only be used if the icon has been tested as understandable in isolation.
+Using [Icons](/components/Icon) as labels should only be used if the icon has
+been tested as understandable in isolation.
 
 <Canvas>
   <SegmentedControl defaultOption="calendar">
@@ -61,24 +61,21 @@ Mixing content types across options should also be avoided. This would create an
 inconsistent experience for users and lead to a jarring visual rhythm.
 
 If you do not have enough horizontal room to allow for readable labels, consider
-using [Menu](/?path=/docs/components-navigation-menu--docs) as an alternative
-single-selection method for modifying the view. Otherwise, truncation will
-prevent the user from reading the label and a label with wrapped text will
-create layout inconsistencies.
+using [Menu](/components/Menu) as an alternative single-selection method for
+modifying the view. Otherwise, truncation will prevent the user from reading the
+label and a label with wrapped text will create layout inconsistencies.
 
 ## Related components
 
-Unlike [Tabs](../?path=/docs/components-navigation-tabs--docs), the contents of
-each segment are not contained by each label. You should use Tabs when you need
-to navigate between related subgroups of different content.
+Unlike [Tabs](/components/Tabs), the contents of each segment are not contained
+by each label. You should use Tabs when you need to navigate between related
+subgroups of different content.
 
-Unlike [Switch](../?path=/docs/components-selections-switch--docs), which
-toggles between a simple On/Off state, the SegmentedControl offers more than two
-options.
+Unlike [Switch](/components/Switch), which toggles between a simple On/Off
+state, the SegmentedControl offers more than two options.
 
 With SegmentedControl, options are more aggressively grouped than
-[Chips](../?path=/docs/components-selections-chips--docs) and also cannot reflow
-when it runs out of room.
+[Chips](/components/Chips) and also cannot reflow when it runs out of room.
 
 ## Accessibility
 

--- a/docs/components/SideDrawer/SideDrawer.stories.mdx
+++ b/docs/components/SideDrawer/SideDrawer.stories.mdx
@@ -11,10 +11,10 @@ with the page's contents while the SideDrawer overlay is open.
 
 ## Related components
 
-Use [Drawer](../?path=/docs/components-layouts-and-structure-drawer--docs) if
-you need to allow users to view supplementary content while still allowing users
-to interact with the main contents of the page.
+Use [Drawer](/components/Drawer) if you need to allow users to view
+supplementary content while still allowing users to interact with the main
+contents of the page.
 
-Use [Modal](../?path=/docs/components-overlays-Modal--docs) if you need to
-overlay the page's content and block user interaction with the page, and do not
-need the user to have visibilty of the page's primary contents.
+Use [Modal](/components/Modal) if you need to overlay the page's content and
+block user interaction with the page, and do not need the user to have visibilty
+of the page's primary contents.

--- a/docs/components/Spinner/Spinner.stories.mdx
+++ b/docs/components/Spinner/Spinner.stories.mdx
@@ -11,9 +11,7 @@ loading time or progress is unknown.
 
 The default Spinner size is `base` and can be used in most cases. The `small`
 Spinner should be used on individual elements of an interface (e.g.
-[Button](../?path=/docs/components-actions-button--docs) or
-[Card](../?path=/docs/components-layouts-and-structure-card--docs) contents) or
-when
+[Button](/components/Button) or [Card](/components/Card) contents) or when
 [inline](../?path=/story/components-status-and-feedback-spinner-web--inline)
 with content.
 
@@ -34,8 +32,8 @@ The following built-in properties help Spinner convey its role effectively:
 ## Related components
 
 If the amount of progress or loading time is known, use
-[ProgressBar](../?path=/docs/components-status-and-feedback-progressbar--docs)
-to give better context around the process.
+[ProgressBar](/components/ProgressBar) to give better context around the
+process.
 
 To indicate loading content in mobile applications, refer to
-[ActivityIndicator](../?path=/docs/components-status-and-feedback-activityindicator--docs).
+[ActivityIndicator](/components/ActivityIndicator).

--- a/docs/components/StatusIndicator/StatusIndicator.stories.mdx
+++ b/docs/components/StatusIndicator/StatusIndicator.stories.mdx
@@ -50,4 +50,4 @@ active workflow.
 ## Related components
 
 If you are looking to use a StatusIndicator with a label, you should use
-[StatusLabel](../?path=/docs/components-status-and-feedback-statuslabel--docs).
+[StatusLabel](/components/StatusLabel).

--- a/docs/components/StatusLabel/StatusLabel.stories.mdx
+++ b/docs/components/StatusLabel/StatusLabel.stories.mdx
@@ -12,8 +12,8 @@ determine the status of an item (e.g., "Active", "Overdue").
 ## Design & usage guidelines
 
 StatusLabel is a more opinionated version of
-[InlineLabel](../?path=/docs/components-status-and-feedback-inlinelabel--docs)
-and offers only 5 possible status representations:
+[InlineLabel](/components/InlineLabel) and offers only 5 possible status
+representations:
 
 ### Success
 
@@ -53,8 +53,8 @@ active workflow.
 
 Align the color indicator with the start or end of a layout as needed.
 
-For example, in a [List](../?path=/docs/components-lists-and-tables-list--docs)
-where the StatusLabel is on the right, use the `end` alignment.
+For example, in a [List](/components/List) where the StatusLabel is on the
+right, use the `end` alignment.
 
 <Canvas>
   <div style={{ display: "flex", justifyContent: "space-between" }}>
@@ -65,8 +65,8 @@ where the StatusLabel is on the right, use the `end` alignment.
 
 ## Related components
 
-[InlineLabel](../?path=/docs/components-status-and-feedback-inlinelabel--docs)
-is a more generic badging element that can be used in non-"status"-y ways
+[InlineLabel](/components/InlineLabel) is a more generic badging element that
+can be used in non-"status"-y ways
 
 - counts
 - trends

--- a/docs/components/Switch/Switch.stories.mdx
+++ b/docs/components/Switch/Switch.stories.mdx
@@ -26,13 +26,11 @@ interface.
 
 ### Related components
 
-A Switch, a [Checkbox](../?path=/docs/components-selections-checkbox--docs), and
-a pair of
-[RadioButton](../?path=/docs/components-forms-and-inputs-radiogroup--docs) can
-seem similar in theory, as all can represent an `either/or decision` for the
-user.
+A Switch, a [Checkbox](/components/Checkbox), and a pair of
+[RadioButton](/components/RadioGroup) can seem similar in theory, as all can
+represent an `either/or decision` for the user.
 
 Use a Switch when the user must make a decision to turn something on or off, and
 a single Checkbox when a user is opting in to a choice. A pair of RadioButtons
-can be used to help the user decide between two discrete options, such as “fixed
-price” and “per visit” invoicing options.
+can be used to help the user decide between two discrete options, such as "fixed
+price" and "per visit" invoicing options.

--- a/docs/components/Table/Table.stories.mdx
+++ b/docs/components/Table/Table.stories.mdx
@@ -24,7 +24,6 @@ distinctions in dollar amounts, inventory counts, and other key business data.
 
 To list more complex collections of information (such as multi-line content like
 a detailed property address), you may want to consider the
-[List](../?path=/docs/components-lists-and-tables-list--docs) component. If you
-have a small list of information with a 1:1 label-to-data relationship (for
-example, the issued and due dates on an invoice), consider using
-[DescriptionList](../?path=/docs/components-lists-and-tables-descriptionlist--docs).
+[List](/components/List) component. If you have a small list of information with
+a 1:1 label-to-data relationship (for example, the issued and due dates on an
+invoice), consider using [DescriptionList](/components/DescriptionList).

--- a/docs/components/Tabs/Tabs.stories.mdx
+++ b/docs/components/Tabs/Tabs.stories.mdx
@@ -29,12 +29,10 @@ pattern for the user.
 
 ## Related components
 
-To show multiple groupings of content at once, use
-[Card](../?path=/docs/components-layouts-and-structure-card--docs).
+To show multiple groupings of content at once, use [Card](/components/Card).
 
 To allow the user to select one-of-many options in a form, use
-[RadioGroup](../?path=/docs/components-forms-and-inputs-radiogroup--docs) or
-[Select](../?path=/docs/components-selections-select--docs).
+[RadioGroup](/components/RadioGroup) or [Select](/components/Select).
 
 ## Accessibility
 

--- a/docs/components/TextList/TextList.stories.mdx
+++ b/docs/components/TextList/TextList.stories.mdx
@@ -15,8 +15,6 @@ making the content easily digestible for the user.
 
 ## Related components
 
-This component is uses the
-[Content](..?path=/docs/components-layouts-and-structure-content--docs) and
-[Text](..?path=/docs/components-text-and-typography-text--docs) components for
-displaying. This is also used for displaying the error list in
-[Banner](..?path=/docs/components-status-and-feedback-banner--docs) component.
+This component is uses the [Content](/components/Content) and
+[Text](/components/Text) components for displaying. This is also used for
+displaying the error list in [Banner](/components/Banner) component.

--- a/docs/components/ThumbnailList/ThumbnailList.stories.mdx
+++ b/docs/components/ThumbnailList/ThumbnailList.stories.mdx
@@ -5,4 +5,4 @@ import { Meta } from "@storybook/addon-docs";
 # Thumbnail List
 
 For guidelines on using this component, see the documentation for web equivalent
-component, [Gallery](../?path=/docs/components-images-and-icons-gallery--docs).
+component, [Gallery](/components/Gallery).

--- a/docs/components/Toast/Toast.stories.mdx
+++ b/docs/components/Toast/Toast.stories.mdx
@@ -22,8 +22,7 @@ Use `Toast` to present non-blocking feedback about the system to a user.
 
 For more persistent feedback (such as displaying errors), communicating a
 background process that is ongoing, or for feedback that has a longer reading
-length or CTA, use
-[Banner.](../?path=/docs/components-status-and-feedback-banner--docs)
+length or CTA, use [Banner.](/components/Banner)
 
 ### Variation (Web only)
 
@@ -38,10 +37,9 @@ background system activity. See
 > Do not use Toast for errors. This is currently an available variation, but
 > should be considered deprecated and not propagated.
 
-Use [Banner](../?path=/docs/components-status-and-feedback-banner--docs) and,
-where necessary, targeted error messaging (such as
-[InputValidation](../?path=/docs/components-forms-and-inputs-inputvalidation--docs))
-so that the user can appropriately assess and recover from the error.
+Use [Banner](/components/Banner) and, where necessary, targeted error messaging
+(such as [InputValidation](/components/InputValidation)) so that the user can
+appropriately assess and recover from the error.
 
 ## Content guidelines
 
@@ -49,9 +47,8 @@ The Toast label should be clear and concise, and should not take up more than
 one line.
 
 Use the pattern "action + subject" to maintain
-[active voice](../?path=/docs/content-voice-tone--docs#active-voice). The
-subject should be specific without overloading too much detail for the user to
-parse at a quick glance.
+[active voice](/content/voice-and-tone). The subject should be specific without
+overloading too much detail for the user to parse at a quick glance.
 
 | ✅ Do             | ❌ Don't                                           |
 | ----------------- | -------------------------------------------------- |
@@ -63,8 +60,7 @@ parse at a quick glance.
   - Examples of action labels: `Undo`, `View`, `Refresh`
 - Toast's label does not require a period
 - Use sentence case, and only capitalize
-  ["branded"](../?path=/docs/content-product-vocabulary--docs#jobber-card-reader)
-  Jobber features
+  ["branded"](/content/product-vocabulary) Jobber features
 
 | ✅ Do      | ❌ Don't                |
 | ---------- | ----------------------- |

--- a/docs/components/Tooltip/Tooltip.stories.mdx
+++ b/docs/components/Tooltip/Tooltip.stories.mdx
@@ -21,8 +21,7 @@ following:
   successfully complete a task. It should provide a "tip" to use the "tools" in
   the UI
 - Tooltip should _not_ be used to introduce a new element to an interface, or
-  contain actions or other content. Use
-  [Popover](../?path=/docs/components-overlays-popover--docs) instead
+  contain actions or other content. Use [Popover](/components/Popover) instead
 
 ## Content guidelines
 
@@ -33,4 +32,4 @@ concise, never exceeding 3 lines.
 
 To introduce a novel change to the interface, highlight new functionality, or
 offer a temporary, dismissible "attached" element to part of the UI, use
-[Popover](../?path=/docs/components-overlays-popover--docs)
+[Popover](/components/Popover)

--- a/docs/components/Typography/Typography.stories.mdx
+++ b/docs/components/Typography/Typography.stories.mdx
@@ -10,11 +10,9 @@ Base component that defines typographic standards across Jobber.
 
 <Banner type="notice" dismissible={false}>
 
-Typography is the component that powers our Heading and Text components “under
-the hood”. You should first look to use
-[Heading](../?path=/docs/components-text-and-typography-heading--docs) and
-[Text](../?path=/docs/components-text-and-typography-text--docs) before you
-reach for Typography.
+Typography is the component that powers our Heading and Text components "under
+the hood". You should first look to use [Heading](/components/Heading) and
+[Text](/components/Text) before you reach for Typography.
 
 </Banner>
 

--- a/docs/design/Borders.stories.mdx
+++ b/docs/design/Borders.stories.mdx
@@ -17,7 +17,7 @@ styling to ensure consistent border thickness throughout Jobber.
 
 Border style should be `solid` unless a specific use case calls for some other
 format, such as indicating a dropzone on the
-[`InputFile` component](../?path=/docs/components-forms-and-inputs-inputfile--docs).
+[`InputFile` component](/components/InputFile).
 
 export function BaseStyle({ of: size }) {
   return {
@@ -47,27 +47,23 @@ export function BorderSize({ of: size }) {
 | `--border-thickest` | <Example of="thickest" /> | <BorderSize of="thickest" /> |
 
 The `base` border width should be used for most use cases (see
-[`Card`](../?path=/docs/components-layouts-and-structure-card--docs) and
-[`List` items](../?path=/docs/components-lists-and-tables-list--docs) for
-in-context examples). You may want to consider thicker borders when the border
-conveys a closing of already-divided sections, such as a
-[`Table` footer](../?path=/docs/components-lists-and-tables-table--docs).
+[`Card`](/components/Card) and [`List` items](/components/List) for in-context
+examples). You may want to consider thicker borders when the border conveys a
+closing of already-divided sections, such as a
+[`Table` footer](/components/Table).
 
 ### Border Colors
 
 Borders should use `--color-border)` for most use cases.
 [`List` sections](../?path=/docs/components-lists-and-tables-list--docs#sectioned-list-items),
-[`Table` headers](../?path=/docs/components-lists-and-tables-table--docs) and
-other scenarios where other bordered content is being further subsectioned
-should use `--color-border--section)`.
+[`Table` headers](/components/Table) and other scenarios where other bordered
+content is being further subsectioned should use `--color-border--section)`.
 
 For accessibility reasons, ensure that color usage is not the only way to
 [convey meaning](https://webaim.org/articles/contrast/#sc141) in an interface.
 
 ## Dividers
 
-The
-[`Divider` component](../?path=/docs/components-layouts-and-structure-divider--docs)
-will help you segment sections of content without writing additional styling.
-This component will render a horizontal rule that takes up the full available
-width.
+The [`Divider` component](/components/Divider) will help you segment sections of
+content without writing additional styling. This component will render a
+horizontal rule that takes up the full available width.

--- a/docs/design/Colors.stories.mdx
+++ b/docs/design/Colors.stories.mdx
@@ -45,7 +45,7 @@ Headings have a bold, high-contrast color to cement their hierarchy.
 A slightly softer color is used for body text for greater readability.
 
 Text that is relevant but less important ("secondary") can be lower-contrast to
-suggest its’ reduced importance. This color should only be used when there is
+suggest its' reduced importance. This color should only be used when there is
 more important text content already present.
 
 ##### Text--Reverse
@@ -63,11 +63,10 @@ standard secondary text.
 ### Interactions
 
 Use these colors in buttons and form controls to communicate the presence and
-meaning of interaction. In cases such as
-[Buttons](../?path=/docs/components-actions-button--docs) where the interactive
-color is functioning as a background color or the text color, the alternative
-color should be `--color-surface` so that the label matches the theme of the
-application's background.
+meaning of interaction. In cases such as [Buttons](/components/Button) where the
+interactive color is functioning as a background color or the text color, the
+alternative color should be `--color-surface` so that the label matches the
+theme of the application's background.
 
 #### Interactive
 
@@ -100,7 +99,7 @@ surface they appear on.
 
 <Swatch colors={[`--color-destructive`, "--color-destructive--hover"]} />
 
-Use to signify that an interaction will destroy something in the users’ account
+Use to signify that an interaction will destroy something in the users' account
 or workflow.
 
 #### Disabled
@@ -242,8 +241,8 @@ application.
 <Swatch colors={["--color-overlay"]} />
 
 Use to mask an area of the interface to promote focus to a foreground action,
-such as a [Modal](../?path=/docs/components-overlays-modal--docs)’s appearance.
-Overlay includes built-in opacity values.
+such as a [Modal](/components/Modal)'s appearance. Overlay includes built-in
+opacity values.
 
 #### Overlay--Dimmed
 
@@ -257,7 +256,7 @@ includes built-in opacity values.
 
 Defining the edges of elements on the same elevation plane, border colors are
 the subtle maintainers of layout structure. Learn more about borders in our
-[Borders guide.](../?path=/docs/design-borders--docs)
+[Borders guide.](/design/borders)
 
 <Swatch
   colors={[
@@ -284,14 +283,14 @@ Use these colors to represent the Jobber brand visual language.
 <Swatch colors={["--color-brand"]} />
 
 The primary color associated with our brand, from website to ads to product; AKA
-“Jobber Green”.
+"Jobber Green".
 
 #### Brand--Highlight
 
 <Swatch colors={["--color-brand--highlight"]} />
 
 Use to highlight an element in a way that aligns with our website. Use with
-caution, it’s _bright!_
+caution, it's _bright!_
 
 <br />
 <br />

--- a/docs/design/Elevations.stories.mdx
+++ b/docs/design/Elevations.stories.mdx
@@ -34,8 +34,7 @@ be represented as having a "low" elevation.
 
 This shadow should be used for most instances of shadows to convey that an
 element is floating overtop related elements, such as in
-[Menu](../?path=/docs/components-navigation-menu--docs) or
-[Popover](../?path=/docs/components-overlays-popover--docs). An element with a
+[Menu](/components/Menu) or [Popover](/components/Popover). An element with a
 base elevation is likely interactive, and this level can indicate and invite the
 use of gesture controls in a mobile app.
 
@@ -46,7 +45,7 @@ use of gesture controls in a mobile app.
 High elements should be elements that float overtop the entire interface,
 typically with a fixed position. The "high" elevation indicates that the element
 has broken the plane of the view. A good example for web would be
-[Toast](../?path=/docs/components-status-and-feedback-toast--docs).
+[Toast](/components/Toast).
 
 ## Web
 

--- a/docs/design/Radii.stories.mdx
+++ b/docs/design/Radii.stories.mdx
@@ -5,21 +5,18 @@ import { Meta } from "@storybook/addon-docs";
 # Border Radius
 
 This base radius can be found in almost all of our components that have a
-defined "edge": [Button](../?path=/docs/components-actions-button--docs),
-[Card](../?path=/docs/components-layouts-and-structure-card--docs),
-[InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs), and
-[Menu](../?path=/docs/components-navigation-menu--docs) are all examples of this
-in practice.
+defined "edge": [Button](/components/Button), [Card](/components/Card),
+[InputText](/components/InputText), and [Menu](/components/Menu) are all
+examples of this in practice.
 
 If an element is nested directly inside of a container with the base radius, or
 is itself smaller than the base radius, the small radius may be applied.
 
 Larger rounded corners should be used sparingly, but are available for cases
 where the user may expect a smoother corner, such as
-[ProgressBar](../?path=/docs/components-status-and-feedback-progressbar--docs).
-`--radius-circle` can be used for circular elements like
-[Radio](../?path=/docs/components-forms-and-inputs-radiogroup--docs) options or
-the "pip" in [Switch](../?path=/docs/components-selections-switch--docs).
+[ProgressBar](/components/ProgressBar). `--radius-circle` can be used for
+circular elements like [Radio](/components/RadioGroup) options or the "pip" in
+[Switch](/components/Switch).
 
 export function Example({ of: radius }) {
   const style = {

--- a/docs/design/ResponsiveBreakpoint.stories.mdx
+++ b/docs/design/ResponsiveBreakpoint.stories.mdx
@@ -8,11 +8,11 @@ import { Banner } from "@jobber/components/Banner";
 We have 3 different ways to deal with responsive breakpoints in our components.
 
 1. CSS variables (`@custom-media`) that are relative to the browser size.
-2. [`useBreakpoints` hook](../?path=/docs/hooks-usebreakpoints--docs) that is
-   the JS counterpart of the CSS variables.
-3. [`useResizeObserver` hook](../?path=/docs/hooks-useresizeobserver--docs) that
-   is used to make components responsive depending on the size of its container
-   rather than the browser.
+2. [`useBreakpoints` hook](/hooks/useBreakpoints) that is the JS counterpart of
+   the CSS variables.
+3. [`useResizeObserver` hook](/hooks/useResizeObserver) that is used to make
+   components responsive depending on the size of its container rather than the
+   browser.
 
 ## CSS variables
 
@@ -69,11 +69,11 @@ your compiler to transform them back to normal media queries.
 ## 2. useBreakpoints hook
 
 This closely mimics the CSS breakpoints but you can use within a JS code. Read
-more about useBreakpoints [here](../?path=/docs/hooks-usebreakpoints--docs).
+more about useBreakpoints [here](/hooks/useBreakpoints).
 
 ## 3. useResizeObserver hook
 
 To make components responsive depending on the size of its container rather than
 the browser, you should use the
-[useResizeObserver hook](../?path=/docs/hooks-useresizeobserver--docs) so that
-the component can be responsive based on its container.
+[useResizeObserver hook](/hooks/useResizeObserver) so that the component can be
+responsive based on its container.

--- a/docs/design/Spacing.stories.mdx
+++ b/docs/design/Spacing.stories.mdx
@@ -13,7 +13,7 @@ Our spacing system exists to support the foundational visual design principle of
 In the shortest, simplest terms: the closer two elements are related, the
 tighter the spacing between them should be.
 
-With this in mind, let’s start small and work our way up.
+With this in mind, let's start small and work our way up.
 
 ## Design & usage guidelines
 
@@ -42,24 +42,21 @@ reflect their relation to each other. An example would be the spacing between
 ### Base
 
 Use `base` as the default spacing in larger content containers with multiple
-children of their own, such as
-[Card.](../?path=/docs/components-layouts-and-structure-card--docs) This should
-also be used as the default starting point for spacing between
-[Form](../?path=/docs/components-forms-and-inputs-form--docs) elements.
+children of their own, such as [Card.](/components/Card) This should also be
+used as the default starting point for spacing between [Form](/components/Form)
+elements.
 
 ![illustration of spacing between form elements inside of a card](https://user-images.githubusercontent.com/39704901/143141662-0f20eec4-8b27-44fe-96f5-1bf1c4d567aa.png)
 
 ### Large
 
 Use `large` spacing for higher-level "parent" containers.
-[Modal](../?path=/docs/components-overlays-modal--docs) uses `large` spacing in
-its header and around the edges to give itself a bit more prominence as a
-"standalone" view, in a similar manner to
-[Page](../?path=/docs/components-layouts-and-structure-page--docs).
+[Modal](/components/Modal) uses `large` spacing in its header and around the
+edges to give itself a bit more prominence as a "standalone" view, in a similar
+manner to [Page](/components/Page).
 
 `Large` can also be used to help give a "floating" element some clear separation
-from the edge of its container, as seen in
-[Toast](../?path=/docs/components-status-and-feedback-toast--docs).
+from the edge of its container, as seen in [Toast](/components/Toast).
 
 ![illustration of the large space around a Modal's header and content, a Page's outer padding, and a Toast near the bottom of a viewport](https://user-images.githubusercontent.com/39704901/143152557-8fca3292-dc07-4f9b-a33b-f4d4603c9dd2.png)
 
@@ -73,8 +70,8 @@ mixed content types that need to be broken up.
 
 ### Largest and Extravagant
 
-You’ll probably never need these unless you’re doing a custom layout, but
-they’re here if you need ‘em. These values are equivalent to `48px` and `64px`
+You'll probably never need these unless you're doing a custom layout, but
+they're here if you need 'em. These values are equivalent to `48px` and `64px`
 respectively.
 
 ---
@@ -83,9 +80,8 @@ respectively.
 
 ### Content
 
-Use the
-[Content component](../?path=/docs/components-layouts-and-structure-content--docs)
-for any instances where you need uniform spacing between elements.
+Use the [Content component](/components/Content) for any instances where you
+need uniform spacing between elements.
 
 Content can set its spacing to any of the spacing token values; follow the
 guidelines above as needed.

--- a/docs/design/Typography.stories.mdx
+++ b/docs/design/Typography.stories.mdx
@@ -19,8 +19,7 @@ interface, and we've built a system that should make it simple for our
 interfaces to be built with consistent, considered typographic elements.
 
 The Atlantis typography system is based on the core components of
-[Heading](../?path=/docs/components-text-and-typography-heading--docs) and
-[Text](../?path=/docs/components-text-and-typography-text--docs).
+[Heading](/components/Heading) and [Text](/components/Text).
 
 <Canvas>
   <Content>
@@ -37,8 +36,7 @@ The Atlantis typography system is based on the core components of
 </Canvas>
 
 Heading and Text are extended by the ability to add
-[Emphasis](../?path=/docs/components-text-and-typography-emphasis--docs) to
-these components as needed.
+[Emphasis](/components/Emphasis) to these components as needed.
 
 There are some foundational elements that make up these components:
 
@@ -114,8 +112,7 @@ to `14px`. Depending on the context in which your typography is being used,
 font-size can be adjusted to be larger or smaller than the base font-size.
 
 Suggestions for when to use varying font-sizes are discussed in the
-[Heading](../?path=/docs/components-text-and-typography-heading--docs)
-component, and within the
+[Heading](/components/Heading) component, and within the
 [Sizes](../?path=/docs/components-text-and-typography-text--docs#sizes) section
 of the Text component.
 

--- a/docs/getting-started-with-react/getting-started-with-react.stories.mdx
+++ b/docs/getting-started-with-react/getting-started-with-react.stories.mdx
@@ -123,10 +123,10 @@ The next section is the return value which will return the TSX defining our
 component. In here you can see that our `GifGift` component is composed of the
 following other react components:
 
-- [Card](../?path=/docs/components-layouts-and-structure-card--docs)
-- [Content](../?path=/docs/components-layouts-and-structure-content--docs)
-- [Button](../?path=/docs/components-actions-button--docs)
-- [InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs)
+- [Card](/components/Card)
+- [Content](/components/Content)
+- [Button](/components/Button)
+- [InputText](/components/InputText)
 
 If you look at the docs for the above components you can see how the different
 props they expose allow us to customize their behaviour given the needs of our
@@ -168,38 +168,34 @@ button. Here we call the `setURL` setter to show the `loadingGIF`. Then, we call
 
 #### 1. Primitive components:
 
-Examples: [Icon](..?path=/docs/components-images-and-icons-icon--docs),
-[Avatar](..?path=/docs/components-images-and-icons-avatar--docs)
+Examples: [Icon](/components/Icon), [Avatar](/components/Avatar)
 
 These components do not accept children and have minimal customization.
 
 #### 2. Simple components:
 
-Examples: [Button](..?path=/docs/components-actions-button--docs),
-[Link](..?path=/docs/components-text-and-typography-link--docs)
+Examples: [Button](/components/Button), [Link](/components/Link)
 
 These allow basic customization through props or limited children, like
 `ReactNode` or specific child types.
 
 #### 3. Compound components:
 
-Examples: [Chip](..?path=/docs/components-selections-chip--docs),
-[DataList](..?path=/docs/components-lists-and-tables-datalist--docs)
+Examples: [Chip](/components/Chip), [DataList](/components/DataList)
 
 These are part of larger compositions and may validate their children types to
 maintain internal consistency.
 
 #### 4. Strict complex components:
 
-Example:
-[Autocomplete](..?path=/docs/components-forms-and-inputs-autocomplete--docs),
+Example: [Autocomplete](/components/Autocomplete)
 
 These have multiple UI pieces they are built out of but strict APIs and limited
 customization.
 
 #### 5. Customizable complex components:
 
-Example: [Combobox](..?path=/docs/components-selections-combobox--docs)
+Example: [Combobox](/components/Combobox)
 
 These also have multiple UI pieces they are built out of but offer options for
 customization.

--- a/docs/guides/adding-an-icon.stories.mdx
+++ b/docs/guides/adding-an-icon.stories.mdx
@@ -31,9 +31,8 @@ When contributing a new icon, design for the `base` size. The `small` and
 | Stroke weight | 2px   |
 
 Icons are only responsible for their own 2px safe area. Spacing when used within
-other components, such as
-[List](../?path=/docs/components-lists-and-tables-list--docs), is the
-responsibility of those components.
+other components, such as [List](/components/List), is the responsibility of
+those components.
 
 #### Corners
 
@@ -123,10 +122,9 @@ Either you (the designer) or your devs can do this step. This assumes that you
 have the Atlantis repo on your machine and know how to use GitHub.
 
 1. Open the Atlantis folder in your machine and navigate to
-   `packages/design/src/icons`
-2. Drop your exported SVG in the icons folder
-3. Open a file called `Icon.stories.mdx` and update the Icons documentation
-4. Find the appropriate section for your icon (such as Arrows, Files, or User)
+   `packages/design/src/icons`2. Drop your exported SVG in the icons folder
+2. Open a file called `Icon.stories.mdx` and update the Icons documentation
+3. Find the appropriate section for your icon (such as Arrows, Files, or User)
    and add it to that list
 
 ### To preview locally

--- a/docs/guides/create-basic-component.stories.mdx
+++ b/docs/guides/create-basic-component.stories.mdx
@@ -199,14 +199,10 @@ Let's look back at the annotated mockup again for guidance.
 
 It seems that we need a:
 
-- **Heading**: We can use the
-  [Heading](../?path=/docs/components-text-and-typography-heading--docs)
-  component
-- **Paragraph**: We can use the
-  [Text](../?path=/docs/components-text-and-typography-text--docs) component
+- **Heading**: We can use the [Heading](/components/Heading) component
+- **Paragraph**: We can use the [Text](/components/Text) component
 - **Input**: We need an input that can only accept number. We can use the
-  [InputNumber](../?path=/docs/components-forms-and-inputs-inputnumber--docs)
-  component
+  [InputNumber](/components/InputNumber) component
 - **Buttons**: This one is special case and for the sake of this guide, we'll
   write our own CSS for it.
 
@@ -336,11 +332,9 @@ get the layout look closed to the mockup.
 
 Few things to note:
 
-- Used the [Icon](../?path=/docs/components-images-and-icons-icon--docs)
-  component instead of `+` or `-`.
-- Check out the
-  [InputNumber](../?path=/docs/components-forms-and-inputs-inputnumber--docs)
-  props to see the details of what I've added.
+- Used the [Icon](/components/Icon) component instead of `+` or `-`.
+- Check out the [InputNumber](/components/InputNumber) props to see the details
+  of what I've added.
 
 Once you've updated your component, it should look like so.
 

--- a/docs/guides/create-basic-component.stories.mdx
+++ b/docs/guides/create-basic-component.stories.mdx
@@ -51,8 +51,8 @@ Easy peasy, right?
 
 ## Prerequisites
 
-1. [Install and run Atlantis](../?path=/docs/introduction--docs) because you
-   need it to create a component in… Atlantis.
+1. [Install and run Atlantis](/welcome-guide) because you need it to create a
+   component in… Atlantis.
 2. Setup your editor to have have the auto fixers. Life is too short to do your
    own fixing for code that can be automatically fixed.
    [Jobber Wiki: Set up Typescript/Javascript linting](https://jobber.atlassian.net/wiki/spaces/JTW/pages/507740239/Set+up+Typescript+Javascript+linting)

--- a/docs/guides/documentation-style.stories.mdx
+++ b/docs/guides/documentation-style.stories.mdx
@@ -40,9 +40,9 @@ bring to the team, or as the system evolves.
 
 Follow Atlantis content guidelines for written content and component examples:
 
-- [formatting](../?path=/docs/content-formatting--docs)
-- [voice & tone](../?path=/docs/content-voice-tone--docs)
-- [vocabulary](../?path=/docs/content-product-vocabulary--docs)
+- [formatting](/content/formatting)
+- [voice & tone](/content/voice-and-tone)
+- [vocabulary](/content/product-vocabulary)
 
 #### Relevance
 

--- a/docs/guides/frontend-style.stories.mdx
+++ b/docs/guides/frontend-style.stories.mdx
@@ -22,17 +22,13 @@ properties to have similar names across the system. For example...
 We use `base` as our default whenever possible when a property has a set range
 of outcomes. This can be seen in..
 
-- the `size` properties of
-  [Button](../?path=/docs/components-actions-button--docs),
-  [Avatar](../?path=/docs/components-images-and-icons-avatar--docs),
-  [InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs),
-  [Text](../?path=/docs/components-text-and-typography-text--docs),
-  [ProgressBar](../?path=/docs/components-status-and-feedback-progressbar--docs),
-  [Spinner](../?path=/docs/components-status-and-feedback-spinner--docs), etc;
-- `maxLines` of [Text](../?path=/docs/components-text-and-typography-text--docs)
-- values of [Shadow](../?path=/docs/design-elevations--docs),
-  [Spacing](../?path=/docs/design-spacing--docs),
-  [Border Radius](../?path=/docs/design-borders--docs) design tokens
+- the `size` properties of [Button](/components/Button),
+  [Avatar](/components/Avatar), [InputText](/components/InputText),
+  [Text](/components/Text), [ProgressBar](/components/ProgressBar),
+  [Spinner](/components/Spinner), etc;
+- `maxLines` of [Text](/components/Text)
+- values of [Shadow](/design/elevationss), [Spacing](/design/spacing),
+  [Border Radius](/design/borders) design tokens
 
 This allows us to set an expectation of the base (or most common) use case when
 a prop is in action.
@@ -42,9 +38,8 @@ a prop is in action.
 If a component has `open` and `closed` states, use a boolean property named
 `open`.
 
-This can be seen in [Modal](../?path=/docs/components-overlays-modal--docs),
-[Drawer](../?path=/docs/components-layouts-and-structure-drawer--docs), and
-[Popover](../?path=/docs/components-overlays-popover--docs).
+This can be seen in [Modal](/components/Modal), [Drawer](/components/Drawer),
+and [Popover](/components/Popover).
 
 ## Typescript
 
@@ -193,8 +188,8 @@ Wherever possible use Atlantis `design` tokens.
 
 ### Spacing (margins and padding)
 
-Use the appropriate [Spacing](../?path=/docs/design-spacing--docs) values for
-spacing. Do not use rems, ems, or hard-coded pixel values.
+Use the appropriate [Spacing](/design/spacing) values for spacing. Do not use
+rems, ems, or hard-coded pixel values.
 
 If you require a space that is larger than the Spacing values, or falls
 somewhere in between, use the CSS `calc` function with Atlantis spacing values

--- a/docs/hooks/useBreakpoints.stories.mdx
+++ b/docs/hooks/useBreakpoints.stories.mdx
@@ -10,8 +10,8 @@ import { useBreakpoints } from "@jobber/hooks/useBreakpoints";
 ```
 
 `useBreakpoints` is the JS version of our
-[Design/Breakpoints](../?path=/docs/design-breakpoints--docs) that uses
-`window.matchMedia` to mimic the CSS media queries.
+[Design/Breakpoints](/design/breakpoints) that uses `window.matchMedia` to mimic
+the CSS media queries.
 
 This allows you to use the same breakpoints in JS as you do in CSS. It also
 returns a `smallOnly`, `mediumOnly`, and `largeOnly` boolean that you can use to

--- a/docs/hooks/useFormState.stories.mdx
+++ b/docs/hooks/useFormState.stories.mdx
@@ -10,7 +10,7 @@ import { UseFormState } from "./UseFormState";
 default values.
 
 `useFormState` should **only** only by used when using a
-[`<Form />`](../?path=/docs/components-forms-and-inputs-form--docs) component.
+[`<Form />`](/components/Form) component.
 
 ```tsx
 import { useFormState } from "@jobber/hooks/useFormState";

--- a/packages/hooks/src/useBreakpoints/useBreakpoints.ts
+++ b/packages/hooks/src/useBreakpoints/useBreakpoints.ts
@@ -4,7 +4,7 @@ export const BREAKPOINT_SIZES = { sm: 490, md: 768, lg: 1080, xl: 1440 };
 
 /**
  * Hook equivalent of CSS media queries with our
- * [supported breakpoints](https://atlantis.getjobber.com/?path=/docs/design-breakpoints--docs).
+ * [supported breakpoints](https://atlantis.getjobber.com/design/breakpoints).
  */
 export function useBreakpoints() {
   const { sm, md, lg, xl } = BREAKPOINT_SIZES;

--- a/packages/site/src/content/Banner/BannerNotes.mdx
+++ b/packages/site/src/content/Banner/BannerNotes.mdx
@@ -13,8 +13,7 @@ for some examples.
 ### Actions (mobile)
 
 Use the `action` prop to specify an `onPress` callback and a `label`. Banner
-will render the action using an
-[ActionLabel](../?path=/docs/components-actions-actionlabel--docs).
+will render the action using an [ActionLabel](/components/ActionLabel).
 
 See
 [Actions in Banners](../?path=/story/components-status-and-feedback-banner-mobile--actions-in-banners)

--- a/packages/site/src/content/Button/ButtonNotes.mdx
+++ b/packages/site/src/content/Button/ButtonNotes.mdx
@@ -10,8 +10,8 @@ that the URL will change to the appropriate route. See
 ### Form submit (web only)
 
 Passing the `submit` prop will allow a Button to submit a
-[Form](../?path=/docs/components-forms-and-inputs-form--docs). Since submitting
-a form is a specific action, only `variation="work"` and `type="primary"` are
+[Form](/components/Form). Since submitting a form is a specific action, only a
+form is a specific action, only `variation="work"` and `type="primary"` are
 allowed. See
 [Web/Form Submit example](../?path=/story/components-actions-button-web--form-submit)
 

--- a/packages/site/src/content/Combobox/ComboboxNotes.mdx
+++ b/packages/site/src/content/Combobox/ComboboxNotes.mdx
@@ -168,6 +168,6 @@ window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 ## Developer notes
 
 - The Combobox confines tabbing to within itself while it's open using
-  [useFocusTrap](../?path=/docs/hooks-usefocustrap--docs)
+  [useFocusTrap](/hooks/useFocusTrap)
 - Pressing `esc` will close the Combobox and return focus to the activator using
-  [useRefocusOnActivator](../?path=/docs/hooks-userefocusonactivator--docs)
+  [useRefocusOnActivator](/hooks/useRefocusOnActivator)

--- a/packages/site/src/content/InputFieldWrapper/InputFieldWrapperNotes.mdx
+++ b/packages/site/src/content/InputFieldWrapper/InputFieldWrapperNotes.mdx
@@ -4,10 +4,9 @@
 
 When setting `showClearAction` to `true` you must also provide an `onClear`
 callback that will clear the input you are wrapping. See
-[InputDate](../?path=/docs/components-forms-and-inputs-inputdate--docs) and
-[InputPressable](../?path=/docs/components-forms-and-inputs-inputpressable--docs)
-or [InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs) for
-examples.
+[InputDate](/components/InputDate) and
+[InputPressable](/components/InputPressable) or
+[InputText](/components/InputText) for examples.
 
 See
 [InputFieldWrapper/Clearable example](../?path=/story/components-private-inputfieldwrapper-mobile--clearable).

--- a/packages/site/src/content/InputNumber/InputNumberNotes.mdx
+++ b/packages/site/src/content/InputNumber/InputNumberNotes.mdx
@@ -3,9 +3,7 @@
 ## Using onValidation
 
 If you need to capture the error message and render it outside of the component.
-Read the
-[InputValidation](../?path=/docs/components-forms-and-inputs-inputvalidation--docs)
-documentation.
+Read the [InputValidation](/components/InputValidation) documentation.
 
 For more details about `validation` using `Input` components, see the
 [InputText](../?path=/docs/components-forms-and-inputs-inputtext--docs#validation-message)

--- a/packages/site/src/content/InputText/InputTextNotes.mdx
+++ b/packages/site/src/content/InputText/InputTextNotes.mdx
@@ -20,9 +20,7 @@ This includes, but is not limited to:
 ### Using onValidation (Web)
 
 If you need to capture the error message and render it outside of the component.
-Read the
-[InputValidation](../?path=/docs/components-forms-and-inputs-inputvalidation--docs)
-documentation.
+Read the [InputValidation](/components/InputValidation) documentation.
 
 ### Version 2 Shim (Experimental)
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

The new doc site needs to link to documentation on the new site, not to Storybook.
I've used the following logic (RegEx, search and replace etc):
1. ONLY modify links that exactly match the pattern `../?path=/docs/*--docs`
2. DO NOT modify if the link contains:
   - `#` anywhere in the string, since the new site currently doesn't support linking to sections of the page
   - /story in the URL, since the new site doesn't have examples yet, which live in Storybook
3. When converting the path:
   - Remove ../?path=/docs/
   - Remove --docs from the end
   - Convert - to / for the first occurrence only
   - Convert remaining - to camelCase

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->
- Go to the new docs site
- Click on the links, e.g. components mentioned on the doc page, links to Product Vocabulary etc (e.g. on `Form` component doc page)
- Verify that links are being open in the new site, and NOT in Storybook
- It is acceptable, that if the links is for the specific usage example, to be redirected to Storybook (old docs site)

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
