### PR TITLE
fix(components): Fix box-sizing issue on Lightbox

### DIFF
--- a/docs/components/LightBox/Web.stories.tsx
+++ b/docs/components/LightBox/Web.stories.tsx
@@ -1,8 +1,7 @@
-import React, { CSSProperties, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Button } from "@jobber/components/Button";
 import { LightBox } from "@jobber/components/LightBox";
-import { Box } from "@jobber/components/Box";
 
 export default {
   title: "Components/Images and Icons/LightBox/Web",
@@ -34,44 +33,16 @@ const images = [
 
 const BasicTemplate: ComponentStory<typeof LightBox> = args => {
   const [isOpen, setIsOpen] = useState(false);
-  const [boxSizing, setBoxSizing] = useState<CSSProperties["boxSizing"]>();
-
-  useEffect(() => {
-    document.documentElement.style.setProperty(
-      "--public-lightbox-box-sizing",
-      boxSizing ?? "inherit",
-    );
-  }, [boxSizing]);
 
   return (
-    <Box direction="column" gap="base">
+    <>
       <Button label="Click me!" onClick={() => setIsOpen(true)} />
-      <Button
-        label="Set Box Sizing to Border Box"
-        onClick={() => setBoxSizing("border-box")}
-      />
-      <Button
-        label="Set Box Sizing to Content Box"
-        onClick={() => setBoxSizing("content-box")}
-      />
-      <Button
-        label="Set Box Sizing to Inherit"
-        onClick={() => setBoxSizing("inherit")}
-      />
-      <Button
-        label="Set Box Sizing to Initial"
-        onClick={() => setBoxSizing("initial")}
-      />
-      <Button
-        label="Set Box Sizing to Unset"
-        onClick={() => setBoxSizing("unset")}
-      />
       <LightBox
         {...args}
         open={isOpen}
         onRequestClose={() => setIsOpen(false)}
       />
-    </Box>
+    </>
   );
 };
 

--- a/docs/components/LightBox/Web.stories.tsx
+++ b/docs/components/LightBox/Web.stories.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { CSSProperties, useEffect, useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Button } from "@jobber/components/Button";
 import { LightBox } from "@jobber/components/LightBox";
+import { Box } from "@jobber/components/Box";
 
 export default {
   title: "Components/Images and Icons/LightBox/Web",
@@ -33,16 +34,44 @@ const images = [
 
 const BasicTemplate: ComponentStory<typeof LightBox> = args => {
   const [isOpen, setIsOpen] = useState(false);
+  const [boxSizing, setBoxSizing] = useState<CSSProperties["boxSizing"]>();
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      "--public-lightbox-box-sizing",
+      boxSizing ?? "inherit",
+    );
+  }, [boxSizing]);
 
   return (
-    <>
+    <Box direction="column" gap="base">
       <Button label="Click me!" onClick={() => setIsOpen(true)} />
+      <Button
+        label="Set Box Sizing to Border Box"
+        onClick={() => setBoxSizing("border-box")}
+      />
+      <Button
+        label="Set Box Sizing to Content Box"
+        onClick={() => setBoxSizing("content-box")}
+      />
+      <Button
+        label="Set Box Sizing to Inherit"
+        onClick={() => setBoxSizing("inherit")}
+      />
+      <Button
+        label="Set Box Sizing to Initial"
+        onClick={() => setBoxSizing("initial")}
+      />
+      <Button
+        label="Set Box Sizing to Unset"
+        onClick={() => setBoxSizing("unset")}
+      />
       <LightBox
         {...args}
         open={isOpen}
         onRequestClose={() => setIsOpen(false)}
       />
-    </>
+    </Box>
   );
 };
 

--- a/packages/components/src/LightBox/LightBox.module.css
+++ b/packages/components/src/LightBox/LightBox.module.css
@@ -15,10 +15,6 @@
   }
 }
 
-:root {
-  --public-lightbox-box-sizing: inherit;
-}
-
 .backgroundImage {
   position: absolute;
   inset: 0;
@@ -75,10 +71,6 @@
   background-color: var(--color-base-grey--400);
   justify-content: center;
   flex-direction: column;
-}
-
-.lightboxWrapper * {
-  box-sizing: var(--public-lightbox-box-sizing);
 }
 
 .toolbar {
@@ -145,11 +137,13 @@
 }
 
 .thumbnailBar {
+  --lightbox--box-sizing: content-box;
   display: flex;
   position: relative;
   z-index: var(--elevation-base);
   width: 100%;
   min-height: 92px;
+  box-sizing: var(--lightbox--box-sizing);
   margin-bottom: var(--space-small);
   padding-bottom: var(--space-small);
   overflow-x: scroll;
@@ -177,6 +171,10 @@
       background: var(--color-interactive--subtle);
     }
   }
+}
+
+.thumbnailBar * {
+  box-sizing: var(--lightbox--box-sizing);
 }
 
 .thumbnailImage {

--- a/packages/components/src/LightBox/LightBox.module.css
+++ b/packages/components/src/LightBox/LightBox.module.css
@@ -15,6 +15,10 @@
   }
 }
 
+:root {
+  --public-lightbox-box-sizing: inherit;
+}
+
 .backgroundImage {
   position: absolute;
   inset: 0;
@@ -71,6 +75,10 @@
   background-color: var(--color-base-grey--400);
   justify-content: center;
   flex-direction: column;
+}
+
+.lightboxWrapper * {
+  box-sizing: var(--public-lightbox-box-sizing);
 }
 
 .toolbar {

--- a/packages/components/src/LightBox/LightBox.tsx
+++ b/packages/components/src/LightBox/LightBox.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-statements */
-import React, { useEffect, useRef, useState } from "react";
+import React, { CSSProperties, useEffect, useRef, useState } from "react";
 import { AnimatePresence, PanInfo, motion } from "framer-motion";
 import ReactDOM from "react-dom";
 import { useRefocusOnActivator } from "@jobber/hooks/useRefocusOnActivator";
@@ -52,6 +52,13 @@ interface LightBoxProps {
    * that has the index of the image the user was on when LightBox was closed.
    */
   onRequestClose(options: RequestCloseOptions): void;
+
+  /**
+   * Sets the box-sizing for the thumbnails in the lightbox. This is a solution for a problem where
+   * tailwind was setting the box-sizing to `border-box` and causing issues with the lightbox.
+   * @default "content-box"
+   */
+  readonly boxSizing?: CSSProperties["boxSizing"];
 }
 
 const swipeConfidenceThreshold = 10000;
@@ -87,6 +94,7 @@ const BUTTON_DEBOUNCE_DELAY = 250;
 const MOVEMENT_DEBOUNCE_DELAY = 1000;
 
 export function LightBox({
+  boxSizing = "content-box",
   open,
   images,
   imageIndex = 0,
@@ -166,7 +174,14 @@ export function LightBox({
           <div className={styles.blurOverlay} onClick={handleRequestClose} />
 
           <AtlantisThemeContextProvider dangerouslyOverrideTheme="dark">
-            <div className={styles.toolbar}>
+            <div
+              className={styles.toolbar}
+              style={
+                {
+                  "--lightbox--box-sizing": boxSizing,
+                } as React.CSSProperties
+              }
+            >
               <div className={styles.slideNumber}>
                 <Text>{`${currentImageIndex + 1}/${images.length}`}</Text>
               </div>

--- a/packages/components/src/LightBox/__snapshots__/LightBoxSnapshots.test.tsx.snap
+++ b/packages/components/src/LightBox/__snapshots__/LightBoxSnapshots.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Images renders an image 1`] = `
     >
       <div
         class="toolbar"
+        style="--lightbox--box-sizing: content-box;"
       >
         <div
           class="slideNumber"

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -495,7 +495,14 @@ export const componentList = [
     to: "/components/LightBox",
     imageURL: "/LightBox.png",
     sections: ["Images & Icons"],
-    additionalMatches: ["Gallery", "Carousel", "Display", "Image"],
+    additionalMatches: [
+      "Gallery",
+      "Carousel",
+      "Display",
+      "Image",
+      "Box Sizing",
+      "Border Box",
+    ],
   },
   {
     title: "Link",

--- a/packages/site/src/content/LightBox/LightBoxNotes.mdx
+++ b/packages/site/src/content/LightBox/LightBoxNotes.mdx
@@ -6,3 +6,13 @@ This function receives the index of the last image the user viewed before
 closing the LightBox component with the lastPosition key. This might we useful
 if we want to return information about the final state when closed (e.g. for
 analytics).
+
+### Box Sizing
+
+The lightbox uses the box-sizing property to ensure that the lightbox and its
+children are rendered in the correct box-sizing context. This is a solution for
+a problem where tailwind was setting the box-sizing to `border-box` and causing
+issues with the lightbox.
+
+This is a one off solution for this type of problem. If we were to encounter
+this issue again, we should consider a more robust solution.


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

An issue was found were CSS libraries such as tailwind were resetting the box-sizing on all elements which was causing issues with the thumbnails .

## Decisions

This was a super specific change to Lightbox this time around. If we start to see more issues relating to this we should consider a system wide change. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added box-sizing prop to Lightbox

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
