### PR TITLE
docs: Add UNSAFE documentation to mobile Button and Text

### DIFF
--- a/docs/components/Button/Mobile.stories.tsx
+++ b/docs/components/Button/Mobile.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Button } from "@jobber/components-native";
-import { tokens } from "@jobber/design";
 
 export default {
   title: "Components/Actions/Button/Mobile",
@@ -21,15 +20,6 @@ export const Basic = BasicTemplate.bind({});
 Basic.args = {
   label: "New Job",
   onPress: () => alert("👍"),
-  UNSAFE_style: {
-    container: { backgroundColor: tokens["color-purple--light"] },
-    contentContainer: {
-      backgroundColor: tokens["color-purple--lighter"],
-      borderRadius: tokens["radius-large"],
-    },
-    iconContainer: { backgroundColor: tokens["color-purple"] },
-    actionLabelContainer: { paddingLeft: tokens["space-larger"] },
-  },
 };
 
 export const Cancel = BasicTemplate.bind({});

--- a/docs/components/Button/Mobile.stories.tsx
+++ b/docs/components/Button/Mobile.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Button } from "@jobber/components-native";
+import { tokens } from "@jobber/design";
 
 export default {
   title: "Components/Actions/Button/Mobile",
@@ -20,6 +21,15 @@ export const Basic = BasicTemplate.bind({});
 Basic.args = {
   label: "New Job",
   onPress: () => alert("👍"),
+  UNSAFE_style: {
+    container: { backgroundColor: tokens["color-purple--light"] },
+    contentContainer: {
+      backgroundColor: tokens["color-purple--lighter"],
+      borderRadius: tokens["radius-large"],
+    },
+    iconContainer: { backgroundColor: tokens["color-purple"] },
+    actionLabelContainer: { paddingLeft: tokens["space-larger"] },
+  },
 };
 
 export const Cancel = BasicTemplate.bind({});

--- a/docs/components/Text/Text.stories.mdx
+++ b/docs/components/Text/Text.stories.mdx
@@ -199,17 +199,3 @@ provided.
 <Canvas>
   <Text size="small">What is this, a font for 🐜s?</Text>
 </Canvas>
-
-## Platform Considerations (Mobile)
-
-### Notes
-
-Text uses the core component [Text](https://reactnative.dev/docs/text) from
-`react-native`.
-
-### Copying text
-
-There are a few caveats around copying text on Android and iOS that you can read
-under the
-[Typography](../?path=/docs/components-text-and-typography-typography--docs#platform-considerations)
-documentation.

--- a/packages/components-native/src/Button/Button.tsx
+++ b/packages/components-native/src/Button/Button.tsx
@@ -81,7 +81,7 @@ interface CommonButtonProps {
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+   * More information in the Customizing components Guide.
    */
   readonly UNSAFE_style?: ButtonUnsafeStyle;
 }

--- a/packages/components-native/src/Button/Button.tsx
+++ b/packages/components-native/src/Button/Button.tsx
@@ -81,7 +81,7 @@ interface CommonButtonProps {
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information in the Customizing components Guide.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
    */
   readonly UNSAFE_style?: ButtonUnsafeStyle;
 }

--- a/packages/components-native/src/Text/Text.tsx
+++ b/packages/components-native/src/Text/Text.tsx
@@ -90,7 +90,7 @@ export interface TextProps
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+   * More information in the Customizing components Guide.
    */
   readonly UNSAFE_style?: TypographyUnsafeStyle;
 }

--- a/packages/components-native/src/Text/Text.tsx
+++ b/packages/components-native/src/Text/Text.tsx
@@ -90,7 +90,7 @@ export interface TextProps
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information in the Customizing components Guide.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
    */
   readonly UNSAFE_style?: TypographyUnsafeStyle;
 }

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -48,7 +48,7 @@ export interface PopoverProps {
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information in the Customizing components Guide.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
    */
   readonly UNSAFE_style?: {
     container?: CSSProperties;

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -37,7 +37,7 @@ export interface PopoverProps {
   /**
    * **Use at your own risk:** Custom class names for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information in the Customizing components Guide.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
    */
   readonly UNSAFE_className?: {
     container?: string;

--- a/packages/components/src/Popover/Popover.tsx
+++ b/packages/components/src/Popover/Popover.tsx
@@ -37,7 +37,7 @@ export interface PopoverProps {
   /**
    * **Use at your own risk:** Custom class names for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+   * More information in the Customizing components Guide.
    */
   readonly UNSAFE_className?: {
     container?: string;
@@ -48,7 +48,7 @@ export interface PopoverProps {
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
-   * More information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+   * More information in the Customizing components Guide.
    */
   readonly UNSAFE_style?: {
     container?: CSSProperties;

--- a/packages/site/src/content/Button/Button.props-mobile.json
+++ b/packages/site/src/content/Button/Button.props-mobile.json
@@ -191,7 +191,7 @@
       },
       "UNSAFE_style": {
         "defaultValue": null,
-        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).",
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the Customizing components Guide.",
         "name": "UNSAFE_style",
         "parent": {
           "fileName": "../components-native/src/Button/Button.tsx",

--- a/packages/site/src/content/Button/Button.props-mobile.json
+++ b/packages/site/src/content/Button/Button.props-mobile.json
@@ -191,7 +191,7 @@
       },
       "UNSAFE_style": {
         "defaultValue": null,
-        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the Customizing components Guide.",
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
         "name": "UNSAFE_style",
         "parent": {
           "fileName": "../components-native/src/Button/Button.tsx",

--- a/packages/site/src/content/Button/ButtonNotes.mdx
+++ b/packages/site/src/content/Button/ButtonNotes.mdx
@@ -21,10 +21,10 @@ sense to allow the `external`, `onClick`, `to`, or `url` props.
 ### UNSAFE\_ props (advanced usage)
 
 General information for using `UNSAFE_` props can be found
-[here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+[here](/guides/customizing-components).
 
 **Note**: Use of `UNSAFE_` props is **at your own risk** and should be
-considered a **last resort**. Future Popover updates may lead to unintended
+considered a **last resort**. Future Button updates may lead to unintended
 breakages.
 
 #### UNSAFE_style (mobile)
@@ -33,12 +33,12 @@ The mobile Button component has four elements that can be targeted with styles.
 These are the container, content container, icon container, and action label
 container.
 
-Use `UNSAFE_style` to apply custom styles to the Button. Because React Native
-does not support className, you can use `UNSAFE_style for either inline styles
-or StyleSheet:
+React Native does not support className. Instead, you can use `UNSAFE_style` to
+apply styles either inline or through a StyleSheet.
+
+##### Inline styles
 
 ```tsx
-// Using inline styles
 UNSAFE_style: {
     container: { backgroundColor: tokens["color-purple--light"] },
     contentContainer: {
@@ -50,30 +50,30 @@ UNSAFE_style: {
   },
 ```
 
-```tsx
-// Using StyleSheet
-import { StyleSheet } from 'react-native';
+##### StyleSheet
 
-const styles = StyleSheet.create({
+```tsx
+// Button.tsx
+  UNSAFE_style={{
+    container: styles.customContainer,
+    contentContainer: styles.customContentContainer,
+    iconContainer: styles.customIconContainer,
+    actionLabelContainer: styles.customActionLabelContainer,
+  }}
+
+// Button.style.ts
+export const styles = StyleSheet.create({
   customContainer: {
-    backgroundColor: "lightblue",
+    backgroundColor: tokens["color-purple--light"],
   },
   customContentContainer: {
-    paddingRight: 8,
+    borderRadius: tokens["radius-large"],
   },
   customIconContainer: {
-    marginRight: 4,
+    backgroundColor: tokens["color-purple--lighter"],
   },
   customActionLabelContainer: {
-    paddingLeft: 8,
+    paddingLeft: tokens["space-larger"],
   },
 });
-
-// Then in your component:
-UNSAFE_style={{
-  container: styles.customContainer,
-  contentContainer: styles.customContentContainer,
-  iconContainer: styles.customIconContainer,
-  actionLabelContainer: styles.customActionLabelContainer,
-}}
 ```

--- a/packages/site/src/content/Button/ButtonNotes.mdx
+++ b/packages/site/src/content/Button/ButtonNotes.mdx
@@ -18,6 +18,8 @@ allowed. See
 Since this type of `Button` will only be used to submit a form, it does not make
 sense to allow the `external`, `onClick`, `to`, or `url` props.
 
+## Component customization
+
 ### UNSAFE\_ props (advanced usage)
 
 General information for using `UNSAFE_` props can be found

--- a/packages/site/src/content/Button/ButtonNotes.mdx
+++ b/packages/site/src/content/Button/ButtonNotes.mdx
@@ -17,3 +17,63 @@ allowed. See
 
 Since this type of `Button` will only be used to submit a form, it does not make
 sense to allow the `external`, `onClick`, `to`, or `url` props.
+
+### UNSAFE\_ props (advanced usage)
+
+General information for using `UNSAFE_` props can be found
+[here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+
+**Note**: Use of `UNSAFE_` props is **at your own risk** and should be
+considered a **last resort**. Future Popover updates may lead to unintended
+breakages.
+
+#### UNSAFE_style (mobile)
+
+The mobile Button component has four elements that can be targeted with styles.
+These are the container, content container, icon container, and action label
+container.
+
+Use `UNSAFE_style` to apply custom styles to the Button. Because React Native
+does not support className, you can use `UNSAFE_style for either inline styles
+or StyleSheet:
+
+```tsx
+// Using inline styles
+UNSAFE_style: {
+    container: { backgroundColor: tokens["color-purple--light"] },
+    contentContainer: {
+      backgroundColor: tokens["color-purple--lighter"],
+      borderRadius: tokens["radius-large"],
+    },
+    iconContainer: { backgroundColor: tokens["color-purple"] },
+    actionLabelContainer: { paddingLeft: tokens["space-larger"] },
+  },
+```
+
+```tsx
+// Using StyleSheet
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  customContainer: {
+    backgroundColor: "lightblue",
+  },
+  customContentContainer: {
+    paddingRight: 8,
+  },
+  customIconContainer: {
+    marginRight: 4,
+  },
+  customActionLabelContainer: {
+    paddingLeft: 8,
+  },
+});
+
+// Then in your component:
+UNSAFE_style={{
+  container: styles.customContainer,
+  contentContainer: styles.customContentContainer,
+  iconContainer: styles.customIconContainer,
+  actionLabelContainer: styles.customActionLabelContainer,
+}}
+```

--- a/packages/site/src/content/Popover/Popover.props.json
+++ b/packages/site/src/content/Popover/Popover.props.json
@@ -77,7 +77,7 @@
         "defaultValue": {
           "value": "{}"
         },
-        "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the Customizing components Guide.",
+        "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
         "name": "UNSAFE_className",
         "parent": {
           "fileName": "../components/src/Popover/Popover.tsx",

--- a/packages/site/src/content/Popover/Popover.props.json
+++ b/packages/site/src/content/Popover/Popover.props.json
@@ -92,7 +92,7 @@
         "defaultValue": {
           "value": "{}"
         },
-        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the Customizing components Guide.",
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
         "name": "UNSAFE_style",
         "parent": {
           "fileName": "../components/src/Popover/Popover.tsx",

--- a/packages/site/src/content/Popover/Popover.props.json
+++ b/packages/site/src/content/Popover/Popover.props.json
@@ -77,7 +77,7 @@
         "defaultValue": {
           "value": "{}"
         },
-        "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).",
+        "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the Customizing components Guide.",
         "name": "UNSAFE_className",
         "parent": {
           "fileName": "../components/src/Popover/Popover.tsx",
@@ -92,7 +92,7 @@
         "defaultValue": {
           "value": "{}"
         },
-        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).",
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the Customizing components Guide.",
         "name": "UNSAFE_style",
         "parent": {
           "fileName": "../components/src/Popover/Popover.tsx",

--- a/packages/site/src/content/Popover/PopoverNotes.mdx
+++ b/packages/site/src/content/Popover/PopoverNotes.mdx
@@ -3,7 +3,7 @@
 ### UNSAFE\_ props (advanced usage)
 
 General information for using `UNSAFE_` props can be found
-[here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).
+[here](/guides/customizing-components).
 
 Popover has three elements that can be targeted with classes or styles. These
 are the container, the dismiss button container, and the arrow.

--- a/packages/site/src/content/Text/Text.props-mobile.json
+++ b/packages/site/src/content/Text/Text.props-mobile.json
@@ -195,7 +195,7 @@
       },
       "UNSAFE_style": {
         "defaultValue": null,
-        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the Customizing components Guide.",
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
         "name": "UNSAFE_style",
         "parent": {
           "fileName": "../components-native/src/Text/Text.tsx",

--- a/packages/site/src/content/Text/Text.props-mobile.json
+++ b/packages/site/src/content/Text/Text.props-mobile.json
@@ -195,7 +195,7 @@
       },
       "UNSAFE_style": {
         "defaultValue": null,
-        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information [here](https://atlantis.getjobber.com/storybook/?path=/docs/guides-customizing-components--docs#unsafe_-props).",
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the Customizing components Guide.",
         "name": "UNSAFE_style",
         "parent": {
           "fileName": "../components-native/src/Text/Text.tsx",

--- a/packages/site/src/content/Text/TextNotes.mdx
+++ b/packages/site/src/content/Text/TextNotes.mdx
@@ -6,7 +6,7 @@ General information for using `UNSAFE_` props can be found
 [here](/guides/customizing-components).
 
 **Note**: Use of `UNSAFE_` props is **at your own risk** and should be
-considered a **last resort**. Future Button updates may lead to unintended
+considered a **last resort**. Future Text updates may lead to unintended
 breakages.
 
 #### UNSAFE_style (mobile)

--- a/packages/site/src/content/Text/TextNotes.mdx
+++ b/packages/site/src/content/Text/TextNotes.mdx
@@ -14,8 +14,29 @@ breakages.
 The mobile Text component can be custom styled using the `textStyle` type via
 the `UNSAFE_style` prop.
 
+React Native does not support className. Instead, you can use `UNSAFE_style` to
+apply styles either inline or through a StyleSheet.
+
+##### Inline styles
+
 ```tsx
 UNSAFE_style={{ textStyle: { color: tokens["color-purple--light"] } }}
+```
+
+##### StyleSheet
+
+```tsx
+// Text.tsx
+  UNSAFE_style={{
+    textStyle: styles.customTextStyle,
+  }}
+
+// Text.style.ts
+export const styles = StyleSheet.create({
+  customTextStyle: {
+    color: tokens["color-purple--light"],
+  },
+});
 ```
 
 ## Platform Considerations (Mobile)

--- a/packages/site/src/content/Text/TextNotes.mdx
+++ b/packages/site/src/content/Text/TextNotes.mdx
@@ -1,0 +1,33 @@
+## Component customization
+
+### UNSAFE\_ props (advanced usage)
+
+General information for using `UNSAFE_` props can be found
+[here](/guides/customizing-components).
+
+**Note**: Use of `UNSAFE_` props is **at your own risk** and should be
+considered a **last resort**. Future Button updates may lead to unintended
+breakages.
+
+#### UNSAFE_style (mobile)
+
+The mobile Text component can be custom styled using the `textStyle` type via
+the `UNSAFE_style` prop.
+
+```tsx
+UNSAFE_style={{ textStyle: { color: tokens["color-purple--light"] } }}
+```
+
+## Platform Considerations (Mobile)
+
+### Notes
+
+Text uses the core component [Text](https://reactnative.dev/docs/text) from
+`react-native`.
+
+### Copying text
+
+There are a few caveats around copying text on Android and iOS that you can read
+under the
+[Typography](../?path=/docs/components-text-and-typography-typography--docs#platform-considerations)
+documentation.

--- a/packages/site/src/content/Text/index.tsx
+++ b/packages/site/src/content/Text/index.tsx
@@ -1,6 +1,7 @@
 import Content from "@atlantis/docs/components/Text/Text.stories.mdx";
 import Props from "./Text.props.json";
 import MobileProps from "./Text.props-mobile.json";
+import Notes from "./TextNotes.mdx";
 import { ContentExport } from "../../types/content";
 import { getStorybookUrl } from "../../layout/getStorybookUrl";
 
@@ -21,4 +22,5 @@ export default {
       ),
     },
   ],
+  notes: () => <Notes />,
 } as const satisfies ContentExport;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Recently we added `UNSAFE_` props to mobile `Text` & `Button`.  

`UNSAFE_` was going to be used by a team and was somewhat time sensitive, so I committed to updating docs as a fast follow, to get the feature out the door.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- New `Text` Implement tab with `UNSAFE_` info
- `UNSAFE_` info to the pre-existing `Button` Implement tab

## Testing

<!-- How to test your changes. -->
Make sure you see `UNSAFE_` info in the Implement tab for `Button` & `Text`.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnl4MmlnbHZqbDN4bnhubDRlNWdjZnh2NTA2M2cyMm9oeWV0MXF1aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zTipq7TOLsYbyBtDjB/giphy.gif)
