### PR TITLE
fix(components): There was a typo in the DataList.ItemAction logic

### DIFF
--- a/packages/components/src/DataList/components/DataListActions/DataListActions.test.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.test.tsx
@@ -136,36 +136,42 @@ describe("DataListActions", () => {
     const label = "Foo";
     const moreLabel = "More actions";
 
+    const setupAlwaysVisible = (alwaysVisible = true) => {
+      render(
+        <DataListActions>
+          <DataListAction
+            alwaysVisible={alwaysVisible}
+            icon="edit"
+            label={label}
+            visible={() => true}
+          />
+        </DataListActions>,
+      );
+    };
+
     describe("is true", () => {
       it("should not render the more actions icon", () => {
-        render(
-          <DataListActions>
-            <DataListAction
-              alwaysVisible
-              icon="edit"
-              label={label}
-              visible={() => true}
-            />
-          </DataListActions>,
-        );
+        setupAlwaysVisible();
 
         expect(screen.queryByLabelText(moreLabel)).not.toBeInTheDocument();
         expect(screen.getByLabelText(label)).toBeInTheDocument();
+      });
+
+      it("should not render the tooltip", async () => {
+        setupAlwaysVisible();
+
+        const actionButton = screen.getByLabelText(label);
+        await userEvent.hover(actionButton);
+
+        expect(
+          document.querySelector("div[role='tooltip']"),
+        ).not.toBeInTheDocument();
       });
     });
 
     describe("is false", () => {
       it("should render the more actions icon", () => {
-        render(
-          <DataListActions>
-            <DataListAction
-              alwaysVisible={false}
-              icon="edit"
-              label={label}
-              visible={() => true}
-            />
-          </DataListActions>,
-        );
+        setupAlwaysVisible(false);
 
         expect(screen.getByLabelText(moreLabel)).toBeInTheDocument();
       });
@@ -176,6 +182,17 @@ describe("DataListActions", () => {
         renderComponent();
 
         expect(screen.getByLabelText("More actions")).toBeInTheDocument();
+      });
+
+      it("should render the tooltip", async () => {
+        renderComponent();
+
+        const moreButton = screen.getByLabelText("More actions");
+        await userEvent.hover(moreButton);
+
+        expect(
+          document.querySelector("div[role='tooltip']"),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
+++ b/packages/components/src/DataList/components/DataListActions/DataListActions.tsx
@@ -46,7 +46,7 @@ export function DataListActions<T extends DataListObject>({
         const actionLabel = getActionLabel();
 
         // If the action is always visible, we don't want a tooltip.
-        if (props.alwaysVisibled) {
+        if (props.alwaysVisible) {
           return (
             <Button
               ariaLabel={actionLabel}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
I merged a typo with my branch last week that prevents the persistent ItemActions from rendering correctly. For shame.

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed
<img width="1490" alt="Screenshot 2025-02-24 at 13 57 29" src="https://github.com/user-attachments/assets/716f2c18-7ec4-4d1d-840b-a1dcae4104cf" />

- Fix spelling so that the DataList.ItemAction properly renders

## Testing
- Open `docs/components/DataList/Web.stories.tsx` and set one of the item actions to alwaysVisible={true}, delete the other item actions
- Navigate to your local story book and verify you no longer see the 'more' icon and instead see your item actions label on hover of the row.

<img width="1728" alt="Screenshot 2025-02-24 at 13 50 52" src="https://github.com/user-attachments/assets/e52a20c9-0b8e-4e7c-bf30-0a2c0a08d6eb" />

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
