### PR TITLE
fix(docx): Stop Triton Link from doing full page navigation

### DIFF
--- a/packages/site/src/components/TritonConversation.tsx
+++ b/packages/site/src/components/TritonConversation.tsx
@@ -1,6 +1,7 @@
-import { Box, Content, Heading, Icon, Link, Text } from "@jobber/components";
+import { Box, Content, Heading, Icon, Text } from "@jobber/components";
 import ReactMarkdown from "react-markdown";
 import { ReactElement } from "react";
+import { Link } from "react-router-dom";
 import styles from "./TritonConversation.module.css";
 import { CopyCodeButton } from "./CodeCopyButton";
 import { componentMap, getComponentPath } from "../utils/TritonLinks";
@@ -48,11 +49,7 @@ const Message = ({ question, response }: MessageProps) => (
                   text.toLowerCase().includes(mapKey.toLowerCase()),
                 );
 
-                return (
-                  <Link url={getComponentPath(key || "")} external={false}>
-                    {children}
-                  </Link>
-                );
+                return <Link to={getComponentPath(key || "")}>{children}</Link>;
               },
               p: ({ children }) => <Text>{children}</Text>,
               pre: ({ children, ...props }) => {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Documentation links from Triton were doing full page navigation, causing Triton chat to lose the questions and answers state in context.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed



### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Triton documentation link now uses `Link` from `react-router-dom` instead of Atlantis `Link`

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
