### PR TITLE
fix(components): Fix Chip Truncation Gradient

### DIFF
--- a/docs/components/Chip/Comparison.stories.tsx
+++ b/docs/components/Chip/Comparison.stories.tsx
@@ -417,7 +417,13 @@ const AllTemplate: ComponentStory<typeof Chip> = () => {
             </Chip.Suffix>
           </Chip>
         </div>
-        <div style={{ maxWidth: "300px" }}>
+        <div
+          style={{
+            maxWidth: "300px",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
           <Typography>Truncation Examples</Typography>
           <Typography>Long Label Only</Typography>
           <Chip label={longLabel} />

--- a/docs/components/Chip/Comparison.stories.tsx
+++ b/docs/components/Chip/Comparison.stories.tsx
@@ -24,6 +24,13 @@ export default {
 } as ComponentMeta<typeof Chip>;
 
 const AllTemplate: ComponentStory<typeof Chip> = () => {
+  const longLabel =
+    "This is a very long chip label that will definitely need to be truncated";
+  const longHeading =
+    "This is a very long heading that will need truncation as well";
+  const shortLabel = "Short Label";
+  const shortHeading = "Short Heading";
+
   return (
     <Content>
       <div style={{ display: "flex", gap: 12 }}>
@@ -402,6 +409,74 @@ const AllTemplate: ComponentStory<typeof Chip> = () => {
             invalid
             disabled
           >
+            <Chip.Prefix>
+              <Avatar initials="st" size="small" />
+            </Chip.Prefix>
+            <Chip.Suffix>
+              <Icon name="cross" size="small" color="interactiveSubtle" />
+            </Chip.Suffix>
+          </Chip>
+        </div>
+        <div style={{ maxWidth: "300px" }}>
+          <Typography>Truncation Examples</Typography>
+          <Typography>Long Label Only</Typography>
+          <Chip label={longLabel} />
+          <Typography>Long Label with Prefix</Typography>
+          <Chip label={longLabel}>
+            <Chip.Prefix>
+              <Avatar initials="st" size="small" />
+            </Chip.Prefix>
+          </Chip>
+          <Typography>Long Label with Suffix</Typography>
+          <Chip label={longLabel}>
+            <Chip.Suffix>
+              <Icon name="cross" size="small" color="interactiveSubtle" />
+            </Chip.Suffix>
+          </Chip>
+          <Typography>Long Label with Both</Typography>
+          <Chip label={longLabel}>
+            <Chip.Prefix>
+              <Avatar initials="st" size="small" />
+            </Chip.Prefix>
+            <Chip.Suffix>
+              <Icon name="cross" size="small" color="interactiveSubtle" />
+            </Chip.Suffix>
+          </Chip>
+          <Typography>Long Heading with Short Label</Typography>
+          <Chip label={shortLabel} heading={longHeading} />
+          <Typography>Short Heading with Long Label</Typography>
+          <Chip label={longLabel} heading={shortHeading} />
+          <Typography>Long Heading and Long Label</Typography>
+          <Chip label={longLabel} heading={longHeading} />
+          <Typography>Long Everything with Prefix and Suffix</Typography>
+          <Chip label={longLabel} heading={longHeading}>
+            <Chip.Prefix>
+              <Avatar initials="st" size="small" />
+            </Chip.Prefix>
+            <Chip.Suffix>
+              <Icon name="cross" size="small" color="interactiveSubtle" />
+            </Chip.Suffix>
+          </Chip>
+          <Typography>Subtle Variation with Long Text</Typography>
+          <Chip label={longLabel} heading={longHeading} variation="subtle">
+            <Chip.Prefix>
+              <Avatar initials="st" size="small" />
+            </Chip.Prefix>
+            <Chip.Suffix>
+              <Icon name="cross" size="small" color="interactiveSubtle" />
+            </Chip.Suffix>
+          </Chip>
+          <Typography>Invalid with Long Text</Typography>
+          <Chip label={longLabel} heading={longHeading} invalid>
+            <Chip.Prefix>
+              <Avatar initials="st" size="small" />
+            </Chip.Prefix>
+            <Chip.Suffix>
+              <Icon name="cross" size="small" color="interactiveSubtle" />
+            </Chip.Suffix>
+          </Chip>
+          <Typography>Disabled with Long Text</Typography>
+          <Chip label={longLabel} heading={longHeading} disabled>
             <Chip.Prefix>
               <Avatar initials="st" size="small" />
             </Chip.Prefix>

--- a/packages/components/src/Chip/Chip.module.css
+++ b/packages/components/src/Chip/Chip.module.css
@@ -212,11 +212,13 @@
 }
 
 .chip:hover .truncateGradient::before,
+.chip:focus .truncateGradient::before,
 .chip:focus-visible .truncateGradient::before {
   opacity: 0;
 }
 
 .chip:hover .truncateGradient::after,
+.chip:focus .truncateGradient::after,
 .chip:focus-visible .truncateGradient::after {
   opacity: 1;
 }

--- a/packages/components/src/Chip/Chip.module.css
+++ b/packages/components/src/Chip/Chip.module.css
@@ -185,6 +185,15 @@
   height: 100%;
 }
 
+.truncateGradient > span {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 10%;
+  background-color: var(--chip-base-bg-color);
+}
+
 .truncateGradient::before,
 .truncateGradient::after {
   content: "";
@@ -196,7 +205,7 @@
 .truncateGradient::before {
   background: linear-gradient(
     to left,
-    var(--chip-base-bg-color) 5%,
+    var(--chip-base-bg-color) 10%,
     rgba(255, 255, 255, 0)
   );
   opacity: 1;
@@ -205,7 +214,7 @@
 .truncateGradient::after {
   background: linear-gradient(
     to left,
-    var(--chip-base-hover-bg-color) 5%,
+    var(--chip-base-hover-bg-color) 10%,
     rgba(255, 255, 255, 0)
   );
   opacity: 0;

--- a/packages/components/src/Chip/Chip.module.css
+++ b/packages/components/src/Chip/Chip.module.css
@@ -107,6 +107,7 @@
 .subtle.invalid {
   --chip-border-color: var(--color-critical);
   --chip-base-bg-color: var(--color-critical--surface);
+  --chip-base-hover-bg-color: var(--color-interactive--background--hover);
 }
 
 /* If these change, please update InternalChip.css focus-visible rules */
@@ -115,19 +116,18 @@
 .subtle.invalid:hover,
 .subtle.invalid:focus-visible {
   --chip-border-color: var(--color-critical);
-  --chip-base-hover-bg-color: var(--color-interactive--background--hover);
 }
 
 .subtle {
   --chip-border-color: var(--color-border--interactive);
   --chip-base-bg-color: var(--color-surface);
+  --chip-base-hover-bg-color: var(--color-interactive--background);
 }
 
 /* If these change, please update InternalChip.css focus-visible rules */
 .subtle:focus-visible,
 .subtle:hover {
   --chip-border-color: var(--chip-base-bg-color);
-  --chip-base-hover-bg-color: var(--color-interactive--background);
 }
 
 .invalid.disabled,
@@ -183,21 +183,42 @@
   right: 0;
   width: var(--space-base);
   height: 100%;
+}
+
+.truncateGradient::before,
+.truncateGradient::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transition: opacity var(--timing-base);
+}
+
+.truncateGradient::before {
   background: linear-gradient(
     to left,
     var(--chip-base-bg-color) 5%,
     rgba(255, 255, 255, 0)
   );
-  transition: all var(--timing-base);
+  opacity: 1;
 }
 
-.chip:focus-visible .truncateGradient,
-.chip:hover .truncateGradient {
+.truncateGradient::after {
   background: linear-gradient(
     to left,
     var(--chip-base-hover-bg-color) 5%,
     rgba(255, 255, 255, 0)
   );
+  opacity: 0;
+}
+
+.chip:hover .truncateGradient::before,
+.chip:focus-visible .truncateGradient::before {
+  opacity: 0;
+}
+
+.chip:hover .truncateGradient::after,
+.chip:focus-visible .truncateGradient::after {
+  opacity: 1;
 }
 
 .chipLabelRef {

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -78,7 +78,9 @@ export const Chip = ({
             <div
               className={styles.truncateGradient}
               data-testid="ATL-Chip-Truncation-Gradient"
-            />
+            >
+              <span />
+            </div>
           )}
         </div>
         {suffix}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

the hover/focus states of the truncation gradient did not look great. this is because you cannot simply apply a `transition` to a `linear-gradient` `background`.

the goal of this PR is to make that look better than the current state.
<!-- Why did you do what you did? -->

## Changes

rather than trying to transition between the same element having 2 different gradient colors, what we're doing is instead having 2 distinct elements with a different gradient color for each of them. one will have `opacity: 1` by default, this will be the same color as the resting Chip variant background color.

the other will be `opacity: 0` by default and will have the hover/focus background color as its gradient.

as we hover, we will swap the opacity of these two gradients that are in the exact same position. since opacity IS a value that responds to `transition` we can give the appearance of the gradient changing at the same rate as the background of the Chip itself which is just a solid color.

solution inspired by
https://keithjgrant.com/posts/2017/07/transitioning-gradients/

### Added

- <!-- new features -->



### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

go to the Chip examples, `Truncation` example

when you hover you should NOT clearly see the gradient block as a distinct element as the background of the Chip changes on hover/focus. it should blend nicely back and forth as you hover/unhover/

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
