### PR TITLE
docs: AutoComplete customRenderMenu sticky footer implementation

### DIFF
--- a/docs/components/Autocomplete/Web.stories.tsx
+++ b/docs/components/Autocomplete/Web.stories.tsx
@@ -558,18 +558,35 @@ const CustomRenderingTemplate = () => {
             });
 
             break;
-          case KeyboardAction.Next:
+          case KeyboardAction.Next: {
             setHighlightedOptionIndex(newNextIndex);
-            menuRef?.children[newNextIndex]?.scrollIntoView?.({
-              behavior: "smooth",
-              block: "nearest",
-              inline: "start",
-            });
+            const nextElement = menuRef?.children[newNextIndex];
+            const footerHeight = footerElement?.offsetHeight || 0;
+
+            if (nextElement) {
+              const rect = nextElement.getBoundingClientRect();
+              const menuRect = menuRef.getBoundingClientRect();
+
+              // If element is hidden behind footer
+              if (rect.bottom > menuRect.bottom - footerHeight) {
+                // Calculate exact scroll position needed
+                const scrollOffset =
+                  rect.bottom - (menuRect.bottom - footerHeight);
+                menuRef.scrollTop += scrollOffset;
+              } else {
+                nextElement.scrollIntoView({
+                  behavior: "smooth",
+                  block: "nearest",
+                  inline: "start",
+                });
+              }
+            }
 
             if (newNextIndex === maxIndex) {
               footerElement?.focus();
             }
             break;
+          }
 
           case KeyboardAction.Select:
             // Don't select the footer
@@ -626,14 +643,16 @@ const CustomRenderingTemplate = () => {
       window.alert("Add new client");
     }
     const footer = (
-      <Button
-        label="+ Add new client"
-        onClick={addNewClient}
-        size="small"
-        id="footerElement"
-        fullWidth
-        type="tertiary"
-      />
+      <div style={{ position: "sticky", bottom: 0 }}>
+        <Button
+          label="+ Add new client"
+          onClick={addNewClient}
+          size="small"
+          id="footerElement"
+          fullWidth
+          type="tertiary"
+        />
+      </div>
     );
 
     return (

--- a/packages/site/src/content/Autocomplete/AutocompleteExamples.tsx
+++ b/packages/site/src/content/Autocomplete/AutocompleteExamples.tsx
@@ -407,7 +407,7 @@ function CustomMenuContent({
   );
 
   const onRequestHighlightChange = useCallback(
-    /* eslint-disable max-statements */
+    // eslint-disable-next-line max-statements
     (event: KeyboardEvent, direction: KeyboardAction) => {
       const indexChange = getRequestedIndexChange({
         event,

--- a/packages/site/src/content/Autocomplete/AutocompleteExamples.tsx
+++ b/packages/site/src/content/Autocomplete/AutocompleteExamples.tsx
@@ -406,8 +406,8 @@ function CustomMenuContent({
     [inputFocused, footerFocused],
   );
 
-  /* eslint-disable max-statements */
   const onRequestHighlightChange = useCallback(
+    /* eslint-disable max-statements */
     (event: KeyboardEvent, direction: KeyboardAction) => {
       const indexChange = getRequestedIndexChange({
         event,

--- a/packages/site/src/content/Autocomplete/AutocompleteExamples.tsx
+++ b/packages/site/src/content/Autocomplete/AutocompleteExamples.tsx
@@ -406,6 +406,7 @@ function CustomMenuContent({
     [inputFocused, footerFocused],
   );
 
+  /* eslint-disable max-statements */
   const onRequestHighlightChange = useCallback(
     (event: KeyboardEvent, direction: KeyboardAction) => {
       const indexChange = getRequestedIndexChange({
@@ -438,18 +439,35 @@ function CustomMenuContent({
           });
 
           break;
-        case KeyboardAction.Next:
+        case KeyboardAction.Next: {
           setHighlightedOptionIndex(newNextIndex);
-          menuRef?.children[newNextIndex]?.scrollIntoView?.({
-            behavior: "smooth",
-            block: "nearest",
-            inline: "start",
-          });
+          const nextElement = menuRef?.children[newNextIndex];
+          const footerHeight = footerElement?.offsetHeight || 0;
+
+          if (nextElement) {
+            const rect = nextElement.getBoundingClientRect();
+            const menuRect = menuRef.getBoundingClientRect();
+
+            // If element is hidden behind footer
+            if (rect.bottom > menuRect.bottom - footerHeight) {
+              // Calculate exact scroll position needed
+              const scrollOffset =
+                rect.bottom - (menuRect.bottom - footerHeight);
+              menuRef.scrollTop += scrollOffset;
+            } else {
+              nextElement.scrollIntoView({
+                behavior: "smooth",
+                block: "nearest",
+                inline: "start",
+              });
+            }
+          }
 
           if (newNextIndex === maxIndex) {
             footerElement?.focus();
           }
           break;
+        }
 
         case KeyboardAction.Select:
           // Don't select the footer
@@ -476,14 +494,16 @@ function CustomMenuContent({
     window.alert("Add new client");
   }
   const footer = (
-    <Button
-      label="+ Add new client"
-      onClick={addNewClient}
-      id="footerElement"
-      size="small"
-      fullWidth
-      type="tertiary"
-    />
+    <div style={{ position: "sticky", bottom: 0 }}>
+      <Button
+        label="+ Add new client"
+        onClick={addNewClient}
+        id="footerElement"
+        size="small"
+        fullWidth
+        type="tertiary"
+      />
+    </div>
   );
 
   return (
@@ -526,14 +546,16 @@ function addNewClient() {
   window.alert("Add new client");
 }
 const footer = (
-  <Button
-    label="+ Add new client"
-    onClick={addNewClient}
-    id="footerElement"
-    size="small"
-    fullWidth
-    type="tertiary"
-  />
+  <div style={{ position: "sticky", bottom: 0 }}>
+    <Button
+      label="+ Add new client"
+      onClick={addNewClient}
+      id="footerElement"
+      size="small"
+      fullWidth
+      type="tertiary"
+    />
+  </div>
 );
 <MenuWrapper visible={menuVisible}>
   {options.map((option, index) => {
@@ -638,18 +660,35 @@ export const AdvancedKeyboardNavigationSnippet = `
             });
   
             break;
-          case KeyboardAction.Next:
+          case KeyboardAction.Next: {
             setHighlightedOptionIndex(newNextIndex);
-            menuRef?.children[newNextIndex]?.scrollIntoView?.({
-              behavior: "smooth",
-              block: "nearest",
-              inline: "start",
-            });
-  
+            const nextElement = menuRef?.children[newNextIndex];
+            const footerHeight = footerElement?.offsetHeight || 0;
+
+            if (nextElement) {
+              const rect = nextElement.getBoundingClientRect();
+              const menuRect = menuRef.getBoundingClientRect();
+
+              // If element is hidden behind footer
+              if (rect.bottom > menuRect.bottom - footerHeight) {
+                // Calculate exact scroll position needed
+                const scrollOffset =
+                  rect.bottom - (menuRect.bottom - footerHeight);
+                menuRef.scrollTop += scrollOffset;
+              } else {
+                nextElement.scrollIntoView({
+                  behavior: "smooth",
+                  block: "nearest",
+                  inline: "start",
+                });
+              }
+            }
+
             if (newNextIndex === maxIndex) {
               footerElement?.focus();
             }
             break;
+          }
   
           case KeyboardAction.Select:
             // Don't select the footer
@@ -819,18 +858,35 @@ interface CustomOption {
             });
   
             break;
-          case KeyboardAction.Next:
+          case KeyboardAction.Next: {
             setHighlightedOptionIndex(newNextIndex);
-            menuRef?.children[newNextIndex]?.scrollIntoView?.({
-              behavior: "smooth",
-              block: "nearest",
-              inline: "start",
-            });
-  
+            const nextElement = menuRef?.children[newNextIndex];
+            const footerHeight = footerElement?.offsetHeight || 0;
+
+            if (nextElement) {
+              const rect = nextElement.getBoundingClientRect();
+              const menuRect = menuRef.getBoundingClientRect();
+
+              // If element is hidden behind footer
+              if (rect.bottom > menuRect.bottom - footerHeight) {
+                // Calculate exact scroll position needed
+                const scrollOffset =
+                  rect.bottom - (menuRect.bottom - footerHeight);
+                menuRef.scrollTop += scrollOffset;
+              } else {
+                nextElement.scrollIntoView({
+                  behavior: "smooth",
+                  block: "nearest",
+                  inline: "start",
+                });
+              }
+            }
+
             if (newNextIndex === maxIndex) {
               footerElement?.focus();
             }
             break;
+          }
   
           case KeyboardAction.Select:
             // Don't select the footer

--- a/packages/site/src/content/Autocomplete/AutocompleteNotes.mdx
+++ b/packages/site/src/content/Autocomplete/AutocompleteNotes.mdx
@@ -95,13 +95,12 @@ In this example we will override the default rendering of the Autocomplete Menu 
 
 In this example we will override the rendering of the menu to render the Options
 in a completely custom way. This example will also include a footer that is
-rendered at the bottom of the menu.
+rendered at the bottom of the menu with sticky positioning.
 
 **Note:** Due to the complexity of the example, we will not be using the
 `useKeyboardNavigation` hook to handle the keyboard navigation of the options.
 
-Instead we will be handling the keyboard navigation manually with the Instead we
-will be handling the keyboard navigation manually with the
+Instead we will be handling the keyboard navigation manually with the
 `useCustomKeyboardNavigation` hook. This requires us to manually keep track of
 the highlighted option index and update it when the user navigates the menu.
 
@@ -122,6 +121,10 @@ handles attaching the menu to the input. Our custom options are wrapped by the
 `BaseMenuOption` component which handles the base styling and functionality for
 the options. Inside the `BaseMenuOption` component the content that we want to
 render is provided as children.
+
+**Note:** For the footer to be sticky at the bottom of the menu without being
+scrollable, the footer needs to be wrapped in a `div` with `position: "sticky"`
+and `bottom: 0`.
 
 <Disclosure title="Menu Option Content (Click to Reveal Code)">
 
@@ -146,6 +149,9 @@ handle the keyboard navigation of the options and the footer.
   navigates the menu.
 - `getRequestedIndexChange` is a helper function that is used to get the index
   change based on the keyboard event, direction and if the option is a group.
+- `KeyboardAction.Next` case should calculate the exact scroll position needed
+  with the footer height offset in mind, when the next element is hidden behind
+  the footer.
 
 <Disclosure title="Keyboard Navigation (Click to Reveal Code)">
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Our documentation for `customRenderMenu` includes a custom menu and a footer button. The footer should not scroll. We want to provide an implementation for this use case and make sure scroll into view with keyboard navigation still works.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->
- Storybook implementation to make sticky footer and keyboard navigation work
- Updates to implementation notes to explain this usage

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
