### PR TITLE
build: Update circle to only report errors when linting javascript

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
     <<: *container_config
     steps:
       - *attach_workspace
-      - run: npm run lint:js -- --format junit -o reports/junit/js-lint-results.xml
+      - run: npm run lint:js -- --quiet --format junit -o reports/junit/js-lint-results.xml
       - store_test_results:
           path: reports/junit
       - store_artifacts:

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -61,10 +61,10 @@ export interface SectionProps {
   actions: ActionProps[];
 }
 
+// eslint-disable-next-line max-statements
 export function Menu({ activator, items }: MenuProps) {
   const [visible, setVisible] = useState(false);
   const popperRef = useRef<HTMLDivElement>(null);
-  const a = 1;
 
   const { width } = useWindowDimensions();
 

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -61,10 +61,10 @@ export interface SectionProps {
   actions: ActionProps[];
 }
 
-// eslint-disable-next-line max-statements
 export function Menu({ activator, items }: MenuProps) {
   const [visible, setVisible] = useState(false);
   const popperRef = useRef<HTMLDivElement>(null);
+  const a = 1;
 
   const { width } = useWindowDimensions();
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
Linting failures can be teadius because warnings are also reported. This PR aims to fix this by using [--quite](https://eslint.org/docs/latest/use/command-line-interface#--quiet)

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

-  Only report errors in Circle CI to make taking issues when linting fails easier 



## Testing

<!-- How to test your changes. -->
Check the eslint failures in circle CI for https://github.com/GetJobber/atlantis/pull/2401/commits/15e1d77a0f9df52b5d79f7e39149b84bcc2f971c and verify that only the errors are reported in the list of failed tests

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
