### PR TITLE
docs: update Triton SideDrawer empty state and add title

### DIFF
--- a/packages/site/src/components/TritonSideDrawer.tsx
+++ b/packages/site/src/components/TritonSideDrawer.tsx
@@ -1,12 +1,14 @@
 import {
   Box,
   Button,
-  Content,
+  Heading,
+  Icon,
   InputPassword,
   InputText,
   InputValidation,
   SideDrawer,
   Text,
+  Tooltip,
 } from "@jobber/components";
 import { useCallback, useEffect, useState } from "react";
 import { TritonConversation } from "./TritonConversation";
@@ -32,21 +34,32 @@ const ApiKeyForm = ({
   };
 
   return (
-    <Box margin={{ bottom: "base" }}>
-      <Content>
-        <Text>
-          To authenticate with Triton, paste the secret API key below.
-        </Text>
-        <InputPassword
-          value={apiKey}
-          onChange={value => {
-            setApiKey(value as string);
-            if (!value) setValidationError("");
-          }}
-        />
-        {validationError && <InputValidation message={validationError} />}
-        <Button label="Save" onClick={handleSubmit} loading={loading} />
-      </Content>
+    <Box
+      padding="larger"
+      gap="base"
+      alignItems="center"
+      margin={{ bottom: "base" }}
+      background="surface--background--subtle"
+      radius="base"
+    >
+      <Box gap="small" alignItems="center">
+        <Icon name="warning" size="large" />
+        <Heading level={3}>Authentication required</Heading>
+      </Box>
+      <Text align="center">
+        Enter your Atlantis AI API key to access Triton
+      </Text>
+      <InputPassword
+        value={apiKey}
+        align="center"
+        placeholder="API key"
+        onChange={value => {
+          setApiKey(value as string);
+          if (!value) setValidationError("");
+        }}
+      />
+      {validationError && <InputValidation message={validationError} />}
+      <Button label="Submit" onClick={handleSubmit} loading={loading} />
     </Box>
   );
 };
@@ -129,6 +142,18 @@ export function TritonSideDrawer() {
 
   return (
     <SideDrawer open={tritonOpen} onRequestClose={onCloseTriton}>
+      <SideDrawer.Title>Triton</SideDrawer.Title>
+      <SideDrawer.Actions>
+        <Tooltip message="Visit Triton Site">
+          <Button
+            ariaLabel="Visit Triton Site"
+            icon="export"
+            type="secondary"
+            variation="subtle"
+            url="https://atlantis-ai.jobber.dev"
+          />
+        </Tooltip>
+      </SideDrawer.Actions>
       <SideDrawer.Toolbar>
         {isValidKey ? (
           <ChatInterface


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Noticed that the empty state for the Triton could be a bit clearer

## Changes

### Changed

- Styling and content of Triton empty state

## Testing

Run site locally

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
