### PR TITLE
fix(components):Autocomplete portal has 0 height and width when not visible

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.module.css
+++ b/packages/components/src/Autocomplete/Autocomplete.module.css
@@ -6,10 +6,8 @@
 .options {
   visibility: hidden;
   z-index: calc(var(--elevation-menu) + var(--elevation-modal));
-  width: 100%;
-  /* Unfortunately this is how we define our line item picker height in jobber online.
-  This is a concession to maintain visual parity. */
-  max-height: 300px;
+  width: 0;
+  height: 0;
   box-shadow: var(--shadow-base);
   box-sizing: border-box;
   margin: 0;
@@ -29,6 +27,9 @@
 
 .options.visible {
   visibility: visible;
+  width: 100%;
+  height: auto;
+  max-height: 300px;
   opacity: 1;
 }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

- Implementation tab for Autocomplete has empty space and scrolling issue. It is due to the portal of menu option being not visible, but still rendered on the DOM. It should be set to have width and height 0 when not visible. 

https://github.com/user-attachments/assets/eb5c6991-c554-4b18-84a5-80c55bb7af8f



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- MenuWrapper css set to width and height 0 when not visible

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Go to Autocomplete page -> Implementation tab, verify the scrolling & blank space issue does not exist anymore

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
