### PR TITLE
docs: use h3 instead of h2 for Triton welcome message

### DIFF
--- a/packages/site/src/components/TritonConversation.tsx
+++ b/packages/site/src/components/TritonConversation.tsx
@@ -9,7 +9,7 @@ import { useTritonChat } from "../providers/TritonProvider";
 
 const WelcomeMessage = () => (
   <Content>
-    <Heading level={2}>Welcome!</Heading>
+    <Heading level={3}>Welcome!</Heading>
     <div style={{ marginBottom: 80 }}>
       <Text>
         I am an early-stage AI that can help you build with Atlantis components.


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

With the new SideDrawer title, the welcome heading was identical in weight to the drawer title.

![image](https://github.com/user-attachments/assets/78966b4a-abaa-49ff-8c47-c85cb300c733)

## Changes

### Fixed

- Better visual and semantic hierarchy for the Triton drawer when you first interact with it.

## Testing

Run locally or on CF

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
