### PR TITLE
feat(design): update value of interactive borders for light mode

### DIFF
--- a/packages/design/src/tokens/semanticColor.tokens.json
+++ b/packages/design/src/tokens/semanticColor.tokens.json
@@ -197,7 +197,7 @@
     },
     "border-": {
       "interactive": {
-        "$value": "{color.base.blue-.300}",
+        "$value": "{color.base.blue-.500}",
         "$description": "Use for the borders of interactive elements to give greater visual significance and ensure the element meets WCAG contrast standards."
       },
       "section": {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The base value of the `--color-border--interactive` should match Figma designs that ensure our inputs, buttons and other interactive elements meet WCAG AA contrast standards in light mode. (In dark mode, the contrast ratings are already compliant and match the designs).

## Changes

### Changed

- Updated the base value of `--color-border-interactive` in light mode

### Fixed

- Form input borders now pass WCAG 3:1 contrast ratio in light mode

## Testing

Component-level: verify locally (need to run `npm run bootstrap` to pick up the `design` package changes in `components`) and/or in CF builds.

**This must be thoroughly tested in-product for "visual breaking changes".**

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
