### PR TITLE
fix(components): Export form field internal components.

### DIFF
--- a/packages/components/src/FormField/FormFieldAffix.tsx
+++ b/packages/components/src/FormField/FormFieldAffix.tsx
@@ -11,6 +11,9 @@ interface AffixLabelProps extends Affix {
   readonly variation?: "prefix" | "suffix";
 }
 
+/**
+ * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ */
 export function AffixLabel({
   label,
   variation = "prefix",
@@ -27,6 +30,10 @@ export function AffixLabel({
     </div>
   );
 }
+
+/**
+ * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ */
 interface AffixIconProps extends Pick<FormFieldProps, "size"> {
   readonly variation?: "prefix" | "suffix";
 }

--- a/packages/components/src/FormField/FormFieldAffix.tsx
+++ b/packages/components/src/FormField/FormFieldAffix.tsx
@@ -12,7 +12,7 @@ interface AffixLabelProps extends Affix {
 }
 
 /**
- * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ * @internal Reach out to UX Foundations if using this component since it is possible it might change
  */
 export function AffixLabel({
   label,
@@ -32,7 +32,7 @@ export function AffixLabel({
 }
 
 /**
- * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ * @internal Reach out to UX Foundations if using this component since it is possible it might change
  */
 interface AffixIconProps extends Pick<FormFieldProps, "size"> {
   readonly variation?: "prefix" | "suffix";

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -134,12 +134,18 @@ export function FormFieldWrapper({
   );
 }
 
+/**
+ * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ */
 export function FormFieldInputHorizontalWrapper({
   children,
 }: PropsWithChildren) {
   return <div className={styles.horizontalWrapper}>{children}</div>;
 }
 
+/**
+ * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ */
 export function FormFieldInputWrapperStyles({
   children,
 }: {
@@ -148,6 +154,9 @@ export function FormFieldInputWrapperStyles({
   return <div className={styles.inputWrapper}>{children}</div>;
 }
 
+/**
+ * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ */
 export function FormFieldWrapperMain({
   children,
   tabIndex = -1,
@@ -186,6 +195,9 @@ export function FormFieldLabel({
   );
 }
 
+/**
+ * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ */
 export function FormFieldWrapperToolbar({
   toolbar,
   isToolbarVisible,

--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -135,7 +135,7 @@ export function FormFieldWrapper({
 }
 
 /**
- * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ * @internal Reach out to UX Foundations if using this component since it is possible it might change
  */
 export function FormFieldInputHorizontalWrapper({
   children,
@@ -144,7 +144,7 @@ export function FormFieldInputHorizontalWrapper({
 }
 
 /**
- * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ * @internal Reach out to UX Foundations if using this component since it is possible it might change
  */
 export function FormFieldInputWrapperStyles({
   children,
@@ -155,7 +155,7 @@ export function FormFieldInputWrapperStyles({
 }
 
 /**
- * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ * @internal Reach out to UX Foundations if using this component since it is possible it might change
  */
 export function FormFieldWrapperMain({
   children,
@@ -196,7 +196,7 @@ export function FormFieldLabel({
 }
 
 /**
- * @internal Reach out to UX Foundations is using this component since it is possible it might change
+ * @internal Reach out to UX Foundations if using this component since it is possible it might change
  */
 export function FormFieldWrapperToolbar({
   toolbar,

--- a/packages/components/src/FormField/index.ts
+++ b/packages/components/src/FormField/index.ts
@@ -4,7 +4,16 @@ export { useAtlantisFormField } from "./hooks/useAtlantisFormField";
 export { useAtlantisFormFieldActions } from "./hooks/useAtlantisFormFieldActions";
 export { useAtlantisFormFieldName } from "./hooks/useAtlantisFormFieldName";
 export { useAtlantisReactHookForm } from "./hooks/useAtlantisReactHookForm";
-export { FormFieldLabel, FormFieldWrapper } from "./FormFieldWrapper";
+export {
+  FormFieldInputHorizontalWrapper,
+  FormFieldInputWrapperStyles,
+  FormFieldLabel,
+  FormFieldWrapper,
+  FormFieldWrapperMain,
+  FormFieldWrapperToolbar,
+  FormFieldWrapperProps,
+} from "./FormFieldWrapper";
+export { AffixIcon, AffixLabel } from "./FormFieldAffix";
 export {
   useFormFieldWrapperStyles,
   useFormFieldWrapperStylesProps,

--- a/packages/components/src/utils/meta/meta.json
+++ b/packages/components/src/utils/meta/meta.json
@@ -1,5 +1,7 @@
 {
   "exportedComponents": [
+    "AffixIcon",
+    "AffixLabel",
     "AnimatedPresence",
     "AnimatedSwitcher",
     "AnimatedSwitcher.Icon",
@@ -57,8 +59,12 @@
     "Footer",
     "Form",
     "FormField",
+    "FormFieldInputHorizontalWrapper",
+    "FormFieldInputWrapperStyles",
     "FormFieldLabel",
     "FormFieldWrapper",
+    "FormFieldWrapperMain",
+    "FormFieldWrapperToolbar",
     "FormatDate",
     "FormatEmail",
     "FormatFile",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

As we work on composability we want to export the internal building blocks of our components to allow consumers to leverage them when composing our components. This PR exports some of the internals

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Export internal of `FormFieldWrapper` for consumers to use if neede3d

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
