### PR TITLE
feat(components): Linking the Sitemap in the Head

### DIFF
--- a/packages/site/index.html
+++ b/packages/site/index.html
@@ -14,6 +14,7 @@
   <link rel="prefetch" href="/styles.css" as="style">
   <link rel="prefetch" href="/foundation.css" as="style">
   <link rel="prefetch" href="/dark.mode.css" as="style">
+  <link rel="sitemap" href="sitemap.xml" type="application/xml" />
 </head>
 
 <body>


### PR DESCRIPTION
## Motivations

1. Wanted to see if linking the sitemap in the head of the html helped crawlers out at all.

## Changes

1. Added the sitemap to the head of the html document for the docs site.


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
