### PR TITLE
docs: Add personality SegmentedControl to Triton SideDrawer

### DIFF
--- a/packages/site/src/components/TritonSideDrawer.tsx
+++ b/packages/site/src/components/TritonSideDrawer.tsx
@@ -6,6 +6,7 @@ import {
   InputPassword,
   InputText,
   InputValidation,
+  SegmentedControl,
   SideDrawer,
   Text,
   Tooltip,
@@ -134,6 +135,8 @@ export function TritonSideDrawer() {
     loading,
     validateApiKey,
     isValidKey,
+    personality,
+    setPersonality,
   } = useTritonChat();
 
   useEffect(() => {
@@ -144,15 +147,29 @@ export function TritonSideDrawer() {
     <SideDrawer open={tritonOpen} onRequestClose={onCloseTriton}>
       <SideDrawer.Title>Triton</SideDrawer.Title>
       <SideDrawer.Actions>
-        <Tooltip message="Visit Triton Site">
-          <Button
-            ariaLabel="Visit Triton Site"
-            icon="export"
-            type="secondary"
-            variation="subtle"
-            url="https://atlantis-ai.jobber.dev"
-          />
-        </Tooltip>
+        <Box direction="row" gap="small" alignItems="center">
+          <SegmentedControl
+            selectedValue={personality}
+            onSelectValue={setPersonality}
+            size="small"
+          >
+            <SegmentedControl.Option value="developer">
+              Developer
+            </SegmentedControl.Option>
+            <SegmentedControl.Option value="designer">
+              Designer
+            </SegmentedControl.Option>
+          </SegmentedControl>
+          <Tooltip message="Visit Triton Site">
+            <Button
+              ariaLabel="Visit Triton Site"
+              icon="export"
+              type="secondary"
+              variation="subtle"
+              url="https://atlantis-ai.jobber.dev"
+            />
+          </Tooltip>
+        </Box>
       </SideDrawer.Actions>
       <Box padding={{ left: "base", right: "base" }}>
         {isValidKey ? (

--- a/packages/site/src/components/TritonSideDrawer.tsx
+++ b/packages/site/src/components/TritonSideDrawer.tsx
@@ -92,7 +92,8 @@ const ChatInterface = ({
       style={{
         display: "flex",
         flexDirection: "column",
-        height: "calc(100vh - 80px)",
+        flex: 1,
+        minHeight: 0,
         gap: 16,
       }}
     >
@@ -147,7 +148,18 @@ export function TritonSideDrawer() {
     <SideDrawer open={tritonOpen} onRequestClose={onCloseTriton}>
       <SideDrawer.Title>Triton</SideDrawer.Title>
       <SideDrawer.Actions>
-        <Box direction="row" gap="small" alignItems="center">
+        <Tooltip message="Visit Triton Site">
+          <Button
+            ariaLabel="Visit Triton Site"
+            icon="export"
+            type="secondary"
+            variation="subtle"
+            url="https://atlantis-ai.jobber.dev"
+          />
+        </Tooltip>
+      </SideDrawer.Actions>
+      {isValidKey && (
+        <SideDrawer.Toolbar>
           <SegmentedControl
             selectedValue={personality}
             onSelectValue={setPersonality}
@@ -160,18 +172,13 @@ export function TritonSideDrawer() {
               Designer
             </SegmentedControl.Option>
           </SegmentedControl>
-          <Tooltip message="Visit Triton Site">
-            <Button
-              ariaLabel="Visit Triton Site"
-              icon="export"
-              type="secondary"
-              variation="subtle"
-              url="https://atlantis-ai.jobber.dev"
-            />
-          </Tooltip>
-        </Box>
-      </SideDrawer.Actions>
-      <Box padding={{ left: "base", right: "base" }}>
+        </SideDrawer.Toolbar>
+      )}
+      <Box
+        padding={{ left: "base", right: "base", bottom: "base" }}
+        direction="column"
+        height="grow"
+      >
         {isValidKey ? (
           <ChatInterface
             question={question}

--- a/packages/site/src/providers/TritonProvider.tsx
+++ b/packages/site/src/providers/TritonProvider.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable max-statements */
 import { PropsWithChildren, createContext, useContext, useState } from "react";
-import { useTritonApi } from "../utils/useTritonApi";
+import { ActivePersonalities, useTritonApi } from "../utils/useTritonApi";
 
 interface TritonContextType {
   tritonOpen: boolean;
@@ -15,6 +16,8 @@ interface TritonContextType {
   setLoading: (loading: boolean) => void;
   validateApiKey: () => Promise<void>;
   isValidKey: boolean;
+  personality: ActivePersonalities;
+  setPersonality: (value: ActivePersonalities) => void;
 }
 
 const TritonContext = createContext<TritonContextType>({
@@ -31,6 +34,8 @@ const TritonContext = createContext<TritonContextType>({
   setLoading: () => ({}),
   validateApiKey: async () => Promise.resolve(),
   isValidKey: false,
+  personality: "developer",
+  setPersonality: () => ({}),
 });
 
 export function TritonProvider({ children }: PropsWithChildren) {
@@ -40,6 +45,8 @@ export function TritonProvider({ children }: PropsWithChildren) {
   const [questions, setQuestions] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [isValidKey, setIsValidKey] = useState(false);
+  const [personality, setPersonality] =
+    useState<ActivePersonalities>("developer");
   const { validateApiKey, sendSearch } = useTritonApi();
 
   const handleValidateApiKey = async (key?: string) => {
@@ -59,6 +66,7 @@ export function TritonProvider({ children }: PropsWithChildren) {
       setQuestions,
       setResponses,
       setQuestion,
+      personality,
     });
   };
 
@@ -76,6 +84,8 @@ export function TritonProvider({ children }: PropsWithChildren) {
     setLoading,
     validateApiKey: handleValidateApiKey,
     isValidKey,
+    personality,
+    setPersonality,
   };
 
   return (

--- a/packages/site/src/utils/useTritonApi.ts
+++ b/packages/site/src/utils/useTritonApi.ts
@@ -5,6 +5,8 @@ interface TritonApiOptions {
   key?: string;
 }
 
+export type ActivePersonalities = "developer" | "designer";
+
 interface UseTritonApi {
   invokeTritonApi: (options: TritonApiOptions) => Promise<Response>;
   validateApiKey: (
@@ -21,6 +23,7 @@ interface UseTritonApi {
     setQuestions: React.Dispatch<React.SetStateAction<string[]>>;
     setResponses: React.Dispatch<React.SetStateAction<string[]>>;
     setQuestion: (question: string) => void;
+    personality: ActivePersonalities;
   }) => Promise<void>;
 }
 
@@ -107,6 +110,7 @@ export function useTritonApi(): UseTritonApi {
     setQuestions,
     setResponses,
     setQuestion,
+    personality,
   }: {
     question: string;
     questions: string[];
@@ -115,6 +119,7 @@ export function useTritonApi(): UseTritonApi {
     setQuestions: React.Dispatch<React.SetStateAction<string[]>>;
     setResponses: React.Dispatch<React.SetStateAction<string[]>>;
     setQuestion: (question: string) => void;
+    personality: ActivePersonalities;
   }) => {
     if (!question.trim()) return;
 
@@ -123,7 +128,7 @@ export function useTritonApi(): UseTritonApi {
       const response = await invokeTritonApi({
         endpoint: "/stream",
         body: {
-          personality: "developer",
+          personality,
           query: question,
           questions,
           questionType: "web",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Developers and Designers can use the Triton SideDrawer, so we should offer both personalities.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- A `SegmentedControl` is now in the Triton SideDrawer to toggle back and forth between personalities
- an `ActivePersonalities` type for `developer` and `designer` (mirrors the Triton API)
- `TritonProvider` manages the value of `ActivePersonalities` in it's context state, when the `SegmentedControl` is toggled, the context's `setPersonality` is called, updating the personality

## Testing

<!-- How to test your changes. -->
- In `useTritonApi.ts` in the `response` update the url: `http://localhost:8788/${endpoint}`
- start the `atlantis-ai` server
- in atlantis, cd into `packages/site` and run `npm run dev`
- enter the Triton API key in the SideDrawer and ask a question with `developer` selected and then `designer` selected
- go to the Network tab and watch for `stream`. You will see the correct personality in the payload:

![Screenshot 2025-03-18 at 12 05 16 PM](https://github.com/user-attachments/assets/1966e2e4-ecb5-4ea9-87e4-01579d494afc)


![Screenshot 2025-03-18 at 12 04 32 PM](https://github.com/user-attachments/assets/87aaeeed-b74c-48b3-8a22-b3dbd7305308)


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
