### PR TITLE
docs: adjust layout of doc site chrome

### DIFF
--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -10,7 +10,7 @@
   box-sizing: border-box;
 
   @media screen and (min-width: 768px) {
-    padding: 35px 0 0 0;
+    padding: var(--space-large) 0 0 0;
     height: 100dvh;
   }
 }

--- a/packages/site/src/layout/TopNav.tsx
+++ b/packages/site/src/layout/TopNav.tsx
@@ -13,14 +13,17 @@ export const TopNav = () => {
   const { toggleMobileMenu, isMinimal } = useAtlantisSite();
 
   return (
-    <Box
-      padding="base"
-      direction="row"
-      alignItems="center"
-      gap="small"
-      justifyContent={
-        isMinimal ? "flex-end" : mediumAndUp ? "" : "space-between"
-      }
+    <nav
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: isMinimal
+          ? "flex-end"
+          : mediumAndUp
+          ? ""
+          : "space-between",
+        padding: "12px 16px",
+      }}
     >
       {!mediumAndUp && !isMinimal && (
         <Box
@@ -73,6 +76,6 @@ export const TopNav = () => {
         </Box>
         <ToggleThemeButton />
       </Box>
-    </Box>
+    </nav>
   );
 };

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -235,7 +235,7 @@ iframe {
 
 .baseView-sideRail {
   width: var(--sideBarWidth);
-  padding: 36px var(--space-base);
+  padding: 84px var(--space-large);
   display: none;
   flex-direction: column;
   flex-shrink: 0;

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -235,7 +235,7 @@ iframe {
 
 .baseView-sideRail {
   width: var(--sideBarWidth);
-  padding: 84px var(--space-large);
+  padding: 90px var(--space-large);
   display: none;
   flex-direction: column;
   flex-shrink: 0;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

With some of the recent changes to the doc site (notably top nav), the balance is a little off.

## Changes

### Changed

- Padding of topnav and alignment of items in the side nav and side rail
![image](https://github.com/user-attachments/assets/794d1421-e0ac-428e-9ad1-402e23e272f5)
![image](https://github.com/user-attachments/assets/bbf95e5c-f67c-448b-9907-1f08dd33e3ed)

## Testing

Run site locally.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
