### PR TITLE
docs: make docs tables more predictable

### DIFF
--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -85,12 +85,12 @@ blockquote {
 custom-elements,
 section[role="tabpanel"] {
   & table {
-    min-width: 66%;
+    min-width: 100%;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-overflow-scrolling: touch;
-    margin: var(--space-large) auto;
+    margin: var(--space-large) 0;
     font-size: var(--typography--fontSize-base);
     line-height: 24px;
     padding: 0;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Before we had more sensible line-lengths/width restrictions in the docs site, center-aligning and capping the width of tables was a practical approach to making sure they never got too wide, and had less of a "river" effect when used in sequence.

However, since we've tightened up our document layouts, the tables can fairly safely run full-width and have a less jarring jump in content alignment.

## Changes

### Changed

- Table layout (before/afters):
![image](https://github.com/user-attachments/assets/73182718-eaec-43ae-bdc6-b5f42aad3e1f)
![image](https://github.com/user-attachments/assets/b4a632d3-ada5-4fb2-8367-133ad8d48733)
![image](https://github.com/user-attachments/assets/51b65050-4e55-4eb3-b74a-812ff9d3146a)
![image](https://github.com/user-attachments/assets/b29946a2-4d0d-420e-a06c-2a1e3802a921)

## Testing

Run docs site locally (design and content pages, as well as patterns, have a decent set of tables)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
