### PR TITLE
fix(components): fix controlled SegmentedControl render state update

### DIFF
--- a/packages/components/src/SegmentedControl/SegmentedControlProvider.test.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControlProvider.test.tsx
@@ -79,7 +79,7 @@ describe("SegmentedControlProvider", () => {
       });
     });
 
-    it("initializes with the correct value", () => {
+    it("initializes with the correct value via onSelectValue", async () => {
       const handleSelectValue = jest.fn();
       render(
         <SegmentedControlProvider
@@ -89,6 +89,10 @@ describe("SegmentedControlProvider", () => {
           <SegmentedControl />
         </SegmentedControlProvider>,
       );
+
+      await waitFor(() => {
+        expect(handleSelectValue).toHaveBeenCalledWith("option2");
+      });
 
       expect(screen.getByLabelText("Option 2")).toBeChecked();
     });

--- a/packages/components/src/SegmentedControl/SegmentedControlProvider.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControlProvider.tsx
@@ -4,6 +4,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -66,10 +67,12 @@ export function SegmentedControlProvider<T>({
 
   const hasInitialized = useRef(false);
 
-  if (!hasInitialized.current && currentSelectedOption !== undefined) {
-    onSelectValue?.(currentSelectedOption);
-    hasInitialized.current = true;
-  }
+  useEffect(() => {
+    if (!hasInitialized.current && currentSelectedOption !== undefined) {
+      onSelectValue?.(currentSelectedOption);
+      hasInitialized.current = true;
+    }
+  }, [currentSelectedOption, onSelectValue]);
 
   return (
     <SegmentedControlContext.Provider

--- a/packages/components/src/SegmentedControl/SegmentedControlProvider.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControlProvider.tsx
@@ -5,7 +5,6 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useRef,
   useState,
 } from "react";
 
@@ -65,14 +64,11 @@ export function SegmentedControlProvider<T>({
     ? selectedValue
     : internalSelectedValue;
 
-  const hasInitialized = useRef(false);
-
   useEffect(() => {
-    if (!hasInitialized.current && currentSelectedOption !== undefined) {
+    if (isControlled && currentSelectedOption !== undefined) {
       onSelectValue?.(currentSelectedOption);
-      hasInitialized.current = true;
     }
-  }, [currentSelectedOption, onSelectValue]);
+  }, []);
 
   return (
     <SegmentedControlContext.Provider


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
The controlled variation of `SegmentedControl` calls `onSelectValue` during rendering, which is usually a `setState` call. There should not be side effects during render phase.

This was first discovered as part of this [PR](https://github.com/GetJobber/atlantis/pull/2423) where `onSelectValue` (which is a `setPersonality` setState call in its parent) is called during render phase. This is the error:
`Cannot update a component (TritonProvider) while rendering a different component (SegmentedControlProvider).`

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Wrapped onSelectValue call in SegmentedControlProvider in `useEffect` to make sure it only gets called after initial render

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
