### PR TITLE
feat(components): Add UNSAFE_ props to Typography

### DIFF
--- a/packages/components/src/Typography/Typography.test.tsx
+++ b/packages/components/src/Typography/Typography.test.tsx
@@ -316,7 +316,7 @@ describe("underlining", () => {
 describe("UNSAFE props", () => {
   it("should apply the UNSAFE_className to the element", () => {
     render(
-      <Typography UNSAFE_className="custom-class">
+      <Typography UNSAFE_className={{ textStyle: "custom-class" }}>
         Text with custom class
       </Typography>,
     );
@@ -326,7 +326,7 @@ describe("UNSAFE props", () => {
 
   it("should apply the UNSAFE_style to the element", () => {
     render(
-      <Typography UNSAFE_style={{ color: "#0066CC" }}>
+      <Typography UNSAFE_style={{ textStyle: { color: "#0066CC" } }}>
         Text with custom style
       </Typography>,
     );

--- a/packages/components/src/Typography/Typography.test.tsx
+++ b/packages/components/src/Typography/Typography.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import { Typography } from ".";
 
@@ -310,5 +310,27 @@ describe("underlining", () => {
       `;
 
     expect(container).toMatchInlineSnapshot(snapshot);
+  });
+});
+
+describe("UNSAFE props", () => {
+  it("should apply the UNSAFE_className to the element", () => {
+    render(
+      <Typography UNSAFE_className="custom-class">
+        Text with custom class
+      </Typography>,
+    );
+    const element = screen.getByText("Text with custom class");
+    expect(element).toHaveClass("custom-class");
+  });
+
+  it("should apply the UNSAFE_style to the element", () => {
+    render(
+      <Typography UNSAFE_style={{ color: "#0066CC" }}>
+        Text with custom style
+      </Typography>,
+    );
+    const element = screen.getByText("Text with custom style");
+    expect(element).toHaveStyle({ color: "#0066CC" });
   });
 });

--- a/packages/components/src/Typography/Typography.tsx
+++ b/packages/components/src/Typography/Typography.tsx
@@ -67,14 +67,14 @@ export interface TypographyProps {
    * **last resort**. Using this may result in unexpected side effects.
    * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
    */
-  readonly UNSAFE_className?: string;
+  readonly UNSAFE_className?: { textStyle?: string };
 
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
    * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
    */
-  readonly UNSAFE_style?: CSSProperties;
+  readonly UNSAFE_style?: { textStyle?: CSSProperties };
 }
 export type TypographyOptions = Omit<TypographyProps, "children">;
 
@@ -108,7 +108,7 @@ export function Typography({
     {
       ...(align && { [alignment[align]]: align !== `start` }),
     },
-    UNSAFE_className,
+    UNSAFE_className?.textStyle,
   );
 
   let stylesOverrides: CSSProperties = {};
@@ -134,7 +134,7 @@ export function Typography({
     <Tag
       id={id}
       className={className}
-      style={{ ...stylesOverrides, ...UNSAFE_style }}
+      style={{ ...stylesOverrides, ...UNSAFE_style?.textStyle }}
     >
       {children}
     </Tag>

--- a/packages/components/src/Typography/Typography.tsx
+++ b/packages/components/src/Typography/Typography.tsx
@@ -111,47 +111,48 @@ export function Typography({
     UNSAFE_className?.textStyle,
   );
 
-  let stylesOverrides: CSSProperties = {};
+  const truncateStyles: CSSProperties = shouldTruncateText
+    ? {
+        WebkitLineClamp: numberOfLines,
+        WebkitBoxOrient: "vertical",
+      }
+    : {};
 
-  if (shouldTruncateText) {
-    stylesOverrides = {
-      WebkitLineClamp: numberOfLines,
-      WebkitBoxOrient: "vertical",
-    };
-  }
-
-  if (underline) {
-    const [underlineStyle, underlineColor] = underline.split(" ");
-
-    stylesOverrides.textDecorationStyle = underlineStyle as UnderlineStyle;
-    stylesOverrides.textDecorationColor = computeUnderlineColor(
-      underlineColor,
-      textColor,
-    );
-  }
+  const underlineInlineStyles = computeUnderlineStyles(underline, textColor);
 
   return (
     <Tag
       id={id}
       className={className}
-      style={{ ...stylesOverrides, ...UNSAFE_style?.textStyle }}
+      style={{
+        ...truncateStyles,
+        ...underlineInlineStyles,
+        ...UNSAFE_style?.textStyle,
+      }}
     >
       {children}
     </Tag>
   );
 }
 
-function computeUnderlineColor(
-  textDecorationColor: string,
+function computeUnderlineStyles(
+  underline?: UnderlineStyle | UnderlineStyleWithColor,
   textColor?: keyof typeof textColors,
-): string | undefined {
-  // Use the specified underline color if one is provided. If no underline color
-  // is specified, fall back to the text color for the underline.
-  if (textDecorationColor) {
-    return `var(--${textDecorationColor})`;
+): CSSProperties {
+  if (!underline) {
+    return {};
   }
 
-  if (textColor) {
-    return textColors[textColor];
+  const [underlineStyle, underlineColor] = underline.split(" ");
+  const underlineInlineStyles: CSSProperties = {
+    textDecorationStyle: underlineStyle as UnderlineStyle,
+  };
+
+  if (underlineColor) {
+    underlineInlineStyles.textDecorationColor = `var(--${underlineColor})`;
+  } else if (textColor) {
+    underlineInlineStyles.textDecorationColor = textColors[textColor];
   }
+
+  return underlineInlineStyles;
 }

--- a/packages/components/src/Typography/Typography.tsx
+++ b/packages/components/src/Typography/Typography.tsx
@@ -61,6 +61,20 @@ export interface TypographyProps {
    * @example "double color-invoice" for a double underline in the specified color
    */
   readonly underline?: UnderlineStyle | UnderlineStyleWithColor | undefined;
+
+  /**
+   * **Use at your own risk:** Custom classNames for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_className?: string;
+
+  /**
+   * **Use at your own risk:** Custom style for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_style?: CSSProperties;
 }
 export type TypographyOptions = Omit<TypographyProps, "children">;
 
@@ -77,6 +91,8 @@ export function Typography({
   numberOfLines,
   fontFamily,
   underline,
+  UNSAFE_className,
+  UNSAFE_style,
 }: TypographyProps) {
   const shouldTruncateText = numberOfLines && numberOfLines > 0;
   const className = classnames(
@@ -92,6 +108,7 @@ export function Typography({
     {
       ...(align && { [alignment[align]]: align !== `start` }),
     },
+    UNSAFE_className,
   );
 
   let stylesOverrides: CSSProperties = {};
@@ -114,7 +131,11 @@ export function Typography({
   }
 
   return (
-    <Tag id={id} className={className} style={stylesOverrides}>
+    <Tag
+      id={id}
+      className={className}
+      style={{ ...stylesOverrides, ...UNSAFE_style }}
+    >
       {children}
     </Tag>
   );

--- a/packages/site/src/content/Typography/Typography.props.json
+++ b/packages/site/src/content/Typography/Typography.props.json
@@ -165,7 +165,7 @@
         },
         "required": false,
         "type": {
-          "name": "string"
+          "name": "{ textStyle?: string; }"
         }
       },
       "UNSAFE_style": {
@@ -178,7 +178,7 @@
         },
         "required": false,
         "type": {
-          "name": "CSSProperties"
+          "name": "{ textStyle?: CSSProperties; }"
         }
       }
     }

--- a/packages/site/src/content/Typography/Typography.props.json
+++ b/packages/site/src/content/Typography/Typography.props.json
@@ -154,6 +154,32 @@
         "type": {
           "name": "UnderlineStyle | \"solid color-indigo\" | \"solid color-indigo--light\" | \"solid color-indigo--lighter\" | \"solid color-indigo--lightest\" | \"solid color-indigo--dark\" | ... 634 more ... | \"dashed color-client\""
         }
+      },
+      "UNSAFE_className": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom classNames for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "../components/src/Typography/Typography.tsx",
+          "name": "TypographyProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "../components/src/Typography/Typography.tsx",
+          "name": "TypographyProps"
+        },
+        "required": false,
+        "type": {
+          "name": "CSSProperties"
+        }
       }
     }
   }

--- a/packages/site/src/content/Typography/TypographyNotes.mdx
+++ b/packages/site/src/content/Typography/TypographyNotes.mdx
@@ -1,3 +1,51 @@
+## Component customization
+
+### UNSAFE\_ props (advanced usage)
+
+General information for using `UNSAFE_` props can be found
+[here](/guides/customizing-components).
+
+**Note**: Use of `UNSAFE_` props is **at your own risk** and should be
+considered a **last resort**. Future Typography updates may lead to unintended
+breakages.
+
+#### UNSAFE_className (web)
+
+Use `UNSAFE_className` to apply custom classes to the Typography component. This
+can be useful for applying styles via CSS Modules.
+
+```tsx
+// Typography.tsx
+<Typography
+  UNSAFE_className={{
+    textStyle: styles.customText,
+  }}
+>
+  Text with UNSAFE className
+</Typography>
+
+// Typography.module.css
+.customText {
+  color: var(--color-purple);
+}
+```
+
+#### UNSAFE_style (web & mobile)
+
+Use `UNSAFE_style` to apply inline custom styles to the Typography component.
+
+```tsx
+<Typography
+  UNSAFE_style={{
+    textStyle: {
+      color: "var(--color-purple)",
+    },
+  }}
+>
+  Text with UNSAFE style
+</Typography>
+```
+
 ## Platform considerations
 
 React Native has a lot of limitations around Android and iOS when it comes to

--- a/packages/site/src/content/Typography/TypographyNotes.mdx
+++ b/packages/site/src/content/Typography/TypographyNotes.mdx
@@ -1,3 +1,5 @@
+import { Tabs, Tab } from "@jobber/components/Tabs";
+
 ## Component customization
 
 ### UNSAFE\_ props (advanced usage)
@@ -9,37 +11,57 @@ General information for using `UNSAFE_` props can be found
 considered a **last resort**. Future Typography updates may lead to unintended
 breakages.
 
-#### UNSAFE_className (web)
+#### UNSAFE\_ props in web
 
-Use `UNSAFE_className` to apply custom classes to the Typography component. This
-can be useful for applying styles via CSS Modules.
+<Tabs>
+  <Tab label="UNSAFE_className">
+    Use `UNSAFE_className` to apply custom classes to the Typography component. This
+    can be useful for applying styles via CSS Modules.
 
-```tsx
-// Typography.tsx
-<Typography
-  UNSAFE_className={{
-    textStyle: styles.customText,
-  }}
->
-  Text with UNSAFE className
-</Typography>
+    ```tsx
+    // Typography.tsx
+    <Typography
+      UNSAFE_className={{
+        textStyle: styles.customText,
+      }}
+    >
+      Text with UNSAFE className
+    </Typography>
 
-// Typography.module.css
-.customText {
-  color: var(--color-purple);
-}
-```
+    // Typography.module.css
+    .customText {
+      color: var(--color-purple);
+    }
+    ```
 
-#### UNSAFE_style (web & mobile)
+  </Tab>
 
-Use `UNSAFE_style` to apply inline custom styles to the Typography component.
+  <Tab label="UNSAFE_style">
+    Use `UNSAFE_style` to apply inline custom styles to the Typography component.
+
+    ```tsx
+    <Typography
+      UNSAFE_style={{
+        textStyle: {
+          color: "var(--color-purple)",
+        },
+      }}
+    >
+      Text with UNSAFE style
+    </Typography>
+    ```
+
+  </Tab>
+</Tabs>
+
+#### UNSAFE\_ props in mobile
+
+Use `UNSAFE_style` to apply custom styles to the Typography component.
 
 ```tsx
 <Typography
   UNSAFE_style={{
-    textStyle: {
-      color: "var(--color-purple)",
-    },
+    textStyle: { color: tokens["color-purple--light"] },
   }}
 >
   Text with UNSAFE style


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
As we add `UNSAFE_` props to move and more components, it's important and helpful to get `UNSAFE_` into atom components first. Updating `Typography` will help unlock maximum customization in components like `Text`, `Disclosure`, etc.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `UNSAFE_className` and `UNSAFE_style` on `Typography`. I decided to make these props a keyed object, even though we just have one element here.  This is for a few reasons:
1. Consistency - the mobile `Typography` component has a `textStyle` key; now `UNSAFE_` is 1:1 in mobile and web
2. Future-proofing - if we ever need to add more targetable elements in the future, we don't need to change the API structure

- Updated the Implement tab to include `UNSAFE_` info
- tests

## Testing

<!-- How to test your changes. -->
Add this to `docs/components/Typography/Web.stories.tsx` to see that you can override via `UNSAFE_`. See how if you then try and change `textColor` via props table in Storybook, the red remains.

```
export const UNSAFE_style = BasicTemplate.bind({});
UNSAFE_style.args = {
  UNSAFE_style: {
    textStyle: {
      color: "red",
      fontSize: "20px",
      textDecoration: "underline",
      textDecorationColor: "blue",
      textDecorationThickness: "13px",
    },
  },
};
```

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
