### PR TITLE
feat(components): Add UNSAFE_ props to Disclosure

### DIFF
--- a/packages/components/src/Disclosure/Disclosure.test.tsx
+++ b/packages/components/src/Disclosure/Disclosure.test.tsx
@@ -167,3 +167,215 @@ describe("Disclosure", () => {
     );
   });
 });
+
+describe("UNSAFE_ props", () => {
+  describe("UNSAFE_className", () => {
+    type ElementTestCase = [
+      element: string,
+      className: string | { textStyle: string },
+      getElement: () => HTMLElement | null,
+    ];
+
+    const testCases: ElementTestCase[] = [
+      ["container", "custom-container", () => screen.getByRole("group")],
+      [
+        "summary",
+        "custom-summary",
+        () => screen.getByText("Test Title").closest("summary"),
+      ],
+      [
+        "summaryWrap",
+        "custom-summary-wrap",
+        () => screen.getByText("Test Title").closest("div"),
+      ],
+      [
+        "title",
+        { textStyle: "custom-title" },
+        () => screen.getByRole("heading"),
+      ],
+      [
+        "arrowIconWrapper",
+        "custom-arrow-wrapper",
+        () => screen.getByTestId("arrowDown").parentElement,
+      ],
+      [
+        "content",
+        "custom-content",
+        () => screen.getByText("Content").parentElement,
+      ],
+    ];
+
+    it.each<ElementTestCase>(testCases)(
+      "applies to %s",
+      (element, className, getElement) => {
+        render(
+          <Disclosure
+            title="Test Title"
+            UNSAFE_className={{ [element]: className }}
+          >
+            <span>Content</span>
+          </Disclosure>,
+        );
+        expect(getElement()).toHaveClass(
+          typeof className === "string" ? className : className.textStyle,
+        );
+      },
+    );
+
+    it("applies to icon", () => {
+      render(
+        <Disclosure
+          title="Test Title"
+          UNSAFE_className={{
+            icon: {
+              svg: "custom-icon-svg",
+              path: "custom-icon-path",
+            },
+          }}
+        >
+          <span>Content</span>
+        </Disclosure>,
+      );
+      expect(screen.getByTestId("arrowDown")).toHaveClass("custom-icon-svg");
+      expect(screen.getByTestId("arrowDown").querySelector("path")).toHaveClass(
+        "custom-icon-path",
+      );
+    });
+  });
+
+  describe("UNSAFE_style", () => {
+    it("applies to container", () => {
+      render(
+        <Disclosure
+          title="Test Title"
+          UNSAFE_style={{
+            container: { backgroundColor: "var(--color-yellow)" },
+          }}
+        >
+          <span>Content</span>
+        </Disclosure>,
+      );
+      expect(screen.getByRole("group")).toHaveStyle({
+        backgroundColor: "var(--color-yellow)",
+      });
+    });
+
+    it("applies to summary", () => {
+      render(
+        <Disclosure
+          title="Test Title"
+          UNSAFE_style={{
+            summary: { padding: "var(--space-large)" },
+          }}
+        >
+          <span>Content</span>
+        </Disclosure>,
+      );
+      expect(screen.getByText("Test Title").closest("summary")).toHaveStyle({
+        padding: "var(--space-large)",
+      });
+    });
+
+    it("applies to summary wrap", () => {
+      render(
+        <Disclosure
+          title="Test Title"
+          UNSAFE_style={{
+            summaryWrap: { margin: "var(--space-small)" },
+          }}
+        >
+          <span>Content</span>
+        </Disclosure>,
+      );
+      expect(screen.getByText("Test Title").closest("div")).toHaveStyle({
+        margin: "var(--space-small)",
+      });
+    });
+
+    it("applies to title", () => {
+      render(
+        <Disclosure
+          title="Test Title"
+          UNSAFE_style={{
+            title: { textStyle: { color: "var(--color-blue)" } },
+          }}
+        >
+          <span>Content</span>
+        </Disclosure>,
+      );
+      expect(screen.getByRole("heading")).toHaveStyle({
+        color: "var(--color-blue)",
+      });
+    });
+
+    it("applies to icon", () => {
+      render(
+        <Disclosure
+          title="Test Title"
+          UNSAFE_style={{
+            icon: {
+              svg: { width: "var(--space-large)" },
+              path: { fill: "var(--color-green)" },
+            },
+          }}
+        >
+          <span>Content</span>
+        </Disclosure>,
+      );
+      expect(screen.getByTestId("arrowDown")).toHaveStyle({
+        width: "var(--space-large)",
+      });
+      expect(screen.getByTestId("arrowDown").querySelector("path")).toHaveStyle(
+        { fill: "var(--color-green)" },
+      );
+    });
+
+    it("applies to arrow icon wrapper", () => {
+      render(
+        <Disclosure
+          title="Test Title"
+          UNSAFE_style={{ arrowIconWrapper: { display: "flex" } }}
+        >
+          <span>Content</span>
+        </Disclosure>,
+      );
+      expect(screen.getByTestId("arrowDown").parentElement).toHaveStyle({
+        display: "flex",
+      });
+    });
+
+    it("applies to content", () => {
+      render(
+        <Disclosure
+          title="Test Title"
+          UNSAFE_style={{
+            content: { fontSize: "var(--typography--fontSize-large)" },
+          }}
+        >
+          <span>Content</span>
+        </Disclosure>,
+      );
+      expect(screen.getByText("Content").parentElement).toHaveStyle({
+        fontSize: "var(--typography--fontSize-large)",
+      });
+    });
+  });
+
+  it("should work with both className and style customizations simultaneously", () => {
+    render(
+      <Disclosure
+        title="Test Title"
+        UNSAFE_className={{ container: "custom-container" }}
+        UNSAFE_style={{
+          container: { backgroundColor: "var(--color-yellow)" },
+        }}
+      >
+        <span>Content</span>
+      </Disclosure>,
+    );
+
+    const container = screen.getByRole("group");
+    expect(container).toHaveClass("custom-container");
+    expect(container).toHaveStyle({ backgroundColor: "var(--color-yellow)" });
+  });
+});

--- a/packages/components/src/Disclosure/Disclosure.tsx
+++ b/packages/components/src/Disclosure/Disclosure.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useState } from "react";
+import React, { CSSProperties, ReactElement, ReactNode, useState } from "react";
 import classnames from "classnames";
 import {
   Breakpoints,
@@ -37,6 +37,42 @@ interface DisclosureProps {
    * Used to make the disclosure a Controlled Component.
    */
   readonly open?: boolean;
+
+  /**
+   * **Use at your own risk:** Custom classNames for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_className?: {
+    container?: string;
+    summary?: string;
+    summaryWrap?: string;
+    title?: { textStyle?: string };
+    icon?: {
+      svg?: string;
+      path?: string;
+    };
+    arrowIconWrapper?: string;
+    content?: string;
+  };
+
+  /**
+   * **Use at your own risk:** Custom style for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_style?: {
+    container?: CSSProperties;
+    summary?: CSSProperties;
+    summaryWrap?: CSSProperties;
+    title?: { textStyle?: CSSProperties };
+    icon?: {
+      svg?: CSSProperties;
+      path?: CSSProperties;
+    };
+    arrowIconWrapper?: CSSProperties;
+    content?: CSSProperties;
+  };
 }
 
 export function Disclosure({
@@ -45,6 +81,8 @@ export function Disclosure({
   defaultOpen = false,
   onToggle,
   open,
+  UNSAFE_className = {},
+  UNSAFE_style = {},
 }: DisclosureProps) {
   const [internalOpen, setInternalOpen] = useState(
     defaultOpen || open || false,
@@ -54,26 +92,77 @@ export function Disclosure({
   const isBelowBreakpoint = exactWidth && exactWidth < Breakpoints.small;
   const isTitleString = typeof title === "string";
 
+  const containerClassNames = classnames(
+    styles.details,
+    UNSAFE_className.container,
+  );
+
+  const summaryClassNames = classnames(
+    styles.summary,
+    UNSAFE_className.summary,
+  );
+
+  const summaryWrapClassNames = classnames(
+    styles.summaryWrap,
+    { [styles.customSummaryWrap]: !isTitleString },
+    UNSAFE_className.summaryWrap,
+  );
+
+  const arrowIconWrapperClassNames = classnames(
+    styles.arrowIconWrapper,
+    UNSAFE_className.arrowIconWrapper,
+  );
+
+  const contentClassNames = classnames(
+    styles.content,
+    UNSAFE_className.content,
+  );
+
   return (
-    <details open={isOpen} className={styles.details}>
-      <summary className={styles.summary} onClick={handleToggle}>
+    <details
+      open={isOpen}
+      className={containerClassNames}
+      style={UNSAFE_style.container}
+    >
+      <summary
+        className={summaryClassNames}
+        style={UNSAFE_style.summary}
+        onClick={handleToggle}
+      >
         <div
-          className={classnames(styles.summaryWrap, {
-            [styles.customSummaryWrap]: !isTitleString,
-          })}
+          className={summaryWrapClassNames}
+          style={UNSAFE_style.summaryWrap}
           ref={titleRef}
         >
           <DisclosureTitle
             title={title}
             size={isBelowBreakpoint ? "base" : "large"}
             isTitleString={isTitleString}
+            UNSAFE_className={UNSAFE_className.title}
+            UNSAFE_style={UNSAFE_style.title}
           />
-          <span className={styles.arrowIconWrapper}>
-            <Icon name="arrowDown" color="interactive" />
+          <span
+            className={arrowIconWrapperClassNames}
+            style={UNSAFE_style.arrowIconWrapper}
+          >
+            <Icon
+              name="arrowDown"
+              color="interactive"
+              UNSAFE_className={{
+                svg: UNSAFE_className.icon?.svg,
+                path: UNSAFE_className.icon?.path,
+              }}
+              UNSAFE_style={{
+                svg: UNSAFE_style.icon?.svg,
+                path: UNSAFE_style.icon?.path,
+              }}
+            />
           </span>
         </div>
       </summary>
-      <span className={styles.content}>{children}</span>
+      <span className={contentClassNames} style={UNSAFE_style.content}>
+        {children}
+      </span>
     </details>
   );
 
@@ -98,13 +187,34 @@ interface DisclosureTitleProps {
    * Whether the title is a string.
    */
   readonly isTitleString: boolean;
+  /**
+   * Custom className for the DisclosureTitle.
+   */
+  readonly UNSAFE_className?: { textStyle?: string };
+  /**
+   * Custom style for the DisclosureTitle.
+   */
+  readonly UNSAFE_style?: { textStyle?: CSSProperties };
 }
 
-function DisclosureTitle({ title, size, isTitleString }: DisclosureTitleProps) {
+function DisclosureTitle({
+  title,
+  size,
+  isTitleString,
+  UNSAFE_className,
+  UNSAFE_style,
+}: DisclosureTitleProps) {
   if (!isTitleString) return <>{title}</>;
 
   return (
-    <Typography element="h4" size={size} fontWeight="bold" textColor="heading">
+    <Typography
+      element="h4"
+      size={size}
+      fontWeight="bold"
+      textColor="heading"
+      UNSAFE_className={UNSAFE_className}
+      UNSAFE_style={UNSAFE_style}
+    >
       {title}
     </Typography>
   );

--- a/packages/site/src/content/Disclosure/Disclosure.props.json
+++ b/packages/site/src/content/Disclosure/Disclosure.props.json
@@ -72,6 +72,36 @@
         "type": {
           "name": "boolean"
         }
+      },
+      "UNSAFE_className": {
+        "defaultValue": {
+          "value": "{}"
+        },
+        "description": "**Use at your own risk:** Custom classNames for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "../components/src/Disclosure/Disclosure.tsx",
+          "name": "DisclosureProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ container?: string; summary?: string; summaryWrap?: string; title?: { textStyle?: string; }; icon?: { svg?: string; path?: string; }; arrowIconWrapper?: string; content?: string; }"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": {
+          "value": "{}"
+        },
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "../components/src/Disclosure/Disclosure.tsx",
+          "name": "DisclosureProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ container?: CSSProperties; summary?: CSSProperties; summaryWrap?: CSSProperties; title?: { textStyle?: CSSProperties; }; icon?: { ...; }; arrowIconWrapper?: CSSProperties; content?: CSSProperties; }"
+        }
       }
     }
   }

--- a/packages/site/src/content/Disclosure/DisclosureNotes.mdx
+++ b/packages/site/src/content/Disclosure/DisclosureNotes.mdx
@@ -1,0 +1,74 @@
+## Component customization
+
+### UNSAFE\_ props (advanced usage)
+
+General information for using `UNSAFE_` props can be found
+[here](/guides/customizing-components).
+
+**Note**: Use of `UNSAFE_` props is **at your own risk** and should be
+considered a **last resort**. Future Disclosure updates may lead to unintended
+breakages.
+
+Disclosure has multiple elements that can be targeted with classes or styles:
+
+- `container`: The container element of the Disclosure
+- `summary`: The clickable header area of the Disclosure
+- `summaryWrap`: The inner content within the summary, containing the title and
+  toggle arrow
+- `title`: The title element of the Disclosure
+- `icon`: The toggle arrow of the Disclosure
+- `arrowIconWrapper`: The wrapper element for the toggle arrow
+- `content`: The content inside the Disclosure
+
+#### UNSAFE_className (web)
+
+Use `UNSAFE_className` to apply custom classes to the Disclosure. This can be
+useful for applying styles via CSS Modules.
+
+```tsx
+// Disclosure.tsx
+UNSAFE_className={{
+  container: styles.customDisclosure,
+  summary: styles.customSummary,
+}}
+
+// Disclosure.stories.css
+.customDisclosure {
+  border: 3px solid var(--color-interactive);
+  border-radius: var(--radius-base);
+}
+
+.customSummary {
+  padding: var(--space-base);
+}
+```
+
+#### UNSAFE_style (web)
+
+The `UNSAFE_style` prop provides granular control over the Disclosure's
+appearance through inline styles, allowing you to modify the dimensions and
+colors independently.
+
+```tsx
+<Disclosure
+  ...
+  UNSAFE_style={{
+    container: {
+      border: "3px solid var(--color-interactive)",
+      borderRadius: "var(--radius-base)",
+    },
+    title: {
+      textStyle: {
+        color: "var(--color-interactive--hover)",
+      },
+    },
+    icon: {
+      path: {
+        fill: "var(--color-interactive--subtle)",
+      },
+    },
+  }}
+>
+  ...
+</Disclosure>
+```

--- a/packages/site/src/content/Disclosure/index.tsx
+++ b/packages/site/src/content/Disclosure/index.tsx
@@ -1,6 +1,7 @@
 import DisclosureContent from "@atlantis/docs/components/Disclosure/Disclosure.stories.mdx";
 import Props from "./Disclosure.props.json";
 import MobileProps from "./Disclosure.props-mobile.json";
+import Notes from "./DisclosureNotes.mdx";
 import { getStorybookUrl } from "../../layout/getStorybookUrl";
 import { ContentExport } from "../../types/content";
 
@@ -32,4 +33,5 @@ export default {
       ),
     },
   ],
+  notes: () => <Notes />,
 } as const satisfies ContentExport;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

`Disclosure` is a high priority component for composability so we've decided to add `UNSAFE_` props.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `UNSAFE_className` & `UNSAFE_style` props for each element of the `Disclosure` (including `Typography` and `Icon` being surfaced)
- Tests for both `UNSAFE_` prop type
- Implement Tab for `Disclosure`, outlining how to use `UNSAFE_` props 

## Testing

You can add this to `docs/components/Disclosure/Web.stories.tsx` and see how we can successfully target `Disclosure` elements including the `Icon` and `Text`

```
export const UNSAFECustomization = BasicTemplate.bind({});
UNSAFECustomization.args = {
  title: "Customized Disclosure",
  UNSAFE_style: {
    container: {
      border: "3px solid var(--color-purple)",
      borderRadius: "var(--radius-base)",
    },
    summary: {
      background: "var(--color-yellow--lighter)",
      padding: "var(--space-base)",
    },
    summaryWrap: {
      border: "2px dotted var(--color-purple--light)",
    },
    title: {
      textStyle: {
        color: "var(--color-pink)",
      },
    },
    icon: {
      path: {
        fill: "var(--color-pink)",
      },
    },
    arrowIconWrapper: {
      border: "2px solid var(--color-pink)",
      borderRadius: "var(--radius-base)",
    },
    content: {
      backgroundColor: "var(--color-purple--lightest)",
      padding: "var(--space-base)",
    },
  },
};
```

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
