### PR TITLE
feat(components): add optional intent prop to Tooltip

### DIFF
--- a/packages/components/src/Tooltip/Tooltip.module.css
+++ b/packages/components/src/Tooltip/Tooltip.module.css
@@ -85,7 +85,7 @@
   left: var(--tooltip--offset);
 }
 
-.help {
+.help > * {
   cursor: help;
 }
 

--- a/packages/components/src/Tooltip/Tooltip.module.css
+++ b/packages/components/src/Tooltip/Tooltip.module.css
@@ -85,6 +85,10 @@
   left: var(--tooltip--offset);
 }
 
+.help {
+  cursor: help;
+}
+
 .tooltipMessage {
   margin: 0;
   color: var(--color-text--reverse);

--- a/packages/components/src/Tooltip/Tooltip.module.css.d.ts
+++ b/packages/components/src/Tooltip/Tooltip.module.css.d.ts
@@ -7,8 +7,8 @@ declare const styles: {
   readonly "bottom": string;
   readonly "left": string;
   readonly "right": string;
-  readonly "tooltipMessage": string;
   readonly "help": string;
+  readonly "tooltipMessage": string;
 };
 export = styles;
 

--- a/packages/components/src/Tooltip/Tooltip.module.css.d.ts
+++ b/packages/components/src/Tooltip/Tooltip.module.css.d.ts
@@ -8,6 +8,7 @@ declare const styles: {
   readonly "left": string;
   readonly "right": string;
   readonly "tooltipMessage": string;
+  readonly "help": string;
 };
 export = styles;
 

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -155,7 +155,7 @@ describe("with help intent prop provided", () => {
     const content = "Help content";
     const contentID = "help-content";
 
-    render(
+    const { container } = render(
       <Tooltip message={message} intent="help">
         <div data-testid={contentID}>{content}</div>
       </Tooltip>,
@@ -164,7 +164,8 @@ describe("with help intent prop provided", () => {
     const tooltipContent = screen.getByTestId(contentID);
     await userEvent.hover(tooltipContent);
 
-    const tooltip = screen.getByRole("tooltip");
-    expect(tooltip).toHaveClass("help");
+    // The help class is applied to the span wrapping the children, not the tooltip itself
+    const helpSpan = container.querySelector(`.help`);
+    expect(helpSpan).toBeInTheDocument();
   });
 });

--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -148,3 +148,23 @@ describe("with a preferred placement", () => {
     },
   );
 });
+
+describe("with help intent prop provided", () => {
+  it("should use help cursor style on hover", async () => {
+    const message = "Help tooltip message";
+    const content = "Help content";
+    const contentID = "help-content";
+
+    render(
+      <Tooltip message={message} intent="help">
+        <div data-testid={contentID}>{content}</div>
+      </Tooltip>,
+    );
+
+    const tooltipContent = screen.getByTestId(contentID);
+    await userEvent.hover(tooltipContent);
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveClass("help");
+  });
+});

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -59,13 +59,16 @@ export function Tooltip({
     placement === "top" && styles.top,
     placement === "left" && styles.left,
     placement === "right" && styles.right,
-    intent === "help" && styles.help,
   );
 
   return (
     <>
       <span className={styles.shadowActivator} ref={shadowRef} />
-      {children}
+      {intent === "help" ? (
+        <span className={styles.help}>{children}</span>
+      ) : (
+        <>{children}</>
+      )}
       <TooltipPortal>
         {show && Boolean(message) && (
           <div

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -6,7 +6,7 @@ import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
 import { useIsMounted } from "@jobber/hooks/useIsMounted";
 import styles from "./Tooltip.module.css";
 import { useTooltipPositioning } from "./useTooltipPositioning";
-import { Placement } from "./Tooltip.types";
+import { Intent, Placement } from "./Tooltip.types";
 
 const variation = {
   startOrStop: { opacity: 0 },
@@ -24,6 +24,11 @@ interface TooltipProps {
    * @default 'top'
    */
   readonly preferredPlacement?: Placement;
+  /**
+   * The intent of the tooltip.
+   * @default 'info'
+   */
+  readonly intent?: Intent;
 
   readonly setTabIndex?: boolean;
 }
@@ -32,6 +37,7 @@ export function Tooltip({
   message,
   children,
   preferredPlacement = "top",
+  intent = "info",
   setTabIndex = true,
 }: TooltipProps) {
   const [show, setShow] = useState(false);
@@ -53,6 +59,7 @@ export function Tooltip({
     placement === "top" && styles.top,
     placement === "left" && styles.left,
     placement === "right" && styles.right,
+    intent === "help" && styles.help,
   );
 
   return (

--- a/packages/components/src/Tooltip/Tooltip.types.ts
+++ b/packages/components/src/Tooltip/Tooltip.types.ts
@@ -1,1 +1,3 @@
 export type Placement = "top" | "bottom" | "left" | "right";
+
+export type Intent = "info" | "help";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
- We wish to update the `Tooltip` component to allow for specific treatment (such as custom cursor styles) depending on the intent of the tooltip
- Specifically, we want to enable users to specify that a tooltip's intent is to display help information, so we can use the `help` cursor style in this case ([docs](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor))

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added an optional `intent` prop to the `Tooltip`
- The default value of the `intent` prop is `info` which will use the default cursor style and apply no special treatments
- `help` is also supported as a value for the `intent` prop, and if specified, it will apply the `help` cursor style on hover

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
