### PR TITLE
refactor(components): Replace popperjs with floating-ui in combobox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4197,16 +4197,39 @@
         "@floating-ui/utils": "^0.1.3"
       }
     },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.4",
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.5.tgz",
+      "integrity": "sha512-BX3jKxo39Ba05pflcQmqPPwc0qdNsdNi/eweAFtoIdrJWNen2sVEWMEac3i6jU55Qfx+lOcdMNKYn2CtWmlnOQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.5.1"
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
+    },
+    "node_modules/@floating-ui/react/node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.1.6",
@@ -41687,6 +41710,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -44667,6 +44696,7 @@
       "version": "6.22.0",
       "license": "MIT",
       "dependencies": {
+        "@floating-ui/react": "^0.27.5",
         "@jobber/formatters": "^0.4.0",
         "@popperjs/core": "^2.0.6",
         "@tanstack/react-table": "8.5.13",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -418,6 +418,7 @@
     "dist/*"
   ],
   "dependencies": {
+    "@floating-ui/react": "^0.27.5",
     "@jobber/formatters": "^0.4.0",
     "@popperjs/core": "^2.0.6",
     "@tanstack/react-table": "8.5.13",

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.module.css
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.module.css
@@ -2,7 +2,6 @@
   z-index: var(--elevation-tooltip);
   width: calc(var(--space-extravagant) * 3.75);
   box-shadow: var(--shadow-base);
-  margin-top: var(--space-small);
   border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
   overflow: auto;

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -14,7 +14,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
   const optionsExist = props.options.length > 0;
   const { optionsListRef } = useComboboxContent(props.open, props.selected);
 
-  const { popperRef, popperStyles, attributes } = useComboboxAccessibility(
+  const { popperRef, popperStyles, floatingProps } = useComboboxAccessibility(
     props.handleSelection,
     props.options,
     optionsListRef,
@@ -30,8 +30,8 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       data-elevation={"elevated"}
       tabIndex={0}
       className={classnames(styles.content, { [styles.hidden]: !props.open })}
-      style={popperStyles.popper}
-      {...attributes.popper}
+      style={popperStyles}
+      {...floatingProps}
     >
       <ComboboxContentSearch
         open={props.open}

--- a/packages/components/src/Combobox/hooks/useComboboxAccessibility.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxAccessibility.ts
@@ -4,6 +4,8 @@ import {
   UseInteractionsReturn,
   autoPlacement,
   autoUpdate,
+  offset,
+  shift,
   useDismiss,
   useFloating,
   useInteractions,
@@ -11,6 +13,8 @@ import {
 import { useFocusTrap } from "@jobber/hooks/useFocusTrap";
 import { ComboboxOption } from "../Combobox.types";
 import { ComboboxContext } from "../ComboboxProvider";
+
+const COMBOBOX_OFFSET = 8;
 
 // eslint-disable-next-line max-statements
 export function useComboboxAccessibility(
@@ -42,7 +46,9 @@ export function useComboboxAccessibility(
       if (!openState) handleClose();
     },
     middleware: [
+      offset(COMBOBOX_OFFSET),
       autoPlacement({ allowedPlacements: ["bottom-start", "top-start"] }),
+      shift({ padding: COMBOBOX_OFFSET }),
     ],
     placement: "bottom-start",
     whileElementsMounted: autoUpdate,


### PR DESCRIPTION
## Motivations

Since PopperJS is EOL we are aiming to replace it with Floating UI. This is the first PR to remove PopperJS from our repo.

Decisions:
 - I updated the keyboard dismiss logic to take advantage of Floating UI's [useDismiss](https://floating-ui.com/docs/useDismiss) functionality
 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Changed Combobox content to be rendered with Floating UI instead of PopperJS

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing


Open up combox box stories
 - Verify the following with both mouse navigation and keyboard navigation
   - On the non-keep open on click story verify that selecting the Combobox action closes the combobox
   - On the keep open on click story verify that selecting the action keeps the combobox open
   - Verify on single select, selecting an option closes the combobox
   - Verify on multi select, selecting an option does not close the combobox
   - Verify that custom activators open the combobox as expected

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
