### PR TITLE
fix(components): remove unnecessary useEffect in SegmentedControlProvider

### DIFF
--- a/packages/components/src/SegmentedControl/SegmentedControlProvider.test.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControlProvider.test.tsx
@@ -92,5 +92,20 @@ describe("SegmentedControlProvider", () => {
 
       expect(screen.getByLabelText("Option 2")).toBeChecked();
     });
+
+    it("does not call onSelectValue on mount", () => {
+      const handleSelectValue = jest.fn();
+      render(
+        <SegmentedControlProvider
+          selectedValue="option1"
+          onSelectValue={handleSelectValue}
+        >
+          <SegmentedControl />
+        </SegmentedControlProvider>,
+      );
+
+      // Verify that onSelectValue was never called during mount
+      expect(handleSelectValue).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/components/src/SegmentedControl/SegmentedControlProvider.test.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControlProvider.test.tsx
@@ -79,7 +79,7 @@ describe("SegmentedControlProvider", () => {
       });
     });
 
-    it("initializes with the correct value via onSelectValue", async () => {
+    it("initializes with the correct value", () => {
       const handleSelectValue = jest.fn();
       render(
         <SegmentedControlProvider
@@ -89,10 +89,6 @@ describe("SegmentedControlProvider", () => {
           <SegmentedControl />
         </SegmentedControlProvider>,
       );
-
-      await waitFor(() => {
-        expect(handleSelectValue).toHaveBeenCalledWith("option2");
-      });
 
       expect(screen.getByLabelText("Option 2")).toBeChecked();
     });

--- a/packages/components/src/SegmentedControl/SegmentedControlProvider.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControlProvider.tsx
@@ -4,7 +4,6 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useState,
 } from "react";
 
@@ -63,12 +62,6 @@ export function SegmentedControlProvider<T>({
   const currentSelectedOption = isControlled
     ? selectedValue
     : internalSelectedValue;
-
-  useEffect(() => {
-    if (isControlled && currentSelectedOption !== undefined) {
-      onSelectValue?.(currentSelectedOption);
-    }
-  }, []);
 
   return (
     <SegmentedControlContext.Provider


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

The `useEffect` was unnecessary. In a controlled component pattern, the parent is the
source of truth  and the child should only notify of actual user interactions,
not try to sync or manage state with the parent.

This change:
- Removes the `useEffect` that was calling `onSelectValue` on mount
- Maintains proper parent-child relationship where parent is all-knowing
- Prevents unwanted navigation when the component loads

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
