### PR TITLE
refactor(components): Make Card component composable

### DIFF
--- a/docs/components/Card/Web.stories.tsx
+++ b/docs/components/Card/Web.stories.tsx
@@ -9,6 +9,7 @@ import { InputText } from "@jobber/components/InputText";
 import { Button } from "@jobber/components/Button";
 import { Icon } from "@jobber/components/Icon";
 import { Flex } from "@jobber/components/Flex";
+import { Box } from "@jobber/components/Box";
 
 export default {
   title: "Components/Layouts and Structure/Card/Web",
@@ -148,3 +149,51 @@ const HeaderActionTemplate: ComponentStory<typeof Card> = () => (
 );
 
 export const HeaderAction = HeaderActionTemplate.bind({});
+
+const CompoundComponentTemplate: ComponentStory<typeof Card> = args => (
+  <Card {...args}>
+    <Card.Header>
+      <Box padding="base">
+        <Flex template={["grow", "shrink"]} align="start">
+          <Heading level={4}>Company settings</Heading>
+          <Button type="tertiary" icon="cog" ariaLabel="Settings" />
+        </Flex>
+      </Box>
+    </Card.Header>
+    <Card.Body>
+      <Content>
+        <Heading level={4}>Details</Heading>
+        <InputGroup>
+          <InputText defaultValue="Quest Provider" placeholder="Company name" />
+          <InputText placeholder="Years in business" />
+        </InputGroup>
+        <Heading level={4}>Contact</Heading>
+        <InputGroup>
+          <InputText
+            prefix={{
+              icon: "phone",
+            }}
+            placeholder="Phone number"
+          />
+          <InputText
+            prefix={{
+              icon: "presentation",
+            }}
+            placeholder="Website"
+          />
+          <InputText
+            prefix={{
+              icon: "email",
+            }}
+            placeholder="Email"
+          />
+        </InputGroup>
+      </Content>
+    </Card.Body>
+  </Card>
+);
+
+export const CompoundComponent = CompoundComponentTemplate.bind({});
+CompoundComponent.args = {
+  elevation: "base",
+};

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -39,6 +39,7 @@ type ClickableCardProps = CardProps & {
    */
   onClick(event: React.MouseEvent<HTMLAnchorElement | HTMLDivElement>): void;
   url?: never;
+  readonly external?: never;
 };
 
 /**
@@ -47,6 +48,7 @@ type ClickableCardProps = CardProps & {
 type RegularCardProps = CardProps & {
   url?: never;
   onClick?: never;
+  readonly external?: never;
 };
 
 type CardPropOptions = LinkCardProps | ClickableCardProps | RegularCardProps;
@@ -137,12 +139,21 @@ function renderCardWrapper(
 }
 
 export function Card(props: CardPropOptions) {
-  const { accent, header, children, title, elevation = "none" } = props;
+  const {
+    accent,
+    header,
+    children,
+    title,
+    elevation = "none",
+    onClick,
+    url,
+    external,
+  } = props;
 
   const className = classnames(
     styles.card,
     accent && styles.accent,
-    ("url" in props || "onClick" in props) && styles.clickable,
+    (url || onClick) && styles.clickable,
     accent && colors[accent],
     elevation !== "none" && elevations[`${elevation}Elevation`],
   );
@@ -158,13 +169,7 @@ export function Card(props: CardPropOptions) {
     ? children
     : renderCardContent(children, title, header);
 
-  return renderCardWrapper(
-    className,
-    content,
-    "onClick" in props ? props.onClick : undefined,
-    "url" in props ? props.url : undefined,
-    "url" in props && "external" in props ? props.external : undefined,
-  );
+  return renderCardWrapper(className, content, onClick, url, external);
 }
 
 Card.Header = CardHeaderCompoundComponent;

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -67,7 +67,7 @@ type CardPropOptions = LinkCardProps | ClickableCardProps | RegularCardProps;
  * </Card>
  * ```
  */
-function CardHeaderComponent({ children }: CardHeaderProps) {
+function CardHeaderCompoundComponent({ children }: CardHeaderProps) {
   return <>{children}</>;
 }
 
@@ -87,7 +87,7 @@ function CardHeaderComponent({ children }: CardHeaderProps) {
  * </Card>
  * ```
  */
-function CardBodyComponent({ children }: CardBodyProps) {
+function CardBodyCompoundComponent({ children }: CardBodyProps) {
   return <>{children}</>;
 }
 
@@ -150,7 +150,8 @@ export function Card(props: CardPropOptions) {
   const isUsingCompoundPattern = React.Children.toArray(children).some(
     child =>
       React.isValidElement(child) &&
-      (child.type === CardHeaderComponent || child.type === CardBodyComponent),
+      (child.type === CardHeaderCompoundComponent ||
+        child.type === CardBodyCompoundComponent),
   );
 
   const content = isUsingCompoundPattern
@@ -166,5 +167,5 @@ export function Card(props: CardPropOptions) {
   );
 }
 
-Card.Header = CardHeaderComponent;
-Card.Body = CardBodyComponent;
+Card.Header = CardHeaderCompoundComponent;
+Card.Body = CardBodyCompoundComponent;

--- a/packages/components/src/Card/tests/Card.test.tsx
+++ b/packages/components/src/Card/tests/Card.test.tsx
@@ -154,3 +154,75 @@ it("renders a card with an elevation", () => {
   expect(container.firstChild).toHaveClass("card baseElevation");
   expect(getByText("This is the card content.")).toBeDefined();
 });
+
+it("renders a card with compound components", () => {
+  const { getByText, container } = render(
+    <Card accent="green">
+      <Card.Header>
+        <Text>Compound Header</Text>
+      </Card.Header>
+      <Card.Body>
+        <p>This is the card content.</p>
+      </Card.Body>
+    </Card>,
+  );
+
+  expect(container.firstChild).toHaveClass("card accent green");
+  expect(getByText("Compound Header")).toBeInTheDocument();
+  expect(getByText("This is the card content.")).toBeInTheDocument();
+});
+
+it("renders a clickable card with compound components", () => {
+  const clickHandler = jest.fn();
+  const { getByText, container } = render(
+    <Card accent="green" onClick={clickHandler}>
+      <Card.Header>
+        <Text>Clickable Header</Text>
+      </Card.Header>
+      <Card.Body>
+        <p>This is a clickable card.</p>
+      </Card.Body>
+    </Card>,
+  );
+
+  expect(container.firstChild).toHaveClass("card accent clickable green");
+  expect(getByText("Clickable Header")).toBeInTheDocument();
+  expect(getByText("This is a clickable card.")).toBeInTheDocument();
+  fireEvent.click(container.firstChild as HTMLElement);
+  expect(clickHandler).toHaveBeenCalledTimes(1);
+});
+
+it("renders a link card with compound components", () => {
+  const { getByText, getByRole } = render(
+    <Card accent="green" url="https://frend.space">
+      <Card.Header>
+        <Text>Link Header</Text>
+      </Card.Header>
+      <Card.Body>
+        <p>This is a link card.</p>
+      </Card.Body>
+    </Card>,
+  );
+
+  expect(getByRole("link")).toHaveClass("card accent clickable green");
+  expect(getByRole("link")).toHaveAttribute("href", "https://frend.space");
+  expect(getByText("Link Header")).toBeInTheDocument();
+  expect(getByText("This is a link card.")).toBeInTheDocument();
+});
+
+it("renders a card with compound components and elevation", () => {
+  const { getByText, container } = render(
+    <Card elevation="base">
+      <Card.Header>
+        <Text>Elevated Header</Text>
+      </Card.Header>
+      <Card.Body>
+        <p>This is an elevated card.</p>
+      </Card.Body>
+    </Card>,
+  );
+
+  expect(container.firstChild).toHaveClass("card baseElevation");
+  expect(getByText("Elevated Header")).toBeInTheDocument();
+  expect(getByText("This is an elevated card.")).toBeInTheDocument();
+});

--- a/packages/components/src/Card/types.ts
+++ b/packages/components/src/Card/types.ts
@@ -30,7 +30,6 @@ export interface CardProps {
   /**
    * @deprecated
    * Use header instead.
-   *
    */
   readonly title?: string;
 
@@ -39,4 +38,17 @@ export interface CardProps {
    */
   readonly header?: string | HeaderActionProps | ReactElement;
   readonly elevation?: elevationProp;
+}
+
+export interface CardHeaderProps {
+  readonly children: ReactNode;
+}
+
+export interface CardBodyProps {
+  readonly children: ReactNode;
+}
+
+export interface CardCompositionProps {
+  Header: React.FC<CardHeaderProps>;
+  Body: React.FC<CardBodyProps>;
 }

--- a/packages/components/src/utils/meta/meta.json
+++ b/packages/components/src/utils/meta/meta.json
@@ -18,6 +18,8 @@
     "Button.Label",
     "ButtonDismiss",
     "Card",
+    "Card.Body",
+    "Card.Header",
     "Cell",
     "CellCurrency",
     "CellNumeric",

--- a/packages/site/src/content/Card/Card.props.json
+++ b/packages/site/src/content/Card/Card.props.json
@@ -6,47 +6,6 @@
     "displayName": "Card",
     "methods": [],
     "props": {
-      "url": {
-        "defaultValue": null,
-        "description": "URL that the card would navigate to once clicked.",
-        "name": "url",
-        "parent": {
-          "fileName": "../components/src/Card/Card.tsx",
-          "name": "LinkCardProps"
-        },
-        "required": false,
-        "type": {
-          "name": "string"
-        }
-      },
-      "external": {
-        "defaultValue": {
-          "value": false
-        },
-        "description": "Makes the URL open in new tab on click.",
-        "name": "external",
-        "parent": {
-          "fileName": "../components/src/Card/Card.tsx",
-          "name": "LinkCardProps"
-        },
-        "required": false,
-        "type": {
-          "name": "boolean"
-        }
-      },
-      "onClick": {
-        "defaultValue": null,
-        "description": "",
-        "name": "onClick",
-        "parent": {
-          "fileName": "../components/src/Card/Card.tsx",
-          "name": "ClickableCardProps"
-        },
-        "required": false,
-        "type": {
-          "name": "(event: React.MouseEvent<HTMLAnchorElement | HTMLDivElement>) => void"
-        }
-      },
       "accent": {
         "defaultValue": null,
         "description": "The `accent`, if provided, will effect the color accent at the top of\nthe card.",
@@ -87,9 +46,7 @@
         }
       },
       "elevation": {
-        "defaultValue": {
-          "value": "none"
-        },
+        "defaultValue": null,
         "description": "",
         "name": "elevation",
         "parent": {
@@ -100,7 +57,54 @@
         "type": {
           "name": "elevationProp"
         }
+      },
+      "url": {
+        "defaultValue": null,
+        "description": "URL that the card would navigate to once clicked.",
+        "name": "url",
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "external": {
+        "defaultValue": null,
+        "description": "Makes the URL open in new tab on click.",
+        "name": "external",
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "onClick": {
+        "defaultValue": null,
+        "description": "Event handler that gets called when the card is clicked.",
+        "name": "onClick",
+        "required": false,
+        "type": {
+          "name": "(event: React.MouseEvent<HTMLAnchorElement | HTMLDivElement>) => void"
+        }
       }
     }
+  },
+  {
+    "tags": {
+      "example": "```tsx\n<Card>\n  <Card.Header>\n    <Text>Header Content</Text>\n  </Card.Header>\n  <Card.Body>\n    <p>Card content</p>\n  </Card.Body>\n</Card>\n```"
+    },
+    "filePath": "../components/src/Card/Card.tsx",
+    "description": "Header component for the Card.\nUsed in the compound component pattern to provide a consistent header layout.",
+    "displayName": "Card.Header",
+    "methods": [],
+    "props": {}
+  },
+  {
+    "tags": {
+      "example": "```tsx\n<Card>\n  <Card.Header>\n    <Text>Header Content</Text>\n  </Card.Header>\n  <Card.Body>\n    <p>Card content</p>\n  </Card.Body>\n</Card>\n```"
+    },
+    "filePath": "../components/src/Card/Card.tsx",
+    "description": "Body component for the Card.\nUsed in the compound component pattern to provide a consistent content layout.",
+    "displayName": "Card.Body",
+    "methods": [],
+    "props": {}
   }
 ]

--- a/packages/site/src/content/Card/CardNotes.mdx
+++ b/packages/site/src/content/Card/CardNotes.mdx
@@ -1,0 +1,104 @@
+## Configuration
+
+### Card Types
+
+The Card component supports three distinct types of cards:
+
+1. **Regular Card** - A basic card without any click behavior
+2. **Link Card** - A card that navigates to a URL when clicked
+3. **Clickable Card** - A card that triggers a custom click handler
+
+### Component Customization
+
+#### Composable Usage
+
+The Card component supports both prop-driven and composable approaches. The
+standard prop-driven usage with `title` and `header` props is straightforward
+and suitable for most use cases. For advanced customization needs, the Card
+component also provides `Card.Header` and `Card.Body` components.
+
+`Card.Header` is used to display custom header content of the card. `Card.Body`
+is used to display the main content of the card.
+
+Here's an example of converting a prop-driven card to a composable one when more
+customization is needed:
+
+```tsx
+<Card title="Card Title" header="Header Text">
+  <p>Card content</p>
+</Card>
+```
+
+becomes
+
+```tsx
+<Card>
+  <Card.Header>
+    <Text>Card Title</Text>
+  </Card.Header>
+  <Card.Body>
+    <p>Card content</p>
+  </Card.Body>
+</Card>
+```
+
+#### Link Card Example
+
+```tsx
+<Card url="/dashboard" external={true}>
+  <Card.Header>
+    <Text>External Link</Text>
+  </Card.Header>
+  <Card.Body>
+    <p>Click to navigate to dashboard</p>
+  </Card.Body>
+</Card>
+```
+
+#### Clickable Card Example
+
+```tsx
+<Card onClick={handleClick}>
+  <Card.Header>
+    <Text>Interactive Card</Text>
+  </Card.Header>
+  <Card.Body>
+    <p>Click to trigger action</p>
+  </Card.Body>
+</Card>
+```
+
+### Props Compatibility
+
+The Card component uses a discriminated union pattern to ensure proper usage.
+This means that the component can be one of three distinct types, each with its
+own set of valid props:
+
+- A Link Card must have a `url` prop and cannot have an `onClick` handler
+- A Clickable Card must have an `onClick` prop and cannot have a `url`
+- A Regular Card has neither `url` nor `onClick`
+
+This type system ensures that each card has a clear and single responsibility
+for its interaction behavior, making it impossible to create ambiguous card
+states (like having both a URL and click handler).
+
+### Styling
+
+Cards can be customized with the following props:
+
+- `accent`: Applies an accent color to the card
+- `elevation`: Controls the card's shadow elevation ("none" | "base" | "raised"
+  | "floating")
+
+Example with styling:
+
+```tsx
+<Card accent="purple" elevation="raised">
+  <Card.Header>
+    <Text>Styled Card</Text>
+  </Card.Header>
+  <Card.Body>
+    <p>Card with purple accent and raised elevation</p>
+  </Card.Body>
+</Card>
+```

--- a/packages/site/src/content/Card/index.tsx
+++ b/packages/site/src/content/Card/index.tsx
@@ -1,6 +1,7 @@
 import CardContent from "@atlantis/docs/components/Card/Card.stories.mdx";
 import Props from "./Card.props.json";
 import MobileProps from "./Card.props-mobile.json";
+import Notes from "./CardNotes.mdx";
 import { ContentExport } from "../../types/content";
 import { getStorybookUrl } from "../../layout/getStorybookUrl";
 
@@ -42,4 +43,5 @@ export default {
       ),
     },
   ],
+  notes: () => <Notes />,
 } as const satisfies ContentExport;


### PR DESCRIPTION
# refactor(components): Make Card component composable

## Motivations

Enhance the Card component's flexibility and usability by implementing a compound component pattern, which allows for better composition and more intuitive usage of Card subcomponents.

## Changes

### Added
- Added comprehensive documentation for Card component usage and customization
- Added `CardHeader` and `CardBody` sub-components for better composition
- Added detailed documentation for `url`, `external`, and `onClick` props
- Added `CompoundComponent` story to showcase the `Card` component with header and body structure
- Added comprehensive tests for compound components scenarios

### Changed
- Simplified prop destructuring and enhanced rendering logic in Card component
- Renamed header and body components for consistency
- Refactored `Card` component to support three distinct card types: LinkCard, ClickableCard, and RegularCard
- Updated type definitions to improve clarity and enforce correct usage of props
- Enhanced rendering logic to accommodate new prop structures while maintaining existing functionality
- Updated `Card` component to handle children as compound components with fallback to title and header props 

### Fixed
- Improved type definitions and documentation clarity
- Enhanced test coverage for various card scenarios

## Testing

The changes can be tested by:
- Verifying the new compound component pattern works as expected
- Testing different card types (Link, Clickable, Regular)
- Checking accessibility features
- Reviewing the new documentation and stories in Storybook

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)