### PR TITLE
refactor(components): Rename useButton to useButtonContext

### DIFF
--- a/packages/components/src/Button/ButtonInternals.tsx
+++ b/packages/components/src/Button/ButtonInternals.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ButtonProps } from "./Button.types";
-import { useButton } from "./ButtonProvider";
+import { useButtonContext } from "./ButtonProvider";
 import { Icon, IconProps } from "../Icon";
 import { Typography, TypographyProps } from "../Typography";
 
@@ -38,7 +38,7 @@ export function ButtonIcon({
   size: sizeProp,
   ...props
 }: Pick<IconProps, "size" | "name" | "testID">) {
-  const { size: contextSize } = useButton();
+  const { size: contextSize } = useButtonContext();
   const size = sizeProp || contextSize;
 
   return <Icon {...props} size={size} />;
@@ -51,7 +51,7 @@ export function ButtonLabel({
   size: sizeProp,
   ...props
 }: Omit<TypographyProps, "textColor">) {
-  const { size: contextSize } = useButton();
+  const { size: contextSize } = useButtonContext();
   const size = sizeProp || contextSize;
 
   return (

--- a/packages/components/src/Button/ButtonProvider.tsx
+++ b/packages/components/src/Button/ButtonProvider.tsx
@@ -20,6 +20,6 @@ export function ButtonProvider({
   );
 }
 
-export function useButton() {
+export function useButtonContext() {
   return useContext(ButtonContext);
 }

--- a/packages/components/src/Button/index.ts
+++ b/packages/components/src/Button/index.ts
@@ -1,4 +1,4 @@
 export { Button } from "./Button";
 export * from "./Button.types";
 export { useButtonStyles, UseButtonStylesProps } from "./useButtonStyles";
-export { useButton } from "./ButtonProvider";
+export { useButtonContext } from "./ButtonProvider";

--- a/packages/components/src/Button/useButtonStyles.ts
+++ b/packages/components/src/Button/useButtonStyles.ts
@@ -1,7 +1,7 @@
 import classnames from "classnames";
 import styles from "./Button.module.css";
 import { ButtonSize, ButtonType, ButtonVariation } from "./Button.types";
-import { useButton } from "./ButtonProvider";
+import { useButtonContext } from "./ButtonProvider";
 
 /**
  * The props that are used to style the button
@@ -23,7 +23,7 @@ export function useButtonStyles({
   variation = "work",
   type = "primary",
 }: UseButtonStylesProps) {
-  const { size: contextSize } = useButton();
+  const { size: contextSize } = useButtonContext();
   const size = sizeProp || contextSize;
   const wrapper = classnames(
     [styles.button, styles[size], styles[variation], styles[type]],


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This renames `useButton` to `useButtonContext` which aligns with recent discussions we've had.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Renamed `useButton` to `useButtonContext`


## Testing

Testing isn't very necessary as typescript would catch any errors. If you check out [this story](https://cleanup-rename-usebutton-hoo.atlantis.pages.dev/storybook/?path=/story/components-actions-button-web--composed-links) you'll see it loads fine still.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)
