### PR TITLE
feat(components): Add secondary action support to Page component even without primary action

### DIFF
--- a/docs/components/Page/Web.stories.tsx
+++ b/docs/components/Page/Web.stories.tsx
@@ -118,6 +118,18 @@ WithActions.args = {
   ],
 };
 
+export const SecondaryActionOnly = BasicTemplate.bind({});
+
+SecondaryActionOnly.args = {
+  title: "Settings",
+  secondaryAction: {
+    label: "View Documentation",
+    onClick: () => {
+      alert("View Documentation!");
+    },
+  },
+};
+
 export const WithIntro = BasicTemplate.bind({});
 WithIntro.args = {
   title: "Notifications",

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -123,7 +123,7 @@ describe("When actions are provided", () => {
       </Page>,
     );
 
-    expect(getByText("Secondary Action")).toBeInTheDocument();
+    expect(getByText("Secondary Action")).toBeVisible();
     fireEvent.click(getByText("Secondary Action"));
     expect(handleSecondaryAction).toHaveBeenCalledTimes(1);
   });

--- a/packages/components/src/Page/Page.test.tsx
+++ b/packages/components/src/Page/Page.test.tsx
@@ -108,6 +108,26 @@ describe("When actions are provided", () => {
     expect(handleSecondaryAction).toHaveBeenCalledTimes(1);
   });
 
+  it("renders secondary action without primary action", () => {
+    const handleSecondaryAction = jest.fn();
+
+    const { getByText } = render(
+      <Page
+        title="Secondary Only"
+        secondaryAction={{
+          label: "Secondary Action",
+          onClick: handleSecondaryAction,
+        }}
+      >
+        Content
+      </Page>,
+    );
+
+    expect(getByText("Secondary Action")).toBeInTheDocument();
+    fireEvent.click(getByText("Secondary Action"));
+    expect(handleSecondaryAction).toHaveBeenCalledTimes(1);
+  });
+
   describe("getActionProps", () => {
     it("given action props, it returns the correct props", () => {
       const buttonActionProps = {

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -57,7 +57,6 @@ interface PageFoundationProps {
 
   /**
    * Page title secondary action button settings.
-   *   Only shown if there is a primaryAction.
    */
   readonly secondaryAction?: ButtonActionProps;
 
@@ -110,7 +109,7 @@ export function Page({
   });
 
   const showMenu = moreActionsMenu.length > 0;
-  const showActionGroup = showMenu || primaryAction;
+  const showActionGroup = showMenu || primaryAction || secondaryAction;
 
   if (primaryAction != undefined) {
     primaryAction = Object.assign({ fullWidth: true }, primaryAction);

--- a/packages/site/src/content/Page/Page.props.json
+++ b/packages/site/src/content/Page/Page.props.json
@@ -101,7 +101,7 @@
       },
       "secondaryAction": {
         "defaultValue": null,
-        "description": "Page title secondary action button settings.\n  Only shown if there is a primaryAction.",
+        "description": "Page title secondary action button settings.",
         "name": "secondaryAction",
         "parent": {
           "fileName": "../components/src/Page/Page.tsx",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

New Pages are in need of actions that are not primary actions.

## Changes

### Added

- Introduced a new `SecondaryActionOnly` story to showcase the Page component with only a secondary action.

### Changed

- Updated documentation to reflect changes in the secondary action behavior.
- Updated the Page component to display the secondary action button even when no primary action is provided.

## Testing

- Enhanced tests to verify rendering and functionality of the secondary action button independently.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
