### PR TITLE
feat(components): Add UNSAFE props to Text

### DIFF
--- a/packages/components/src/Text/Text.test.tsx
+++ b/packages/components/src/Text/Text.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import { Text } from ".";
 
@@ -147,4 +147,26 @@ it("renders a center-aligned text", () => {
       </p>
     </div>
   `);
+});
+
+describe("UNSAFE props", () => {
+  it("should apply the UNSAFE_className to the element", () => {
+    render(
+      <Text UNSAFE_className={{ textStyle: "custom-class" }}>
+        Text with custom class
+      </Text>,
+    );
+    const element = screen.getByText("Text with custom class");
+    expect(element).toHaveClass("custom-class");
+  });
+
+  it("should apply the UNSAFE_style to the element", () => {
+    render(
+      <Text UNSAFE_style={{ textStyle: { color: "red" } }}>
+        Text with custom style
+      </Text>,
+    );
+    const element = screen.getByText("Text with custom style");
+    expect(element).toHaveStyle({ color: "red" });
+  });
 });

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from "react";
-import { Typography, TypographyOptions } from "../Typography";
+import { Typography, TypographyOptions, TypographyProps } from "../Typography";
 
 export interface TextProps {
   readonly maxLines?:
@@ -22,6 +22,20 @@ export interface TextProps {
   readonly align?: "start" | "center" | "end";
 
   readonly size?: "small" | "base" | "large";
+
+  /**
+   * **Use at your own risk:** Custom classNames for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_className?: TypographyProps["UNSAFE_className"];
+
+  /**
+   * **Use at your own risk:** Custom style for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_style?: TypographyProps["UNSAFE_style"];
 }
 
 type TextColor = Extract<TypographyOptions, "textColor">;
@@ -32,6 +46,8 @@ export function Text({
   align = "start",
   children,
   maxLines = "unlimited",
+  UNSAFE_className,
+  UNSAFE_style,
 }: PropsWithChildren<TextProps>) {
   const textColors = {
     default: "text",
@@ -58,6 +74,8 @@ export function Text({
       size={size}
       numberOfLines={maxLineToNumber[maxLines]}
       align={align}
+      UNSAFE_className={UNSAFE_className}
+      UNSAFE_style={UNSAFE_style}
     >
       {children}
     </Typography>

--- a/packages/site/src/content/InputFile/InputFile.props.json
+++ b/packages/site/src/content/InputFile/InputFile.props.json
@@ -520,6 +520,32 @@
         "type": {
           "name": "\"small\" | \"base\" | \"large\""
         }
+      },
+      "UNSAFE_className": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom classNames for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "packages/components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ textStyle?: string; }"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "packages/components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ textStyle?: CSSProperties; }"
+        }
       }
     }
   },
@@ -590,6 +616,32 @@
         "required": false,
         "type": {
           "name": "\"small\" | \"base\" | \"large\""
+        }
+      },
+      "UNSAFE_className": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom classNames for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "packages/components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ textStyle?: string; }"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "packages/components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ textStyle?: CSSProperties; }"
         }
       }
     }

--- a/packages/site/src/content/Text/Text.props.json
+++ b/packages/site/src/content/Text/Text.props.json
@@ -65,6 +65,32 @@
         "type": {
           "name": "\"small\" | \"base\" | \"large\""
         }
+      },
+      "UNSAFE_className": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom classNames for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "../components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ textStyle?: string; }"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "../components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ textStyle?: CSSProperties; }"
+        }
       }
     }
   }

--- a/packages/site/src/content/Text/TextNotes.mdx
+++ b/packages/site/src/content/Text/TextNotes.mdx
@@ -1,3 +1,5 @@
+import { Tabs, Tab } from "@jobber/components/Tabs";
+
 ## Component customization
 
 ### UNSAFE\_ props (advanced usage)
@@ -8,6 +10,39 @@ General information for using `UNSAFE_` props can be found
 **Note**: Use of `UNSAFE_` props is **at your own risk** and should be
 considered a **last resort**. Future Text updates may lead to unintended
 breakages.
+
+#### UNSAFE\_ props (web)
+
+<Tabs>
+  <Tab label="UNSAFE_className">
+    Use `UNSAFE_className` to apply custom classes to the Text component. This
+    can be useful for applying styles via CSS Modules.
+
+    ```tsx
+    // YourComponent.tsx
+    <Text UNSAFE_className={{ textStyle: styles.customText }}>
+      Custom text style
+    </Text>
+
+    // YourComponent.module.css
+    .customText {
+      color: var(--color-purple);
+    }
+    ```
+
+  </Tab>
+
+  <Tab label="UNSAFE_style">
+    Use `UNSAFE_style` to apply inline custom styles to the Text component.
+
+    ```tsx
+    <Text UNSAFE_style={{ textStyle: { color: "var(--color-purple)" } }}>
+      Custom text style
+    </Text>
+    ```
+
+  </Tab>
+</Tabs>
 
 #### UNSAFE_style (mobile)
 

--- a/packages/site/src/content/Typography/TypographyNotes.mdx
+++ b/packages/site/src/content/Typography/TypographyNotes.mdx
@@ -11,7 +11,7 @@ General information for using `UNSAFE_` props can be found
 considered a **last resort**. Future Typography updates may lead to unintended
 breakages.
 
-#### UNSAFE\_ props in web
+#### UNSAFE\_ props (web)
 
 <Tabs>
   <Tab label="UNSAFE_className">
@@ -19,7 +19,7 @@ breakages.
     can be useful for applying styles via CSS Modules.
 
     ```tsx
-    // Typography.tsx
+    // YourComponent.tsx
     <Typography
       UNSAFE_className={{
         textStyle: styles.customText,
@@ -28,7 +28,7 @@ breakages.
       Text with UNSAFE className
     </Typography>
 
-    // Typography.module.css
+    // YourComponent.module.css
     .customText {
       color: var(--color-purple);
     }
@@ -54,7 +54,7 @@ breakages.
   </Tab>
 </Tabs>
 
-#### UNSAFE\_ props in mobile
+#### UNSAFE\_ props (mobile)
 
 Use `UNSAFE_style` to apply custom styles to the Typography component.
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
We are currently making our way through atom components, adding `UNSAFE_` props in these small building blocks so it is easier to surface in larger components later on.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `UNSAFE_` props in web `Text` (just surfacing via `Typography`)
- tests for `UNSAFE_` props
- new section in the `Text` `Implement` tab explaining how to use the props
- update in `Text` props file
- update in `InputFile` props file (comment below talking about it)

### Changed

- some markup was changed in `TypographyNotes` while I'm in the area

## Testing

<!-- How to test your changes. -->

Update existing Storybook example and look at the Basic story:

```
Basic.args = {
  children:
    '"640K is more memory than anyone will ever need on a computer" - Not Bill Gates',
  UNSAFE_style: {
    textStyle: {
      color: "red",
      fontSize: "20px",
    },
  },
};
```

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
