### PR TITLE
DRAFT / SPIKE: Data table exanding row prototype

### DIFF
--- a/docs/components/DataTable/Web.stories.tsx
+++ b/docs/components/DataTable/Web.stories.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/button-has-type */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useMemo, useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import sortBy from "lodash/sortBy";
@@ -8,6 +10,7 @@ import { Text } from "@jobber/components/Text";
 import { DataDump } from "@jobber/components/DataDump";
 import { Typography } from "@jobber/components/Typography";
 import { Heading } from "@jobber/components/Heading";
+import { Icon } from "@jobber/components/Icon";
 
 export default {
   title: "Components/Lists and Tables/DataTable/Web",
@@ -31,35 +34,7 @@ const BasicTemplate: ComponentStory<typeof DataTable> = args => (
   <DataTable {...args} />
 );
 
-const exampleData = [
-  {
-    name: "Eddard",
-    house: "Stark",
-    region: "North",
-    sigil: "Direwolf",
-    isAlive: "No",
-  },
-  {
-    name: "Catelyn",
-    house: "Stark",
-    region: "North",
-    sigil: "Direwolf",
-    isAlive: "No",
-  },
-  {
-    name: "Jon Snow",
-    house: "Stark",
-    region: "North",
-    sigil: "Direwolf",
-    isAlive: "Yes",
-  },
-  {
-    name: "Robert",
-    house: "Stark",
-    region: "North",
-    sigil: "Direwolf",
-    isAlive: "No",
-  },
+const exampleSubRows = [
   {
     name: "Rickon",
     house: "Stark",
@@ -68,11 +43,62 @@ const exampleData = [
     isAlive: "No",
   },
   {
+    name: "Pickon",
+    house: "Lark",
+    region: "North",
+    sigil: "Direwolf",
+    isAlive: "No",
+  },
+];
+
+const exampleData = [
+  {
+    name: "Eddard",
+    house: "Stark",
+    region: "North",
+    sigil: "Direwolf",
+    isAlive: "No",
+    subRows: exampleSubRows,
+  },
+  {
+    name: "Catelyn",
+    house: "Stark",
+    region: "North",
+    sigil: "Direwolf",
+    isAlive: "No",
+    subRows: exampleSubRows,
+  },
+  {
+    name: "Jon Snow",
+    house: "Stark",
+    region: "North",
+    sigil: "Direwolf",
+    isAlive: "Yes",
+    subRows: exampleSubRows,
+  },
+  {
+    name: "Robert",
+    house: "Stark",
+    region: "North",
+    sigil: "Direwolf",
+    isAlive: "No",
+    subRows: exampleSubRows,
+  },
+  {
+    name: "Rickon",
+    house: "Stark",
+    region: "North",
+    sigil: "Direwolf",
+    isAlive: "No",
+    subRows: exampleSubRows,
+  },
+  {
     name: "Robert",
     house: "Baratheon",
     region: "Stormlands",
     sigil: "Black Stag",
     isAlive: "No",
+    subRows: exampleSubRows,
   },
   {
     name: "Cercei",
@@ -80,6 +106,7 @@ const exampleData = [
     region: "Westerlands",
     sigil: "Golden Lion",
     isAlive: "Yes",
+    subRows: exampleSubRows,
   },
   {
     name: "Sansa",
@@ -87,6 +114,7 @@ const exampleData = [
     region: "North",
     sigil: "Direwolf",
     isAlive: "Yes",
+    subRows: exampleSubRows,
   },
   {
     name: "Arya",
@@ -94,6 +122,7 @@ const exampleData = [
     region: "North",
     sigil: "Direwolf",
     isAlive: "Yes",
+    subRows: exampleSubRows,
   },
   {
     name: "Bran",
@@ -247,6 +276,75 @@ ClientSidePagination.args = {
       accessorKey: "isAlive",
       cell: info => info.getValue(),
       header: "Alive",
+    },
+  ],
+};
+
+export const ClientSidePaginationWithSubRows = BasicTemplate.bind({});
+ClientSidePaginationWithSubRows.args = {
+  data: exampleData,
+  stickyHeader: true,
+  height: 400,
+  pagination: { manualPagination: false, itemsPerPage: [10, 20, 30] },
+  sorting: { manualSorting: false },
+  onRowClick: row => {
+    if (row.depth > 0) {
+      alert("Subrow clicked");
+
+      return;
+    }
+
+    if (row.getCanExpand()) {
+      row.getToggleExpandedHandler()?.();
+
+      return;
+    }
+
+    alert(JSON.stringify(row.original, null, 2));
+  },
+  getSubRows: (row: any) =>
+    row.subRows?.map((subRow: any) => ({ ...subRow, depth: 1 })),
+  columns: [
+    {
+      accessorKey: "name",
+      cell: info => {
+        const row = info.row;
+
+        return (
+          <div
+            style={{
+              marginLeft: `${row.depth * 1.25}rem`,
+            }}
+          >
+            {row.getCanExpand() ? (
+              <div style={{ display: "flex", flexDirection: "row", gap: 5 }}>
+                <div>
+                  {row.getIsExpanded() ? (
+                    <Icon name="arrowDown" size="small" />
+                  ) : (
+                    <Icon name="arrowRight" size="small" />
+                  )}
+                </div>
+                <div>{info.getValue<string>()}</div>
+              </div>
+            ) : (
+              <div>{info.getValue<string>()}</div>
+            )}
+          </div>
+        );
+      },
+      header: "Name",
+      enableSorting: false,
+    },
+    {
+      accessorKey: "house",
+      cell: info => info.getValue(),
+      header: "House",
+    },
+    {
+      accessorKey: "region",
+      cell: info => info.getValue(),
+      header: "Region",
     },
   ],
 };

--- a/packages/components/src/DataTable/Body.tsx
+++ b/packages/components/src/DataTable/Body.tsx
@@ -41,6 +41,7 @@ export function Body<T extends object>({
                 key={row.id}
                 onClick={handleRowClick(row)}
                 className={bodyRowClasses}
+                style={getRowStyle(row)}
               >
                 {row.getVisibleCells().map(cell => {
                   return (
@@ -77,4 +78,12 @@ export function Body<T extends object>({
       )}
     </>
   );
+}
+
+function getRowStyle<T>(row: Row<T>) {
+  return row.depth > 0
+    ? {
+        backgroundColor: "var(--color-surface--background--subtle)",
+      }
+    : undefined;
 }

--- a/packages/components/src/DataTable/DataTable.tsx
+++ b/packages/components/src/DataTable/DataTable.tsx
@@ -1,4 +1,11 @@
-import { ColumnDef, Row, useReactTable } from "@tanstack/react-table";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  ColumnDef,
+  ExpandedState,
+  Row,
+  getExpandedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
 import classNames from "classnames";
 import React, { LegacyRef, ReactNode } from "react";
 import {
@@ -73,6 +80,10 @@ export interface DataTableProps<T> {
    * When true, shows the loading state of the DataTable
    */
   readonly loading?: boolean;
+
+  readonly getSubRows?:
+    | ((originalRow: unknown, index: number) => undefined | unknown[])
+    | undefined;
 }
 
 export function DataTable<T extends object>({
@@ -84,6 +95,7 @@ export function DataTable<T extends object>({
   stickyHeader,
   pinFirstColumn,
   onRowClick,
+  getSubRows,
   emptyState,
   loading = false,
 }: DataTableProps<T>) {
@@ -97,7 +109,21 @@ export function DataTable<T extends object>({
     [styles.pinFirstColumn]: pinFirstColumn,
   });
 
-  const table = useReactTable(tableSettings);
+  const [expanded, setExpanded] = React.useState<ExpandedState>({});
+
+  const exandableRowTableSettings = {
+    getSubRows,
+    state: {
+      expanded,
+    },
+    onExpandedChange: setExpanded,
+    getExpandedRowModel: getExpandedRowModel(),
+  };
+
+  const table = useReactTable({
+    ...tableSettings,
+    ...exandableRowTableSettings,
+  } as any);
 
   return (
     <div className={styles.dataTableContainer}>


### PR DESCRIPTION
## Description
As a team that is building the payouts table, we want to better understand what needs to change in the DataTable component to support nested rows so that SP’s can export full payouts data, while being able to view it in the list, as well as being able to navigate to these subrows to get to detail pages

This proves it can be done, I am looking for feedback, and to start a discussion on how we can add this feature to DataTable

### Assumptions:
An expandable row can't be a link somewhere
We don't need to add any additional filtering or sorting to subrows
Subrows can link elsewhere/have onclick support

How to test:
Go to:
http://localhost:6005/?path=/story/components-lists-and-tables-datatable-web--client-side-pagination-with-sub-rows

How it looks:
![Screenshot 2025-04-03 at 12 32 07 AM](https://github.com/user-attachments/assets/dcbcec4c-5706-4f72-b19d-2dd9d5e903ca)

## Reference
https://jobber.atlassian.net/jira/software/c/projects/JOB/boards/57?selectedIssue=JOB-119265&useStoredSettings=true

Figma Design for payouts with expandable rows
<img width="771" alt="Screenshot 2025-04-07 at 4 07 23 PM" src="https://github.com/user-attachments/assets/4d580ca2-6743-43a9-9376-2add3df3d3f1" />
