### PR TITLE
feat(components): Add UNSAFE props to Heading

### DIFF
--- a/packages/components/src/Heading/Heading.test.tsx
+++ b/packages/components/src/Heading/Heading.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import { Heading } from ".";
 
@@ -82,4 +82,26 @@ it("renders a non heading inline element", () => {
       </span>
     </div>
   `);
+});
+
+describe("UNSAFE_props", () => {
+  it("should apply the UNSAFE_className to the element", () => {
+    render(
+      <Heading level={1} UNSAFE_className={{ textStyle: "custom-class" }}>
+        Test with custom class name
+      </Heading>,
+    );
+    const element = screen.getByText("Test with custom class name");
+    expect(element).toHaveClass("custom-class");
+  });
+
+  it("should apply the UNSAFE_style to the element", () => {
+    render(
+      <Heading level={1} UNSAFE_style={{ textStyle: { color: "red" } }}>
+        Test with custom style
+      </Heading>,
+    );
+    const element = screen.getByText("Test with custom style");
+    expect(element).toHaveStyle({ color: "red" });
+  });
 });

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Typography, TypographyOptions } from "../Typography";
+import { Typography, TypographyOptions, TypographyProps } from "../Typography";
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -13,11 +13,31 @@ interface HeadingProps {
    * Allows overriding of the element rendered. Defaults to the heading specified with level.
    */
   readonly element?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
+
+  /**
+   * **Use at your own risk:** Custom classNames for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_className?: TypographyProps["UNSAFE_className"];
+
+  /**
+   * **Use at your own risk:** Custom styles for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_style?: TypographyProps["UNSAFE_style"];
 }
 
 export type LevelMap = Record<HeadingLevel, TypographyOptions>;
 
-export function Heading({ level = 5, children, element }: HeadingProps) {
+export function Heading({
+  level = 5,
+  children,
+  element,
+  UNSAFE_className,
+  UNSAFE_style,
+}: HeadingProps) {
   const levelMap: LevelMap = {
     1: {
       element: "h1",
@@ -62,6 +82,8 @@ export function Heading({ level = 5, children, element }: HeadingProps) {
     <Typography
       {...levelMap[level]}
       element={element || levelMap[level].element}
+      UNSAFE_className={UNSAFE_className}
+      UNSAFE_style={UNSAFE_style}
     >
       {children}
     </Typography>

--- a/packages/site/src/content/Heading/Heading.props.json
+++ b/packages/site/src/content/Heading/Heading.props.json
@@ -33,6 +33,32 @@
         "type": {
           "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"span\""
         }
+      },
+      "UNSAFE_className": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom classNames for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "../components/src/Heading/Heading.tsx",
+          "name": "HeadingProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ textStyle?: string; }"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom styles for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "../components/src/Heading/Heading.tsx",
+          "name": "HeadingProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ textStyle?: CSSProperties; }"
+        }
       }
     }
   }

--- a/packages/site/src/content/Heading/HeadingNotes.mdx
+++ b/packages/site/src/content/Heading/HeadingNotes.mdx
@@ -1,0 +1,42 @@
+import { Tabs, Tab } from "@jobber/components/Tabs";
+
+## Component customization
+
+### UNSAFE\_ props (advanced usage)
+
+General information for using `UNSAFE_` props can be found
+[here](/guides/customizing-components).
+
+**Note**: Use of `UNSAFE_` props is **at your own risk** and should be
+considered a **last resort**. Future Icon updates may lead to unintended
+breakages.
+
+#### UNSAFE_props (web)
+
+<Tabs>
+  <Tab label="UNSAFE_className">
+    Use `UNSAFE_className` to apply custom classes to the Heading component. This can be
+    useful for applying styles via CSS Modules.
+
+    ```tsx
+    <Heading level={1} UNSAFE_className={{ textStyle: styles.customHeading }}>
+      Test with custom class name
+    </Heading>
+
+    // YourComponent.module.css
+    .customHeading {
+      color: var(--color-red);
+    }
+    ```
+
+  </Tab>
+  <Tab label="UNSAFE_style">
+    Use `UNSAFE_style` to apply inline custom styles to the Heading component.
+    
+    ```tsx
+    <Heading level={1} UNSAFE_style={{ textStyle: { color: "red" } }}>
+      Test with custom style
+    </Heading>
+    ```
+  </Tab>
+</Tabs>

--- a/packages/site/src/content/Heading/index.tsx
+++ b/packages/site/src/content/Heading/index.tsx
@@ -1,6 +1,7 @@
 import HeadingContent from "@atlantis/docs/components/Heading/Heading.stories.mdx";
 import Props from "./Heading.props.json";
 import MobileProps from "./Heading.props-mobile.json";
+import Notes from "./HeadingNotes.mdx";
 import { ContentExport } from "../../types/content";
 import { getStorybookUrl } from "../../layout/getStorybookUrl";
 
@@ -22,4 +23,5 @@ export default {
       ),
     },
   ],
+  notes: () => <Notes />,
 } as const satisfies ContentExport;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Adding UNSAFE props to atom components to allow more customizations

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added `UNSAFE_className` and `UNSAFE_style` props to `Heading` (which just get forwarded to `Typography`
- Tests for UNSAFE props
- Notes in the Implementations tab with UNSAFE props use explanation
- `Heading` props file update

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Add this to the existing story and make sure it renders as expected
```
<Heading
    level={1}
    UNSAFE_style={{ textStyle: { color: "var(--color-red" } }}
>
    Custom Heading
</Heading>
```
Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
