### PR TITLE
docs: clean up Banner prop docs

### DIFF
--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -11,10 +11,14 @@ import { ButtonDismiss } from "../ButtonDismiss/ButtonDismiss";
 
 interface BannerProps {
   readonly children: ReactNode;
-  readonly type: BannerType;
+
   /**
-   * The default cta variation should be a 'work' variation. If the banner
-   * 'type' is set to 'notice' we change the cta variation to 'learning'
+   * Sets the status-based theme of the Banner
+   */
+  readonly type: BannerType;
+
+  /**
+   * Accepts props for Button. Default action uses a 'subtle' Button.
    */
   readonly primaryAction?: ButtonProps;
 
@@ -24,14 +28,14 @@ interface BannerProps {
   readonly dismissible?: boolean;
 
   /**
-   * Adds an icon to the left of the banner content
+   * Use to override the default status Icon
    */
   readonly icon?: IconNames;
 
   onDismiss?(): void;
 
   /**
-   * When provided, the banner's visibility is controlled by this value.
+   * When provided, Banner's visibility is controlled by this value.
    * @default undefined
    */
   readonly controlledVisiblity?: boolean;

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -18,11 +18,12 @@ interface BannerProps {
   readonly type: BannerType;
 
   /**
-   * Accepts props for Button. Default action uses a 'subtle' Button.
+   * Accepts props for Button. Default action uses a 'subtle' Button
    */
   readonly primaryAction?: ButtonProps;
 
   /**
+   * Set to false to hide the dismiss button
    * @default true
    */
   readonly dismissible?: boolean;
@@ -35,7 +36,7 @@ interface BannerProps {
   onDismiss?(): void;
 
   /**
-   * When provided, Banner's visibility is controlled by this value.
+   * When provided, Banner's visibility is controlled by this value
    * @default undefined
    */
   readonly controlledVisiblity?: boolean;

--- a/packages/site/src/content/Banner/Banner.props.json
+++ b/packages/site/src/content/Banner/Banner.props.json
@@ -8,7 +8,7 @@
     "props": {
       "type": {
         "defaultValue": null,
-        "description": "",
+        "description": "Sets the status-based theme of the Banner",
         "name": "type",
         "parent": {
           "fileName": "../components/src/Banner/Banner.tsx",
@@ -21,7 +21,7 @@
       },
       "primaryAction": {
         "defaultValue": null,
-        "description": "The default cta variation should be a 'work' variation. If the banner\n'type' is set to 'notice' we change the cta variation to 'learning'",
+        "description": "Accepts props for Button. Default action uses a 'subtle' Button",
         "name": "primaryAction",
         "parent": {
           "fileName": "../components/src/Banner/Banner.tsx",
@@ -36,7 +36,7 @@
         "defaultValue": {
           "value": true
         },
-        "description": "",
+        "description": "Set to false to hide the dismiss button",
         "name": "dismissible",
         "parent": {
           "fileName": "../components/src/Banner/Banner.tsx",
@@ -49,7 +49,7 @@
       },
       "icon": {
         "defaultValue": null,
-        "description": "Adds an icon to the left of the banner content",
+        "description": "Use to override the default status Icon",
         "name": "icon",
         "parent": {
           "fileName": "../components/src/Banner/Banner.tsx",
@@ -77,7 +77,7 @@
         "defaultValue": {
           "value": "undefined"
         },
-        "description": "When provided, the banner's visibility is controlled by this value.",
+        "description": "When provided, Banner's visibility is controlled by this value",
         "name": "controlledVisiblity",
         "parent": {
           "fileName": "../components/src/Banner/Banner.tsx",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Banner has some prop descriptions that are missing or outdated 

Missing: **type** description
_Probably the most commonly needed prop_

Outdated: **icon** description
_There's always an icon now, you can just override it as an option_

Outdated: **primaryAction** description
_primaryAction defaults to a subtle Button now and there's no more conditional switching based on Banner type_

![image](https://github.com/user-attachments/assets/a1e1d0e5-8796-442a-83ba-05d7e1f6a71d)

## Changes

### Changed

- Descriptions of some Banner props

## Testing

Review the Banner docs in Storybook and the docs site

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
