### PR TITLE
feat(design): add slim spacing token and add to docs

### DIFF
--- a/docs/design/Spacing.stories.mdx
+++ b/docs/design/Spacing.stories.mdx
@@ -39,6 +39,14 @@ reflect their relation to each other. An example would be the spacing between
 
 ![illustration of a small space between Chip components](https://user-images.githubusercontent.com/39704901/143141613-193ceeb2-b393-44ab-a5e8-21d2f88c67c4.png)
 
+### Slim
+
+Use `slim` spacing when you don't quite need a `small` space, but `base` is just
+too much. This is often useful for optically balancing the internal padding of a
+UI element.
+
+![illustration of a slim space between two components](https://user-images.githubusercontent.com/39704901/143141629-77777777-7777-7777-7777-777777777777.png)
+
 ### Base
 
 Use `base` as the default spacing in larger content containers with multiple
@@ -112,6 +120,7 @@ export function Height({ of: size }) {
 | `--space-smallest`    | <Example of="smallest" />    | <Height of="smallest" />    |
 | `--space-smaller`     | <Example of="smaller" />     | <Height of="smaller" />     |
 | `--space-small`       | <Example of="small" />       | <Height of="small" />       |
+| `--space-slim`        | <Example of="slim" />        | <Height of="slim" />        |
 | `--space-base`        | <Example of="base" />        | <Height of="base" />        |
 | `--space-large`       | <Example of="large" />       | <Height of="large" />       |
 | `--space-larger`      | <Example of="larger" />      | <Height of="larger" />      |

--- a/docs/design/Spacing.stories.mdx
+++ b/docs/design/Spacing.stories.mdx
@@ -23,13 +23,31 @@ At their respective sizes (`1px` and `2px` equivalent), these values should
 mostly be used to provide optical adjustments where an element is visually
 misaligned.
 
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="350"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24730-28758&embed-host=share"
+></iframe>
+
 ### Smaller
 
 The `smaller` spacing value can be used between contents of a single component.
 For example, see the spacing between an Icon and the label inside of a
 [Button.](../?path=/docs/components-actions-button--docs#icons)
 
-![illustration of a smaller space between icon and button label](https://user-images.githubusercontent.com/39704901/143141489-679fa61b-5497-4e81-bfe0-b5f463673e4b.png)
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="450"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24730-16011&embed-host=share"
+></iframe>
 
 ### Small
 
@@ -37,7 +55,15 @@ Sibling items within a container can be separated by the `small` value to
 reflect their relation to each other. An example would be the spacing between
 [Chips in a selection group.](../?path=/docs/components-selections-chips--docs#single-select)
 
-![illustration of a small space between Chip components](https://user-images.githubusercontent.com/39704901/143141613-193ceeb2-b393-44ab-a5e8-21d2f88c67c4.png)
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="450"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24714-21111&embed-host=share"
+></iframe>
 
 ### Slim
 
@@ -45,42 +71,101 @@ Use `slim` spacing when you don't quite need a `small` space, but `base` is just
 too much. This is often useful for optically balancing the internal padding of a
 UI element.
 
-![illustration of a slim space between two components](https://user-images.githubusercontent.com/39704901/143141629-77777777-7777-7777-7777-777777777777.png)
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="450"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24714-21038&embed-host=share"
+></iframe>
 
 ### Base
 
-Use `base` as the default spacing in larger content containers with multiple
-children of their own, such as [Card.](/components/Card) This should also be
-used as the default starting point for spacing between [Form](/components/Form)
-elements.
+Use `base` as the default spacing in larger content containers with multiple
+children of their own, such as [Card.](/components/Card)
 
-![illustration of spacing between form elements inside of a card](https://user-images.githubusercontent.com/39704901/143141662-0f20eec4-8b27-44fe-96f5-1bf1c4d567aa.png)
+`Base` should also be used as the default starting point for spacing
+form elements.
+
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="450"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24714-21056&embed-host=share"
+></iframe>
 
 ### Large
 
 Use `large` spacing for higher-level "parent" containers.
 [Modal](/components/Modal) uses `large` spacing in its header and around the
-edges to give itself a bit more prominence as a "standalone" view, in a similar
+edges to give itself a bit more prominence as a standalone view, in a similar
 manner to [Page](/components/Page).
 
 `Large` can also be used to help give a "floating" element some clear separation
-from the edge of its container, as seen in [Toast](/components/Toast).
+from the edge of the viewport, as seen in [Toast](/components/Toast).
 
-![illustration of the large space around a Modal's header and content, a Page's outer padding, and a Toast near the bottom of a viewport](https://user-images.githubusercontent.com/39704901/143152557-8fca3292-dc07-4f9b-a33b-f4d4603c9dd2.png)
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="800"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24728-98&embed-host=share"
+></iframe>
 
 ### Larger
 
 `Larger` doubles the value of `base` to very clearly delineate two groups of
-content that themselves use `base`. It may be useful if you have a long list of
-mixed content types that need to be broken up.
+content. It can be useful if you have a long list of mixed content types that
+need to be broken up.
 
-![illustration of larger spacing being used to break up unrelated sections of content](https://user-images.githubusercontent.com/39704901/143141846-43606573-1383-4ad2-9d95-46611488cbae.png)
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="600"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24758-308&t=LxjCmBWlPHgTUxGk-1&embed-host=share"
+></iframe>
 
-### Largest and Extravagant
+### Largest
 
-You'll probably never need these unless you're doing a custom layout, but
-they're here if you need 'em. These values are equivalent to `48px` and `64px`
-respectively.
+`Largest` is useful for giving content-rich containers ample breathing room to
+create hierarchy. When the parent has such generous spacing, it allows for the
+children to leverage a broader range of techniques for grouping amongst
+themselves.
+
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="900"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24759-856&embed-host=share"
+></iframe>
+
+### Extravagant
+
+`Extravagant` is used infrequently in Jobber’s web and mobile applications, but
+can be useful for lower-density consumer applications like websites.
+
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+  }}
+  width="800"
+  height="900"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=24761-271&embed-host=share"
+></iframe>
 
 ---
 
@@ -95,6 +180,8 @@ Content can set its spacing to any of the spacing token values; follow the
 guidelines above as needed.
 
 ### Values
+
+You can use spacing tokens directly in your stylesheets using the values below.
 
 export function Example({ of: size }) {
   const style = {

--- a/packages/components/src/Box/styles/BoxGap.module.css
+++ b/packages/components/src/Box/styles/BoxGap.module.css
@@ -14,6 +14,10 @@
   gap: var(--space-small);
 }
 
+.gap-slim {
+  gap: var(--space-slim);
+}
+
 .gap-base {
   gap: var(--space-base);
 }

--- a/packages/components/src/Box/styles/BoxGap.module.css.d.ts
+++ b/packages/components/src/Box/styles/BoxGap.module.css.d.ts
@@ -3,6 +3,7 @@ declare const styles: {
   readonly "gap-smallest": string;
   readonly "gap-smaller": string;
   readonly "gap-small": string;
+  readonly "gap-slim": string;
   readonly "gap-base": string;
   readonly "gap-large": string;
   readonly "gap-larger": string;

--- a/packages/design/src/tokens/space.tokens.json
+++ b/packages/design/src/tokens/space.tokens.json
@@ -14,6 +14,9 @@
     "small": {
       "$value": "8px"
     },
+    "slim": {
+      "$value": "12px"
+    },
     "base": {
       "$value": "16px"
     },

--- a/packages/site/src/content/Box/Box.props.json
+++ b/packages/site/src/content/Box/Box.props.json
@@ -81,7 +81,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"slim\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\""
+          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\""
         }
       },
       "height": {

--- a/packages/site/src/content/Box/Box.props.json
+++ b/packages/site/src/content/Box/Box.props.json
@@ -81,7 +81,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\""
+          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"slim\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\""
         }
       },
       "height": {

--- a/packages/site/src/content/Box/Box.props.json
+++ b/packages/site/src/content/Box/Box.props.json
@@ -81,7 +81,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\""
+          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"slim\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\""
         }
       },
       "height": {
@@ -109,7 +109,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\" | BoxSpace"
+          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"slim\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\" | BoxSpace"
         }
       },
       "padding": {
@@ -122,7 +122,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\" | BoxSpace"
+          "name": "\"base\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"slim\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\" | BoxSpace"
         }
       },
       "preserveWhiteSpace": {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In Atlantis alone, we work around the lack of a space in between `small` and `base` in several places:

Adding small (8) and smaller (4):
![image](https://github.com/user-attachments/assets/16bd8e91-a828-4fe3-9332-afe197158d38)

Subtracting smaller (4) from base (16):
![image](https://github.com/user-attachments/assets/4fcc972a-28d6-4156-b91f-352b0f5b5055)

In addition, the Jobber web and mobile codebases (either directly or through calcs) get to this number a few dozen times between them.

As a note: I would prefer to _add_ the token here and then fast-follow with the in-Atlantis replacements of the calcs for ease of testing/reviewing, but if you, reviewer, would prefer I do all of that in one shot I can!

[Figma](https://www.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/branch/1LPdYn25btQCAiEdg23IUE/Product%2FBase?m=auto&node-id=13731-0&t=IVHs08XV7u2iIYHI-1)

## Changes

### Changed

- Updated the outdated spacing patterns imagery with embedded Figmas for "live" updates
![image](https://github.com/user-attachments/assets/adf25289-f53b-4ecb-991f-fe88a3683717)


### Added

- New spacing token: `slim`: `12px`
![image](https://github.com/user-attachments/assets/e62bcae4-b184-41d4-8335-91cc9b6195f2)

## Testing

Ensure that the token exists and can be used

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
