### PR TITLE
feat(components): Add ref to Button and Chip

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -25,6 +25,7 @@ function ButtonWrapper(props: ButtonProps) {
     ariaLabel,
     disabled = false,
     external,
+    htmlButtonRef,
     id,
     name,
     onClick,
@@ -62,6 +63,7 @@ function ButtonWrapper(props: ButtonProps) {
     "aria-label": ariaLabel,
     role: role,
   };
+  const refProp = url ? {} : { ref: htmlButtonRef };
 
   const buttonInternals = children || <ButtonContent {...props} />;
 
@@ -73,9 +75,15 @@ function ButtonWrapper(props: ButtonProps) {
     );
   }
 
-  const Tag = url ? "a" : "button";
+  if (url) {
+    return <a {...tagProps}>{buttonInternals}</a>;
+  }
 
-  return <Tag {...tagProps}>{buttonInternals}</Tag>;
+  return (
+    <button {...tagProps} {...refProp}>
+      {buttonInternals}
+    </button>
+  );
 }
 
 Button.Label = ButtonLabel;

--- a/packages/components/src/Button/Button.types.ts
+++ b/packages/components/src/Button/Button.types.ts
@@ -121,6 +121,8 @@ interface BasicButtonProps extends ButtonFoundationProps {
    * Used to override the default button role.
    */
   readonly role?: string;
+
+  readonly htmlButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 type BaseButtonProps = XOR<

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -9,56 +9,58 @@ import { useChildComponent } from "./hooks/useChildComponent";
 import { Typography } from "../Typography";
 import { Tooltip } from "../Tooltip";
 
-export const Chip = ({
-  ariaLabel,
-  disabled,
-  heading,
-  invalid,
-  label,
-  value,
-  testID,
-  onClick,
-  onKeyDown,
-  children,
-  role = "button",
-  tabIndex = 0,
-  variation = "base",
-}: ChipProps): JSX.Element => {
-  const classes = classnames(styles.chip, {
-    [styles.invalid]: invalid,
-    [styles.base]: variation === "base",
-    [styles.subtle]: variation === "subtle",
-    [styles.disabled]: disabled,
-  });
+// Define a type for the Chip component with the properties we add to it
+type ChipComponent = React.ForwardRefExoticComponent<
+  ChipProps & React.RefAttributes<HTMLButtonElement | HTMLDivElement>
+> & {
+  Prefix: typeof ChipPrefix;
+  Suffix: typeof ChipSuffix;
+  displayName: string;
+};
 
-  const prefix = useChildComponent(children, d => d.type === Chip.Prefix);
-  const suffix = useChildComponent(children, d => d.type === Chip.Suffix);
+export const Chip = React.forwardRef<
+  HTMLButtonElement | HTMLDivElement,
+  ChipProps
+>(
+  (
+    {
+      ariaLabel,
+      disabled,
+      heading,
+      invalid,
+      label,
+      value,
+      testID,
+      onClick,
+      onKeyDown,
+      children,
+      role = "button",
+      tabIndex = 0,
+      variation = "base",
+    },
+    ref,
+  ) => {
+    const classes = classnames(styles.chip, {
+      [styles.invalid]: invalid,
+      [styles.base]: variation === "base",
+      [styles.subtle]: variation === "subtle",
+      [styles.disabled]: disabled,
+    });
 
-  const [labelRef, labelFullyVisible] = useInView<HTMLSpanElement>();
-  const [headingRef, headingFullyVisible] = useInView<HTMLSpanElement>();
-  const tooltipMessage = getTooltipMessage(
-    labelFullyVisible,
-    headingFullyVisible,
-    label,
-    heading,
-  );
-  const Tag = onClick ? "button" : "div";
+    const prefix = useChildComponent(children, d => d.type === Chip.Prefix);
+    const suffix = useChildComponent(children, d => d.type === Chip.Suffix);
 
-  return (
-    <Tooltip message={tooltipMessage} setTabIndex={false}>
-      <Tag
-        className={classes}
-        onClick={(ev: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) =>
-          onClick?.(value, ev)
-        }
-        tabIndex={disabled ? -1 : tabIndex}
-        onKeyDown={onKeyDown}
-        aria-label={ariaLabel}
-        disabled={disabled}
-        role={role}
-        data-testid={testID}
-        type="button"
-      >
+    const [labelRef, labelFullyVisible] = useInView<HTMLSpanElement>();
+    const [headingRef, headingFullyVisible] = useInView<HTMLSpanElement>();
+    const tooltipMessage = getTooltipMessage(
+      labelFullyVisible,
+      headingFullyVisible,
+      label,
+      heading,
+    );
+
+    const chipContent = (
+      <>
         {prefix}
         <div className={styles.chipContent}>
           {heading && (
@@ -84,10 +86,47 @@ export const Chip = ({
           )}
         </div>
         {suffix}
-      </Tag>
-    </Tooltip>
-  );
-};
+      </>
+    );
+
+    // Use createElement to properly handle the ref typing
+    return (
+      <Tooltip message={tooltipMessage} setTabIndex={false}>
+        {onClick
+          ? React.createElement(
+              "button",
+              {
+                className: classes,
+                onClick: (ev: React.MouseEvent<HTMLButtonElement>) =>
+                  onClick?.(value, ev),
+                tabIndex: disabled ? -1 : tabIndex,
+                onKeyDown,
+                "aria-label": ariaLabel,
+                disabled,
+                role,
+                "data-testid": testID,
+                type: "button",
+                ref,
+              },
+              chipContent,
+            )
+          : React.createElement(
+              "div",
+              {
+                className: classes,
+                tabIndex: disabled ? -1 : tabIndex,
+                onKeyDown,
+                "aria-label": ariaLabel,
+                role,
+                "data-testid": testID,
+                ref,
+              },
+              chipContent,
+            )}
+      </Tooltip>
+    );
+  },
+) as ChipComponent;
 
 function getTooltipMessage(
   labelFullyVisible: boolean,
@@ -108,3 +147,4 @@ function getTooltipMessage(
 
 Chip.Prefix = ChipPrefix;
 Chip.Suffix = ChipSuffix;
+Chip.displayName = "Chip";

--- a/packages/components/src/utils/meta/meta.test.tsx
+++ b/packages/components/src/utils/meta/meta.test.tsx
@@ -5,6 +5,7 @@ describe("meta", () => {
   // If this test fails, please update meta.json accordingly.
   it("verifies that the meta.json file is up to date", async () => {
     const meta = await fs.readFile(`${__dirname}/meta.json`, "utf-8");
+
     const allNames = findComponentNamesDeep(allExports);
     allNames.sort();
 
@@ -73,6 +74,10 @@ function findComponentNamesDeep(objectOrFunction: any, name?: string) {
     } else if (isForwardedRef(k, v) || isMemoizedComponent(k, v)) {
       const thisName = name ? `${name}.${k}` : k;
       allNames.push(thisName);
+
+      // Also check for child components in forwardRef and memoized components
+      const childComponents = findComponentNamesDeep(v, k);
+      allNames.push(...childComponents);
     } else if (isComponent(k, v)) {
       const thisName = name ? `${name}.${k}` : k;
       allNames.push(thisName);


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

With React Hook Forms, there's a feature where if there's an error on a field it will scroll to that input, and also focus it for the user.

If a Combobox were to be used in such a way, we don't have a way to offer the ref of it's activator, thus blocking that behavior in the ideal way anyway. 

To enable this behavior, we're going to expose a ref for Chip. It's a bit odd because Chip can be either a div or a button, and I'm not too sure what the use case would even be for needing a ref to the div.

Button is a reasonable other usage for a Combobox activator, so I'm preemptively adding a ref to that too. Button I've omitted the ref prop when the `to` prop is provided because that is deprecated and going away. I've also omitted it when `url` is provided, making it into an `a` tag. Perhaps that's not right though, and it would be valid to expose the ref to the anchor tag.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

updated the meta.test.tsx helper function because now that Chip is both a forwarded ref component AND it has child components (Chip.Prefix & Chip.Suffix) we need to apply some recursive searching like we do in other components.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
