### PR TITLE
feat(components): Add ability to only open Chips menu on search [JOB-119726]

### DIFF
--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -95,6 +95,8 @@ const SelectionTemplate: ComponentStory<typeof Chips> = args => {
       isLoadingMore={loading}
       onSearch={handleSearch}
       onLoadMore={handleLoadMore}
+      onlyShowMenuOnSearch={true}
+      submitInputOnFocusShift={true}
     >
       {options.map(name => (
         <Chip key={name} label={name} value={name} />

--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -75,15 +75,8 @@ export const MultiSelect = MultiSelectTemplate.bind({});
 MultiSelect.args = {};
 
 const SelectionTemplate: ComponentStory<typeof Chips> = args => {
-  const {
-    selected,
-    options,
-    loading,
-    handleLoadMore,
-    handleSearch,
-    handleSelect,
-    handleCustomAdd,
-  } = useFakeOptionQuery();
+  const { selected, options, handleSearch, handleSelect, handleCustomAdd } =
+    useFakeOptionQuery();
 
   return (
     <Chips
@@ -92,11 +85,9 @@ const SelectionTemplate: ComponentStory<typeof Chips> = args => {
       selected={selected}
       onChange={handleSelect}
       onCustomAdd={handleCustomAdd}
-      isLoadingMore={loading}
       onSearch={handleSearch}
-      onLoadMore={handleLoadMore}
-      onlyShowMenuOnSearch={true}
-      submitInputOnFocusShift={true}
+      // onlyShowMenuOnSearch={true}
+      // submitInputOnFocusShift={true}
     >
       {options.map(name => (
         <Chip key={name} label={name} value={name} />

--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -95,8 +95,6 @@ const SelectionTemplate: ComponentStory<typeof Chips> = args => {
       isLoadingMore={loading}
       onSearch={handleSearch}
       onLoadMore={handleLoadMore}
-      onlyShowMenuOnSearch={true}
-      submitInputOnFocusShift={true}
     >
       {options.map(name => (
         <Chip key={name} label={name} value={name} />

--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -75,8 +75,15 @@ export const MultiSelect = MultiSelectTemplate.bind({});
 MultiSelect.args = {};
 
 const SelectionTemplate: ComponentStory<typeof Chips> = args => {
-  const { selected, options, handleSearch, handleSelect, handleCustomAdd } =
-    useFakeOptionQuery();
+  const {
+    selected,
+    options,
+    loading,
+    handleLoadMore,
+    handleSearch,
+    handleSelect,
+    handleCustomAdd,
+  } = useFakeOptionQuery();
 
   return (
     <Chips
@@ -85,9 +92,11 @@ const SelectionTemplate: ComponentStory<typeof Chips> = args => {
       selected={selected}
       onChange={handleSelect}
       onCustomAdd={handleCustomAdd}
+      isLoadingMore={loading}
       onSearch={handleSearch}
-      // onlyShowMenuOnSearch={true}
-      // submitInputOnFocusShift={true}
+      onLoadMore={handleLoadMore}
+      onlyShowMenuOnSearch={true}
+      submitInputOnFocusShift={true}
     >
       {options.map(name => (
         <Chip key={name} label={name} value={name} />

--- a/docs/components/Chips/utils/storyUtils.ts
+++ b/docs/components/Chips/utils/storyUtils.ts
@@ -2,75 +2,49 @@
  * For playground purposes only.
  */
 import uniq from "lodash/uniq";
-import { useCallback, useState } from "react";
-
-const ALL_OPTIONS = [
-  "Apple",
-  "Banana",
-  "Cherry",
-  "Date",
-  "Fig",
-  "Grape",
-  "Honeydew",
-  "Kiwi",
-  "Lemon",
-  "Mango",
-  "Nectarine",
-  "Orange",
-  "Papaya",
-  "Quince",
-  "Raspberry",
-  "Strawberry",
-  "Tangerine",
-  "Ugli fruit",
-  "Vanilla bean",
-  "Watermelon",
-  "Xigua",
-  "Yuzu",
-  "Zucchini", // Technically a fruit!
-];
-
-// Initial selected items can be anything, even if not in ALL_OPTIONS initially
-const INITIAL_SELECTED = ["Mando", "Din Djarin"];
+import { useEffect, useState } from "react";
 
 export function useFakeOptionQuery() {
-  const [selected, setSelected] = useState<string[]>(INITIAL_SELECTED);
-  // Initialize options with selected items + all available options
-  const [options, setOptions] = useState<string[]>(() =>
-    uniq([...INITIAL_SELECTED, ...ALL_OPTIONS]),
-  );
+  const [options, setOptions] = useState<string[]>([]);
+  const initialDataGetUrl = "https://swapi.dev/api/people/?format=json";
+  const [nextGet, setNextGet] = useState(initialDataGetUrl);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState(["Mando", "Din Djarin"]);
 
-  const handleSearch = useCallback(
-    (searchValue: string) => {
-      if (!searchValue) {
-        // Show all options (including selected) if search is cleared
-        setOptions(uniq([...selected, ...ALL_OPTIONS]));
-      } else {
-        // Filter all options based on search, but always include currently selected ones
-        const filtered = ALL_OPTIONS.filter(option =>
-          option.toLowerCase().includes(searchValue.toLowerCase()),
-        );
-        setOptions(uniq([...selected, ...filtered]));
-      }
+  const actions = {
+    handleLoadMore: () => {
+      if (loading || !nextGet) return;
+
+      setLoading(true);
+      fetchData(nextGet).then(result => {
+        const newOptions = uniq([...selected, ...options, ...result.options]);
+        setOptions(newOptions);
+        setNextGet(result.next);
+        setLoading(false);
+      });
     },
-    [selected], // Re-create search handler if selected changes
-  );
-
-  const handleSelect = (value: string[]) => {
-    setSelected(value);
-    // Ensure newly deselected options are still available if they are part of ALL_OPTIONS
-    setOptions(prevOptions => uniq([...value, ...prevOptions, ...ALL_OPTIONS]));
+    handleSearch: (searchValue: string) => {
+      setNextGet(initialDataGetUrl + `&search=${searchValue}`);
+      setOptions(selected);
+    },
+    handleSelect: (value: string[]) => {
+      setSelected(value);
+    },
+    handleCustomAdd: (value: string) => {
+      setSelected(uniq([...selected, value]));
+    },
   };
 
-  const handleCustomAdd = (value: string) => {
-    const newSelected = uniq([...selected, value]);
-    setSelected(newSelected);
-    // Add the custom value to the available options as well
-    setOptions(prevOptions => uniq([...newSelected, ...prevOptions, value]));
-  };
+  useEffect(() => actions.handleLoadMore(), []); // load once on mount
+  useEffect(() => actions.handleLoadMore(), [nextGet]);
 
-  // Note: loading and handleLoadMore are removed as they are not needed for static data
-  return { selected, options, handleSearch, handleSelect, handleCustomAdd };
+  return { selected, options, loading, ...actions };
 }
 
-// fetchData function is removed as it's no longer needed
+async function fetchData(url: string) {
+  const response = await fetch(url);
+  const { results, next } = await response.json();
+  const options: string[] = results.map((data: { name: string }) => data.name);
+
+  return { options, next };
+}

--- a/packages/components/src/Chips/ChipsTypes.tsx
+++ b/packages/components/src/Chips/ChipsTypes.tsx
@@ -112,6 +112,8 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
 
   /**
    * If true, automatically selects an option based on the current search value when the input loses focus.
+   * The automatic selection order is: an exact match of the search value if available, a custom option if
+   * onCustomOptionSelect is provided, or the closest match.
    * @default false
    */
   readonly submitInputOnFocusShift?: boolean;

--- a/packages/components/src/Chips/ChipsTypes.tsx
+++ b/packages/components/src/Chips/ChipsTypes.tsx
@@ -103,6 +103,18 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
    * @param searchValue - The input value
    */
   onLoadMore?(searchValue: string): void;
+
+  /**
+   * Control whether the menu only appears once the user types.
+   * @default false
+   */
+  readonly onlyShowMenuOnSearch?: boolean;
+
+  /**
+   * Select the last available option when focus shifts away from the input.
+   * @default false
+   */
+  readonly submitInputOnFocusShift?: boolean;
 }
 
 export type ChipsProps =

--- a/packages/components/src/Chips/ChipsTypes.tsx
+++ b/packages/components/src/Chips/ChipsTypes.tsx
@@ -116,7 +116,7 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
    * onCustomOptionSelect is provided, or the closest match.
    * @default false
    */
-  readonly submitInputOnFocusShift?: boolean;
+  readonly autoSelectOnClickOutside?: boolean;
 }
 
 export type ChipsProps =

--- a/packages/components/src/Chips/ChipsTypes.tsx
+++ b/packages/components/src/Chips/ChipsTypes.tsx
@@ -111,7 +111,7 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
   readonly onlyShowMenuOnSearch?: boolean;
 
   /**
-   * Select the last available option when focus shifts away from the input.
+   * If true, automatically selects an option based on the current search value when the input loses focus.
    * @default false
    */
   readonly submitInputOnFocusShift?: boolean;

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
@@ -57,7 +57,7 @@ export function InternalChipDismissible(props: InternalChipDismissibleProps) {
         onSearch={props.onSearch}
         onLoadMore={props.onLoadMore}
         onlyShowMenuOnSearch={props.onlyShowMenuOnSearch}
-        submitInputOnFocusShift={props.submitInputOnFocusShift}
+        autoSelectOnClickOutside={props.autoSelectOnClickOutside}
       />
     </div>
   );

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
@@ -56,6 +56,8 @@ export function InternalChipDismissible(props: InternalChipDismissibleProps) {
         onCustomOptionSelect={handleCustomAdd}
         onSearch={props.onSearch}
         onLoadMore={props.onLoadMore}
+        onlyShowMenuOnSearch={props.onlyShowMenuOnSearch}
+        submitInputOnFocusShift={props.submitInputOnFocusShift}
       />
     </div>
   );

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import classNames from "classnames";
-import debounce from "lodash/debounce";
 import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
 import styles from "./InternalChipDismissible.module.css";
 import { ChipDismissibleInputProps } from "./InternalChipDismissibleTypes";
@@ -13,8 +12,6 @@ import {
 import { Text } from "../../Text";
 import { Button } from "../../Button";
 import { Spinner } from "../../Spinner";
-
-const DEBOUNCE_TIME = 200;
 
 // eslint-disable-next-line max-statements
 export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
@@ -35,6 +32,7 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     menuId,
     menuOpen,
     searchValue,
+    showInput,
     generateDescendantId,
     handleBlur,
     handleOpenMenu,
@@ -44,12 +42,10 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     handleSetActiveOnMouseOver,
     handleKeyDown,
     handleSelectOption,
+    handleShowInput,
     handleDebouncedSearch,
   } = useInternalChipDismissibleInput(props);
 
-  // Controls whether the input field or the activator button is rendered.
-  // This state is only used when `onlyShowMenuOnSearch` is true.
-  const [showInput, setShowInput] = useState(false);
   const menuRef = useScrollToActive(activeIndex);
   const { ref: visibleChildRef, isInView } = useInView<HTMLDivElement>();
 
@@ -73,41 +69,11 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     isInView && onLoadMore && onLoadMore(searchValue);
   }, [isInView]);
 
-  if (onlyShowMenuOnSearch) {
-    if (!showInput) {
-      const handleActivate = () => {
-        setShowInput(true);
-        setTimeout(() => inputRef.current?.focus(), 0);
-      };
-
-      return React.cloneElement(activator, { onClick: handleActivate });
-    }
-  } else {
-    if (!menuOpen) {
-      return React.cloneElement(activator, { onClick: handleOpenMenu });
-    }
+  if (!showInput) {
+    return React.cloneElement(activator, { onClick: handleShowInput });
   }
 
-  const handleInputBlur = () => {
-    if (onlyShowMenuOnSearch) {
-      const valueBeforeBlur = inputRef.current?.value;
-
-      handleBlur();
-
-      setTimeout(() => {
-        if (valueBeforeBlur === "") {
-          setShowInput(false);
-        }
-      }, DEBOUNCE_TIME);
-    } else {
-      debounce(handleBlur, DEBOUNCE_TIME)();
-    }
-  };
-
-  const shouldShowMenu =
-    menuOpen &&
-    (hasAvailableOptions || isLoadingMore) &&
-    (!onlyShowMenuOnSearch || !!searchValue);
+  const shouldShowMenu = menuOpen && (hasAvailableOptions || isLoadingMore);
 
   return (
     <>
@@ -124,7 +90,7 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
         value={searchValue}
         onChange={handleSearchChange}
         onKeyDown={handleKeyDown}
-        onBlur={handleInputBlur}
+        onBlur={() => setTimeout(handleBlur, 200)}
         onFocus={onlyShowMenuOnSearch ? undefined : handleOpenMenu}
         autoFocus={true}
       />

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -13,7 +13,6 @@ import { Text } from "../../Text";
 import { Button } from "../../Button";
 import { Spinner } from "../../Spinner";
 
-// eslint-disable-next-line max-statements
 export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
   const {
     activator = <Button icon="add" type="secondary" ariaLabel="Add" />,

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -73,9 +73,7 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     isInView && onLoadMore && onLoadMore(searchValue);
   }, [isInView]);
 
-  // Conditionally render the activator button or the input section.
   if (onlyShowMenuOnSearch) {
-    // Mode: Only show menu after typing.
     if (!showInput) {
       const handleActivate = () => {
         setShowInput(true);
@@ -84,34 +82,24 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
 
       return React.cloneElement(activator, { onClick: handleActivate });
     }
-    // If showInput is true, fall through to render the input section below.
   } else {
-    // Mode: Show menu on focus/click (default).
     if (!menuOpen) {
       return React.cloneElement(activator, { onClick: handleOpenMenu });
     }
-    // If menuOpen is true, fall through to render the input section below.
   }
 
-  // If we didn't return an activator above, render the input and potentially the menu.
   const handleInputBlur = () => {
     if (onlyShowMenuOnSearch) {
-      // Mode: Only show menu after typing.
-
-      // Capture input value BEFORE calling the hook's blur
       const valueBeforeBlur = inputRef.current?.value;
 
-      // Allow hook to reset menu state immediately
       handleBlur();
 
       setTimeout(() => {
-        // Check the value *as it was when blur occurred*
         if (valueBeforeBlur === "") {
-          setShowInput(false); // This will trigger rerender with activator
+          setShowInput(false);
         }
       }, DEBOUNCE_TIME);
     } else {
-      // Mode: Show menu on focus/click (default).
       debounce(handleBlur, DEBOUNCE_TIME)();
     }
   };

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 import debounce from "lodash/debounce";
@@ -17,6 +16,7 @@ import { Spinner } from "../../Spinner";
 
 const DEBOUNCE_TIME = 200;
 
+// eslint-disable-next-line max-statements
 export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
   const {
     activator = <Button icon="add" type="secondary" ariaLabel="Add" />,
@@ -47,6 +47,8 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     handleDebouncedSearch,
   } = useInternalChipDismissibleInput(props);
 
+  // Controls whether the input field or the activator button is rendered.
+  // This state is only used when `onlyShowMenuOnSearch` is true.
   const [showInput, setShowInput] = useState(false);
   const menuRef = useScrollToActive(activeIndex);
   const { ref: visibleChildRef, isInView } = useInView<HTMLDivElement>();
@@ -71,7 +73,9 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     isInView && onLoadMore && onLoadMore(searchValue);
   }, [isInView]);
 
+  // Conditionally render the activator button or nothing (if input is shown).
   if (onlyShowMenuOnSearch && !showInput) {
+    // Mode: Only show menu after typing.
     const handleActivate = () => {
       setShowInput(true);
       setTimeout(() => inputRef.current?.focus(), 0);
@@ -79,17 +83,23 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
 
     return React.cloneElement(activator, { onClick: handleActivate });
   } else if (!onlyShowMenuOnSearch && !menuOpen) {
+    // Mode: Show menu on focus/click (default).
     return React.cloneElement(activator, { onClick: handleOpenMenu });
   }
 
   const handleInputBlur = () => {
-    handleBlur();
-
-    setTimeout(() => {
-      if (inputRef.current?.value === "") {
-        setShowInput(false);
-      }
-    }, DEBOUNCE_TIME);
+    if (onlyShowMenuOnSearch) {
+      // Mode: Only show menu after typing.
+      handleBlur();
+      setTimeout(() => {
+        if (inputRef.current?.value === "") {
+          setShowInput(false);
+        }
+      }, DEBOUNCE_TIME);
+    } else {
+      // Mode: Show menu on focus/click (default).
+      debounce(handleBlur, DEBOUNCE_TIME)();
+    }
   };
 
   const shouldShowMenu =
@@ -112,12 +122,8 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
         value={searchValue}
         onChange={handleSearchChange}
         onKeyDown={handleKeyDown}
-        onBlur={
-          onlyShowMenuOnSearch
-            ? handleInputBlur
-            : debounce(handleBlur, DEBOUNCE_TIME)
-        }
-        onFocus={!onlyShowMenuOnSearch ? handleOpenMenu : undefined}
+        onBlur={handleInputBlur}
+        onFocus={onlyShowMenuOnSearch ? undefined : handleOpenMenu}
         autoFocus={true}
       />
 

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -73,27 +73,41 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     isInView && onLoadMore && onLoadMore(searchValue);
   }, [isInView]);
 
-  // Conditionally render the activator button or nothing (if input is shown).
-  if (onlyShowMenuOnSearch && !showInput) {
+  // Conditionally render the activator button or the input section.
+  if (onlyShowMenuOnSearch) {
     // Mode: Only show menu after typing.
-    const handleActivate = () => {
-      setShowInput(true);
-      setTimeout(() => inputRef.current?.focus(), 0);
-    };
+    if (!showInput) {
+      const handleActivate = () => {
+        setShowInput(true);
+        setTimeout(() => inputRef.current?.focus(), 0);
+      };
 
-    return React.cloneElement(activator, { onClick: handleActivate });
-  } else if (!onlyShowMenuOnSearch && !menuOpen) {
+      return React.cloneElement(activator, { onClick: handleActivate });
+    }
+    // If showInput is true, fall through to render the input section below.
+  } else {
     // Mode: Show menu on focus/click (default).
-    return React.cloneElement(activator, { onClick: handleOpenMenu });
+    if (!menuOpen) {
+      return React.cloneElement(activator, { onClick: handleOpenMenu });
+    }
+    // If menuOpen is true, fall through to render the input section below.
   }
 
+  // If we didn't return an activator above, render the input and potentially the menu.
   const handleInputBlur = () => {
     if (onlyShowMenuOnSearch) {
       // Mode: Only show menu after typing.
+
+      // Capture input value BEFORE calling the hook's blur
+      const valueBeforeBlur = inputRef.current?.value;
+
+      // Allow hook to reset menu state immediately
       handleBlur();
+
       setTimeout(() => {
-        if (inputRef.current?.value === "") {
-          setShowInput(false);
+        // Check the value *as it was when blur occurred*
+        if (valueBeforeBlur === "") {
+          setShowInput(false); // This will trigger rerender with activator
         }
       }, DEBOUNCE_TIME);
     } else {

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -20,7 +20,6 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     isLoadingMore = false,
     onLoadMore,
     options,
-    onlyShowMenuOnSearch = false,
   } = props;
 
   const {
@@ -34,7 +33,7 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     showInput,
     generateDescendantId,
     handleBlur,
-    handleOpenMenu,
+    handleFocus,
     handleSearchChange,
     handleCancelBlur,
     handleEnableBlur,
@@ -90,7 +89,7 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
         onChange={handleSearchChange}
         onKeyDown={handleKeyDown}
         onBlur={() => setTimeout(handleBlur, 200)}
-        onFocus={onlyShowMenuOnSearch ? undefined : handleOpenMenu}
+        onFocus={handleFocus}
         autoFocus={true}
       />
 

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
@@ -12,13 +12,17 @@ export interface ChipDismissibleInputProps
   readonly options: ChipProps[];
   onCustomOptionSelect?(value: string): void;
   onOptionSelect(value: string): void;
+
   /**
    * Control whether the menu only appears once the user types.
    * @default false
    */
   readonly onlyShowMenuOnSearch?: boolean;
+
   /**
    * If true, automatically selects an option based on the current search value when the input loses focus.
+   * The automatic selection order is: an exact match of the search value if available, a custom option if
+   * onCustomOptionSelect is provided, or the closest match.
    * @default false
    */
   readonly submitInputOnFocusShift?: boolean;

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
@@ -12,6 +12,11 @@ export interface ChipDismissibleInputProps
   readonly options: ChipProps[];
   onCustomOptionSelect?(value: string): void;
   onOptionSelect(value: string): void;
+  /**
+   * Control whether the menu only appears once the user types.
+   * @default false
+   */
+  readonly onlyShowMenuOnSearch?: boolean;
 }
 
 export interface ChipDismissibleInputOptionProps extends ChipProps {

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
@@ -17,6 +17,11 @@ export interface ChipDismissibleInputProps
    * @default false
    */
   readonly onlyShowMenuOnSearch?: boolean;
+  /**
+   * Select the last available option when focus shifts away from the input.
+   * @default false
+   */
+  readonly submitInputOnFocusShift?: boolean;
 }
 
 export interface ChipDismissibleInputOptionProps extends ChipProps {

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
@@ -18,7 +18,7 @@ export interface ChipDismissibleInputProps
    */
   readonly onlyShowMenuOnSearch?: boolean;
   /**
-   * Select the last available option when focus shifts away from the input.
+   * If true, automatically selects an option based on the current search value when the input loses focus.
    * @default false
    */
   readonly submitInputOnFocusShift?: boolean;

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
@@ -25,7 +25,7 @@ export interface ChipDismissibleInputProps
    * onCustomOptionSelect is provided, or the closest match.
    * @default false
    */
-  readonly submitInputOnFocusShift?: boolean;
+  readonly autoSelectOnClickOutside?: boolean;
 }
 
 export interface ChipDismissibleInputOptionProps extends ChipProps {

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -1,18 +1,35 @@
 import React from "react";
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 import { InternalChipDismissibleInput } from "../InternalChipDismissibleInput";
 import { ChipProps } from "../../Chip";
 
-const mockIsInView = jest.fn(() => false);
+const initialMockIsInView = jest.fn(() => false);
+
+// Rename variable to follow Jest's allowed pattern
+let mockCurrentIsInView = initialMockIsInView();
+
+// Update function to modify the renamed variable
+const mockSetIsInView = (value: boolean) => {
+  mockCurrentIsInView = value;
+};
+// Create ref outside the mock factory
+const mockRef = React.createRef<HTMLDivElement>();
 
 jest.mock("../hooks/useInView", () => ({
-  useInView: () => ({ isInView: mockIsInView() }),
+  useInView: () => {
+    // Return the external variable (now named mock*) and ref
+    return { ref: mockRef, isInView: mockCurrentIsInView };
+  },
 }));
 
-const handleOptionSelect = jest.fn(value => value);
-const handleCustomOptionSelect = jest.fn(value => value);
-const handleSearch = jest.fn(value => value);
-const handleLoadMore = jest.fn(value => value);
+const handleOptionSelect = jest.fn();
+const handleCustomOptionSelect = jest.fn();
+const handleSearch = jest.fn();
+const handleLoadMore = jest.fn();
+
+// Fix: Create a valid ref object for attachTo
+const mockAttachToRef = React.createRef<HTMLDivElement>();
 
 const optionsArray = ["Amazing", "Fabulous", "Magical"];
 const options: ChipProps[] = optionsArray.map(opt => ({
@@ -20,9 +37,10 @@ const options: ChipProps[] = optionsArray.map(opt => ({
   label: opt,
 }));
 
-const props = {
+const baseProps = {
   options: options,
-  attachTo: { current: undefined },
+  // Fix: Use the created ref
+  attachTo: mockAttachToRef,
   isLoadingMore: false,
   onOptionSelect: handleOptionSelect,
   onCustomOptionSelect: handleCustomOptionSelect,
@@ -37,11 +55,39 @@ let rerender: (
   >,
 ) => void;
 
-beforeEach(async () => {
+// Add a dummy element for attachTo ref
+beforeAll(() => {
+  const dummyElement = document.createElement("div");
+  dummyElement.setAttribute("id", "dummy-attach-to");
+  document.body.appendChild(dummyElement);
+  (mockAttachToRef as React.MutableRefObject<HTMLDivElement>).current =
+    dummyElement;
+});
+
+afterAll(() => {
+  const dummyElement = document.getElementById("dummy-attach-to");
+
+  if (dummyElement) {
+    document.body.removeChild(dummyElement);
+  }
+  (mockAttachToRef as React.MutableRefObject<HTMLDivElement | null>).current =
+    null;
+});
+
+beforeEach(() => {
+  // Reset mocks and state before each test
+  jest.clearAllMocks();
+  mockSetIsInView(false); // Reset isInView state
+
   const { rerender: rerenderComponent } = render(
-    <InternalChipDismissibleInput {...props} />,
+    <InternalChipDismissibleInput {...baseProps} />,
   );
   rerender = rerenderComponent;
+});
+
+// Use fake timers for tests involving debounce/setTimeout
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 describe("Menu closed", () => {
@@ -67,16 +113,19 @@ describe("Menu open", () => {
   });
 
   it("should not show the add button", () => {
-    expect(addButton).not.toBeInTheDocument();
+    // Button role might still exist if input is also a button, query specifically
+    expect(
+      screen.queryByRole("button", { name: "Add" }),
+    ).not.toBeInTheDocument();
   });
 
   it("should show an input and menu", () => {
-    expect(screen.queryByRole("combobox")).toBeInTheDocument();
-    expect(screen.queryByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
   });
 
   it("should focus on the input", () => {
-    expect(screen.queryByRole("combobox")).toHaveFocus();
+    expect(screen.getByRole("combobox")).toHaveFocus();
   });
 
   it("should highlight the first option", () => {
@@ -84,7 +133,9 @@ describe("Menu open", () => {
   });
 
   it("should have a loading spinner", () => {
-    rerender(<InternalChipDismissibleInput {...props} isLoadingMore={true} />);
+    rerender(
+      <InternalChipDismissibleInput {...baseProps} isLoadingMore={true} />,
+    );
     expect(screen.getByRole("alert", { name: "loading" })).toBeInTheDocument();
   });
 });
@@ -96,34 +147,40 @@ describe("Arrow keys", () => {
   });
 
   it("should highlight the next option on arrow down", () => {
-    fireEvent.keyDown(screen.queryByRole("combobox"), { key: "ArrowDown" });
+    // Fix: Use getByRole as combobox should exist
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
     isOptionhighlighted(optionsArray[1]);
   });
 
   it("should highlight the last option on arrow up", () => {
-    fireEvent.keyDown(screen.queryByRole("combobox"), { key: "ArrowUp" });
+    // Fix: Use getByRole
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowUp" });
     isOptionhighlighted(optionsArray[optionsArray.length - 1]);
   });
 
   it("should highlight the first option on arrow down when the last option is highlighted", () => {
+    const input = screen.getByRole("combobox");
     // Ensure last option is highlighted
-    fireEvent.keyDown(screen.queryByRole("combobox"), { key: "ArrowUp" });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
     isOptionhighlighted(optionsArray[optionsArray.length - 1]);
 
-    fireEvent.keyDown(screen.queryByRole("combobox"), { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
     isOptionhighlighted(optionsArray[0]);
   });
 
   it("should not do anything on arrow down when the last option is highlighted and it's loading", () => {
-    rerender(<InternalChipDismissibleInput {...props} isLoadingMore={true} />);
+    rerender(
+      <InternalChipDismissibleInput {...baseProps} isLoadingMore={true} />,
+    );
     expect(screen.getByRole("alert", { name: "loading" })).toBeInTheDocument();
     const highlighted = optionsArray[optionsArray.length - 1];
+    const input = screen.getByRole("combobox");
 
     // Ensure last option is highlighted
-    fireEvent.keyDown(screen.queryByRole("combobox"), { key: "ArrowUp" });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
     isOptionhighlighted(highlighted);
 
-    fireEvent.keyDown(screen.queryByRole("combobox"), { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
     isOptionhighlighted(highlighted);
   });
 });
@@ -135,15 +192,18 @@ describe("Add/delete via keyboard", () => {
   });
 
   it("should add the highlighted option on enter", () => {
-    fireEvent.keyDown(screen.queryByRole("combobox"), { key: "Enter" });
+    // Fix: Use getByRole
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Enter" });
+    // Fix: Expect the value string, not the object
     expect(handleOptionSelect).toHaveBeenCalledWith(optionsArray[0]);
     expect(handleCustomOptionSelect).not.toHaveBeenCalled();
   });
 
   it("should add the highlighted option on tab", () => {
-    const input = screen.queryByRole("combobox");
+    const input = screen.getByRole("combobox");
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Tab" });
+    // Fix: Expect the value string, not the object
     expect(handleOptionSelect).toHaveBeenCalledWith(optionsArray[1]);
     expect(handleCustomOptionSelect).not.toHaveBeenCalled();
   });
@@ -154,7 +214,7 @@ describe("Activator", () => {
   beforeEach(() => {
     rerender(
       <InternalChipDismissibleInput
-        {...props}
+        {...baseProps}
         activator={<div>{activatorLabel}</div>}
       />,
     );
@@ -171,22 +231,227 @@ describe("Activator", () => {
     const target = screen.getByText(activatorLabel);
     expect(target).toBeInTheDocument();
     fireEvent.click(target);
-    expect(screen.queryByRole("combobox")).toBeInTheDocument();
-    expect(screen.queryByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
   });
 });
 
+describe("onLoadMore", () => {
+  it("should call onLoadMore when the trigger element is in view", () => {
+    const addButton = screen.getByRole("button", { name: "Add" });
+    fireEvent.click(addButton);
+
+    // Simulate element coming into view
+    act(() => {
+      mockSetIsInView(true);
+      // Manually rerender after changing the mock value
+      rerender(<InternalChipDismissibleInput {...baseProps} />);
+    });
+
+    expect(handleLoadMore).toHaveBeenCalledTimes(1);
+    expect(handleLoadMore).toHaveBeenCalledWith("");
+
+    // Simulate element going out of view
+    act(() => {
+      mockSetIsInView(false);
+      rerender(<InternalChipDismissibleInput {...baseProps} />);
+    });
+    expect(handleLoadMore).toHaveBeenCalledTimes(1);
+
+    // Simulate coming into view again
+    act(() => {
+      mockSetIsInView(true);
+      rerender(<InternalChipDismissibleInput {...baseProps} />);
+    });
+    expect(handleLoadMore).toHaveBeenCalledTimes(2);
+  });
+
+  it("should call onLoadMore with current search value", () => {
+    const addButton = screen.getByRole("button", { name: "Add" });
+    fireEvent.click(addButton);
+    const input = screen.getByRole("combobox");
+    const searchValue = "test";
+    fireEvent.change(input, { target: { value: searchValue } });
+
+    // Simulate element coming into view AFTER search
+    act(() => {
+      mockSetIsInView(true);
+      // Rerender needed here too
+      rerender(<InternalChipDismissibleInput {...baseProps} />);
+    });
+
+    expect(handleLoadMore).toHaveBeenCalledWith(searchValue);
+  });
+});
+
+describe("Blur Behavior", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Open menu by default
+    const addButton = screen.getByRole("button", { name: "Add" });
+    fireEvent.click(addButton);
+  });
+
+  it("should close the menu after debounce timeout on blur (default mode)", () => {
+    const input = screen.getByRole("combobox");
+    fireEvent.blur(input);
+
+    // Menu should still be open immediately
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(handleOptionSelect).not.toHaveBeenCalled(); // Assuming blur doesn't select
+
+    // Advance timers past the debounce time (DEBOUNCE_TIME = 200)
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    // Now the menu should be closed (assuming handleBlur closes it)
+    // We check if the input is gone, as it implies the component state reset
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    // Check if the activator is back
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  // Simulate clicking on a menu item which also triggers blur
+  it("should select item and close menu if blur happens due to item click (default mode)", () => {
+    const firstOption = screen.getByRole("option", { name: optionsArray[0] });
+
+    // Simulate clicking the option (fires mousedown, mouseup, click) and blurs input
+    // fireEvent.click handles this sequence generally
+    fireEvent.click(firstOption);
+
+    // Option should be selected immediately
+    expect(handleOptionSelect).toHaveBeenCalledWith(optionsArray[0]);
+
+    // Advance timers
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    // Menu and input should be closed/gone now
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});
+
+describe("onlyShowMenuOnSearch", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    rerender(
+      <InternalChipDismissibleInput
+        {...baseProps}
+        onlyShowMenuOnSearch={true}
+      />,
+    );
+  });
+
+  it("should initially show only the activator", () => {
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("should show the input on activator click", () => {
+    const addButton = screen.getByRole("button", { name: "Add" });
+    fireEvent.click(addButton);
+
+    expect(
+      screen.queryByRole("button", { name: "Add" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    // Menu should NOT show until typing
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    // Should focus input after timeout
+    act(() => {
+      jest.advanceTimersByTime(1); // Advance timers slightly for the setTimeout(..., 0)
+    });
+    expect(screen.getByRole("combobox")).toHaveFocus();
+  });
+
+  it("should show the menu only when typing", () => {
+    const addButton = screen.getByRole("button", { name: "Add" });
+    fireEvent.click(addButton);
+    const input = screen.getByRole("combobox");
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "A" } });
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("should hide input on blur if empty", () => {
+    const addButton = screen.getByRole("button", { name: "Add" });
+    fireEvent.click(addButton);
+    const input = screen.getByRole("combobox");
+
+    // Blur the input while it's empty
+    fireEvent.blur(input);
+
+    // Input should still be there immediately
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+
+    // Advance timers
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    // Input should be gone, activator should be back
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  it("should NOT hide input on blur if not empty", () => {
+    const addButton = screen.getByRole("button", { name: "Add" });
+    fireEvent.click(addButton);
+    const input = screen.getByRole("combobox");
+
+    // Type something
+    fireEvent.change(input, { target: { value: "test" } });
+
+    // Blur the input
+    fireEvent.blur(input);
+
+    // Input should still be there immediately
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+
+    // Advance timers
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    // Input should still be there
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// Helper function
 function isOptionhighlighted(highlighted: string) {
   const activeClass = "activeOption";
-  expect(screen.getByRole("option", { name: highlighted })).toHaveClass(
-    activeClass,
-  );
+  const option = screen.getByRole("option", { name: highlighted });
+  expect(option).toHaveClass(activeClass);
+
+  // Fix: Check aria-activedescendant on the combobox input
+  const input = screen.getByRole("combobox");
+  expect(input).toHaveAttribute("aria-activedescendant", option.id);
 
   optionsArray
     .filter(opt => opt !== highlighted)
-    .map(opt => {
-      expect(screen.getByRole("option", { name: opt })).not.toHaveClass(
-        activeClass,
+    .forEach(opt => {
+      const otherOption = screen.getByRole("option", { name: opt });
+      expect(otherOption).not.toHaveClass(activeClass);
+      // Check that aria-selected is not true or is absent (Removed the check entirely as it's not used)
+      // expect(otherOption).not.toHaveAttribute("aria-selected", "true");
+      // Check that the input's active descendant is not this option's ID
+      expect(input.getAttribute("aria-activedescendant")).not.toBe(
+        otherOption.id,
       );
     });
 }

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -581,6 +581,30 @@ describe("onlyShowMenuOnSearch", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
   });
+
+  it("should close the menu on option selection", () => {
+    const addButton = screen.getByRole("button", { name: "Add" });
+    fireEvent.click(addButton);
+    const input = screen.getByRole("combobox");
+
+    fireEvent.change(input, { target: { value: "A" } });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    const firstOption = screen.getByRole("option", { name: optionsArray[0] });
+    fireEvent.click(firstOption);
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add" }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 function isOptionhighlighted(highlighted: string) {

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -391,13 +391,13 @@ describe("Default Blur Behavior", () => {
   });
 });
 
-describe("submitInputOnFocusShift", () => {
+describe("autoSelectOnClickOutside", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     rerender(
       <InternalChipDismissibleInput
         {...props}
-        submitInputOnFocusShift={true}
+        autoSelectOnClickOutside={true}
       />,
     );
     const addButton = screen.getByRole("button", { name: "Add" });
@@ -444,7 +444,7 @@ describe("submitInputOnFocusShift", () => {
   });
 });
 
-describe("submitInputOnFocusShift without onCustomOptionSelect", () => {
+describe("autoSelectOnClickOutside without onCustomOptionSelect", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     cleanup();
@@ -452,7 +452,7 @@ describe("submitInputOnFocusShift without onCustomOptionSelect", () => {
       <InternalChipDismissibleInput
         {...props}
         onCustomOptionSelect={undefined}
-        submitInputOnFocusShift={true}
+        autoSelectOnClickOutside={true}
       />,
     );
     const addButton = screen.getByRole("button", { name: "Add" });

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -397,7 +397,7 @@ describe("onlyShowMenuOnSearch", () => {
     expect(screen.getByRole("combobox")).toHaveFocus();
   });
 
-  it("should update input value, but not show menu immediately on type", () => {
+  it("should update input value, and eventually show menu on type", () => {
     const addButton = screen.getByRole("button", { name: "Add" });
     fireEvent.click(addButton);
     const input = screen.getByRole("combobox");
@@ -408,6 +408,12 @@ describe("onlyShowMenuOnSearch", () => {
 
     expect(input).toHaveValue(searchValue);
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
   });
 
   it("should clear input value and keep menu hidden on clear", () => {

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -335,7 +335,7 @@ describe("Default Blur Behavior", () => {
     jest.useRealTimers();
   });
 
-  it("should hide input on blur if empty", () => {
+  it("should hide input and menu on blur", () => {
     const input = screen.getByRole("combobox");
     expect(input).toHaveValue("");
     fireEvent.blur(input);
@@ -350,26 +350,6 @@ describe("Default Blur Behavior", () => {
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
-  });
-
-  it("should close the menu but keep input on blur (non-empty input)", () => {
-    const input = screen.getByRole("combobox");
-    const searchValue = "test";
-    fireEvent.change(input, { target: { value: searchValue } });
-    expect(input).toHaveValue(searchValue);
-    fireEvent.blur(input);
-
-    expect(screen.getByRole("listbox")).toBeInTheDocument();
-
-    act(() => {
-      jest.runOnlyPendingTimers();
-    });
-
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
-    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Add" }),
-    ).not.toBeInTheDocument();
   });
 
   it("should select item and keep input focused if blur happens due to item click", () => {
@@ -443,7 +423,7 @@ describe("onlyShowMenuOnSearch", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
-  it("should hide input on blur if empty", () => {
+  it("should hide input on blur", () => {
     const addButton = screen.getByRole("button", { name: "Add" });
     fireEvent.click(addButton);
     const input = screen.getByRole("combobox");
@@ -460,26 +440,6 @@ describe("onlyShowMenuOnSearch", () => {
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
-  });
-
-  it("should not hide input on blur if not empty", () => {
-    const addButton = screen.getByRole("button", { name: "Add" });
-    fireEvent.click(addButton);
-    const input = screen.getByRole("combobox");
-
-    fireEvent.change(input, { target: { value: "test" } });
-    fireEvent.blur(input);
-
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
-
-    act(() => {
-      jest.runOnlyPendingTimers();
-    });
-
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Add" }),
-    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -207,10 +207,8 @@ describe("Add/delete via keyboard", () => {
     const newValue = "Brand New Option";
     fireEvent.change(input, { target: { value: newValue } });
 
-    // Wait for debounce that updates options/state based on search
     act(() => {
-      // jest.advanceTimersByTime(300);
-      jest.runOnlyPendingTimers(); // Run the search debounce timer
+      jest.runOnlyPendingTimers();
     });
 
     fireEvent.keyDown(input, { key: "Enter" });

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -218,24 +218,20 @@ describe("onLoadMore", () => {
     const addButton = screen.getByRole("button", { name: "Add" });
     fireEvent.click(addButton);
 
-    // Simulate element coming into view
     act(() => {
       mockSetIsInView(true);
-      // Manually rerender after changing the mock value
       rerender(<InternalChipDismissibleInput {...props} />);
     });
 
     expect(handleLoadMore).toHaveBeenCalledTimes(1);
     expect(handleLoadMore).toHaveBeenCalledWith("");
 
-    // Simulate element going out of view
     act(() => {
       mockSetIsInView(false);
       rerender(<InternalChipDismissibleInput {...props} />);
     });
     expect(handleLoadMore).toHaveBeenCalledTimes(1);
 
-    // Simulate coming into view again
     act(() => {
       mockSetIsInView(true);
       rerender(<InternalChipDismissibleInput {...props} />);
@@ -250,7 +246,6 @@ describe("onLoadMore", () => {
     const searchValue = "test";
     fireEvent.change(input, { target: { value: searchValue } });
 
-    // Simulate element coming into view after search
     act(() => {
       mockSetIsInView(true);
       rerender(<InternalChipDismissibleInput {...props} />);
@@ -285,7 +280,6 @@ describe("Default Blur Behavior", () => {
     expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
   });
 
-  // Simulate clicking on a menu item which also triggers blur
   it("should select item and close menu if blur happens due to item click", () => {
     const firstOption = screen.getByRole("option", { name: optionsArray[0] });
     fireEvent.click(firstOption);
@@ -351,7 +345,6 @@ describe("onlyShowMenuOnSearch", () => {
     fireEvent.click(addButton);
     const input = screen.getByRole("combobox");
 
-    // Blur the input while it's empty
     fireEvent.blur(input);
 
     // Input should still be there immediately

--- a/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/__tests__/InternalChipDismissibleInput.test.tsx
@@ -194,14 +194,6 @@ describe("Add/delete via keyboard", () => {
     expect(handleCustomOptionSelect).not.toHaveBeenCalled();
   });
 
-  it("should add the highlighted option on tab", () => {
-    const input = screen.getByRole("combobox");
-    fireEvent.keyDown(input, { key: "ArrowDown" });
-    fireEvent.keyDown(input, { key: "Tab" });
-    expect(handleOptionSelect).toHaveBeenCalledWith(optionsArray[1]);
-    expect(handleCustomOptionSelect).not.toHaveBeenCalled();
-  });
-
   it("should call onCustomOptionSelect on enter when search value is new", () => {
     const input = screen.getByRole("combobox");
     const newValue = "Brand New Option";
@@ -212,6 +204,29 @@ describe("Add/delete via keyboard", () => {
     });
 
     fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(handleCustomOptionSelect).toHaveBeenCalledWith(newValue);
+    expect(handleOptionSelect).not.toHaveBeenCalled();
+  });
+
+  it("should add the highlighted option on tab", () => {
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Tab" });
+    expect(handleOptionSelect).toHaveBeenCalledWith(optionsArray[1]);
+    expect(handleCustomOptionSelect).not.toHaveBeenCalled();
+  });
+
+  it("should add the current input as a custom option on comma", () => {
+    const input = screen.getByRole("combobox");
+    const newValue = "Comma Option";
+    fireEvent.change(input, { target: { value: newValue } });
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    fireEvent.keyDown(input, { key: "," });
 
     expect(handleCustomOptionSelect).toHaveBeenCalledWith(newValue);
     expect(handleOptionSelect).not.toHaveBeenCalled();

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
@@ -25,298 +25,214 @@ function setupHook(params?: Partial<typeof hookParams>) {
   return result;
 }
 
-beforeEach(() => {
-  jest.clearAllMocks();
-  jest.useFakeTimers();
+describe("handleReset", () => {
+  it("should reset active index and search value", () => {
+    const result = setupHook();
+
+    // set the value to no  default
+    const initialValue = "I am here!";
+    act(() => {
+      result.current.handleSearchChange(fakeChangeEvent(initialValue));
+      result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+    });
+    expect(result.current.searchValue).toBe(initialValue);
+    expect(result.current.activeIndex).toBe(1);
+
+    act(() => result.current.handleReset());
+    expect(result.current.activeIndex).toBe(0);
+    expect(result.current.searchValue).toBe("");
+  });
 });
 
-afterEach(() => {
-  jest.useRealTimers();
+describe("handleOpenMenu", () => {
+  it("should reset active index and close the menu", () => {
+    const result = setupHook();
+    expect(result.current.menuOpen).toBe(false);
+
+    act(() => result.current.handleOpenMenu());
+    expect(result.current.menuOpen).toBe(true);
+  });
 });
 
-describe("useInternalChipDismissibleInput", () => {
-  describe("handleReset", () => {
-    it("should reset active index and search value", () => {
-      const result = setupHook();
-      const initialValue = "I am here!";
+describe("handleCloseMenu", () => {
+  it("should reset active index and close the menu", () => {
+    const result = setupHook();
+    expect(result.current.menuOpen).toBe(false);
+    expect(result.current.activeIndex).toBe(0);
 
-      act(() => {
-        result.current.handleSearchChange(fakeChangeEvent(initialValue));
-        result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
-      });
-
-      expect(result.current.searchValue).toBe(initialValue);
-      expect(result.current.activeIndex).toBe(1);
-
-      act(() => result.current.handleReset());
-      expect(result.current.activeIndex).toBe(0);
-      expect(result.current.searchValue).toBe("");
+    act(() => {
+      result.current.handleOpenMenu();
+      result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
     });
+    expect(result.current.menuOpen).toBe(true);
+    expect(result.current.activeIndex).toBe(1);
+
+    act(() => result.current.handleCloseMenu());
+    expect(result.current.menuOpen).toBe(false);
+    expect(result.current.activeIndex).toBe(0);
+  });
+});
+
+describe("handleBlur", () => {
+  it("should allow blur", () => {
+    const result = setupHook();
+
+    act(() => {
+      result.current.handleOpenMenu();
+      result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+    });
+    expect(result.current.menuOpen).toBe(true);
+    expect(result.current.activeIndex).toBe(1);
+
+    act(() => result.current.handleBlur());
+    expect(result.current.menuOpen).toBe(false);
+    expect(result.current.activeIndex).toBe(0);
   });
 
-  describe("menu controls", () => {
-    it("handleOpenMenu should open the menu", () => {
-      const result = setupHook();
-      expect(result.current.menuOpen).toBe(false);
+  it("should not reset the menu open and active index when blurring is disabled", () => {
+    const result = setupHook();
 
-      act(() => result.current.handleOpenMenu());
-      expect(result.current.menuOpen).toBe(true);
+    act(() => {
+      result.current.handleOpenMenu();
+      result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
     });
+    act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
+    expect(result.current.menuOpen).toBe(true);
+    expect(result.current.activeIndex).toBe(2);
 
-    it("handleCloseMenu should reset active index and close the menu", () => {
-      const result = setupHook();
-      act(() => {
-        result.current.handleOpenMenu();
-        result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
-      });
+    act(() => result.current.handleCancelBlur());
+    act(() => result.current.handleBlur());
+    expect(result.current.shouldCancelBlur).toBe(true);
+    expect(result.current.menuOpen).toBe(true);
+    expect(result.current.activeIndex).toBe(2);
+  });
+});
 
-      expect(result.current.menuOpen).toBe(true);
-      expect(result.current.activeIndex).toBe(1);
+describe("setSearchValue", () => {
+  it("should set the searchValue", () => {
+    const result = setupHook();
 
-      act(() => result.current.handleCloseMenu());
-      expect(result.current.menuOpen).toBe(false);
-      expect(result.current.activeIndex).toBe(0);
-    });
+    const value = "🍩";
+    act(() => result.current.handleSearchChange(fakeChangeEvent(value)));
+    expect(result.current.searchValue).toBe(value);
   });
 
-  describe("handleBlur", () => {
-    it("should allow blur", () => {
-      const result = setupHook();
-      act(() => {
-        result.current.handleOpenMenu();
-        result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
-      });
+  it("should reset the active index on search", () => {
+    const result = setupHook();
 
-      act(() => result.current.handleBlur());
-      expect(result.current.menuOpen).toBe(false);
-      expect(result.current.activeIndex).toBe(0);
-    });
+    act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
+    expect(result.current.activeIndex).toBe(1);
 
-    it("should not reset menu state if shouldCancelBlur is true", () => {
-      const result = setupHook();
+    act(() => result.current.handleSearchChange(fakeChangeEvent("🍩")));
+    expect(result.current.activeIndex).toBe(0);
+  });
+});
 
-      act(() => {
-        result.current.handleOpenMenu();
-        result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
-        result.current.handleCancelBlur();
-      });
-
-      act(() => result.current.handleBlur());
-
-      expect(result.current.shouldCancelBlur).toBe(true);
-      expect(result.current.menuOpen).toBe(true);
-      expect(result.current.activeIndex).toBe(1);
-    });
-
-    it("should allow enabling blur again", () => {
-      const result = setupHook();
-      act(() => {
-        result.current.handleCancelBlur();
-        result.current.handleEnableBlur();
-      });
-
-      expect(result.current.shouldCancelBlur).toBe(false);
-    });
-
-    it("should select fallback option if submitInputOnFocusShift is true", () => {
-      const result = setupHook({
-        submitInputOnFocusShift: true,
-      });
-
-      act(() => result.current.handleSearchChange(fakeChangeEvent("Mag")));
-      act(() => result.current.handleBlur());
-
-      expect(handleOptionSelect).toHaveBeenCalledWith("Magical");
-    });
-
-    it("should select custom option if submitInputOnFocusShift and custom option is enabled", () => {
-      const result = setupHook({
-        submitInputOnFocusShift: true,
-      });
-
-      const value = "Mystical";
-
-      act(() => {
-        result.current.handleSearchChange(fakeChangeEvent(value));
-      });
-
-      act(() => {
-        result.current.handleDebouncedSearch(value, []);
-        jest.runAllTimers();
-      });
-
-      act(() => {
-        result.current.handleBlur();
-      });
-
-      expect(handleCustomOptionSelect).toHaveBeenCalledWith(value);
-    });
+describe("handleSetActiveOnMouseOver", () => {
+  it("should return a function", () => {
+    const result = setupHook();
+    expect(result.current.handleSetActiveOnMouseOver(2)).toEqual(
+      expect.any(Function),
+    );
   });
 
-  describe("handleSearchChange", () => {
-    it("should update the searchValue and reset index", () => {
-      const result = setupHook();
+  it("should update the active index", () => {
+    const result = setupHook();
+    result.current.handleSetActiveOnMouseOver(2)();
+    expect(result.current.activeIndex).toEqual(2);
+  });
+});
 
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
-      expect(result.current.activeIndex).toBe(1);
-
-      act(() => result.current.handleSearchChange(fakeChangeEvent("🍩")));
-      expect(result.current.searchValue).toBe("🍩");
-      expect(result.current.activeIndex).toBe(0);
-    });
-
-    it("should toggle menu open state with onlyShowMenuOnSearch", () => {
-      const result = setupHook({ onlyShowMenuOnSearch: true });
-
-      act(() => result.current.handleSearchChange(fakeChangeEvent("Hello")));
-      expect(result.current.menuOpen).toBe(true);
-
-      act(() => result.current.handleSearchChange(fakeChangeEvent("")));
-      expect(result.current.menuOpen).toBe(false);
-    });
+describe("Selecting an option", () => {
+  it("should only trigger the onOptionSelect callback when the value is from the option provided", () => {
+    const result = setupHook();
+    const selectedOption = result.current.allOptions[2];
+    expect(selectedOption.custom).toBe(false);
+    act(() => result.current.handleSelectOption(selectedOption));
+    expect(handleOptionSelect).toHaveBeenCalledWith(selectedOption.value);
+    expect(handleCustomOptionSelect).not.toHaveBeenCalled();
   });
 
-  describe("handleSetActiveOnMouseOver", () => {
-    it("should set active index", () => {
-      const result = setupHook();
-      act(() => result.current.handleSetActiveOnMouseOver(2)());
-      expect(result.current.activeIndex).toBe(2);
-    });
+  it("should only trigger the onCustomOptionSelect callback when the value is custom", () => {
+    const result = setupHook();
+
+    const value = "🍩";
+    const selectedOption = { label: value, value, custom: true };
+    act(() => result.current.handleSelectOption(selectedOption));
+    expect(handleCustomOptionSelect).toHaveBeenCalledWith(selectedOption.value);
+    expect(handleCustomOptionSelect).toHaveBeenCalledWith(value);
+    expect(handleOptionSelect).not.toHaveBeenCalled();
   });
 
-  describe("handleSelectOption", () => {
-    it("should call onOptionSelect", () => {
-      const result = setupHook();
-      const option = result.current.allOptions[1];
-
-      act(() => result.current.handleSelectOption(option));
-      expect(handleOptionSelect).toHaveBeenCalledWith(option.value);
-    });
-
-    it("should call onCustomOptionSelect", () => {
-      const result = setupHook();
-      const option = {
-        value: "🍩",
-        label: "🍩",
-        custom: true,
-        prefix: undefined,
-      };
-
-      act(() => result.current.handleSelectOption(option));
-      expect(handleCustomOptionSelect).toHaveBeenCalledWith("🍩");
-    });
-
-    it("should do nothing if no options exist", () => {
-      const result = setupHook({ options: [] });
-
-      act(() =>
-        result.current.handleSelectOption({
-          label: "Ghost",
-          value: "Ghost",
-          custom: false,
-        }),
-      );
-
-      expect(handleOptionSelect).not.toHaveBeenCalled();
-    });
+  it("should not do anything when you press enter and there's no search value nor options to select", () => {
+    const result = setupHook({ options: [] });
+    act(() => result.current.handleKeyDown(fakeKeyDownEvent("Enter")));
+    expect(handleOptionSelect).not.toHaveBeenCalled();
+    expect(handleCustomOptionSelect).not.toHaveBeenCalled();
   });
 
   describe("handleKeyDown", () => {
-    it("should ignore if shift key is pressed", () => {
+    it("should select the first option on 'Enter'", () => {
       const result = setupHook();
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("Enter")));
+      expect(handleOptionSelect).toHaveBeenCalledWith(chips[0]);
+    });
 
-      const event = {
-        key: "Enter",
-        preventDefault: jest.fn(),
-        shiftKey: true,
-      } as unknown as KeyboardEvent<HTMLInputElement>;
+    it("should select the active option on 'Tab'", () => {
+      const result = setupHook();
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("Tab")));
+      expect(handleOptionSelect).toHaveBeenCalledWith(chips[1]);
+    });
 
-      act(() => result.current.handleKeyDown(event));
+    it("should add the typed text on 'Comma'", () => {
+      const result = setupHook();
+      const value = "Marvelous";
+      act(() => result.current.handleSearchChange(fakeChangeEvent(value)));
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent(",")));
+      expect(handleCustomOptionSelect).toHaveBeenCalledWith(value);
       expect(handleOptionSelect).not.toHaveBeenCalled();
     });
 
-    it("should handle Enter, Tab, Comma, ArrowDown, ArrowUp", () => {
+    it("should not add an empty string 'Comma'", () => {
       const result = setupHook();
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent(",")));
+      expect(handleCustomOptionSelect).not.toHaveBeenCalled();
+      expect(handleOptionSelect).not.toHaveBeenCalled();
+    });
 
+    it("should increment the active index by one on 'ArrowDown'", () => {
+      const result = setupHook();
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
+      expect(result.current.activeIndex).toBe(1);
+
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
+      expect(result.current.activeIndex).toBe(2);
+    });
+
+    it("should decrement the active index by one on 'ArrowUp'", () => {
+      const result = setupHook();
       act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
       expect(result.current.activeIndex).toBe(1);
 
       act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowUp")));
       expect(result.current.activeIndex).toBe(0);
+    });
 
+    it("should go to the last index when the active index is at 0 and you press 'ArrowUp'", () => {
+      const result = setupHook();
+      expect(result.current.activeIndex).toBe(0);
       act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowUp")));
       expect(result.current.activeIndex).toBe(chips.length - 1);
+    });
 
+    it("should go to the first index when the active index is at the last option and you press 'ArrowDown'", () => {
+      const result = setupHook();
+      expect(result.current.activeIndex).toBe(0);
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowUp")));
+      expect(result.current.activeIndex).toBe(chips.length - 1);
       act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
       expect(result.current.activeIndex).toBe(0);
-
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("Enter")));
-      expect(handleOptionSelect).toHaveBeenCalledWith(chips[0]);
-
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("Tab")));
-      expect(handleOptionSelect).toHaveBeenCalledWith(chips[0]);
-
-      const value = "Xylophonic";
-
-      act(() => {
-        result.current.handleSearchChange(fakeChangeEvent(value));
-      });
-
-      act(() => {
-        result.current.handleDebouncedSearch(value, []);
-        jest.runAllTimers();
-      });
-
-      act(() => {
-        result.current.handleKeyDown(fakeKeyDownEvent(","));
-      });
-
-      expect(handleCustomOptionSelect).toHaveBeenCalledWith(value);
-
-      act(() => result.current.handleSearchChange(fakeChangeEvent("")));
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent(",")));
-      expect(handleCustomOptionSelect).toHaveBeenCalledTimes(1);
-    });
-
-    it("should focus previous element on Backspace when empty", () => {
-      const result = setupHook();
-
-      const sibling = document.createElement("button");
-      sibling.focus = jest.fn();
-
-      const input = document.createElement("input");
-      Object.defineProperty(input, "previousElementSibling", {
-        value: sibling,
-      });
-
-      result.current.inputRef.current = input;
-
-      act(() => result.current.handleSearchChange(fakeChangeEvent("")));
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("Backspace")));
-
-      expect(sibling.focus).toHaveBeenCalled();
-    });
-  });
-
-  describe("generateDescendantId", () => {
-    it("should return a valid id", () => {
-      const result = setupHook();
-      const id = result.current.generateDescendantId(3);
-      expect(id).toBe(`${result.current.menuId}-3`);
-    });
-  });
-
-  describe("handleDebouncedSearch", () => {
-    it("should debounce and update options", () => {
-      const result = setupHook();
-      act(() => {
-        result.current.handleDebouncedSearch("Magical", hookParams.options);
-      });
-      act(() => {
-        jest.runAllTimers();
-      });
-      expect(result.current.allOptions.length).toBe(1);
-      expect(result.current.allOptions[0].label).toBe("Magical");
     });
   });
 });
@@ -330,7 +246,6 @@ function fakeChangeEvent(initialValue: string) {
 function fakeKeyDownEvent(key: string) {
   return {
     key: key,
-    preventDefault: jest.fn(),
-    shiftKey: false,
+    preventDefault: jest.fn,
   } as unknown as KeyboardEvent<HTMLInputElement>;
 }

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
@@ -25,214 +25,298 @@ function setupHook(params?: Partial<typeof hookParams>) {
   return result;
 }
 
-describe("handleReset", () => {
-  it("should reset active index and search value", () => {
-    const result = setupHook();
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
 
-    // set the value to no  default
-    const initialValue = "I am here!";
-    act(() => {
-      result.current.handleSearchChange(fakeChangeEvent(initialValue));
-      result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("useInternalChipDismissibleInput", () => {
+  describe("handleReset", () => {
+    it("should reset active index and search value", () => {
+      const result = setupHook();
+      const initialValue = "I am here!";
+
+      act(() => {
+        result.current.handleSearchChange(fakeChangeEvent(initialValue));
+        result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+      });
+
+      expect(result.current.searchValue).toBe(initialValue);
+      expect(result.current.activeIndex).toBe(1);
+
+      act(() => result.current.handleReset());
+      expect(result.current.activeIndex).toBe(0);
+      expect(result.current.searchValue).toBe("");
     });
-    expect(result.current.searchValue).toBe(initialValue);
-    expect(result.current.activeIndex).toBe(1);
-
-    act(() => result.current.handleReset());
-    expect(result.current.activeIndex).toBe(0);
-    expect(result.current.searchValue).toBe("");
   });
-});
 
-describe("handleOpenMenu", () => {
-  it("should reset active index and close the menu", () => {
-    const result = setupHook();
-    expect(result.current.menuOpen).toBe(false);
+  describe("menu controls", () => {
+    it("handleOpenMenu should open the menu", () => {
+      const result = setupHook();
+      expect(result.current.menuOpen).toBe(false);
 
-    act(() => result.current.handleOpenMenu());
-    expect(result.current.menuOpen).toBe(true);
-  });
-});
-
-describe("handleCloseMenu", () => {
-  it("should reset active index and close the menu", () => {
-    const result = setupHook();
-    expect(result.current.menuOpen).toBe(false);
-    expect(result.current.activeIndex).toBe(0);
-
-    act(() => {
-      result.current.handleOpenMenu();
-      result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+      act(() => result.current.handleOpenMenu());
+      expect(result.current.menuOpen).toBe(true);
     });
-    expect(result.current.menuOpen).toBe(true);
-    expect(result.current.activeIndex).toBe(1);
 
-    act(() => result.current.handleCloseMenu());
-    expect(result.current.menuOpen).toBe(false);
-    expect(result.current.activeIndex).toBe(0);
-  });
-});
+    it("handleCloseMenu should reset active index and close the menu", () => {
+      const result = setupHook();
+      act(() => {
+        result.current.handleOpenMenu();
+        result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+      });
 
-describe("handleBlur", () => {
-  it("should allow blur", () => {
-    const result = setupHook();
+      expect(result.current.menuOpen).toBe(true);
+      expect(result.current.activeIndex).toBe(1);
 
-    act(() => {
-      result.current.handleOpenMenu();
-      result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+      act(() => result.current.handleCloseMenu());
+      expect(result.current.menuOpen).toBe(false);
+      expect(result.current.activeIndex).toBe(0);
     });
-    expect(result.current.menuOpen).toBe(true);
-    expect(result.current.activeIndex).toBe(1);
-
-    act(() => result.current.handleBlur());
-    expect(result.current.menuOpen).toBe(false);
-    expect(result.current.activeIndex).toBe(0);
   });
 
-  it("should not reset the menu open and active index when blurring is disabled", () => {
-    const result = setupHook();
+  describe("handleBlur", () => {
+    it("should allow blur", () => {
+      const result = setupHook();
+      act(() => {
+        result.current.handleOpenMenu();
+        result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+      });
 
-    act(() => {
-      result.current.handleOpenMenu();
-      result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+      act(() => result.current.handleBlur());
+      expect(result.current.menuOpen).toBe(false);
+      expect(result.current.activeIndex).toBe(0);
     });
-    act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
-    expect(result.current.menuOpen).toBe(true);
-    expect(result.current.activeIndex).toBe(2);
 
-    act(() => result.current.handleCancelBlur());
-    act(() => result.current.handleBlur());
-    expect(result.current.shouldCancelBlur).toBe(true);
-    expect(result.current.menuOpen).toBe(true);
-    expect(result.current.activeIndex).toBe(2);
-  });
-});
+    it("should not reset menu state if shouldCancelBlur is true", () => {
+      const result = setupHook();
 
-describe("setSearchValue", () => {
-  it("should set the searchValue", () => {
-    const result = setupHook();
+      act(() => {
+        result.current.handleOpenMenu();
+        result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown"));
+        result.current.handleCancelBlur();
+      });
 
-    const value = "🍩";
-    act(() => result.current.handleSearchChange(fakeChangeEvent(value)));
-    expect(result.current.searchValue).toBe(value);
-  });
+      act(() => result.current.handleBlur());
 
-  it("should reset the active index on search", () => {
-    const result = setupHook();
+      expect(result.current.shouldCancelBlur).toBe(true);
+      expect(result.current.menuOpen).toBe(true);
+      expect(result.current.activeIndex).toBe(1);
+    });
 
-    act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
-    expect(result.current.activeIndex).toBe(1);
+    it("should allow enabling blur again", () => {
+      const result = setupHook();
+      act(() => {
+        result.current.handleCancelBlur();
+        result.current.handleEnableBlur();
+      });
 
-    act(() => result.current.handleSearchChange(fakeChangeEvent("🍩")));
-    expect(result.current.activeIndex).toBe(0);
-  });
-});
+      expect(result.current.shouldCancelBlur).toBe(false);
+    });
 
-describe("handleSetActiveOnMouseOver", () => {
-  it("should return a function", () => {
-    const result = setupHook();
-    expect(result.current.handleSetActiveOnMouseOver(2)).toEqual(
-      expect.any(Function),
-    );
-  });
+    it("should select fallback option if submitInputOnFocusShift is true", () => {
+      const result = setupHook({
+        submitInputOnFocusShift: true,
+      });
 
-  it("should update the active index", () => {
-    const result = setupHook();
-    result.current.handleSetActiveOnMouseOver(2)();
-    expect(result.current.activeIndex).toEqual(2);
-  });
-});
+      act(() => result.current.handleSearchChange(fakeChangeEvent("Mag")));
+      act(() => result.current.handleBlur());
 
-describe("Selecting an option", () => {
-  it("should only trigger the onOptionSelect callback when the value is from the option provided", () => {
-    const result = setupHook();
-    const selectedOption = result.current.allOptions[2];
-    expect(selectedOption.custom).toBe(false);
-    act(() => result.current.handleSelectOption(selectedOption));
-    expect(handleOptionSelect).toHaveBeenCalledWith(selectedOption.value);
-    expect(handleCustomOptionSelect).not.toHaveBeenCalled();
-  });
+      expect(handleOptionSelect).toHaveBeenCalledWith("Magical");
+    });
 
-  it("should only trigger the onCustomOptionSelect callback when the value is custom", () => {
-    const result = setupHook();
+    it("should select custom option if submitInputOnFocusShift and custom option is enabled", () => {
+      const result = setupHook({
+        submitInputOnFocusShift: true,
+      });
 
-    const value = "🍩";
-    const selectedOption = { label: value, value, custom: true };
-    act(() => result.current.handleSelectOption(selectedOption));
-    expect(handleCustomOptionSelect).toHaveBeenCalledWith(selectedOption.value);
-    expect(handleCustomOptionSelect).toHaveBeenCalledWith(value);
-    expect(handleOptionSelect).not.toHaveBeenCalled();
+      const value = "Mystical";
+
+      act(() => {
+        result.current.handleSearchChange(fakeChangeEvent(value));
+      });
+
+      act(() => {
+        result.current.handleDebouncedSearch(value, []);
+        jest.runAllTimers();
+      });
+
+      act(() => {
+        result.current.handleBlur();
+      });
+
+      expect(handleCustomOptionSelect).toHaveBeenCalledWith(value);
+    });
   });
 
-  it("should not do anything when you press enter and there's no search value nor options to select", () => {
-    const result = setupHook({ options: [] });
-    act(() => result.current.handleKeyDown(fakeKeyDownEvent("Enter")));
-    expect(handleOptionSelect).not.toHaveBeenCalled();
-    expect(handleCustomOptionSelect).not.toHaveBeenCalled();
+  describe("handleSearchChange", () => {
+    it("should update the searchValue and reset index", () => {
+      const result = setupHook();
+
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
+      expect(result.current.activeIndex).toBe(1);
+
+      act(() => result.current.handleSearchChange(fakeChangeEvent("🍩")));
+      expect(result.current.searchValue).toBe("🍩");
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it("should toggle menu open state with onlyShowMenuOnSearch", () => {
+      const result = setupHook({ onlyShowMenuOnSearch: true });
+
+      act(() => result.current.handleSearchChange(fakeChangeEvent("Hello")));
+      expect(result.current.menuOpen).toBe(true);
+
+      act(() => result.current.handleSearchChange(fakeChangeEvent("")));
+      expect(result.current.menuOpen).toBe(false);
+    });
+  });
+
+  describe("handleSetActiveOnMouseOver", () => {
+    it("should set active index", () => {
+      const result = setupHook();
+      act(() => result.current.handleSetActiveOnMouseOver(2)());
+      expect(result.current.activeIndex).toBe(2);
+    });
+  });
+
+  describe("handleSelectOption", () => {
+    it("should call onOptionSelect", () => {
+      const result = setupHook();
+      const option = result.current.allOptions[1];
+
+      act(() => result.current.handleSelectOption(option));
+      expect(handleOptionSelect).toHaveBeenCalledWith(option.value);
+    });
+
+    it("should call onCustomOptionSelect", () => {
+      const result = setupHook();
+      const option = {
+        value: "🍩",
+        label: "🍩",
+        custom: true,
+        prefix: undefined,
+      };
+
+      act(() => result.current.handleSelectOption(option));
+      expect(handleCustomOptionSelect).toHaveBeenCalledWith("🍩");
+    });
+
+    it("should do nothing if no options exist", () => {
+      const result = setupHook({ options: [] });
+
+      act(() =>
+        result.current.handleSelectOption({
+          label: "Ghost",
+          value: "Ghost",
+          custom: false,
+        }),
+      );
+
+      expect(handleOptionSelect).not.toHaveBeenCalled();
+    });
   });
 
   describe("handleKeyDown", () => {
-    it("should select the first option on 'Enter'", () => {
+    it("should ignore if shift key is pressed", () => {
       const result = setupHook();
+
+      const event = {
+        key: "Enter",
+        preventDefault: jest.fn(),
+        shiftKey: true,
+      } as unknown as KeyboardEvent<HTMLInputElement>;
+
+      act(() => result.current.handleKeyDown(event));
+      expect(handleOptionSelect).not.toHaveBeenCalled();
+    });
+
+    it("should handle Enter, Tab, Comma, ArrowDown, ArrowUp", () => {
+      const result = setupHook();
+
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
+      expect(result.current.activeIndex).toBe(1);
+
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowUp")));
+      expect(result.current.activeIndex).toBe(0);
+
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowUp")));
+      expect(result.current.activeIndex).toBe(chips.length - 1);
+
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
+      expect(result.current.activeIndex).toBe(0);
+
       act(() => result.current.handleKeyDown(fakeKeyDownEvent("Enter")));
       expect(handleOptionSelect).toHaveBeenCalledWith(chips[0]);
-    });
 
-    it("should select the active option on 'Tab'", () => {
-      const result = setupHook();
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
       act(() => result.current.handleKeyDown(fakeKeyDownEvent("Tab")));
-      expect(handleOptionSelect).toHaveBeenCalledWith(chips[1]);
-    });
+      expect(handleOptionSelect).toHaveBeenCalledWith(chips[0]);
 
-    it("should add the typed text on 'Comma'", () => {
-      const result = setupHook();
-      const value = "Marvelous";
-      act(() => result.current.handleSearchChange(fakeChangeEvent(value)));
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent(",")));
+      const value = "Xylophonic";
+
+      act(() => {
+        result.current.handleSearchChange(fakeChangeEvent(value));
+      });
+
+      act(() => {
+        result.current.handleDebouncedSearch(value, []);
+        jest.runAllTimers();
+      });
+
+      act(() => {
+        result.current.handleKeyDown(fakeKeyDownEvent(","));
+      });
+
       expect(handleCustomOptionSelect).toHaveBeenCalledWith(value);
-      expect(handleOptionSelect).not.toHaveBeenCalled();
-    });
 
-    it("should not add an empty string 'Comma'", () => {
-      const result = setupHook();
+      act(() => result.current.handleSearchChange(fakeChangeEvent("")));
       act(() => result.current.handleKeyDown(fakeKeyDownEvent(",")));
-      expect(handleCustomOptionSelect).not.toHaveBeenCalled();
-      expect(handleOptionSelect).not.toHaveBeenCalled();
+      expect(handleCustomOptionSelect).toHaveBeenCalledTimes(1);
     });
 
-    it("should increment the active index by one on 'ArrowDown'", () => {
+    it("should focus previous element on Backspace when empty", () => {
       const result = setupHook();
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
-      expect(result.current.activeIndex).toBe(1);
 
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
-      expect(result.current.activeIndex).toBe(2);
+      const sibling = document.createElement("button");
+      sibling.focus = jest.fn();
+
+      const input = document.createElement("input");
+      Object.defineProperty(input, "previousElementSibling", {
+        value: sibling,
+      });
+
+      result.current.inputRef.current = input;
+
+      act(() => result.current.handleSearchChange(fakeChangeEvent("")));
+      act(() => result.current.handleKeyDown(fakeKeyDownEvent("Backspace")));
+
+      expect(sibling.focus).toHaveBeenCalled();
     });
+  });
 
-    it("should decrement the active index by one on 'ArrowUp'", () => {
+  describe("generateDescendantId", () => {
+    it("should return a valid id", () => {
       const result = setupHook();
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
-      expect(result.current.activeIndex).toBe(1);
-
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowUp")));
-      expect(result.current.activeIndex).toBe(0);
+      const id = result.current.generateDescendantId(3);
+      expect(id).toBe(`${result.current.menuId}-3`);
     });
+  });
 
-    it("should go to the last index when the active index is at 0 and you press 'ArrowUp'", () => {
+  describe("handleDebouncedSearch", () => {
+    it("should debounce and update options", () => {
       const result = setupHook();
-      expect(result.current.activeIndex).toBe(0);
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowUp")));
-      expect(result.current.activeIndex).toBe(chips.length - 1);
-    });
-
-    it("should go to the first index when the active index is at the last option and you press 'ArrowDown'", () => {
-      const result = setupHook();
-      expect(result.current.activeIndex).toBe(0);
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowUp")));
-      expect(result.current.activeIndex).toBe(chips.length - 1);
-      act(() => result.current.handleKeyDown(fakeKeyDownEvent("ArrowDown")));
-      expect(result.current.activeIndex).toBe(0);
+      act(() => {
+        result.current.handleDebouncedSearch("Magical", hookParams.options);
+      });
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(result.current.allOptions.length).toBe(1);
+      expect(result.current.allOptions[0].label).toBe("Magical");
     });
   });
 });
@@ -246,6 +330,7 @@ function fakeChangeEvent(initialValue: string) {
 function fakeKeyDownEvent(key: string) {
   return {
     key: key,
-    preventDefault: jest.fn,
+    preventDefault: jest.fn(),
+    shiftKey: false,
   } as unknown as KeyboardEvent<HTMLInputElement>;
 }

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
@@ -244,7 +244,7 @@ describe("handleBlur", () => {
   describe("when onlyShowMenuOnSearch is true", () => {
     const onlyShowMenuParams = { ...hookParams, onlyShowMenuOnSearch: true };
 
-    it("should set showInput to false when blurring with empty input", () => {
+    it("should set showInput to false when blurring", () => {
       const result = setupHook(onlyShowMenuParams);
 
       act(() => result.current.handleShowInput()); // Input is shown first
@@ -259,29 +259,6 @@ describe("handleBlur", () => {
       });
 
       expect(result.current.showInput).toBe(false);
-      expect(result.current.menuOpen).toBe(false);
-      expect(result.current.activeIndex).toBe(0);
-      expect(result.current.searchValue).toBe("");
-    });
-
-    it("should keep showInput true when blurring with non-empty input", () => {
-      const result = setupHook(onlyShowMenuParams);
-      const value = "test";
-
-      act(() => result.current.handleShowInput()); // Input is shown first
-      act(() => result.current.handleSearchChange(fakeChangeEvent(value))); // User types
-      expect(result.current.showInput).toBe(true);
-      expect(result.current.searchValue).toBe(value);
-
-      act(() => {
-        if (result.current.inputRef.current) {
-          result.current.inputRef.current.value = value;
-        }
-      });
-
-      act(() => result.current.handleBlur());
-
-      expect(result.current.showInput).toBe(true);
       expect(result.current.menuOpen).toBe(false);
       expect(result.current.activeIndex).toBe(0);
       expect(result.current.searchValue).toBe("");

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
@@ -77,6 +77,7 @@ describe("handleReset", () => {
     act(() => result.current.handleReset());
     expect(result.current.activeIndex).toBe(0);
     expect(result.current.searchValue).toBe("");
+    expect(result.current.menuOpen).toBe(true);
   });
 
   it("should keep active index at 0 if it's already 0", () => {
@@ -87,6 +88,22 @@ describe("handleReset", () => {
 
     act(() => result.current.handleReset());
 
+    expect(result.current.activeIndex).toBe(0);
+    expect(result.current.searchValue).toBe("");
+  });
+
+  it("should close the menu if onlyShowMenuOnSearch is true", () => {
+    const result = setupHook({ onlyShowMenuOnSearch: true });
+
+    act(() => result.current.handleShowInput());
+    act(() => result.current.handleSearchChange(fakeChangeEvent("test")));
+    act(() => jest.advanceTimersByTime(300));
+
+    expect(result.current.menuOpen).toBe(true);
+
+    act(() => result.current.handleReset());
+
+    expect(result.current.menuOpen).toBe(false);
     expect(result.current.activeIndex).toBe(0);
     expect(result.current.searchValue).toBe("");
   });

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
@@ -27,7 +27,7 @@ const hookParams = {
   onOptionSelect: handleOptionSelect,
   onCustomOptionSelect: handleCustomOptionSelect,
   onSearch: handleSearch,
-  submitInputOnFocusShift: false,
+  autoSelectOnClickOutside: false,
   onlyShowMenuOnSearch: false,
 };
 
@@ -154,9 +154,9 @@ describe("handleBlur", () => {
     expect(result.current.menuOpen).toBe(true);
     expect(result.current.activeIndex).toBe(2);
   });
-  describe("when submitInputOnFocusShift is true", () => {
+  describe("when autoSelectOnClickOutside is true", () => {
     it("should submit the custom option on blur when a custom option can be added", () => {
-      const result = setupHook({ submitInputOnFocusShift: true });
+      const result = setupHook({ autoSelectOnClickOutside: true });
       const searchValue = "NewValue";
 
       act(() => {
@@ -181,7 +181,7 @@ describe("handleBlur", () => {
 
     it("should submit the first option on blur when custom option cannot be added", () => {
       const result = setupHook({
-        submitInputOnFocusShift: true,
+        autoSelectOnClickOutside: true,
         onCustomOptionSelect: undefined,
       });
       const searchValue = "Ama";
@@ -203,7 +203,7 @@ describe("handleBlur", () => {
     });
 
     it("should not submit anything on blur when search value is empty", () => {
-      const result = setupHook({ submitInputOnFocusShift: true });
+      const result = setupHook({ autoSelectOnClickOutside: true });
 
       act(() => {
         result.current.handleOpenMenu();
@@ -221,7 +221,7 @@ describe("handleBlur", () => {
     });
 
     it("should not submit anything on blur when search value exists but there are no options", () => {
-      const result = setupHook({ submitInputOnFocusShift: true, options: [] });
+      const result = setupHook({ autoSelectOnClickOutside: true, options: [] });
       const searchValue = "NoMatch";
 
       act(() => {

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -41,6 +41,7 @@ export function useInternalChipDismissibleInput({
   const { liveAnnounce } = useLiveAnnounce();
 
   useEffect(() => {
+    console.log("In useEffect");
     setAllOptions(generateOptions(options, searchValue, canAddCustomOption));
   }, [options]);
 
@@ -83,20 +84,22 @@ export function useInternalChipDismissibleInput({
     handleEnableBlur: () => setShouldCancelBlur(false),
 
     handleBlur: () => {
+      if (shouldCancelBlur) return;
+
       if (
         submitInputOnFocusShift &&
         searchValue.length > 0 &&
         allOptions.length > 0
       ) {
+        console.log(allOptions);
         // If there's a custom option, select it. Otherwise select the best match
         const optionToSelect = canAddCustomOption
           ? allOptions[allOptions.length - 1]
           : allOptions[0];
-
+        console.log(optionToSelect);
         actions.handleSelectOption(optionToSelect);
       }
 
-      if (shouldCancelBlur) return;
       actions.handleReset();
     },
 
@@ -167,7 +170,6 @@ export function useInternalChipDismissibleInput({
 
       handleKeydownEvents(callbacks, event);
     },
-
     handleDebouncedSearch,
   };
 
@@ -187,6 +189,7 @@ function generateOptions(
   searchValue: string,
   canAddCustomOption: boolean,
 ) {
+  console.log(searchValue);
   const allOptions: ChipDismissibleInputOptionProps[] = options
     .filter(option =>
       option.label.toLowerCase().match(searchValue.trim().toLowerCase()),
@@ -199,6 +202,7 @@ function generateOptions(
     canAddCustomOption,
   );
   shouldAddCustomOption && allOptions.push(customOption);
+  console.log(allOptions);
 
   return allOptions;
 }

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -88,8 +88,12 @@ export function useInternalChipDismissibleInput({
         searchValue.length > 0 &&
         allOptions.length > 0
       ) {
-        const lastOption = allOptions[allOptions.length - 1];
-        actions.handleSelectOption(lastOption);
+        // If there's a custom option, select it. Otherwise select the best match
+        const optionToSelect = canAddCustomOption
+          ? allOptions[allOptions.length - 1]
+          : allOptions[0];
+
+        actions.handleSelectOption(optionToSelect);
       }
 
       if (shouldCancelBlur) return;

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -83,6 +83,8 @@ export function useInternalChipDismissibleInput({
     handleEnableBlur: () => setShouldCancelBlur(false),
 
     handleBlur: () => {
+      if (shouldCancelBlur) return;
+
       if (
         submitInputOnFocusShift &&
         searchValue.length > 0 &&
@@ -95,8 +97,6 @@ export function useInternalChipDismissibleInput({
 
         actions.handleSelectOption(optionToSelect);
       }
-
-      if (shouldCancelBlur) return;
       actions.handleReset();
     },
 

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -22,6 +22,7 @@ export function useInternalChipDismissibleInput({
   onCustomOptionSelect,
   onOptionSelect,
   onSearch,
+  onlyShowMenuOnSearch = false,
 }: ChipDismissibleInputProps) {
   const menuId = useId();
   const [allOptions, setAllOptions] = useState<
@@ -67,6 +68,7 @@ export function useInternalChipDismissibleInput({
     handleReset: () => {
       setActiveIndex(activeIndex === 0 ? activeIndex : activeIndex - 1);
       setSearchValue("");
+      actions.handleCloseMenu();
     },
 
     handleOpenMenu: () => setMenuOpen(true),
@@ -82,13 +84,21 @@ export function useInternalChipDismissibleInput({
     handleBlur: () => {
       if (shouldCancelBlur) return;
       actions.handleReset();
-      actions.handleCloseMenu();
     },
 
     handleSearchChange: (event: ChangeEvent<HTMLInputElement>) => {
       setActiveIndex(0);
-      setSearchValue(event.currentTarget.value);
+      const newSearchValue = event.currentTarget.value;
+      setSearchValue(newSearchValue);
       setShouldCancelEnter(true);
+
+      if (onlyShowMenuOnSearch && newSearchValue.length > 0 && !menuOpen) {
+        actions.handleOpenMenu();
+      }
+
+      if (onlyShowMenuOnSearch && newSearchValue.length === 0 && menuOpen) {
+        actions.handleCloseMenu();
+      }
     },
 
     handleSetActiveOnMouseOver: (index: number) => {
@@ -108,22 +118,26 @@ export function useInternalChipDismissibleInput({
     },
 
     handleKeyDown: (event: KeyboardEvent<HTMLInputElement>) => {
-      const callbacks: KeyDownCallBacks = {
-        Enter: () => {
+      const callbacks: KeyDownCallBacks = {};
+
+      if (!onlyShowMenuOnSearch || searchValue.length > 0) {
+        callbacks.Enter = () => {
           if (shouldCancelEnter) return;
           actions.handleSelectOption(computed.activeOption);
-        },
-        Tab: () => actions.handleSelectOption(computed.activeOption),
-        ",": () => {
+        };
+        callbacks.Tab = () => actions.handleSelectOption(computed.activeOption);
+
+        callbacks[","] = () => {
           if (searchValue.length === 0) return;
           actions.handleSelectOption(generateCustomOptionObject(searchValue));
-        },
-        ArrowDown: () => {
+        };
+
+        callbacks.ArrowDown = () => {
           if (isLoadingMore && activeIndex === maxOptionIndex) return;
           setActiveIndex(computed.nextOptionIndex);
-        },
-        ArrowUp: () => setActiveIndex(computed.previousOptionIndex),
-      };
+        };
+        callbacks.ArrowUp = () => setActiveIndex(computed.previousOptionIndex);
+      }
 
       if (searchValue.length === 0) {
         callbacks.Backspace = () => {

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -31,6 +31,7 @@ export function useInternalChipDismissibleInput({
   >([]);
   const [searchValue, setSearchValue] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
+  const [showInput, setShowInput] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const [shouldCancelBlur, setShouldCancelBlur] = useState(false);
   const [shouldCancelEnter, setShouldCancelEnter] = useState(false);
@@ -63,13 +64,13 @@ export function useInternalChipDismissibleInput({
   }
 
   const handleDebouncedSearch = debounce(handleSearch, 300);
+
   const actions = {
     generateDescendantId: (index: number) => `${computed.menuId}-${index}`,
 
     handleReset: () => {
       setActiveIndex(activeIndex === 0 ? activeIndex : activeIndex - 1);
       setSearchValue("");
-      actions.handleCloseMenu();
     },
 
     handleOpenMenu: () => setMenuOpen(true),
@@ -85,6 +86,8 @@ export function useInternalChipDismissibleInput({
     handleBlur: () => {
       if (shouldCancelBlur) return;
 
+      const valueBeforeBlur = computed.inputRef.current?.value;
+
       if (
         submitInputOnFocusShift &&
         searchValue.length > 0 &&
@@ -97,7 +100,12 @@ export function useInternalChipDismissibleInput({
         actions.handleSelectOption(optionToSelect);
       }
 
+      if (valueBeforeBlur === "") {
+        setShowInput(false);
+      }
+
       actions.handleReset();
+      actions.handleCloseMenu();
     },
 
     handleSearchChange: (event: ChangeEvent<HTMLInputElement>) => {
@@ -107,7 +115,9 @@ export function useInternalChipDismissibleInput({
       setShouldCancelEnter(true);
 
       if (onlyShowMenuOnSearch && newSearchValue.length > 0 && !menuOpen) {
-        actions.handleOpenMenu();
+        setTimeout(() => {
+          actions.handleOpenMenu();
+        }, 300);
       }
 
       if (onlyShowMenuOnSearch && newSearchValue.length === 0 && menuOpen) {
@@ -128,6 +138,14 @@ export function useInternalChipDismissibleInput({
         liveAnnounce(`${selected.label} Added`);
         actions.handleReset();
         computed.inputRef.current?.focus();
+      }
+    },
+
+    handleShowInput: () => {
+      setShowInput(true);
+
+      if (!onlyShowMenuOnSearch) {
+        actions.handleOpenMenu();
       }
     },
 
@@ -176,6 +194,7 @@ export function useInternalChipDismissibleInput({
     allOptions,
     ...computed,
     menuOpen,
+    showInput,
     searchValue,
     shouldCancelBlur,
   };

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -95,7 +95,7 @@ export function useInternalChipDismissibleInput({
       ) {
         // If there's a custom option, select it. Otherwise select the best match
         const optionToSelect = canAddCustomOption
-          ? allOptions[allOptions.length - 1]
+          ? generateCustomOptionObject(searchValue)
           : allOptions[0];
         actions.handleSelectOption(optionToSelect);
       }
@@ -103,6 +103,12 @@ export function useInternalChipDismissibleInput({
       actions.handleReset();
       actions.handleCloseMenu();
       setShowInput(false);
+    },
+
+    handleFocus: () => {
+      if (!onlyShowMenuOnSearch) {
+        actions.handleOpenMenu();
+      }
     },
 
     handleSearchChange: (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -88,7 +88,7 @@ export function useInternalChipDismissibleInput({
     handleBlur: () => {
       if (shouldCancelBlur) return;
 
-      const valueBeforeBlur = computed.inputRef.current?.value;
+      // const valueBeforeBlur = computed.inputRef.current?.value;
 
       if (
         submitInputOnFocusShift &&
@@ -102,12 +102,9 @@ export function useInternalChipDismissibleInput({
         actions.handleSelectOption(optionToSelect);
       }
 
-      if (valueBeforeBlur === "") {
-        setShowInput(false);
-      }
-
       actions.handleReset();
       actions.handleCloseMenu();
+      setShowInput(false);
     },
 
     handleSearchChange: (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -25,7 +25,7 @@ export function useInternalChipDismissibleInput({
   onOptionSelect,
   onSearch,
   onlyShowMenuOnSearch = false,
-  submitInputOnFocusShift = false,
+  autoSelectOnClickOutside = false,
 }: ChipDismissibleInputProps) {
   const menuId = useId();
   const [allOptions, setAllOptions] = useState<
@@ -89,7 +89,7 @@ export function useInternalChipDismissibleInput({
       if (shouldCancelBlur) return;
 
       if (
-        submitInputOnFocusShift &&
+        autoSelectOnClickOutside &&
         searchValue.length > 0 &&
         allOptions.length > 0
       ) {

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -73,6 +73,10 @@ export function useInternalChipDismissibleInput({
     handleReset: () => {
       setActiveIndex(activeIndex === 0 ? activeIndex : activeIndex - 1);
       setSearchValue("");
+
+      if (onlyShowMenuOnSearch) {
+        actions.handleCloseMenu();
+      }
     },
 
     handleOpenMenu: () => setMenuOpen(true),

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -15,6 +15,8 @@ import {
 import { Icon } from "../../../Icon";
 import { ChipProps } from "../../Chip";
 
+const SEARCH_DEBOUNCE_TIME = 300;
+
 // eslint-disable-next-line max-statements
 export function useInternalChipDismissibleInput({
   options,
@@ -63,7 +65,7 @@ export function useInternalChipDismissibleInput({
     setShouldCancelEnter(false);
   }
 
-  const handleDebouncedSearch = debounce(handleSearch, 300);
+  const handleDebouncedSearch = debounce(handleSearch, SEARCH_DEBOUNCE_TIME);
 
   const actions = {
     generateDescendantId: (index: number) => `${computed.menuId}-${index}`,
@@ -117,7 +119,7 @@ export function useInternalChipDismissibleInput({
       if (onlyShowMenuOnSearch && newSearchValue.length > 0 && !menuOpen) {
         setTimeout(() => {
           actions.handleOpenMenu();
-        }, 300);
+        }, SEARCH_DEBOUNCE_TIME);
       }
 
       if (onlyShowMenuOnSearch && newSearchValue.length === 0 && menuOpen) {

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -88,8 +88,6 @@ export function useInternalChipDismissibleInput({
     handleBlur: () => {
       if (shouldCancelBlur) return;
 
-      // const valueBeforeBlur = computed.inputRef.current?.value;
-
       if (
         submitInputOnFocusShift &&
         searchValue.length > 0 &&

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -41,7 +41,6 @@ export function useInternalChipDismissibleInput({
   const { liveAnnounce } = useLiveAnnounce();
 
   useEffect(() => {
-    console.log("In useEffect");
     setAllOptions(generateOptions(options, searchValue, canAddCustomOption));
   }, [options]);
 
@@ -91,12 +90,10 @@ export function useInternalChipDismissibleInput({
         searchValue.length > 0 &&
         allOptions.length > 0
       ) {
-        console.log(allOptions);
         // If there's a custom option, select it. Otherwise select the best match
         const optionToSelect = canAddCustomOption
           ? allOptions[allOptions.length - 1]
           : allOptions[0];
-        console.log(optionToSelect);
         actions.handleSelectOption(optionToSelect);
       }
 
@@ -189,7 +186,6 @@ function generateOptions(
   searchValue: string,
   canAddCustomOption: boolean,
 ) {
-  console.log(searchValue);
   const allOptions: ChipDismissibleInputOptionProps[] = options
     .filter(option =>
       option.label.toLowerCase().match(searchValue.trim().toLowerCase()),
@@ -202,7 +198,6 @@ function generateOptions(
     canAddCustomOption,
   );
   shouldAddCustomOption && allOptions.push(customOption);
-  console.log(allOptions);
 
   return allOptions;
 }

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -23,6 +23,7 @@ export function useInternalChipDismissibleInput({
   onOptionSelect,
   onSearch,
   onlyShowMenuOnSearch = false,
+  submitInputOnFocusShift = false,
 }: ChipDismissibleInputProps) {
   const menuId = useId();
   const [allOptions, setAllOptions] = useState<
@@ -82,6 +83,15 @@ export function useInternalChipDismissibleInput({
     handleEnableBlur: () => setShouldCancelBlur(false),
 
     handleBlur: () => {
+      if (
+        submitInputOnFocusShift &&
+        searchValue.length > 0 &&
+        allOptions.length > 0
+      ) {
+        const lastOption = allOptions[allOptions.length - 1];
+        actions.handleSelectOption(lastOption);
+      }
+
       if (shouldCancelBlur) return;
       actions.handleReset();
     },

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -83,8 +83,6 @@ export function useInternalChipDismissibleInput({
     handleEnableBlur: () => setShouldCancelBlur(false),
 
     handleBlur: () => {
-      if (shouldCancelBlur) return;
-
       if (
         submitInputOnFocusShift &&
         searchValue.length > 0 &&
@@ -97,6 +95,8 @@ export function useInternalChipDismissibleInput({
 
         actions.handleSelectOption(optionToSelect);
       }
+
+      if (shouldCancelBlur) return;
       actions.handleReset();
     },
 

--- a/packages/site/src/content/Chips/Chips.props.json
+++ b/packages/site/src/content/Chips/Chips.props.json
@@ -148,6 +148,36 @@
         "type": {
           "name": "(searchValue: string) => void"
         }
+      },
+      "onlyShowMenuOnSearch": {
+        "defaultValue": {
+          "value": "false"
+        },
+        "description": "Control whether the menu only appears once the user types.",
+        "name": "onlyShowMenuOnSearch",
+        "parent": {
+          "fileName": "packages/components/src/Chips/ChipsTypes.tsx",
+          "name": "ChipDismissibleProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "submitInputOnFocusShift": {
+        "defaultValue": {
+          "value": "false"
+        },
+        "description": "If true, automatically selects an option based on the current search value when the input loses focus.\nThe automatic selection order is: an exact match of the search value if available, a custom option if\nonCustomOptionSelect is provided, or the closest match.",
+        "name": "submitInputOnFocusShift",
+        "parent": {
+          "fileName": "packages/components/src/Chips/ChipsTypes.tsx",
+          "name": "ChipDismissibleProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
       }
     }
   }

--- a/packages/site/src/content/Chips/Chips.props.json
+++ b/packages/site/src/content/Chips/Chips.props.json
@@ -164,12 +164,12 @@
           "name": "boolean"
         }
       },
-      "submitInputOnFocusShift": {
+      "autoSelectOnClickOutside": {
         "defaultValue": {
           "value": "false"
         },
         "description": "If true, automatically selects an option based on the current search value when the input loses focus.\nThe automatic selection order is: an exact match of the search value if available, a custom option if\nonCustomOptionSelect is provided, or the closest match.",
-        "name": "submitInputOnFocusShift",
+        "name": "autoSelectOnClickOutside",
         "parent": {
           "fileName": "packages/components/src/Chips/ChipsTypes.tsx",
           "name": "ChipDismissibleProps"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The motivation was to achieve the A/C of this ticket, essentially allowing Chips to be used as an email selection input that has similar functionality to GMail. I'll admit, I don't feel fantastic about these changes as they add more complexity to already quite complex component. I had a conversation with though and we agreed that it made sense to add these additions to Chips for now and then look into building a new component, potentially using autocomplete, to achieve this functionality in the future without relying on Chips. In the meantime though I tried really hard to keep the new logic as simple as possible and add new testing coverage/improve the tests that were existing before.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
Adds two new props:
- `onlyShowMenuOnSearch`: If this is `false` (the default) when you click on the activator the menu will appear immediately to provide the user with options to select. When set to `true` the menu of options will not appear until you start typing in a search value. When the input is cleared, the menu disappears again.
- `submitInputOnFocusShift`: When `false` (the default) when a user has added a search term to the input and then shifts focus away by clicking outside of the input the search term will be cleared. When `true` instead of clearing the search term it will submit the best available value based on the search term. That value is:
  - An exact match if present
  - A new custom value if custom values are allowed
  - The closest match if custom values are not allowed

I didn't add more docs that the prop docstrings. If anyone thinks I should add anything else into the docs please let me know. 

### Changed

- There should be no changes to existing functionality

## Testing

The story for this is kind for this functionality is pretty borked but I have a pre-release of these changes on [this branch](https://github.com/GetJobber/jobber-frontend/pull/2571) and you can test them out there. Also worth double checking that none of the other uses of Chips are broken

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
