### PR TITLE
fix(components): make Glimmer respond to dark mode

### DIFF
--- a/docs/components/Glimmer/Glimmer.stories.mdx
+++ b/docs/components/Glimmer/Glimmer.stories.mdx
@@ -1,6 +1,7 @@
 import { ArgsTable, Canvas, Meta, Source } from "@storybook/addon-docs";
 import { Tab, Tabs } from "@jobber/components/Tabs";
 import { Glimmer } from "@jobber/components/Glimmer";
+import { Box } from "@jobber/components/Box";
 
 <Meta title="Components/Status and Feedback/Glimmer" component={Glimmer} />
 
@@ -19,11 +20,14 @@ the `Glimmer` will automatically darken itself so it's still noticeable.
   <Glimmer />
 </Canvas>
 
-If you have a darker or coloured background, you can toggle the `reverseTheme`
-to switch the colors so it's still noticeable.
+If you the Glimmer sits on a `reverse` background (dark in light mode, light in
+dark mode), you can toggle the `reverseTheme` prop to switch the colors so it's
+still noticeable.
 
 <Canvas style={{ background: "var(--color-surface--reverse)" }}>
-  <Glimmer reverseTheme={true} />
+  <Box background="surface--reverse" padding="base">
+    <Glimmer reverseTheme />
+  </Box>
 </Canvas>
 
 ## Semantic blocks

--- a/docs/components/Glimmer/Glimmer.stories.mdx
+++ b/docs/components/Glimmer/Glimmer.stories.mdx
@@ -20,7 +20,7 @@ the `Glimmer` will automatically darken itself so it's still noticeable.
   <Glimmer />
 </Canvas>
 
-If you the Glimmer sits on a `reverse` background (dark in light mode, light in
+If the Glimmer sits on a `reverse` background (dark in light mode, light in
 dark mode), you can toggle the `reverseTheme` prop to switch the colors so it's
 still noticeable.
 

--- a/docs/components/Glimmer/Web.stories.tsx
+++ b/docs/components/Glimmer/Web.stories.tsx
@@ -62,6 +62,20 @@ const BasicTemplate: ComponentStory<typeof Glimmer> = args => (
       </Text>
       <Glimmer {...args} />
     </div>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-small)",
+        padding: "var(--space-base)",
+        backgroundColor: "var(--color-surface--reverse)",
+      }}
+    >
+      <Text size="small" variation="subdued">
+        On surface--reverse (toggle reverseTheme prop)
+      </Text>
+      <Glimmer {...args} />
+    </div>
   </div>
 );
 

--- a/docs/components/Glimmer/Web.stories.tsx
+++ b/docs/components/Glimmer/Web.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Glimmer } from "@jobber/components/Glimmer";
 import { Content } from "@jobber/components/Content";
+import { Text } from "@jobber/components/Text";
 
 export default {
   title: "Components/Status and Feedback/Glimmer/Web",
@@ -13,7 +14,55 @@ export default {
 } as ComponentMeta<typeof Glimmer>;
 
 const BasicTemplate: ComponentStory<typeof Glimmer> = args => (
-  <Glimmer {...args} />
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+    }}
+  >
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-small)",
+        padding: "var(--space-base)",
+        backgroundColor: "var(--color-surface)",
+      }}
+    >
+      <Text size="small" variation="subdued">
+        On surface
+      </Text>
+      <Glimmer {...args} />
+    </div>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-small)",
+        padding: "var(--space-base)",
+        backgroundColor: "var(--color-surface--background",
+      }}
+    >
+      <Text size="small" variation="subdued">
+        On surface--background
+      </Text>
+      <Glimmer {...args} />
+    </div>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-small)",
+        padding: "var(--space-base)",
+        backgroundColor: "var(--color-surface--background--subtle)",
+      }}
+    >
+      <Text size="small" variation="subdued">
+        On surface--background--subtle
+      </Text>
+      <Glimmer {...args} />
+    </div>
+  </div>
 );
 
 export const Basic = BasicTemplate.bind({});

--- a/packages/components/src/Glimmer/Glimmer.module.css
+++ b/packages/components/src/Glimmer/Glimmer.module.css
@@ -20,8 +20,14 @@
   animation: glimmer 2s infinite linear;
 }
 
+[data-theme="dark"] .glimmer,
 .reverseTheme {
   --glimmer-background: rgba(var(--color-white--rgb), 10%);
+  --glimmer-shine-opacity: 20%;
+}
+
+[data-theme="dark"] .reverseTheme {
+  --glimmer-background: rgba(var(--color-black--rgb), 10%);
   --glimmer-shine-opacity: 25%;
 }
 

--- a/packages/components/src/Glimmer/Glimmer.module.css
+++ b/packages/components/src/Glimmer/Glimmer.module.css
@@ -1,14 +1,33 @@
 .glimmer {
-  --glimmer-background: rgba(var(--color-black--rgb), 5%);
+  --glimmer-background: var(--color-surface--reverse);
+  --glimmer-background-opacity: 7.5%;
+  --glimmer-shine-opacity: 75%;
   --glimmer-shine: rgba(var(--color-white--rgb), var(--glimmer-shine-opacity));
-  --glimmer-shine-opacity: 80%;
   --duration-base: calc(var(--timing-slowest) * 4); /* 2s */
   --duration-fast: calc(var(--duration-base) / 2); /* 1s */
-
+  position: relative;
   width: 100%;
   height: 100%;
   border-radius: var(--radius-base);
+  overflow: hidden;
+}
+
+.glimmer::before,
+.glimmer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.glimmer::before {
   background-color: var(--glimmer-background);
+  opacity: var(--glimmer-background-opacity);
+}
+
+.glimmer::after {
   background-image: linear-gradient(
     90deg,
     transparent 0px,
@@ -22,13 +41,16 @@
 
 [data-theme="dark"] .glimmer,
 .reverseTheme {
-  --glimmer-background: rgba(var(--color-white--rgb), 10%);
   --glimmer-shine-opacity: 20%;
 }
 
+.reverseTheme {
+  --glimmer-background: var(--color-surface);
+}
+
 [data-theme="dark"] .reverseTheme {
-  --glimmer-background: rgba(var(--color-black--rgb), 10%);
-  --glimmer-shine-opacity: 25%;
+  --glimmer-shine-opacity: 75%;
+  --glimmer-background-opacity: 7.5%;
 }
 
 @keyframes glimmer {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

![image](https://github.com/user-attachments/assets/5be230c7-4d57-4a78-98b1-84f20a27cfb4)

Ricardo raises a valid point: the existing Glimmer does not use semantic tokens (fairly, as it relies on opacities in a way that our color tokens do not handle), so Glimmer looks like this in dark mode:
![image](https://github.com/user-attachments/assets/bcacc247-9a8e-47e2-abe2-0beb0c6c29ca)

The dark "track" is barely noticeable, and the white "glimmer" is jarringly bright.

This update checks for Atlantis' dark mode and adjusts the CSS values accordingly:
https://github.com/user-attachments/assets/37b3bf46-dcab-4446-8290-fd70815a2410

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- comparison stories to make it easier to QA visual updates to Glimmer

### Changed

- update Glimmer styling to check for dark theme

### Fixed

- Glimmer is now appropriately visible in dark mode

## Testing

Storybook is _likely_ sufficient, but you can pull in pre-release to verify in Jobber.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
