### PR TITLE
feat(components): Add unsafe props to Avatar web

### DIFF
--- a/packages/components/src/Avatar/Avatar.test.tsx
+++ b/packages/components/src/Avatar/Avatar.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Avatar } from ".";
 
 it("renders a Avatar", () => {
@@ -37,4 +37,115 @@ it("displays an icon if no image and no initials are set", () => {
 it("Renders light text color if `color` is dark", () => {
   const { container } = render(<Avatar initials="JB" color="black" />);
   expect(container.firstChild).toHaveClass("isDark");
+});
+
+describe("UNSAFE props", () => {
+  describe("UNSAFE_className", () => {
+    it("applies to Avatar container", () => {
+      render(
+        <Avatar
+          name="Custom Container Class Name"
+          imageUrl="https://api.adorable.io/avatars/150/jobbler"
+          UNSAFE_className={{ container: "customContainerClassName" }}
+        />,
+      );
+      expect(screen.getByLabelText("Custom Container Class Name")).toHaveClass(
+        "customContainerClassName",
+      );
+    });
+
+    it("applies to Avatar initials", () => {
+      render(
+        <Avatar
+          initials="JB"
+          UNSAFE_className={{ initials: "customInitialsClassName" }}
+        />,
+      );
+      expect(screen.getByText("JB")).toHaveClass("customInitialsClassName");
+    });
+
+    it("applies to Avatar fallback icon", () => {
+      render(
+        <Avatar
+          initials=""
+          UNSAFE_className={{
+            fallbackIcon: {
+              svg: "customFallbackIconSvgClassName",
+              path: "customFallbackIconPathClassName",
+            },
+          }}
+        />,
+      );
+      expect(screen.getByTestId("person")).toHaveClass(
+        "customFallbackIconSvgClassName",
+      );
+      expect(screen.getByTestId("person").querySelector("path")).toHaveClass(
+        "customFallbackIconPathClassName",
+      );
+    });
+  });
+
+  describe("UNSAFE_style", () => {
+    it("applies to Avatar container", () => {
+      render(
+        <Avatar
+          name="Custom Container Style"
+          imageUrl="https://api.adorable.io/avatars/150/jobbler"
+          UNSAFE_style={{
+            container: {
+              borderColor: "var(--color-green)",
+            },
+          }}
+        />,
+      );
+
+      expect(screen.getByLabelText("Custom Container Style")).toHaveStyle({
+        borderColor: "var(--color-green)",
+      });
+    });
+
+    it("applies to Avatar initials", () => {
+      render(
+        <Avatar
+          initials="JB"
+          UNSAFE_style={{
+            initials: {
+              color: "var(--color-blue)",
+            },
+          }}
+        />,
+      );
+
+      expect(screen.getByText("JB")).toHaveStyle({
+        color: "var(--color-blue)",
+      });
+    });
+
+    it("applies to Avatar fallback icon", () => {
+      render(
+        <Avatar
+          initials=""
+          UNSAFE_style={{
+            fallbackIcon: {
+              svg: {
+                width: "59px",
+                height: "59px",
+              },
+              path: {
+                fill: "var(--color-blue)",
+              },
+            },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId("person")).toHaveStyle({
+        width: "59px",
+        height: "59px",
+      });
+      expect(screen.getByTestId("person").querySelector("path")).toHaveStyle({
+        fill: "var(--color-blue)",
+      });
+    });
+  });
 });

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -3,7 +3,7 @@ import classnames from "classnames";
 import { XOR } from "ts-xor";
 import styles from "./Avatar.module.css";
 import { isDark } from "./utilities";
-import { Icon } from "../Icon";
+import { Icon, IconProps } from "../Icon";
 
 type AvatarSize = "base" | "large" | "small";
 interface AvatarFoundationProps {
@@ -42,10 +42,7 @@ interface AvatarFoundationProps {
   readonly UNSAFE_className?: {
     container?: string;
     initials?: string;
-    fallbackIcon?: {
-      svg?: string;
-      path?: string;
-    };
+    fallbackIcon?: IconProps["UNSAFE_className"];
   };
 
   /**
@@ -56,10 +53,7 @@ interface AvatarFoundationProps {
   readonly UNSAFE_style?: {
     container?: CSSProperties;
     initials?: CSSProperties;
-    fallbackIcon?: {
-      svg?: CSSProperties;
-      path?: CSSProperties;
-    };
+    fallbackIcon?: IconProps["UNSAFE_style"];
   };
 }
 
@@ -111,7 +105,19 @@ export function Avatar({
       aria-label={name}
     >
       {!imageUrl && (
-        <Initials initials={initials} dark={shouldBeDark} iconSize={size} />
+        <Initials
+          initials={initials}
+          dark={shouldBeDark}
+          iconSize={size}
+          UNSAFE_className={{
+            initials: UNSAFE_className.initials,
+            fallbackIcon: UNSAFE_className.fallbackIcon,
+          }}
+          UNSAFE_style={{
+            initials: UNSAFE_style.initials,
+            fallbackIcon: UNSAFE_style.fallbackIcon,
+          }}
+        />
       )}
     </div>
   );
@@ -121,22 +127,44 @@ interface InitialsProps {
   readonly dark?: boolean;
   readonly iconSize?: AvatarSize;
   readonly initials?: string;
+
+  readonly UNSAFE_className?: {
+    initials?: string;
+    fallbackIcon?: IconProps["UNSAFE_className"];
+  };
+
+  readonly UNSAFE_style?: {
+    initials?: CSSProperties;
+    fallbackIcon?: IconProps["UNSAFE_style"];
+  };
 }
 
 function Initials({
   initials,
   dark = false,
   iconSize = "base",
+  UNSAFE_className,
+  UNSAFE_style,
 }: InitialsProps) {
   if (!initials) {
     return (
-      <Icon name="person" color={dark ? "white" : "blue"} size={iconSize} />
+      <Icon
+        name="person"
+        color={dark ? "white" : "blue"}
+        size={iconSize}
+        UNSAFE_className={UNSAFE_className?.fallbackIcon}
+        UNSAFE_style={UNSAFE_style?.fallbackIcon}
+      />
     );
   }
 
-  const className = classnames(styles.initials, {
+  const className = classnames(styles.initials, UNSAFE_className?.initials, {
     [styles.smallInitials]: initials.length > 2,
   });
 
-  return <span className={className}>{initials.substr(0, 3)}</span>;
+  return (
+    <span className={className} style={UNSAFE_style?.initials}>
+      {initials.substr(0, 3)}
+    </span>
+  );
 }

--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -31,6 +31,36 @@ interface AvatarFoundationProps {
    * @default "base"
    */
   readonly size?: AvatarSize;
+
+  /**
+   * **Use at your own risk:** Custom class names for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * **Note:** If you are applying fill override to buttonIcon.path, you will need to add !important due
+   * to Button's children element css inheritance.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_className?: {
+    container?: string;
+    initials?: string;
+    fallbackIcon?: {
+      svg?: string;
+      path?: string;
+    };
+  };
+
+  /**
+   * **Use at your own risk:** Custom style for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_style?: {
+    container?: CSSProperties;
+    initials?: CSSProperties;
+    fallbackIcon?: {
+      svg?: CSSProperties;
+      path?: CSSProperties;
+    };
+  };
 }
 
 interface AvatarWithImageProps extends AvatarFoundationProps {
@@ -49,10 +79,13 @@ export function Avatar({
   initials,
   size = "base",
   color,
+  UNSAFE_className = {},
+  UNSAFE_style = {},
 }: AvatarProps) {
   const style: CSSProperties = {
     backgroundColor: color,
     borderColor: color,
+    ...UNSAFE_style.container,
   };
 
   if (imageUrl) {
@@ -65,9 +98,14 @@ export function Avatar({
     [styles.isDark]: shouldBeDark,
   });
 
+  const containerClassNames = classnames(
+    className,
+    UNSAFE_className?.container,
+  );
+
   return (
     <div
-      className={className}
+      className={containerClassNames}
       style={style}
       role={imageUrl && "img"}
       aria-label={name}

--- a/packages/components/src/InputAvatar/InputAvatar.tsx
+++ b/packages/components/src/InputAvatar/InputAvatar.tsx
@@ -5,7 +5,8 @@ import { FileUpload, InputFile, UploadParams } from "../InputFile";
 import { ProgressBar } from "../ProgressBar";
 import { Button } from "../Button";
 
-interface InputAvatarProps extends Omit<AvatarProps, "size"> {
+interface InputAvatarProps
+  extends Omit<AvatarProps, "size" | "UNSAFE_className" | "UNSAFE_style"> {
   /**
    * A callback that receives a file object and returns a `UploadParams` needed
    * to upload the file.

--- a/packages/site/src/content/Avatar/Avatar.props.json
+++ b/packages/site/src/content/Avatar/Avatar.props.json
@@ -72,6 +72,36 @@
         "type": {
           "name": "AvatarSize"
         }
+      },
+      "UNSAFE_className": {
+        "defaultValue": {
+          "value": "{}"
+        },
+        "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\n**Note:** If you are applying fill override to buttonIcon.path, you will need to add !important due\nto Button's children element css inheritance.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "../components/src/Avatar/Avatar.tsx",
+          "name": "AvatarFoundationProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ container?: string; initials?: string; fallbackIcon?: { svg?: string; path?: string; }; }"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": {
+          "value": "{}"
+        },
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "../components/src/Avatar/Avatar.tsx",
+          "name": "AvatarFoundationProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ container?: CSSProperties; initials?: CSSProperties; fallbackIcon?: { svg?: CSSProperties; path?: CSSProperties; }; }"
+        }
       }
     }
   }

--- a/packages/site/src/content/Avatar/AvatarNotes.mdx
+++ b/packages/site/src/content/Avatar/AvatarNotes.mdx
@@ -1,0 +1,105 @@
+import { Tabs, Tab } from "@jobber/components/Tabs";
+
+## Component customization
+
+### UNSAFE\_ props (advanced usage)
+
+General information for using `UNSAFE_` props can be found
+[here](/guides/customizing-components).
+
+**Note**: Use of `UNSAFE_` props is **at your own risk** and should be
+considered a **last resort**. Future Icon updates may lead to unintended
+breakages.
+
+#### UNSAFE_props (web)
+
+<Tabs>
+  <Tab label="UNSAFE_className">
+    Use `UNSAFE_className` to apply custom classes to the Avatar component. This can be
+    useful for applying styles via CSS Modules.
+
+    ```tsx
+    // For Avatar with image
+    <Avatar
+      name="Custom Container Class Name"
+      imageUrl="https://api.adorable.io/avatars/150/jobbler"
+      UNSAFE_className={{ container: styles.customContainerClassName }}
+    />
+
+    // For Avatar with initials
+    <Avatar
+      initials="JB"
+      UNSAFE_className={{ initials: styles.customInitialsClassName }}
+    />,
+
+    // For Avatar with fallback icon
+    <Avatar
+      initials=""
+      UNSAFE_className={{
+        fallbackIcon: {
+          svg: styles.customFallbackIconSvgClassName,
+          path: styles.customFallbackIconPathClassName,
+        },
+      }}
+    />
+
+    // YourComponent.module.css
+    .customContainerClassName {
+      border-color: var(--color-red);
+    }
+
+    .customInitialsClassName {
+      color: var(--color-blue);
+    }
+
+    .customFallbackIconSvgClassName {
+      width: 59px;
+      height: 59px;
+    }
+
+    .customFallbackIconPathClassName {
+      fill: var(--color-blue);
+    }
+    ```
+
+  </Tab>
+  <Tab label="UNSAFE_style">
+    Use `UNSAFE_style` to apply inline custom styles to the Avatar component.
+    
+    ```tsx
+    // For Avatar with image
+     <Avatar
+      name="Custom Container Style"
+      imageUrl="https://api.adorable.io/avatars/150/jobbler"
+      UNSAFE_style={{
+        container: {
+          borderColor: "var(--color-green)",
+        },
+      }}
+    />
+
+    // For Avatar with initials
+    <Avatar
+      initials="JB"
+      UNSAFE_style={{ initials: { color: "var(--color-blue)" } }}
+    />
+
+    // For Avatar with fallback icon
+    <Avatar
+      initials=""
+      UNSAFE_style={{
+        fallbackIcon: {
+          svg: {
+            width: "59px",
+            height: "59px",
+          },
+          path: {
+            fill: "var(--color-blue)",
+          },
+        },
+      }}
+    />,
+    ```
+
+  </Tab>
+</Tabs>

--- a/packages/site/src/content/Avatar/index.tsx
+++ b/packages/site/src/content/Avatar/index.tsx
@@ -1,5 +1,6 @@
 import Content from "@atlantis/docs/components/Avatar/Avatar.stories.mdx";
 import Props from "./Avatar.props.json";
+import Notes from "./AvatarNotes.mdx";
 import { ContentExport } from "../../types/content";
 import { getStorybookUrl } from "../../layout/getStorybookUrl";
 
@@ -25,4 +26,5 @@ export default {
       ),
     },
   ],
+  notes: () => <Notes />,
 } as const satisfies ContentExport;

--- a/packages/site/src/content/InputAvatar/InputAvatar.props.json
+++ b/packages/site/src/content/InputAvatar/InputAvatar.props.json
@@ -96,32 +96,6 @@
         "type": {
           "name": "string"
         }
-      },
-      "UNSAFE_className": {
-        "defaultValue": null,
-        "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\n**Note:** If you are applying fill override to buttonIcon.path, you will need to add !important due\nto Button's children element css inheritance.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
-        "name": "UNSAFE_className",
-        "parent": {
-          "fileName": "packages/components/src/Avatar/Avatar.tsx",
-          "name": "AvatarFoundationProps"
-        },
-        "required": false,
-        "type": {
-          "name": "{ container?: string; initials?: string; fallbackIcon?: { svg?: string; path?: string; }; }"
-        }
-      },
-      "UNSAFE_style": {
-        "defaultValue": null,
-        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
-        "name": "UNSAFE_style",
-        "parent": {
-          "fileName": "packages/components/src/Avatar/Avatar.tsx",
-          "name": "AvatarFoundationProps"
-        },
-        "required": false,
-        "type": {
-          "name": "{ container?: CSSProperties; initials?: CSSProperties; fallbackIcon?: { svg?: CSSProperties; path?: CSSProperties; }; }"
-        }
       }
     }
   }

--- a/packages/site/src/content/InputAvatar/InputAvatar.props.json
+++ b/packages/site/src/content/InputAvatar/InputAvatar.props.json
@@ -96,6 +96,32 @@
         "type": {
           "name": "string"
         }
+      },
+      "UNSAFE_className": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\n**Note:** If you are applying fill override to buttonIcon.path, you will need to add !important due\nto Button's children element css inheritance.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "packages/components/src/Avatar/Avatar.tsx",
+          "name": "AvatarFoundationProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ container?: string; initials?: string; fallbackIcon?: { svg?: string; path?: string; }; }"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "packages/components/src/Avatar/Avatar.tsx",
+          "name": "AvatarFoundationProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ container?: CSSProperties; initials?: CSSProperties; fallbackIcon?: { svg?: CSSProperties; path?: CSSProperties; }; }"
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Adding UNSAFE props to atom components to allow more customizations

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added UNSAFE_className and UNSAFE_style props to Avatar, which target the container, `Initials`, and `Icon`
- Tests for UNSAFE props
- Notes in the Implementations tab with UNSAFE props use explanation
- Avatar props file update

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

Add this story to make sure everything renders as expected
```
// Target the fallback icon
export const FallbackIconCustomStyles = BasicTemplate.bind({});
FallbackIconCustomStyles.args = {
  color: "var(--color-indigo)",
  initials: "",
  name: "The Jobbler",
  size: "large",
  UNSAFE_style: {
    fallbackIcon: {
      svg: {
        width: "59px",
        height: "59px",
      },
      path: {
        fill: "var(--color-blue)",
      },
    },
  },
};

// Target the container
export const ContainerCustomStyles = BasicTemplate.bind({});
ContainerCustomStyles.args = {
  color: "var(--color-indigo)",
  imageUrl:
    "https://images.unsplash.com/photo-1533858539156-90ea20bafd17?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80",
  name: "The Jobbler",
  size: "large",
  UNSAFE_style: {
    container: {
      borderColor: "var(--color-green)",
    },
  },
};

// Target Initials
export const InitialsCustomStyles = BasicTemplate.bind({});
InitialsCustomStyles.args = {
  color: "var(--color-indigo)",
  initials: "JBLR",
  name: "The Jobbler",
  size: "large",
  UNSAFE_style: {
    initials: {
      color: "var(--color-blue)",
    },
  },
};
```

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
