### PR TITLE
feat(components): add UNSAFE_className and UNSAFE_style props to Divider

### DIFF
--- a/packages/components/src/Divider/Divider.test.tsx
+++ b/packages/components/src/Divider/Divider.test.tsx
@@ -60,4 +60,27 @@ describe("Divider", () => {
       });
     });
   });
+
+  describe("UNSAFE props", () => {
+    it("should apply UNSAFE_className to the container", () => {
+      const { getByTestId } = render(
+        <Divider
+          UNSAFE_className={{ container: "custom-class" }}
+          testID="ATL-divider"
+        />,
+      );
+
+      expect(getByTestId("ATL-divider")).toHaveClass("custom-class");
+    });
+
+    it("should apply UNSAFE_style to the container", () => {
+      const { getByTestId } = render(
+        <Divider
+          UNSAFE_style={{ container: { color: "red" } }}
+          testID="ATL-divider"
+        />,
+      );
+      expect(getByTestId("ATL-divider")).toHaveStyle("color: red");
+    });
+  });
 });

--- a/packages/components/src/Divider/Divider.tsx
+++ b/packages/components/src/Divider/Divider.tsx
@@ -23,20 +23,46 @@ interface DividerProps {
    * A reference to the element in the rendered output
    */
   readonly testID?: string;
+
+  /**
+   * **Use at your own risk:** Custom classNames for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_className?: {
+    readonly container?: string;
+  };
+
+  /**
+   * **Use at your own risk:** Custom style for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
+   */
+  readonly UNSAFE_style?: {
+    readonly container?: React.CSSProperties;
+  };
 }
 
 export function Divider({
   size = "base",
   direction = "horizontal",
   testID,
+  UNSAFE_className,
+  UNSAFE_style,
 }: DividerProps) {
   const className = classnames(
     styles.divider,
     sizes[size],
     directions[direction],
+    UNSAFE_className?.container,
   );
 
   return (
-    <div className={className} data-testid={testID} role="none presentation" />
+    <div
+      className={className}
+      style={UNSAFE_style?.container}
+      data-testid={testID}
+      role="none presentation"
+    />
   );
 }

--- a/packages/site/src/content/Divider/Divider.props.json
+++ b/packages/site/src/content/Divider/Divider.props.json
@@ -48,6 +48,32 @@
         "type": {
           "name": "string"
         }
+      },
+      "UNSAFE_className": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom classNames for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "../components/src/Divider/Divider.tsx",
+          "name": "DividerProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ readonly container?: string; }"
+        }
+      },
+      "UNSAFE_style": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "../components/src/Divider/Divider.tsx",
+          "name": "DividerProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ readonly container?: React.CSSProperties; }"
+        }
       }
     }
   }

--- a/packages/site/src/content/Divider/DividerNotes.mdx
+++ b/packages/site/src/content/Divider/DividerNotes.mdx
@@ -1,0 +1,52 @@
+## Component customization
+
+### UNSAFE\_ props (advanced usage)
+
+General information for using `UNSAFE_` props can be found
+[here](/guides/customizing-components).
+
+**Note**: Use of `UNSAFE_` props is **at your own risk** and should be
+considered a **last resort**. Future Divider updates may lead to unintended
+breakages.
+
+Divider has one element that can be targeted with classes or styles:
+
+- `container`: The main `div` element of the Divider
+
+#### UNSAFE_className (web)
+
+Use `UNSAFE_className` to apply custom classes to the Divider. This can be
+useful for applying styles via CSS Modules.
+
+```tsx
+// YourComponent.tsx
+import styles from "./YourStyles.module.css";
+
+<Divider
+  UNSAFE_className={{
+    container: styles.customDivider,
+  }}
+/>
+
+// YourStyles.module.css
+.customDivider {
+  background-color: var(--color-background-brand-bold);
+  height: 5px;
+}
+```
+
+#### UNSAFE_style (web)
+
+The `UNSAFE_style` prop provides granular control over the Divider's appearance
+through inline styles.
+
+```tsx
+<Divider
+  UNSAFE_style={{
+    container: {
+      backgroundColor: "var(--color-background-danger-bold)",
+      height: "10px",
+    },
+  }}
+/>
+```

--- a/packages/site/src/content/Divider/index.tsx
+++ b/packages/site/src/content/Divider/index.tsx
@@ -1,6 +1,7 @@
 import Content from "@atlantis/docs/components/Divider/Divider.stories.mdx";
 import Props from "./Divider.props.json";
 import MobileProps from "./Divider.props-mobile.json";
+import Notes from "./DividerNotes.mdx";
 import { ContentExport } from "../../types/content";
 import { getStorybookUrl } from "../../layout/getStorybookUrl";
 
@@ -32,4 +33,5 @@ export default {
       ),
     },
   ],
+  notes: () => <Notes />,
 } as const satisfies ContentExport;


### PR DESCRIPTION
## Motivations

Introduced UNSAFE_className and UNSAFE_style props to the Divider component, allowing users to apply custom class names and inline styles to the container element.

## Changes

### Added

- UNSAFE_className and UNSAFE_style props to Divider
- Enhanced documentation with examples for using UNSAFE props on the new docs site.

### Changed

### Deprecated

### Removed

### Fixed

### Security

## Testing

Changes can be tested via Pre-release

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
