### PR TITLE
chore: New manual GitHub Action to diff bundled outputs

### DIFF
--- a/.github/workflows/diff-outputs.yml
+++ b/.github/workflows/diff-outputs.yml
@@ -1,6 +1,6 @@
 name: Diff Outputs
 
-on: pull_request
+on: workflow_dispatch
 
 jobs:
   diff-outputs:

--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -109,4 +109,4 @@ export const CheckboxRebuilt = forwardRef(function CheckboxRebuiltInternal(
   );
 });
 
-CheckboxRebuilt.displayName = "CheckboxRebuiltTestDiff";
+CheckboxRebuilt.displayName = "CheckboxRebuilt";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This PR adds a new manually-triggered GitHub Action that _diffs the outputs of our packages_ on a given branch.

If you're testing a PR... let's say a dependabot version bump of some dependency... and you're not sure whether it's safe to ship because it could affect the final built assets that we ship, THIS ACTION IS FOR YOU!

Simply run this GH Action against your branch and you'll see one of two things:

✅ No differences found in built assets!

OR

⚠️ Differences found in built assets! This indicates that the compiled outputs in this branch don't match what master produces.
👉 Please investigate the differences above to see if they are expected.

If you see the latter warning, look above it and you'll see a git diff showing what exactly changed. Usually it will be something within a `dist` directory in one of the packages. Just review the diff to see if it makes sense and whether it's safe to ship OR if you need to do more testing, then do that!

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- New GitHub Action to diff bundle/package outputs


## Testing

No need to test, I ran this on this PR a few times.

UPDATE 2026: The screenshots below are a bit outdated due to slight modifications to the echo logs, but the general concept is the exact same as below.

### When there's no changes

https://github.com/GetJobber/atlantis/actions/runs/14503388190

<img width="569" alt="Screenshot 2025-04-16 at 3 12 30 PM" src="https://github.com/user-attachments/assets/b8552fb4-82f1-4d24-9f54-3c96c992c6dd" />


### When there are changes

https://github.com/GetJobber/atlantis/actions/runs/14503583543/job/40688621884



<img width="1024" alt="Screenshot 2025-04-16 at 3 15 59 PM" src="https://github.com/user-attachments/assets/a8c8950d-db31-4162-9431-5c4c542260dc" />


Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

