### PR TITLE
fix(components): Update text color on autofill in FormField

### DIFF
--- a/packages/components/src/FormField/FormField.module.css
+++ b/packages/components/src/FormField/FormField.module.css
@@ -239,6 +239,7 @@
 .input:-webkit-autofill:focus,
 .input:-webkit-autofill:active {
   -webkit-box-shadow: 0 0 0 30px var(--color-surface) inset !important;
+  -webkit-text-fill-color: var(--field--value-color);
 }
 
 .textarea:not(:has(.label)) {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
A small bug was noticed when using autofill in Chrome on our Input fields, in dark mode. The input text stayed black when it should be white.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `-webkit-text-fill-color: var(--field--value-color);` to target the -webkit-autofill pseudo-class to maintain consistent text colour when switching between light/dark modes

### Fixed

#### Before
![Kapture 2025-04-16 at 20 01 34](https://github.com/user-attachments/assets/8902f567-54bd-44f1-b82e-3071a295e688)


#### After
![Kapture 2025-04-16 at 19 57 59](https://github.com/user-attachments/assets/69cec3ee-f18b-4f76-974c-f8018bb61325)

_Note:_ the overlap with the text & placeholder when hovering over the autofill option happened before, it is just more noticeable now in dark mode that the text is white. 

## Testing

<!-- How to test your changes. -->
- [ ] Go to Chrome > Settings > Autofill and passwords > Addresses and more. 
- [ ] I think I had to disable 1Password and then it allowed me to add an address
- [ ] Add the following in `docs/components/InputText/Web.stories.tsx`:

```
const AutofillTemplate: ComponentStory<typeof InputText> = args => {
  return <InputText {...args} />;
};

export const Autofill = AutofillTemplate.bind({});
Autofill.args = {
  name: "firstname",
  placeholder: "First name",
  autoComplete: "given-name",
};
```
- [ ] view the story and make sure that when you autofill in the input, the text is the correct color in light _and_ dark mode

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
