### PR TITLE
fix(components): Assign type button to DataListHeaderTile when column is sortable

### DIFF
--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -41,6 +41,7 @@ export function DataListHeaderTile<T extends DataListObject>({
       })}
       onClick={handleOnClick}
       ref={dataListHeaderTileRef}
+      {...(isSortable ? { type: "button" } : {})}
     >
       <Text maxLines="single">{headers[headerKey]}</Text>
       {isSortable && sortableItem?.options && isDropDownOpen && (

--- a/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
+++ b/packages/components/src/DataList/components/DataListHeaderTile/DataListHeaderTile.tsx
@@ -41,7 +41,7 @@ export function DataListHeaderTile<T extends DataListObject>({
       })}
       onClick={handleOnClick}
       ref={dataListHeaderTileRef}
-      {...(isSortable ? { type: "button" } : {})}
+      type={isSortable ? "button" : undefined}
     >
       <Text maxLines="single">{headers[headerKey]}</Text>
       {isSortable && sortableItem?.options && isDropDownOpen && (


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
When `DataListHeaderTile` is sortable, the header is then turned into a html `button`. 

An html `button` will act as `type=submit` when wrapped inside a form.

Therefore, if a `<form>` contains a `DataList` with sortable headers, attempting to sort the `DataList` columns will cause a form submit and therefore, page reload.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/submit#using_submit_buttons

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

```
<Tag
  ...
  {...(isSortable ? { type: "button" } : {})}
>
```

When `isSortable` is true: spreads { type: "button" } onto the element
When `isSortable` is false: add nothing

I could have also done `type={isSortable ? "button" : undefined}`.  This would then mean we're setting `type={undefined}` on a div element - not semantically correct.

## Testing

<!-- How to test your changes. -->

Put the following code into `docs/components/DataList/Web.stories.tsx` and see how when `{...(isSortable ? { type: "button" } : {})}` is present:
- sorting still properly happens (console.log will tell you)
- clicking on the column header to sort does not trigger an alert

If you comment out that line of code:
- see how we get an alert because the form is attempting to submit

```
export const FormSubmissionIssue: StoryFn<typeof DataList> = () => {
  const [sortingState, setSortingState] = useState<DataListSorting>();

  const simpleData = [
    { id: "1", name: "Alice", age: 25 },
    { id: "2", name: "Bob", age: 30 },
    { id: "3", name: "Charlie", age: 35 },
  ];

  return (
    <form
      onSubmit={e => {
        e.preventDefault();
        alert(
          "Form submitted! This shouldn't happen when clicking sort buttons",
        );
      }}
    >
      <DataList
        data={simpleData}
        headers={{
          name: "Name",
          age: "Age",
        }}
        sorting={{
          state: sortingState,
          onSort: sorting => {
            console.log("Sorting changed:", sorting);
            setSortingState(sorting);
          },
          sortable: [
            {
              key: "name",
              sortType: "toggle",
              options: [
                { id: "name", label: "Name (A-Z)", order: "asc" },
                { id: "name", label: "Name (Z-A)", order: "desc" },
              ],
            },
            {
              key: "age",
              sortType: "toggle",
              options: [
                { id: "age", label: "Age (Low to High)", order: "asc" },
                { id: "age", label: "Age (High to Low)", order: "desc" },
              ],
            },
          ],
        }}
      >
        <DataList.Layout size="md">
          {item => (
            <Grid alignItems="center">
              <Grid.Cell size={{ xs: 6 }}>{item.name}</Grid.Cell>
              <Grid.Cell size={{ xs: 6 }}>{item.age}</Grid.Cell>
            </Grid>
          )}
        </DataList.Layout>
      </DataList>
    </form>
  );
};
```

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
