### PR TITLE
fix(docx): Fixing Local Dev Flow with the docs site.

### DIFF
--- a/docs/components/Autocomplete/Web.stories.tsx
+++ b/docs/components/Autocomplete/Web.stories.tsx
@@ -2,11 +2,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import {
-  AnyOption,
+  type AnyOption,
   Autocomplete,
   BaseMenuGroupOption,
   BaseMenuOption,
-  CustomOptionsMenuProp,
+  type CustomOptionsMenuProp,
   KeyboardAction,
   MenuOption,
   Option,

--- a/docs/components/DataList/Web.stories.tsx
+++ b/docs/components/DataList/Web.stories.tsx
@@ -16,7 +16,7 @@ import { Button } from "@jobber/components/Button";
 import { DatePicker } from "@jobber/components/DatePicker";
 import { Chip } from "@jobber/components/Chip";
 import { Icon } from "@jobber/components/Icon";
-import { Combobox, ComboboxOption } from "@jobber/components/Combobox";
+import { Combobox, type ComboboxOption } from "@jobber/components/Combobox";
 import { Flex } from "@jobber/components/Flex";
 // eslint-disable-next-line import/no-internal-modules
 import { useDebounce } from "@jobber/components/utils/useDebounce";

--- a/docs/components/Form/Web.stories.tsx
+++ b/docs/components/Form/Web.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { useFormState } from "@jobber/hooks";
-import { Form, FormRef } from "@jobber/components/Form";
+import { Form, type FormRef } from "@jobber/components/Form";
 import { Content } from "@jobber/components/Content";
 import { InputText } from "@jobber/components/InputText";
 import { Button } from "@jobber/components/Button";

--- a/packages/components/src/AtlantisThemeContext/AtlantisThemeContext.tsx
+++ b/packages/components/src/AtlantisThemeContext/AtlantisThemeContext.tsx
@@ -12,8 +12,8 @@ import {
   AtlantisThemeContextProviderProps,
   AtlantisThemeContextValue,
   THEME_CHANGE_EVENT,
-  Theme,
-  ThemeChangeDetails,
+  type Theme,
+  type ThemeChangeDetails,
 } from "./types";
 import styles from "./AtlantisThemeContext.module.css";
 

--- a/packages/components/src/AtlantisThemeContext/index.ts
+++ b/packages/components/src/AtlantisThemeContext/index.ts
@@ -5,9 +5,9 @@ export {
 } from "./AtlantisThemeContext";
 export {
   THEME_CHANGE_EVENT,
-  Theme,
-  ThemeChangeDetails,
-  AtlantisThemeContextProviderProps,
-  AtlantisThemeContextValue,
+  type AtlantisThemeContextProviderProps,
+  type AtlantisThemeContextValue,
+  type Theme,
+  type ThemeChangeDetails,
 } from "./types";
 export { updateTheme } from "./updateTheme";

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -9,7 +9,11 @@ import React, {
 } from "react";
 import styles from "./Autocomplete.module.css";
 import { Menu } from "./Menu/Menu";
-import { AnyOption, AutocompleteProps, Option } from "./Autocomplete.types";
+import {
+  type AnyOption,
+  type AutocompleteProps,
+  type Option,
+} from "./Autocomplete.types";
 import { isOptionGroup } from "./Autocomplete.utils";
 import { InputText, InputTextRef } from "../InputText";
 import { useDebounce } from "../utils/useDebounce";

--- a/packages/components/src/Autocomplete/Autocomplete.utils.ts
+++ b/packages/components/src/Autocomplete/Autocomplete.utils.ts
@@ -1,4 +1,8 @@
-import { AnyOption, GroupOption, Option } from "./Autocomplete.types";
+import {
+  type AnyOption,
+  type GroupOption,
+  type Option,
+} from "./Autocomplete.types";
 
 export function isOptionSelected(
   selectedOption: Option | undefined,

--- a/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
+++ b/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
@@ -1,6 +1,6 @@
 import React, { RefObject } from "react";
 import { BaseAutocompleteMenuWrapper } from "./MenuWrapper";
-import { AnyOption, Option } from "../Autocomplete.types";
+import { type AnyOption, type Option } from "../Autocomplete.types";
 import { isOptionSelected } from "../Autocomplete.utils";
 import { MenuOption } from "../Option";
 import { useKeyboardNavigation } from "../useKeyboardNavigation";

--- a/packages/components/src/Autocomplete/Menu/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu/Menu.tsx
@@ -3,10 +3,10 @@ import { InputTextRef } from "@jobber/components/InputText";
 import { DefaultMenu, DefaultMenuProps } from "./DefaultMenu";
 import { useAutocompleteMenu } from "./MenuWrapper";
 import {
-  AnyOption,
-  CustomOptionsMenuProp,
-  MenuProps,
-  Option,
+  type AnyOption,
+  type CustomOptionsMenuProp,
+  type MenuProps,
+  type Option,
 } from "../Autocomplete.types";
 
 export function Menu<

--- a/packages/components/src/Autocomplete/Option.tsx
+++ b/packages/components/src/Autocomplete/Option.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren } from "react";
 import classnames from "classnames";
 import styles from "./Autocomplete.module.css";
 import { isOptionGroup } from "./Autocomplete.utils";
-import { AnyOption, Option } from "./Autocomplete.types";
+import { type AnyOption, type Option } from "./Autocomplete.types";
 import { Heading } from "../Heading";
 import { Text } from "../Text";
 import { Icon } from "../Icon";

--- a/packages/components/src/Autocomplete/index.ts
+++ b/packages/components/src/Autocomplete/index.ts
@@ -1,20 +1,20 @@
 export { Autocomplete } from "./Autocomplete";
 export {
-  MenuOptionProps,
+  type MenuOptionProps,
   BaseMenuOption,
-  BaseMenuOptionProps,
+  type BaseMenuOptionProps,
   MenuOption,
   BaseMenuGroupOption,
-  BaseMenuGroupOptionProps,
+  type BaseMenuGroupOptionProps,
 } from "./Option";
 export {
-  AnyOption,
-  AutocompleteProps,
-  BaseOption,
-  CustomOptionsMenuProp,
-  GroupOption,
-  OptionCollection,
-  Option,
+  type AnyOption,
+  type AutocompleteProps,
+  type BaseOption,
+  type CustomOptionsMenuProp,
+  type GroupOption,
+  type OptionCollection,
+  type Option,
 } from "./Autocomplete.types";
 export {
   KeyboardAction,

--- a/packages/components/src/Autocomplete/useKeyboardNavigation.ts
+++ b/packages/components/src/Autocomplete/useKeyboardNavigation.ts
@@ -1,6 +1,6 @@
 import { useOnKeyDown } from "@jobber/hooks/useOnKeyDown";
 import { useCallback, useEffect, useState } from "react";
-import { AnyOption, Option } from "./Autocomplete.types";
+import { type AnyOption, type Option } from "./Autocomplete.types";
 import { isOptionGroup } from "./Autocomplete.utils";
 
 export enum KeyboardAction {

--- a/packages/components/src/Avatar/index.ts
+++ b/packages/components/src/Avatar/index.ts
@@ -1,1 +1,1 @@
-export { Avatar, AvatarProps } from "./Avatar";
+export { Avatar, type AvatarProps } from "./Avatar";

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -1,12 +1,12 @@
 import React, { ReactNode, useState } from "react";
 import classnames from "classnames";
-import { IconNames } from "@jobber/design";
+import { type IconNames } from "@jobber/design";
 import { useResizeObserver } from "@jobber/hooks/useResizeObserver";
 import styles from "./Banner.module.css";
 import { BannerIcon } from "./components/BannerIcon";
-import { BannerType } from "./Banner.types";
+import { type BannerType } from "./Banner.types";
 import { Text } from "../Text";
-import { Button, ButtonProps } from "../Button";
+import { Button, type ButtonProps } from "../Button";
 import { ButtonDismiss } from "../ButtonDismiss/ButtonDismiss";
 
 interface BannerProps {

--- a/packages/components/src/Banner/components/BannerIcon/BannerIcon.tsx
+++ b/packages/components/src/Banner/components/BannerIcon/BannerIcon.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import iconStyles from "./BannerIcon.module.css";
 import bannerStyles from "../../Banner.module.css";
 import { Icon } from "../../../Icon";
-import { BannerType } from "../../Banner.types";
+import { type BannerType } from "../../Banner.types";
 
 export interface BannerIconProps {
   readonly icon: IconNames;

--- a/packages/components/src/Banner/index.ts
+++ b/packages/components/src/Banner/index.ts
@@ -1,2 +1,2 @@
 export { Banner } from "./Banner";
-export { BannerType } from "./Banner.types";
+export type { BannerType } from "./Banner.types";

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import { Link, LinkProps } from "react-router-dom";
 import classnames from "classnames";
-import { ButtonProps, HTMLButtonType } from "./Button.types";
+import { type ButtonProps, type HTMLButtonType } from "./Button.types";
 import { useButtonStyles } from "./useButtonStyles";
 // eslint-disable-next-line import/no-deprecated
 import { ButtonContent, ButtonIcon, ButtonLabel } from "./ButtonInternals";

--- a/packages/components/src/Button/ButtonInternals.tsx
+++ b/packages/components/src/Button/ButtonInternals.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { ButtonProps } from "./Button.types";
+import { type ButtonProps } from "./Button.types";
 import { useButtonContext } from "./ButtonProvider";
-import { Icon, IconProps } from "../Icon";
-import { Typography, TypographyProps } from "../Typography";
+import { Icon, type IconProps } from "../Icon";
+import { Typography, type TypographyProps } from "../Typography";
 
 /**
  * For backwards compatibility with the legacy button

--- a/packages/components/src/Button/index.ts
+++ b/packages/components/src/Button/index.ts
@@ -1,4 +1,4 @@
 export { Button } from "./Button";
-export * from "./Button.types";
-export { useButtonStyles, UseButtonStylesProps } from "./useButtonStyles";
+export type { ButtonProps } from "./Button.types";
+export { useButtonStyles, type UseButtonStylesProps } from "./useButtonStyles";
 export { useButtonContext } from "./ButtonProvider";

--- a/packages/components/src/Card/CardHeader.tsx
+++ b/packages/components/src/Card/CardHeader.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { ActionProps, CardProps, HeaderActionProps } from "./types";
 import styles from "./Card.module.css";
 import { Heading } from "../Heading";
-import { Button, ButtonProps } from "../Button";
-import { Menu, MenuProps } from "../Menu";
+import { Button, type ButtonProps } from "../Button";
+import { Menu, type MenuProps } from "../Menu";
 
 /**
  * Intended to be used in the Card component.

--- a/packages/components/src/Card/types.ts
+++ b/packages/components/src/Card/types.ts
@@ -1,7 +1,7 @@
 import { ReactElement, ReactNode } from "react";
 import colors from "./cardcolors.module.css";
-import { ButtonProps } from "../Button";
-import { MenuProps } from "../Menu";
+import { type ButtonProps } from "../Button";
+import { type MenuProps } from "../Menu";
 
 export type ActionProps = ReactElement<
   Omit<ButtonProps, "size" | "fullWidth"> | MenuProps

--- a/packages/components/src/Chips/ChipTypes.tsx
+++ b/packages/components/src/Chips/ChipTypes.tsx
@@ -1,7 +1,7 @@
 import { KeyboardEvent, MouseEvent, ReactElement } from "react";
-import { ChipButtonProps } from "./InternalChipButton";
-import { AvatarProps } from "../Avatar";
-import { IconProps } from "../Icon";
+import { type ChipButtonProps } from "./InternalChipButton";
+import { type AvatarProps } from "../Avatar";
+import { type IconProps } from "../Icon";
 
 export interface InternalChipProps {
   /**

--- a/packages/components/src/Chips/InternalChipAffix.tsx
+++ b/packages/components/src/Chips/InternalChipAffix.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from "react";
 import { useAssert } from "@jobber/hooks/useAssert";
-import { ChipButtonProps, InternalChipButton } from "./InternalChipButton";
+import { type ChipButtonProps, InternalChipButton } from "./InternalChipButton";
 import styles from "./InternalChip.module.css";
-import { InternalChipProps } from "./ChipTypes";
-import { Avatar, AvatarProps } from "../Avatar";
-import { Icon, IconProps } from "../Icon";
+import { type InternalChipProps } from "./ChipTypes";
+import { Avatar, type AvatarProps } from "../Avatar";
+import { Icon, type IconProps } from "../Icon";
 
 interface InternalChipAffixProps
   extends Pick<InternalChipProps, "active" | "invalid" | "disabled"> {

--- a/packages/components/src/Combobox/ComboboxProvider.tsx
+++ b/packages/components/src/Combobox/ComboboxProvider.tsx
@@ -1,5 +1,5 @@
 import React, { MutableRefObject } from "react";
-import { ComboboxOption } from "./Combobox.types";
+import { type ComboboxOption } from "./Combobox.types";
 
 export interface ComboboxProviderProps {
   readonly children: React.ReactNode;

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.pom.tsx
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.pom.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import noop from "lodash/noop";
 import { ComboboxOption } from "./ComboboxOption";
-import { ComboboxOptionProps } from "../../Combobox.types";
+import { type ComboboxOptionProps } from "../../Combobox.types";
 import {
   ComboboxContextProvider,
   ComboboxProviderProps,

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.tsx
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@jobber/components/Icon";
 import { Flex } from "@jobber/components/Flex";
 import styles from "./ComboboxOption.module.css";
 import { ComboboxContext } from "../../ComboboxProvider";
-import { ComboboxOptionProps } from "../../Combobox.types";
+import { type ComboboxOptionProps } from "../../Combobox.types";
 
 export function ComboboxOption(props: ComboboxOptionProps) {
   const { customRender, ...contentProps } = props;

--- a/packages/components/src/Combobox/hooks/useCombobox.ts
+++ b/packages/components/src/Combobox/hooks/useCombobox.ts
@@ -11,7 +11,7 @@ import {
   UseMakeComboboxHandlersReturn,
   useMakeComboboxHandlers,
 } from "./useMakeComboboxHandlers";
-import { ComboboxOption } from "../Combobox.types";
+import { type ComboboxOption } from "../Combobox.types";
 
 type UseComboboxReturn = {
   wrapperRef: React.RefObject<HTMLDivElement>;

--- a/packages/components/src/Combobox/hooks/useComboboxAccessibility.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxAccessibility.ts
@@ -11,7 +11,7 @@ import {
   useInteractions,
 } from "@floating-ui/react";
 import { useFocusTrap } from "@jobber/hooks/useFocusTrap";
-import { ComboboxOption } from "../Combobox.types";
+import { type ComboboxOption } from "../Combobox.types";
 import { ComboboxContext } from "../ComboboxProvider";
 
 const COMBOBOX_OFFSET = 8;

--- a/packages/components/src/Combobox/hooks/useComboboxContent.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxContent.ts
@@ -1,5 +1,5 @@
 import { MutableRefObject, useContext, useEffect, useRef } from "react";
-import { ComboboxOption } from "../Combobox.types";
+import { type ComboboxOption } from "../Combobox.types";
 import { ComboboxContext } from "../ComboboxProvider";
 
 interface useComboboxContent {

--- a/packages/components/src/Combobox/hooks/useComboboxValidation.ts
+++ b/packages/components/src/Combobox/hooks/useComboboxValidation.ts
@@ -1,14 +1,14 @@
 import React, { Children, ReactElement, isValidElement } from "react";
 import { useAssert } from "@jobber/hooks/useAssert";
 import { ComboboxActivator } from "../components/ComboboxActivator";
-import { ComboboxOption } from "../components/ComboboxOption";
 import {
-  ComboboxActionProps,
-  ComboboxActivatorProps,
-  ComboboxOptionProps,
-  ComboboxProps,
+  type ComboboxActionProps,
+  type ComboboxActivatorProps,
+  type ComboboxOptionProps,
+  type ComboboxProps,
 } from "../Combobox.types";
 import { ComboboxAction } from "../components/ComboboxAction";
+import { ComboboxOption } from "../components/ComboboxOption";
 
 export const COMBOBOX_TRIGGER_COUNT_ERROR_MESSAGE =
   "Combobox must have exactly one Trigger element";

--- a/packages/components/src/Combobox/hooks/useMakeComboboxHandlers.ts
+++ b/packages/components/src/Combobox/hooks/useMakeComboboxHandlers.ts
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { ComboboxOption } from "../Combobox.types";
+import { type ComboboxOption } from "../Combobox.types";
 
 export interface UseMakeComboboxHandlersReturn {
   handleClose: () => void;

--- a/packages/components/src/Combobox/index.ts
+++ b/packages/components/src/Combobox/index.ts
@@ -1,3 +1,6 @@
 export * from "./Combobox";
 export { ComboboxContextProvider } from "./ComboboxProvider";
-export { ComboboxOption, ComboboxCustomActivatorProps } from "./Combobox.types";
+export {
+  type ComboboxCustomActivatorProps,
+  type ComboboxOption,
+} from "./Combobox.types";

--- a/packages/components/src/ConfirmationModal/index.ts
+++ b/packages/components/src/ConfirmationModal/index.ts
@@ -1,1 +1,4 @@
-export { ConfirmationModal, ConfirmationModalRef } from "./ConfirmationModal";
+export {
+  type ConfirmationModalRef,
+  ConfirmationModal,
+} from "./ConfirmationModal";

--- a/packages/components/src/DataList/DataList.types.ts
+++ b/packages/components/src/DataList/DataList.types.ts
@@ -1,10 +1,10 @@
 import { ReactElement, ReactNode } from "react";
 import { IconNames } from "@jobber/design";
 import { XOR } from "ts-xor";
-import { Breakpoints } from "./DataList.const";
-import { ButtonProps } from "../Button";
+import { type Breakpoints } from "./DataList.const";
+import { type ButtonProps } from "../Button";
 
-export { Breakpoints } from "./DataList.const";
+export { type Breakpoints } from "./DataList.const";
 
 export type DataListItemType<T extends DataListObject[]> = Record<
   keyof T[number],

--- a/packages/components/src/DataList/DataList.utils.tsx
+++ b/packages/components/src/DataList/DataList.utils.tsx
@@ -2,9 +2,9 @@ import React, { Children, ReactElement, isValidElement } from "react";
 import isEmpty from "lodash/isEmpty";
 import {
   DataListHeader,
-  DataListItemType,
-  DataListItemTypeFromHeader,
-  DataListObject,
+  type DataListItemType,
+  type DataListItemTypeFromHeader,
+  type DataListObject,
 } from "./DataList.types";
 import { BREAKPOINTS, Breakpoints } from "./DataList.const";
 import { DataListTags } from "./components/DataListTags";

--- a/packages/components/src/DataList/index.ts
+++ b/packages/components/src/DataList/index.ts
@@ -1,11 +1,11 @@
 export * from "./DataList";
 export {
-  DataListItemType,
-  DataListObject,
-  DataListSorting,
-  DataListSortable,
-  DataListSelectedType,
-  DataListSelectedAllType,
-  DataListProps,
-  DataListEmptyStateProps,
+  type DataListItemType,
+  type DataListObject,
+  type DataListSorting,
+  type DataListSortable,
+  type DataListSelectedType,
+  type DataListSelectedAllType,
+  type DataListProps,
+  type DataListEmptyStateProps,
 } from "./DataList.types";

--- a/packages/components/src/Form/index.ts
+++ b/packages/components/src/Form/index.ts
@@ -1,1 +1,1 @@
-export { Form, FormRef } from "./Form";
+export { Form, type FormRef } from "./Form";

--- a/packages/components/src/FormField/hooks/useFormFieldWrapperStyles.ts
+++ b/packages/components/src/FormField/hooks/useFormFieldWrapperStyles.ts
@@ -2,7 +2,7 @@ import classnames from "classnames";
 import { RefObject, useEffect, useState } from "react";
 import { useIsSafari } from "./useIsSafari";
 import styles from "../FormField.module.css";
-import { FormFieldProps } from "../FormFieldTypes";
+import type { FormFieldProps } from "../FormFieldTypes";
 
 export interface useFormFieldWrapperStylesProps
   extends Pick<

--- a/packages/components/src/FormField/index.ts
+++ b/packages/components/src/FormField/index.ts
@@ -1,5 +1,5 @@
-export * from "./FormField";
-export * from "./FormFieldTypes";
+export { FormField } from "./FormField";
+export type { FormFieldProps } from "./FormFieldTypes";
 export { useAtlantisFormField } from "./hooks/useAtlantisFormField";
 export { useAtlantisFormFieldActions } from "./hooks/useAtlantisFormFieldActions";
 export { useAtlantisFormFieldName } from "./hooks/useAtlantisFormFieldName";
@@ -11,10 +11,10 @@ export {
   FormFieldWrapper,
   FormFieldWrapperMain,
   FormFieldWrapperToolbar,
-  FormFieldWrapperProps,
+  type FormFieldWrapperProps,
 } from "./FormFieldWrapper";
 export { AffixIcon, AffixLabel } from "./FormFieldAffix";
 export {
   useFormFieldWrapperStyles,
-  useFormFieldWrapperStylesProps,
+  type useFormFieldWrapperStylesProps,
 } from "./hooks/useFormFieldWrapperStyles";

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from "react";
 import { IconColorNames, IconNames, IconSizes, getIcon } from "@jobber/design";
 
-export { IconColorNames, IconNames } from "@jobber/design";
+export type { IconColorNames, IconNames } from "@jobber/design";
 
 export interface IconProps {
   /** The icon to show.  */

--- a/packages/components/src/InlineLabel/index.ts
+++ b/packages/components/src/InlineLabel/index.ts
@@ -1,1 +1,1 @@
-export { InlineLabel, InlineLabelColors } from "./InlineLabel";
+export { InlineLabel, type InlineLabelColors } from "./InlineLabel";

--- a/packages/components/src/InputAvatar/InputAvatar.tsx
+++ b/packages/components/src/InputAvatar/InputAvatar.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, useState } from "react";
 import styles from "./InputAvatar.module.css";
-import { Avatar, AvatarProps } from "../Avatar";
+import { Avatar, type AvatarProps } from "../Avatar";
 import { FileUpload, InputFile, UploadParams } from "../InputFile";
 import { ProgressBar } from "../ProgressBar";
 import { Button } from "../Button";

--- a/packages/components/src/InputFile/index.ts
+++ b/packages/components/src/InputFile/index.ts
@@ -1,4 +1,9 @@
-export { InputFile, updateFiles, FileUpload, UploadParams } from "./InputFile";
+export {
+  InputFile,
+  updateFiles,
+  type FileUpload,
+  type UploadParams,
+} from "./InputFile";
 export {
   InputFileContentContext,
   useInputFileContentContext,

--- a/packages/components/src/InputNumber/index.ts
+++ b/packages/components/src/InputNumber/index.ts
@@ -1,1 +1,1 @@
-export { InputNumber, InputNumberRef } from "./InputNumber";
+export { InputNumber, type InputNumberRef } from "./InputNumber";

--- a/packages/components/src/InputText/index.tsx
+++ b/packages/components/src/InputText/index.tsx
@@ -2,9 +2,9 @@ import React, { ForwardedRef, forwardRef } from "react";
 import { InputText as InputTextLegacy } from "./InputText";
 import { InputTextSPAR } from "./InputText.rebuilt";
 import {
-  InputTextLegacyProps,
-  InputTextRebuiltProps,
-  InputTextRef,
+  type InputTextLegacyProps,
+  type InputTextRebuiltProps,
+  type InputTextRef,
 } from "./InputText.types";
 
 export type InputTextShimProps = InputTextLegacyProps | InputTextRebuiltProps;

--- a/packages/components/src/List/index.ts
+++ b/packages/components/src/List/index.ts
@@ -1,2 +1,6 @@
 export { List } from "./List";
-export { BaseListItemProps, ListItem, ListItemProps } from "./ListItem";
+export {
+  type BaseListItemProps,
+  ListItem,
+  type ListItemProps,
+} from "./ListItem";

--- a/packages/components/src/Menu/index.ts
+++ b/packages/components/src/Menu/index.ts
@@ -1,1 +1,6 @@
-export { Menu, SectionProps, ActionProps, MenuProps } from "./Menu";
+export {
+  Menu,
+  type SectionProps,
+  type ActionProps,
+  type MenuProps,
+} from "./Menu";

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -10,8 +10,8 @@ import { Heading } from "../Heading";
 import { Text } from "../Text";
 import { Content } from "../Content";
 import { Markdown } from "../Markdown";
-import { Button, ButtonProps } from "../Button";
-import { Menu, SectionProps } from "../Menu";
+import { Button, type ButtonProps } from "../Button";
+import { Menu, type SectionProps } from "../Menu";
 import { Emphasis } from "../Emphasis";
 
 export type ButtonActionProps = ButtonProps & {

--- a/packages/components/src/Page/index.ts
+++ b/packages/components/src/Page/index.ts
@@ -1,1 +1,1 @@
-export { Page, PageProps } from "./Page";
+export { Page, type PageProps } from "./Page";

--- a/packages/site/.eslintrc.cjs
+++ b/packages/site/.eslintrc.cjs
@@ -8,7 +8,11 @@ module.exports = {
     "import/no-unresolved": [
       "error",
       {
-        ignore: ["^@atlantis/docs", "^@atlantis/packages"],
+        ignore: [
+          "^@atlantis/docs",
+          "^@atlantis/packages",
+          "^@jobber-component-styles",
+        ],
       },
     ],
   },

--- a/packages/site/src/components/ToggleThemeButton.tsx
+++ b/packages/site/src/components/ToggleThemeButton.tsx
@@ -1,6 +1,6 @@
 import {
   Button,
-  Theme,
+  type Theme,
   updateTheme,
   useAtlantisTheme,
 } from "@jobber/components";

--- a/packages/site/src/content/Autocomplete/AutocompleteExamples.tsx
+++ b/packages/site/src/content/Autocomplete/AutocompleteExamples.tsx
@@ -10,7 +10,7 @@ import {
   Text,
 } from "@jobber/components";
 import {
-  AnyOption,
+  type AnyOption,
   Autocomplete,
   BaseMenuGroupOption,
   BaseMenuOption,

--- a/packages/site/src/main.tsx
+++ b/packages/site/src/main.tsx
@@ -1,8 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import "@jobber/design/dist/foundation.css";
-import "@jobber/design/dist/dark.mode.css";
-import "@jobber/components/styles";
 import "./main.css";
 import { BrowserRouter } from "react-router-dom";
 import { AtlantisThemeContextProvider } from "@jobber/components";

--- a/packages/site/src/main.tsx
+++ b/packages/site/src/main.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import "./main.css";
 import { BrowserRouter } from "react-router-dom";
 import { AtlantisThemeContextProvider } from "@jobber/components";
 import { Layout } from "./layout/Layout";
@@ -10,6 +9,11 @@ import { initAtlantisTheme } from "./utils/theme";
 import { Analytics } from "./components/Analytics";
 import { handleStorybookRedirect } from "./utils/storybook";
 import { TritonProvider } from "./providers/TritonProvider";
+
+import "@jobber/design/dist/foundation.css";
+import "@jobber/design/dist/dark.mode.css";
+import "@jobber-component-styles/styles.css";
+import "./main.css";
 
 handleStorybookRedirect();
 

--- a/packages/site/src/preview/useAtlantisPreviewCode.tsx
+++ b/packages/site/src/preview/useAtlantisPreviewCode.tsx
@@ -1,6 +1,6 @@
 import { RefObject, useCallback, useState } from "react";
 import { transform } from "@babel/standalone";
-import { Theme } from "@jobber/components";
+import { type Theme } from "@jobber/components";
 import { useAtlantisPreviewSkeleton } from "./useAtlantisPreviewSkeleton";
 
 export const useAtlantisPreviewCode = ({

--- a/packages/site/src/preview/useAtlantisPreviewSkeleton.tsx
+++ b/packages/site/src/preview/useAtlantisPreviewSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Theme } from "@jobber/components";
+import { type Theme } from "@jobber/components";
 import { RefObject } from "react";
 
 const skeletonHTML = (theme: Theme, type: "web" | "mobile") => {

--- a/packages/site/src/utils/theme.ts
+++ b/packages/site/src/utils/theme.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@jobber/components";
+import { type Theme } from "@jobber/components";
 
 const FALLBACK_THEME: Theme = "light";
 

--- a/packages/site/tsconfig.json
+++ b/packages/site/tsconfig.json
@@ -9,6 +9,9 @@
       "@atlantis/docs/*": [
         "../../docs/*"
       ],
+      "@jobber-component-styles/*": [
+        "../components/dist/*"
+      ],
       "react": [
         "./node_modules/@types/react"
       ]

--- a/packages/site/vite.config.ts
+++ b/packages/site/vite.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
       "@jobber/formatters": path.resolve(__dirname, "../formatters/src"),
       "@jobber/hooks": path.resolve(__dirname, "../hooks/src"),
       "@jobber/components": path.resolve(__dirname, "../components/src"),
-      "@jobber/design-system": path.resolve(__dirname, "../design/src"),
+      "@jobber-component-styles": path.resolve(__dirname, "../components/dist"),
       "@storybook/addon-docs": path.resolve(
         __dirname,
         "./src/components/StorybookOverrides",

--- a/packages/site/vite.config.ts
+++ b/packages/site/vite.config.ts
@@ -62,6 +62,8 @@ export default defineConfig({
     alias: {
       "@jobber/formatters": path.resolve(__dirname, "../formatters/src"),
       "@jobber/hooks": path.resolve(__dirname, "../hooks/src"),
+      "@jobber/components": path.resolve(__dirname, "../components/src"),
+      "@jobber/design-system": path.resolve(__dirname, "../design/src"),
       "@storybook/addon-docs": path.resolve(
         __dirname,
         "./src/components/StorybookOverrides",


### PR DESCRIPTION
## Motivations

1. When working on the Layout components, I realized that the dev flow wasn't great when making changes to Atlantis.
2. I tried to fix it as part of the Layout components, but it required updating how we import types in a bunch of cases. I believe there still more of these mis imported types, but this is enough to get going with the dev site.

## Changes

1. Fixed the docs site so it pulls from `src` instead of `dist` for components, which means instant updates.
2. Had to adjust how we import types in a lot of cases.

## Testing

The new visual testing pages are a great working ground now. They don't have any wrapping CSS or structure.

For instance, open up the new layout testing pages /visual-testing/layout

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
