### PR TITLE
docs: add guide to Figma libraries

### DIFF
--- a/docs/guides/figma-101.mdx
+++ b/docs/guides/figma-101.mdx
@@ -5,7 +5,23 @@ import { Banner, Tiles } from "@jobber/components";
 
 # Figma 101
 
-The basics to building with Atlantis in Figma.
+## How we use Figma at Jobber
+
+This guide will help you get oriented on the ways we organize our projects,
+systems, and resources within Figma.
+
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+    overflow: "hidden",
+  }}
+  title="Figma overview"
+  width="100%"
+  height="600"
+  src="https://embed.figma.com/proto/LYwZN9IBZF7BmFTrKkTJhS/Getting-Started-With-Figma-At-Jobber?page-id=0%3A1&node-id=1-655&viewport=196%2C360%2C0.06&scaling=scale-down&content-scaling=fixed&starting-point-node-id=1%3A655&embed-host=share"
+  allowfullscreen
+></iframe>
 
 <Banner type="notice" dismissible={false}>
   Figma libraries are currently limited to internal Jobber usage
@@ -105,18 +121,6 @@ designer who's looking for it!)
     allowfullscreen
   ></iframe>
 </Tiles>
-
-## Choosing the right library
-
-You'll notice several systems-terms being thrown around as you work on Jobber.
-Atlantis, SG-1, Shared components, and more! To make sure you're using
-components from the right library in your work, follow this decision tree.
-
-## How to add and use components
-
-Whether you're adding a new component to our design system or using a component
-in your project, you can reference this guide for everything from naming
-conventions to editing tips.
 
 ## Responsive design / "what size should my artboards be?"
 

--- a/docs/guides/figma-101.mdx
+++ b/docs/guides/figma-101.mdx
@@ -27,7 +27,7 @@ systems, and resources within Figma.
   Figma libraries are currently limited to internal Jobber usage
 </Banner>
 
-## Figma libraries
+## Libraries
 
 <iframe
   style={{

--- a/docs/guides/figma-101.mdx
+++ b/docs/guides/figma-101.mdx
@@ -1,9 +1,11 @@
 import { Meta } from "@storybook/addon-docs";
 import { Banner, Tiles } from "@jobber/components";
 
-<Meta title="Guides/Figma" />
+<Meta title="Guides/Figma 101" />
 
-# Figma
+# Figma 101
+
+The basics to building with Atlantis in Figma.
 
 <Banner type="notice" dismissible={false}>
   Figma libraries are currently limited to internal Jobber usage

--- a/docs/guides/figma-overview.mdx
+++ b/docs/guides/figma-overview.mdx
@@ -1,0 +1,146 @@
+import { Meta } from "@storybook/addon-docs";
+import { Banner, Tiles } from "@jobber/components";
+
+<Meta title="Guides/Figma" />
+
+# Figma overview
+
+<Banner type="notice" dismissible={false}>
+  Figma libraries are currently limited to internal Jobber usage
+</Banner>
+
+## Figma libraries
+
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+    overflow: "hidden",
+  }}
+  title="Figma Product Base Design"
+  width="100%"
+  height="800"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=26021-260&embed-host=share"
+  allowFullScreen
+/>
+
+### Base
+
+Elements that are shared across web and mobile, such as design tokens and icons.
+
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+    overflow: "hidden",
+  }}
+  title="Figma Product Base Design"
+  width="100%"
+  height="450"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=198-1834&embed-host=share"
+  allowfullscreen
+></iframe>
+
+### Online and Mobile
+
+Atlantis and Shared components for the web (incl. responsive web) and mobile
+applications, respectively.
+
+<Tiles
+    gap="var(--space-base)"
+  >
+<iframe   style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+    overflow: "hidden",
+  }}
+  title="Figma Product Online"
+  width="100%"
+  height="250" src="https://embed.figma.com/design/rIIhulZvcp9M82lNOCGv16/Product-Online?m=auto&node-id=12588-94285&embed-host=share" allowfullscreen></iframe>
+
+<iframe   style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+    overflow: "hidden",
+  }}
+  title="Figma Product Mobile"
+  width="100%"
+  height="250" src="https://embed.figma.com/design/avvgu5SkbBvS8lGVePBsqO/Product-Mobile?m=auto&node-id=198-1834&embed-host=share" allowfullscreen></iframe>
+</Tiles>
+
+### Views
+
+The "Views" libraries contain as many of the pages/screens (we generalize this
+language to "views" to apply across platforms) as possible that we have built
+for a given platform. If you're looking for a view and you don't see it here,
+ask the team in #designers-feedback to see if anyone has the most up-to-date
+version in a working file (and ideally add it to the library for the next
+designer who's looking for it!)
+
+<Tiles gap="var(--space-base)">
+  <iframe
+    style={{
+      border: "var(--border-base) solid var(--color-border)",
+      borderRadius: "var(--radius-base)",
+      overflow: "hidden",
+    }}
+    title="Figma Product Online Views"
+    width="100%"
+    height="250"
+    src="https://embed.figma.com/design/LDsmAG7C5oLMW8jXFGSUGw/Product-Online-Views?m=auto&node-id=4-166534&embed-host=share"
+    allowfullscreen
+  ></iframe>
+  <iframe
+    style={{
+      border: "var(--border-base) solid var(--color-border)",
+      borderRadius: "var(--radius-base)",
+      overflow: "hidden",
+    }}
+    title="Figma Product Mobile Views"
+    width="100%"
+    height="250"
+    src="https://embed.figma.com/design/Q8qEFBbktHv3fr8ZBpGj9N/Product-Mobile-Views?m=auto&node-id=7-10319&embed-host=share"
+    allowfullscreen
+  ></iframe>
+</Tiles>
+
+## Choosing the right library
+
+You'll notice several systems-terms being thrown around as you work on Jobber.
+Atlantis, SG-1, Shared components, and more! To make sure you're using
+components from the right library in your work, follow this decision tree.
+
+## How to add and use components
+
+Whether you're adding a new component to our design system or using a component
+in your project, you can reference this guide for everything from naming
+conventions to editing tips.
+
+## Responsive design / "what size should my artboards be?"
+
+Our default artboard recommended sizes are based on usage data.
+
+| Device type | Default artboard size |
+| ----------- | --------------------- |
+| Desktop     | 1680 × 1200           |
+| Tablet      | 768 × 1024            |
+| Phone       | 375 × 812             |
+
+You should verify that your designs work at
+[responsive breakpoints.](../design/breakpoints) It's recommended to build with
+autolayout, to make this easier to check!
+
+<iframe
+  style={{
+    border: "var(--border-base) solid var(--color-border)",
+    borderRadius: "var(--radius-base)",
+    overflow: "hidden",
+  }}
+  title="Figma Product Base Design"
+  width="100%"
+  height="450"
+  src="https://embed.figma.com/design/HXWXusJPZLmaJNGlKEpiyhXW/Product-Base?m=auto&node-id=20707-66&embed-host=share"
+  allowfullscreen
+></iframe>
+
+**Remember:** auto-layout is your friend!

--- a/docs/guides/figma-overview.mdx
+++ b/docs/guides/figma-overview.mdx
@@ -3,7 +3,7 @@ import { Banner, Tiles } from "@jobber/components";
 
 <Meta title="Guides/Figma" />
 
-# Figma overview
+# Figma
 
 <Banner type="notice" dismissible={false}>
   Figma libraries are currently limited to internal Jobber usage

--- a/packages/site/src/guidesList.ts
+++ b/packages/site/src/guidesList.ts
@@ -17,6 +17,10 @@ export const guidesList = [
     to: "/guides/adding-an-icon",
   },
   {
+    title: "Figma overview",
+    to: "/guides/figma-overview",
+  },
+  {
     title: "Frontend styleguide",
     to: "/guides/frontend-styleguide",
   },

--- a/packages/site/src/guidesList.ts
+++ b/packages/site/src/guidesList.ts
@@ -17,7 +17,7 @@ export const guidesList = [
     to: "/guides/adding-an-icon",
   },
   {
-    title: "Figma overview",
+    title: "Figma 101",
     to: "/guides/figma-101",
   },
   {

--- a/packages/site/src/guidesList.ts
+++ b/packages/site/src/guidesList.ts
@@ -18,7 +18,7 @@ export const guidesList = [
   },
   {
     title: "Figma overview",
-    to: "/guides/figma-overview",
+    to: "/guides/figma-101",
   },
   {
     title: "Frontend styleguide",

--- a/packages/site/src/maps/guidesContent.tsx
+++ b/packages/site/src/maps/guidesContent.tsx
@@ -5,7 +5,7 @@ import FrontendStyleguideComponent from "@atlantis/docs/guides/frontend-style.st
 import AddingAnIcon from "@atlantis/docs/guides/adding-an-icon.stories.mdx";
 import GettingStartedWithReactComponent from "@atlantis/docs/getting-started-with-react/getting-started-with-react.stories.mdx";
 import PullRequestTitleGeneratorComponent from "@atlantis/docs/guides/pull-request-title-generator.stories.mdx";
-import FigmaOverviewComponent from "@atlantis/docs/guides/figma-overview.mdx";
+import Figma101Component from "@atlantis/docs/guides/figma-101.mdx";
 import PageLayoutsComponent from "../guides/page-layouts.stories.mdx";
 import ScaffoldingComponent from "../guides/scaffolding.stories.mdx";
 import { ContentMapItems } from "../types/maps";
@@ -31,10 +31,10 @@ export const guidesContentMap: ContentMapItems = {
     title: "Adding an icon",
     content: () => <AddingAnIcon />,
   },
-  "figma-overview": {
+  "figma-101": {
     intro: "Figma overview",
     title: "Figma overview",
-    content: () => <FigmaOverviewComponent />,
+    content: () => <Figma101Component />,
   },
   "frontend-styleguide": {
     intro: "Frontend styleguide",

--- a/packages/site/src/maps/guidesContent.tsx
+++ b/packages/site/src/maps/guidesContent.tsx
@@ -32,8 +32,8 @@ export const guidesContentMap: ContentMapItems = {
     content: () => <AddingAnIcon />,
   },
   "figma-101": {
-    intro: "Figma overview",
-    title: "Figma overview",
+    intro: "Figma 101",
+    title: "Figma 101",
     content: () => <Figma101Component />,
   },
   "frontend-styleguide": {

--- a/packages/site/src/maps/guidesContent.tsx
+++ b/packages/site/src/maps/guidesContent.tsx
@@ -5,6 +5,7 @@ import FrontendStyleguideComponent from "@atlantis/docs/guides/frontend-style.st
 import AddingAnIcon from "@atlantis/docs/guides/adding-an-icon.stories.mdx";
 import GettingStartedWithReactComponent from "@atlantis/docs/getting-started-with-react/getting-started-with-react.stories.mdx";
 import PullRequestTitleGeneratorComponent from "@atlantis/docs/guides/pull-request-title-generator.stories.mdx";
+import FigmaOverviewComponent from "@atlantis/docs/guides/figma-overview.mdx";
 import PageLayoutsComponent from "../guides/page-layouts.stories.mdx";
 import ScaffoldingComponent from "../guides/scaffolding.stories.mdx";
 import { ContentMapItems } from "../types/maps";
@@ -29,6 +30,11 @@ export const guidesContentMap: ContentMapItems = {
     intro: "Adding an icon",
     title: "Adding an icon",
     content: () => <AddingAnIcon />,
+  },
+  "figma-overview": {
+    intro: "Figma overview",
+    title: "Figma overview",
+    content: () => <FigmaOverviewComponent />,
   },
   "frontend-styleguide": {
     intro: "Frontend styleguide",

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -220,7 +220,7 @@ export const routes: Array<AtlantisRoute> = [
         exact: true,
       },
       {
-        path: "/guides/figma-overview",
+        path: "/guides/figma-101",
         handle: "Figma overview",
         exact: true,
       },

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -221,7 +221,7 @@ export const routes: Array<AtlantisRoute> = [
       },
       {
         path: "/guides/figma-101",
-        handle: "Figma overview",
+        handle: "Figma 101",
         exact: true,
       },
       {

--- a/packages/site/src/routes.tsx
+++ b/packages/site/src/routes.tsx
@@ -220,6 +220,11 @@ export const routes: Array<AtlantisRoute> = [
         exact: true,
       },
       {
+        path: "/guides/figma-overview",
+        handle: "Figma overview",
+        exact: true,
+      },
+      {
         path: "/guides/getting-started-with-react",
         handle: "Getting started with React",
         exact: true,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There's some good Figma onboarding pieces scattered around internal wikis that would be helpful for new Jobber designers to have consolidated access to. Would like to link this on the Home page once it lands.

![image](https://github.com/user-attachments/assets/c58a6b94-4871-4ecf-ac70-2d9f1d145321)

## Changes

### Added

- Guide to our Figma library setup and general Jobber-specific approaches to file setup and structure

### Security

- Note: Figmas are not publicly viewable and are also have no real "trade secret" content - IMO this is secure enough. If the team feels strongly otherwise, I can leave the content in internal wikis, or we could look at some of the ideas around conditional authentication like we have in place on Triton. FWIW we already have embedded Figmas in our icon guidance docs and some patterns docs.

## Testing

- Run locally/in CF
- When not logged in to Figma, you should not see the Figma files previewed in the iframes

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
