### PR TITLE
fix(components): Properly Exclude DefaultValue from InputTimev2 Props

### DIFF
--- a/packages/components/src/InputTime/InputTime.types.ts
+++ b/packages/components/src/InputTime/InputTime.types.ts
@@ -50,7 +50,10 @@ export interface InputTimeLegacyProps extends InputTimeProps {
 }
 
 export interface InputTimeRebuiltProps
-  extends Omit<InputTimeProps, "defaultValue" | "version"> {
+  extends Omit<
+    InputTimeProps,
+    "defaultValue" | "version" | "validations" | "onValidation"
+  > {
   /**
    * Version 2 is highly experimental, avoid using it unless you have talked with Atlantis first.
    */

--- a/packages/components/src/InputTime/InputTime.types.ts
+++ b/packages/components/src/InputTime/InputTime.types.ts
@@ -52,6 +52,9 @@ export interface InputTimeLegacyProps extends InputTimeProps {
 export interface InputTimeRebuiltProps
   extends Omit<InputTimeProps, "defaultValue" | "version"> {
   defaultValue?: never;
+  /**
+   * Version 2 is highly experimental, avoid using it unless you have talked with Atlantis first.
+   */
   version: 2;
   error?: string;
 }

--- a/packages/components/src/InputTime/InputTime.types.ts
+++ b/packages/components/src/InputTime/InputTime.types.ts
@@ -43,10 +43,10 @@ export interface InputTimeProps
    * Function called when user changes input value.
    */
   onChange?(newValue?: Date): void;
-  /**
-   * The version of the component.
-   */
-  version?: 1 | 2;
+}
+
+export interface InputTimeLegacyProps extends InputTimeProps {
+  version?: 1;
 }
 
 export interface InputTimeRebuiltProps

--- a/packages/components/src/InputTime/InputTime.types.ts
+++ b/packages/components/src/InputTime/InputTime.types.ts
@@ -51,7 +51,6 @@ export interface InputTimeLegacyProps extends InputTimeProps {
 
 export interface InputTimeRebuiltProps
   extends Omit<InputTimeProps, "defaultValue" | "version"> {
-  defaultValue?: never;
   /**
    * Version 2 is highly experimental, avoid using it unless you have talked with Atlantis first.
    */

--- a/packages/components/src/InputTime/index.tsx
+++ b/packages/components/src/InputTime/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { InputTimeProps, InputTimeRebuiltProps } from "./InputTime.types";
+import { InputTimeLegacyProps, InputTimeRebuiltProps } from "./InputTime.types";
 import { InputTimeRebuilt } from "./InputTime.rebuilt";
 import { InputTime as InputTimeLegacy } from "./InputTime";
 
-export type InputTimeShimProps = InputTimeProps | InputTimeRebuiltProps;
+export type InputTimeShimProps = InputTimeLegacyProps | InputTimeRebuiltProps;
 
 function isNewInputTimeProps(
   props: InputTimeShimProps,

--- a/packages/site/src/content/InputTime/InputTime.props.json
+++ b/packages/site/src/content/InputTime/InputTime.props.json
@@ -45,19 +45,6 @@
           "name": "(newValue?: Date) => void"
         }
       },
-      "version": {
-        "defaultValue": null,
-        "description": "The version of the component.",
-        "name": "version",
-        "parent": {
-          "fileName": "packages/components/src/InputTime/InputTime.types.ts",
-          "name": "InputTimeProps"
-        },
-        "required": false,
-        "type": {
-          "name": "1 | 2"
-        }
-      },
       "id": {
         "defaultValue": null,
         "description": "A unique identifier for the input.",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

we removed the functionality of `defaultValue` on `InputTime` v2 - since it's meant to be a controlled component. however the types are not correctly reflecting that, I believe it's because we had defined `version?: 1 | 2` and so it could meet that criteria of the "old" set of props and not exclude it like we'd like



## Changes

re-jigged the types a bit to properly tell TS that if you do `version={2}` there is no `defaultValue` prop

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

`<InputTime version={2} defaultValue={new Date()} .../>` should NOT do anything with the provided date, and TS should tell you that's invalid.

`<InputTime version={1} defaultValue={new Date()} ... />` should continue to work

`<InputTime defaultValue={new Date()} ... />` should continue to work

anything referencing `InputTimeProps` should continue to work. I made a new type that extends from the old one, making sure to not remove it. though nothing really should be referencing it, nor can I find anything trying to.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
