### PR TITLE
feat(components): make onClear optional on FormFieldWrapper

### DIFF
--- a/packages/components/src/FormField/FormFieldWrapper.tsx
+++ b/packages/components/src/FormField/FormFieldWrapper.tsx
@@ -17,7 +17,7 @@ export interface FormFieldWrapperProps extends FormFieldProps {
   readonly identifier: string;
   readonly descriptionIdentifier: string;
   readonly clearable: Clearable;
-  readonly onClear: () => void;
+  readonly onClear?: () => void;
   readonly showMiniLabel?: boolean;
   readonly readonly?: boolean;
 }

--- a/packages/components/src/FormField/components/ClearAction.tsx
+++ b/packages/components/src/FormField/components/ClearAction.tsx
@@ -6,7 +6,7 @@ interface ClearActionProps {
   /**
    * Click handler
    */
-  readonly onClick: () => void;
+  readonly onClick?: () => void;
   readonly visible?: boolean;
 }
 
@@ -19,7 +19,7 @@ export function ClearAction({
   return (
     <button
       className={styles.clearInput}
-      onClick={onClick}
+      onClick={() => onClick?.()}
       type="button"
       aria-label="Clear input"
       data-testid="ATL-FormField-clearButton"

--- a/packages/components/src/FormField/components/ClearAction.tsx
+++ b/packages/components/src/FormField/components/ClearAction.tsx
@@ -19,7 +19,7 @@ export function ClearAction({
   return (
     <button
       className={styles.clearInput}
-      onClick={() => onClick?.()}
+      onClick={onClick}
       type="button"
       aria-label="Clear input"
       data-testid="ATL-FormField-clearButton"

--- a/packages/components/src/Select/Select.rebuilt.tsx
+++ b/packages/components/src/Select/Select.rebuilt.tsx
@@ -27,12 +27,11 @@ export function SelectRebuilt(props: SelectRebuiltProps) {
     id: id,
   });
 
-  const { handleChange, handleBlur, handleFocus, handleClear } =
-    useSelectActions({
-      onChange: props.onChange,
-      onBlur: props.onBlur,
-      onFocus: props.onFocus,
-    });
+  const { handleChange, handleBlur, handleFocus } = useSelectActions({
+    onChange: props.onChange,
+    onBlur: props.onBlur,
+    onFocus: props.onFocus,
+  });
 
   const inputProps = omit(props, [
     "onChange",
@@ -71,7 +70,6 @@ export function SelectRebuilt(props: SelectRebuiltProps) {
       value={props.value}
       prefix={props.prefix}
       suffix={props.suffix}
-      onClear={handleClear}
       clearable="never"
     >
       <>

--- a/packages/components/src/Select/hooks/useSelectActions.ts
+++ b/packages/components/src/Select/hooks/useSelectActions.ts
@@ -30,15 +30,9 @@ export function useSelectActions({
     onFocus?.();
   }
 
-  // Noop for SelectRebuilt since onClear is a required prop for FormFieldWrapper
-  // but Select is not clearable.
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  function handleClear() {}
-
   return {
     handleChange,
     handleBlur,
     handleFocus,
-    handleClear,
   };
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

For some inputs, they are not clearable (e.g. `Select`). However even if `clearable` is set to "never", `onClear` handler is still a required prop on `FormFieldWrapper`, making us create `handleClear` function that will never be used.


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `onClear` prop of `FormFieldWrapper` is now optional
- `onClick` prop of `ClearAction` now has a `?` conditional check.
- Removed empty `handleClear` function in Select rebuilt 

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Test in legacy InputText's clearable story, where `onClear` handler comes from `useAtlantisFormFieldActions`. Confirm value is still being cleared.
- In Select rebuilt, `onClear` is not being passed into `FormFieldWrapper`. Confirm no typescript error.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
