### PR TITLE
feat(components): Add maxLength prop to both Select versions

### DIFF
--- a/docs/components/Select/Web.stories.tsx
+++ b/docs/components/Select/Web.stories.tsx
@@ -149,6 +149,7 @@ export const VersionComparison = () => {
     sizeSmall: "",
     sizeLarge: "",
     loading: "",
+    maxLength: "",
   });
 
   const [inline, setInline] = useState(false);
@@ -302,6 +303,16 @@ export const VersionComparison = () => {
             ...extraProps,
           },
           "loading",
+        )}
+
+        {renderBothVersions(
+          "Max Length",
+          {
+            placeholder: "Max length select",
+            maxLength: 5,
+            ...extraProps,
+          },
+          "maxLength",
         )}
       </div>
 

--- a/packages/components/src/Select/Select.rebuilt.tsx
+++ b/packages/components/src/Select/Select.rebuilt.tsx
@@ -73,6 +73,7 @@ export function SelectRebuilt(props: SelectRebuiltProps) {
       suffix={props.suffix}
       onClear={handleClear}
       clearable="never"
+      maxLength={props.maxLength}
     >
       <>
         <select {...fieldProps} ref={selectRef} className={inputStyle}>

--- a/packages/components/src/Select/Select.types.ts
+++ b/packages/components/src/Select/Select.types.ts
@@ -30,8 +30,12 @@ export interface SelectLegacyProps
       | "suffix"
       | "defaultValue"
       | "version"
-      | "maxLength"
-    > {}
+    > {
+  /**
+   * Changes the width to roughly the same size as the maximum character length
+   */
+  readonly maxLength?: number;
+}
 
 /**
  * Rebuilt version of the Select component without React Hook Form dependency.

--- a/packages/components/src/Select/Select.types.ts
+++ b/packages/components/src/Select/Select.types.ts
@@ -30,6 +30,7 @@ export interface SelectLegacyProps
       | "suffix"
       | "defaultValue"
       | "version"
+      | "maxLength"
     > {}
 
 /**

--- a/packages/site/src/content/Select/Select.props.json
+++ b/packages/site/src/content/Select/Select.props.json
@@ -317,6 +317,19 @@
         "type": {
           "name": "1"
         }
+      },
+      "maxLength": {
+        "defaultValue": null,
+        "description": "Maximum character length for an input. This also changes the width to\nroughly the same size as the max length. This is to communicate that the\nuser that on certain cases, they can only type a limited amount of\ncharacters.",
+        "name": "maxLength",
+        "parent": {
+          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
+          "name": "FormFieldProps"
+        },
+        "required": false,
+        "type": {
+          "name": "number"
+        }
       }
     }
   }

--- a/packages/site/src/content/Select/Select.props.json
+++ b/packages/site/src/content/Select/Select.props.json
@@ -6,6 +6,19 @@
     "displayName": "Select",
     "methods": [],
     "props": {
+      "maxLength": {
+        "defaultValue": null,
+        "description": "Changes the width to roughly the same size as the maximum character length",
+        "name": "maxLength",
+        "parent": {
+          "fileName": "packages/components/src/Select/Select.types.ts",
+          "name": "SelectLegacyProps"
+        },
+        "required": false,
+        "type": {
+          "name": "number"
+        }
+      },
       "id": {
         "defaultValue": null,
         "description": "A unique identifier for the input.",
@@ -316,19 +329,6 @@
         "required": false,
         "type": {
           "name": "1"
-        }
-      },
-      "maxLength": {
-        "defaultValue": null,
-        "description": "Maximum character length for an input. This also changes the width to\nroughly the same size as the max length. This is to communicate that the\nuser that on certain cases, they can only type a limited amount of\ncharacters.",
-        "name": "maxLength",
-        "parent": {
-          "fileName": "packages/components/src/FormField/FormFieldTypes.ts",
-          "name": "FormFieldProps"
-        },
-        "required": false,
-        "type": {
-          "name": "number"
         }
       }
     }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

It turns out `maxLength` is not only used on `input` and `textarea`, but also fed into `useFormFieldWrapperStyles` to determine the width of the input. This PR adds the prop back to `SelectLegacy` that originally had it.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Added `maxLength` to `SelectLegacyProps` and `SelectRebuiltProps`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
