### PR TITLE
feat(components): Add Default Activator Ref to Combobox

### DIFF
--- a/packages/components/src/Combobox/Combobox.tsx
+++ b/packages/components/src/Combobox/Combobox.tsx
@@ -68,7 +68,11 @@ export function Combobox(props: ComboboxProps): JSX.Element {
           />
         )}
         {triggerElement || (
-          <ComboboxTrigger label={props.label} selected={props.selected} />
+          <ComboboxTrigger
+            label={props.label}
+            selected={props.selected}
+            activatorRef={props.defaultActivatorRef}
+          />
         )}
         <ComboboxContent
           multiselect={props.multiSelect}

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -62,7 +62,7 @@ export interface ComboboxProps {
   /**
    * A ref to the default activator button element.
    */
-  readonly defaultActivatorRef: React.RefObject<HTMLButtonElement>;
+  readonly defaultActivatorRef?: React.RefObject<HTMLButtonElement>;
 }
 
 export interface ComboboxCustomActivatorProps {
@@ -107,7 +107,7 @@ export interface ComboboxActivatorProps {
 export interface ComboboxTriggerProps
   extends Pick<ComboboxContentProps, "selected"> {
   readonly label?: string;
-  readonly activatorRef: React.RefObject<HTMLButtonElement>;
+  readonly activatorRef?: React.RefObject<HTMLButtonElement>;
 }
 
 export interface ComboboxOptionProps {

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -58,6 +58,11 @@ export interface ComboboxProps {
    * Should the Combobox display the loading state.
    */
   readonly loading?: boolean;
+
+  /**
+   * A ref to the default activator button element.
+   */
+  readonly defaultActivatorRef: React.RefObject<HTMLButtonElement>;
 }
 
 export interface ComboboxCustomActivatorProps {
@@ -102,6 +107,7 @@ export interface ComboboxActivatorProps {
 export interface ComboboxTriggerProps
   extends Pick<ComboboxContentProps, "selected"> {
   readonly label?: string;
+  readonly activatorRef: React.RefObject<HTMLButtonElement>;
 }
 
 export interface ComboboxOptionProps {

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -62,7 +62,7 @@ export interface ComboboxProps {
   /**
    * A ref to the default activator button element.
    */
-  readonly defaultActivatorRef?: React.RefObject<HTMLButtonElement>;
+  readonly defaultActivatorRef?: React.Ref<HTMLButtonElement>;
 }
 
 export interface ComboboxCustomActivatorProps {
@@ -107,7 +107,7 @@ export interface ComboboxActivatorProps {
 export interface ComboboxTriggerProps
   extends Pick<ComboboxContentProps, "selected"> {
   readonly label?: string;
-  readonly activatorRef?: React.RefObject<HTMLButtonElement>;
+  readonly activatorRef?: React.Ref<HTMLButtonElement>;
 }
 
 export interface ComboboxOptionProps {

--- a/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
+++ b/packages/components/src/Combobox/components/ComboboxTrigger/ComboboxTrigger.tsx
@@ -7,6 +7,7 @@ import { ComboboxTriggerProps } from "../../Combobox.types";
 export function ComboboxTrigger({
   label = "Select",
   selected,
+  activatorRef,
 }: ComboboxTriggerProps) {
   const { handleOpen } = React.useContext(ComboboxContext);
 
@@ -21,6 +22,7 @@ export function ComboboxTrigger({
       heading={label}
       onClick={handleOpen}
       role="combobox"
+      ref={activatorRef}
     >
       {!hasSelection && (
         <Chip.Suffix>

--- a/packages/site/src/content/Combobox/Combobox.props.json
+++ b/packages/site/src/content/Combobox/Combobox.props.json
@@ -137,6 +137,19 @@
         "type": {
           "name": "boolean"
         }
+      },
+      "defaultActivatorRef": {
+        "defaultValue": null,
+        "description": "A ref to the default activator button element.",
+        "name": "defaultActivatorRef",
+        "parent": {
+          "fileName": "packages/components/src/Combobox/Combobox.types.ts",
+          "name": "ComboboxProps"
+        },
+        "required": false,
+        "type": {
+          "name": "RefObject<HTMLButtonElement>"
+        }
       }
     }
   },

--- a/packages/site/src/content/Combobox/Combobox.props.json
+++ b/packages/site/src/content/Combobox/Combobox.props.json
@@ -148,7 +148,7 @@
         },
         "required": false,
         "type": {
-          "name": "RefObject<HTMLButtonElement>"
+          "name": "Ref<HTMLButtonElement>"
         }
       }
     }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Recently we added `ref` to `Chip` so that if you are using a Combobox to make a selection that is required on a form, specifically Zod + RHF though a similar effect could be achieved other ways, we'd have a ref to register with the form to scroll to and focus.

The only way to provide a ref would be thru a custom activator, which is not ideal if all you want is the default activator with a ref. Having to rebuild the activator just to access that isn't great.

So, to allow for the default to have a ref we're adding a `defaultActivatorRef` prop. The intent of the name is to communicate that it is ONLY going to work if you are using the default activator since the way COmbobox works is that if you want to override the default you provide `Combobox.Activator`, if you want the default you do not provide one at all.



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

`defaultActivatorRef` to top level `Combobox` to pass a ref to the `Chip` we use as the default activator

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
