### PR TITLE
feat(components): Add noopener and noreferrer attributes to Link

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -54,7 +54,10 @@ function ButtonWrapper(props: ButtonProps) {
     ...(!disabled && { href: url }),
     ...(!disabled && { onClick: onClick }),
     ...(!disabled && { onMouseDown: onMouseDown }),
-    ...(external && { target: "_blank" }),
+    ...(external && {
+      target: "_blank",
+      rel: "noopener noreferrer",
+    }),
     ...(url === undefined && to === undefined && { type: buttonType }),
     "aria-controls": ariaControls,
     "aria-haspopup": ariaHaspopup,

--- a/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/Button.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`renders a Button with a link and opens in new tab 1`] = `
   <a
     class="button base work primary buttonChildren"
     href="💩.com"
+    rel="noopener noreferrer"
     target="_blank"
   >
     <span

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -18,7 +18,10 @@ export function Link({
   return (
     <a
       href={url}
-      {...(external && { target: "_blank" })}
+      {...(external && {
+        target: "_blank",
+        rel: "noopener noreferrer",
+      })}
       {...(ariaLabel && { "aria-label": ariaLabel })}
       {...(ariaExpanded && { "aria-expanded": ariaExpanded })}
       className={styles.link}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Add security attributes to external links to prevent potential security vulnerabilities when using `target="_blank"`. This follows web security best practices by preventing the new page from accessing the `window.opener` property and hiding the referrer information.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added `rel="noopener noreferrer"` to external links in the `Link` component when `external` prop is true

## Testing

<!-- How to test your changes. -->
1. Go to the `Basic` Link story
2. Inspect & verify that the rendered anchor tag includes both `target="_blank"` and `rel="noopener noreferrer"`
3. Click the link and ensure it still opens in a new tab as expected

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
