### PR TITLE
feat(components): Add element prop to Text

### DIFF
--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -2,6 +2,12 @@ import React, { PropsWithChildren } from "react";
 import { Typography, TypographyOptions, TypographyProps } from "../Typography";
 
 export interface TextProps {
+  /**
+   * The HTML element to render the text as.
+   * @default "p"
+   */
+  readonly element?: TypographyProps["element"];
+
   readonly maxLines?:
     | "single"
     | "small"
@@ -44,6 +50,7 @@ export function Text({
   variation = "default",
   size = "base",
   align = "start",
+  element = "p",
   children,
   maxLines = "unlimited",
   UNSAFE_className,
@@ -70,6 +77,7 @@ export function Text({
 
   return (
     <Typography
+      element={element}
       textColor={textColors[variation] as TextColor}
       size={size}
       numberOfLines={maxLineToNumber[maxLines]}

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -1,12 +1,17 @@
 import React, { PropsWithChildren } from "react";
 import { Typography, TypographyOptions, TypographyProps } from "../Typography";
 
+type TextElement = Extract<
+  TypographyProps["element"],
+  "p" | "b" | "em" | "dd" | "dt" | "strong" | "span"
+>;
+
 export interface TextProps {
   /**
    * The HTML element to render the text as.
    * @default "p"
    */
-  readonly element?: TypographyProps["element"];
+  readonly element?: TextElement;
 
   readonly maxLines?:
     | "single"

--- a/packages/site/src/content/InputFile/InputFile.props.json
+++ b/packages/site/src/content/InputFile/InputFile.props.json
@@ -491,6 +491,21 @@
     "displayName": "InputFile.Description",
     "methods": [],
     "props": {
+      "element": {
+        "defaultValue": {
+          "value": "\"p\""
+        },
+        "description": "The HTML element to render the text as.",
+        "name": "element",
+        "parent": {
+          "fileName": "packages/components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"b\" | \"em\" | \"dd\" | \"dt\" | \"strong\" | \"span\""
+        }
+      },
       "maxLines": {
         "defaultValue": null,
         "description": "",
@@ -590,6 +605,21 @@
     "displayName": "InputFile.HintText",
     "methods": [],
     "props": {
+      "element": {
+        "defaultValue": {
+          "value": "\"p\""
+        },
+        "description": "The HTML element to render the text as.",
+        "name": "element",
+        "parent": {
+          "fileName": "packages/components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"b\" | \"em\" | \"dd\" | \"dt\" | \"strong\" | \"span\""
+        }
+      },
       "maxLines": {
         "defaultValue": null,
         "description": "",

--- a/packages/site/src/content/InputFile/InputFile.props.json
+++ b/packages/site/src/content/InputFile/InputFile.props.json
@@ -503,7 +503,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"b\" | \"em\" | \"dd\" | \"dt\" | \"strong\" | \"span\""
+          "name": "TextElement"
         }
       },
       "maxLines": {
@@ -617,7 +617,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"b\" | \"em\" | \"dd\" | \"dt\" | \"strong\" | \"span\""
+          "name": "TextElement"
         }
       },
       "maxLines": {

--- a/packages/site/src/content/Text/Text.props.json
+++ b/packages/site/src/content/Text/Text.props.json
@@ -6,6 +6,21 @@
     "displayName": "Text",
     "methods": [],
     "props": {
+      "element": {
+        "defaultValue": {
+          "value": "p"
+        },
+        "description": "The HTML element to render the text as.",
+        "name": "element",
+        "parent": {
+          "fileName": "../components/src/Text/Text.tsx",
+          "name": "TextProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"b\" | \"em\" | \"dd\" | \"dt\" | \"strong\" | \"span\""
+        }
+      },
       "maxLines": {
         "defaultValue": {
           "value": "unlimited"

--- a/packages/site/src/content/Text/Text.props.json
+++ b/packages/site/src/content/Text/Text.props.json
@@ -18,7 +18,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"b\" | \"em\" | \"dd\" | \"dt\" | \"strong\" | \"span\""
+          "name": "TextElement"
         }
       },
       "maxLines": {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Allow users of the `Text` component to specify which HTML element they want to render, providing the same flexibility as the `Typography` component. This enables more semantic markup while maintaining consistent text styling.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added `element` prop to `Text` component that accepts all HTML elements supported by `Typography` (h1-h6, p, b, em, dd, dt, strong, span)
- Default value is "p" to maintain existing behavior
- Type is derived from `Typography` component to ensure consistency

## Testing

Use `Text` component with different element values:
2. Verify that each renders with the correct HTML tag while maintaining Text component styling
3. Verify that existing Text component usage without the element prop continues to render as a paragraph

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
