### PR TITLE
docs: fix link to layouts guide provided by the search

### DIFF
--- a/packages/site/src/guidesList.ts
+++ b/packages/site/src/guidesList.ts
@@ -30,7 +30,7 @@ export const guidesList = [
   },
   {
     title: "Page Layouts",
-    to: "/guides/layouts",
+    to: "/guides/page-layouts",
   },
   {
     title: "Scaffolding",


### PR DESCRIPTION
## Motivations

<!-- Why did you do what you did? -->
When using search for layouts and clicking the layouts guide it leads to a 404. This PR fixes that.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Fixed link to Layouts guide when using search

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

 - On [atlantis](https://atlantis.getjobber.com/) search for layouts and click the guides to page layouts. Notice that it 404s. This also happens from https://atlantis.getjobber.com/guides
- On the preview site. Search for layouts and click the page layouts guide. Observe it redirects correctly. Confirm that layouts page loads when you click Page Layouts on the [guides page](https://mike-fix-layouts-link.atlantis.pages.dev/guides)

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
