### PR TITLE
feat(components): Generate a CSS File for Each Web Component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,16 +35,19 @@
       "import": "./dist/AtlantisThemeContext/index.mjs",
       "require": "./dist/AtlantisThemeContext/index.cjs"
     },
+    "./Autocomplete/styles.css": "./dist/Autocomplete/Autocomplete.css",
     "./Autocomplete": {
       "types": "./dist/Autocomplete/index.d.ts",
       "import": "./dist/Autocomplete/index.mjs",
       "require": "./dist/Autocomplete/index.cjs"
     },
+    "./Avatar/styles.css": "./dist/Avatar/Avatar.css",
     "./Avatar": {
       "types": "./dist/Avatar/index.d.ts",
       "import": "./dist/Avatar/index.mjs",
       "require": "./dist/Avatar/index.cjs"
     },
+    "./Banner/styles.css": "./dist/Banner/Banner.css",
     "./Banner": {
       "types": "./dist/Banner/index.d.ts",
       "import": "./dist/Banner/index.mjs",
@@ -55,6 +58,7 @@
       "import": "./dist/Box/index.mjs",
       "require": "./dist/Box/index.cjs"
     },
+    "./Button/styles.css": "./dist/Button/Button.css",
     "./Button": {
       "types": "./dist/Button/index.d.ts",
       "import": "./dist/Button/index.mjs",
@@ -65,16 +69,19 @@
       "import": "./dist/ButtonDismiss/index.mjs",
       "require": "./dist/ButtonDismiss/index.cjs"
     },
+    "./Card/styles.css": "./dist/Card/Card.css",
     "./Card": {
       "types": "./dist/Card/index.d.ts",
       "import": "./dist/Card/index.mjs",
       "require": "./dist/Card/index.cjs"
     },
+    "./Checkbox/styles.css": "./dist/Checkbox/Checkbox.css",
     "./Checkbox": {
       "types": "./dist/Checkbox/index.d.ts",
       "import": "./dist/Checkbox/index.mjs",
       "require": "./dist/Checkbox/index.cjs"
     },
+    "./Chip/styles.css": "./dist/Chip/Chip.css",
     "./Chip": {
       "types": "./dist/Chip/index.d.ts",
       "import": "./dist/Chip/index.mjs",
@@ -85,11 +92,13 @@
       "import": "./dist/Chips/index.mjs",
       "require": "./dist/Chips/index.cjs"
     },
+    "./Cluster/styles.css": "./dist/Cluster/Cluster.css",
     "./Cluster": {
       "types": "./dist/Cluster/index.d.ts",
       "import": "./dist/Cluster/index.mjs",
       "require": "./dist/Cluster/index.cjs"
     },
+    "./Combobox/styles.css": "./dist/Combobox/Combobox.css",
     "./Combobox": {
       "types": "./dist/Combobox/index.d.ts",
       "import": "./dist/Combobox/index.mjs",
@@ -100,21 +109,25 @@
       "import": "./dist/ConfirmationModal/index.mjs",
       "require": "./dist/ConfirmationModal/index.cjs"
     },
+    "./Cover/styles.css": "./dist/Cover/Cover.css",
     "./Cover": {
       "types": "./dist/Cover/index.d.ts",
       "import": "./dist/Cover/index.mjs",
       "require": "./dist/Cover/index.cjs"
     },
+    "./Container/styles.css": "./dist/Container/Container.css",
     "./Container": {
       "types": "./dist/Container/index.d.ts",
       "import": "./dist/Container/index.mjs",
       "require": "./dist/Container/index.cjs"
     },
+    "./Content/styles.css": "./dist/Content/Content.css",
     "./Content": {
       "types": "./dist/Content/index.d.ts",
       "import": "./dist/Content/index.mjs",
       "require": "./dist/Content/index.cjs"
     },
+    "./ContentBlock/styles.css": "./dist/ContentBlock/ContentBlock.css",
     "./ContentBlock": {
       "types": "./dist/ContentBlock/index.d.ts",
       "import": "./dist/ContentBlock/index.mjs",
@@ -130,36 +143,43 @@
       "import": "./dist/DataDump/index.mjs",
       "require": "./dist/DataDump/index.cjs"
     },
+    "./DataList/styles.css": "./dist/DataList/DataList.css",
     "./DataList": {
       "types": "./dist/DataList/index.d.ts",
       "import": "./dist/DataList/index.mjs",
       "require": "./dist/DataList/index.cjs"
     },
+    "./DataTable/styles.css": "./dist/DataTable/DataTable.css",
     "./DataTable": {
       "types": "./dist/DataTable/index.d.ts",
       "import": "./dist/DataTable/index.mjs",
       "require": "./dist/DataTable/index.cjs"
     },
+    "./DatePicker/styles.css": "./dist/DatePicker/DatePicker.css",
     "./DatePicker": {
       "types": "./dist/DatePicker/index.d.ts",
       "import": "./dist/DatePicker/index.mjs",
       "require": "./dist/DatePicker/index.cjs"
     },
+    "./DescriptionList/styles.css": "./dist/DescriptionList/DescriptionList.css",
     "./DescriptionList": {
       "types": "./dist/DescriptionList/index.d.ts",
       "import": "./dist/DescriptionList/index.mjs",
       "require": "./dist/DescriptionList/index.cjs"
     },
+    "./Disclosure/styles.css": "./dist/Disclosure/Disclosure.css",
     "./Disclosure": {
       "types": "./dist/Disclosure/index.d.ts",
       "import": "./dist/Disclosure/index.mjs",
       "require": "./dist/Disclosure/index.cjs"
     },
+    "./Divider/styles.css": "./dist/Divider/Divider.css",
     "./Divider": {
       "types": "./dist/Divider/index.d.ts",
       "import": "./dist/Divider/index.mjs",
       "require": "./dist/Divider/index.cjs"
     },
+    "./Drawer/styles.css": "./dist/Drawer/Drawer.css",
     "./Drawer": {
       "types": "./dist/Drawer/index.d.ts",
       "import": "./dist/Drawer/index.mjs",
@@ -170,11 +190,13 @@
       "import": "./dist/Emphasis/index.mjs",
       "require": "./dist/Emphasis/index.cjs"
     },
+    "./FeatureSwitch/styles.css": "./dist/FeatureSwitch/FeatureSwitch.css",
     "./FeatureSwitch": {
       "types": "./dist/FeatureSwitch/index.d.ts",
       "import": "./dist/FeatureSwitch/index.mjs",
       "require": "./dist/FeatureSwitch/index.cjs"
     },
+    "./Flex/styles.css": "./dist/Flex/Flex.css",
     "./Flex": {
       "types": "./dist/Flex/index.d.ts",
       "import": "./dist/Flex/index.mjs",
@@ -185,6 +207,7 @@
       "import": "./dist/Form/index.mjs",
       "require": "./dist/Form/index.cjs"
     },
+    "./FormField/styles.css": "./dist/FormField/FormField.css",
     "./FormField": {
       "types": "./dist/FormField/index.d.ts",
       "import": "./dist/FormField/index.mjs",
@@ -195,11 +218,13 @@
       "import": "./dist/FormatDate/index.mjs",
       "require": "./dist/FormatDate/index.cjs"
     },
+    "./FormatEmail/styles.css": "./dist/FormatEmail/FormatEmail.css",
     "./FormatEmail": {
       "types": "./dist/FormatEmail/index.d.ts",
       "import": "./dist/FormatEmail/index.mjs",
       "require": "./dist/FormatEmail/index.cjs"
     },
+    "./FormatFile/styles.css": "./dist/FormatFile/FormatFile.css",
     "./FormatFile": {
       "types": "./dist/FormatFile/index.d.ts",
       "import": "./dist/FormatFile/index.mjs",
@@ -215,21 +240,25 @@
       "import": "./dist/FormatTime/index.mjs",
       "require": "./dist/FormatTime/index.cjs"
     },
+    "./Frame/styles.css": "./dist/Frame/Frame.css",
     "./Frame": {
       "types": "./dist/Frame/index.d.ts",
       "import": "./dist/Frame/index.mjs",
       "require": "./dist/Frame/index.cjs"
     },
+    "./Gallery/styles.css": "./dist/Gallery/Gallery.css",
     "./Gallery": {
       "types": "./dist/Gallery/index.d.ts",
       "import": "./dist/Gallery/index.mjs",
       "require": "./dist/Gallery/index.cjs"
     },
+    "./Glimmer/styles.css": "./dist/Glimmer/Glimmer.css",
     "./Glimmer": {
       "types": "./dist/Glimmer/index.d.ts",
       "import": "./dist/Glimmer/index.mjs",
       "require": "./dist/Glimmer/index.cjs"
     },
+    "./Grid/styles.css": "./dist/Grid/Grid.css",
     "./Grid": {
       "types": "./dist/Grid/index.d.ts",
       "import": "./dist/Grid/index.mjs",
@@ -245,11 +274,13 @@
       "import": "./dist/Icon/index.mjs",
       "require": "./dist/Icon/index.cjs"
     },
+    "./InlineLabel/styles.css": "./dist/InlineLabel/InlineLabel.css",
     "./InlineLabel": {
       "types": "./dist/InlineLabel/index.d.ts",
       "import": "./dist/InlineLabel/index.mjs",
       "require": "./dist/InlineLabel/index.cjs"
     },
+    "./InputAvatar/styles.css": "./dist/InputAvatar/InputAvatar.css",
     "./InputAvatar": {
       "types": "./dist/InputAvatar/index.d.ts",
       "import": "./dist/InputAvatar/index.mjs",
@@ -270,6 +301,7 @@
       "import": "./dist/InputFile/index.mjs",
       "require": "./dist/InputFile/index.cjs"
     },
+    "./InputGroup/styles.css": "./dist/InputGroup/InputGroup.css",
     "./InputGroup": {
       "types": "./dist/InputGroup/index.d.ts",
       "import": "./dist/InputGroup/index.mjs",
@@ -300,21 +332,25 @@
       "import": "./dist/InputTime/index.mjs",
       "require": "./dist/InputTime/index.cjs"
     },
+    "./InputValidation/styles.css": "./dist/InputValidation/InputValidation.css",
     "./InputValidation": {
       "types": "./dist/InputValidation/index.d.ts",
       "import": "./dist/InputValidation/index.mjs",
       "require": "./dist/InputValidation/index.cjs"
     },
+    "./LightBox/styles.css": "./dist/LightBox/LightBox.css",
     "./LightBox": {
       "types": "./dist/LightBox/index.d.ts",
       "import": "./dist/LightBox/index.mjs",
       "require": "./dist/LightBox/index.cjs"
     },
+    "./Link/styles.css": "./dist/Link/Link.css",
     "./Link": {
       "types": "./dist/Link/index.d.ts",
       "import": "./dist/Link/index.mjs",
       "require": "./dist/Link/index.cjs"
     },
+    "./List/styles.css": "./dist/List/List.css",
     "./List": {
       "types": "./dist/List/index.d.ts",
       "import": "./dist/List/index.mjs",
@@ -325,46 +361,55 @@
       "import": "./dist/Markdown/index.mjs",
       "require": "./dist/Markdown/index.cjs"
     },
+    "./Menu/styles.css": "./dist/Menu/Menu.css",
     "./Menu": {
       "types": "./dist/Menu/index.d.ts",
       "import": "./dist/Menu/index.mjs",
       "require": "./dist/Menu/index.cjs"
     },
+    "./Modal/styles.css": "./dist/Modal/Modal.css",
     "./Modal": {
       "types": "./dist/Modal/index.d.ts",
       "import": "./dist/Modal/index.mjs",
       "require": "./dist/Modal/index.cjs"
     },
+    "./MultiSelect/styles.css": "./dist/MultiSelect/MultiSelect.css",
     "./MultiSelect": {
       "types": "./dist/MultiSelect/index.d.ts",
       "import": "./dist/MultiSelect/index.mjs",
       "require": "./dist/MultiSelect/index.cjs"
     },
+    "./Page/styles.css": "./dist/Page/Page.css",
     "./Page": {
       "types": "./dist/Page/index.d.ts",
       "import": "./dist/Page/index.mjs",
       "require": "./dist/Page/index.cjs"
     },
+    "./Popover/styles.css": "./dist/Popover/Popover.css",
     "./Popover": {
       "types": "./dist/Popover/index.d.ts",
       "import": "./dist/Popover/index.mjs",
       "require": "./dist/Popover/index.cjs"
     },
+    "./ProgressBar/styles.css": "./dist/ProgressBar/ProgressBar.css",
     "./ProgressBar": {
       "types": "./dist/ProgressBar/index.d.ts",
       "import": "./dist/ProgressBar/index.mjs",
       "require": "./dist/ProgressBar/index.cjs"
     },
+    "./RadioGroup/styles.css": "./dist/RadioGroup/RadioGroup.css",
     "./RadioGroup": {
       "types": "./dist/RadioGroup/index.d.ts",
       "import": "./dist/RadioGroup/index.mjs",
       "require": "./dist/RadioGroup/index.cjs"
     },
+    "./RecurringSelect/styles.css": "./dist/RecurringSelect/RecurringSelect.css",
     "./RecurringSelect": {
       "types": "./dist/RecurringSelect/index.d.ts",
       "import": "./dist/RecurringSelect/index.mjs",
       "require": "./dist/RecurringSelect/index.cjs"
     },
+    "./ResponsiveSwitcher/styles.css": "./dist/ResponsiveSwitcher/ResponsiveSwitcher.css",
     "./ResponsiveSwitcher": {
       "types": "./dist/ResponsiveSwitcher/index.d.ts",
       "import": "./dist/ResponsiveSwitcher/index.mjs",
@@ -375,41 +420,49 @@
       "import": "./dist/Select/index.mjs",
       "require": "./dist/Select/index.cjs"
     },
+    "./SideKick/styles.css": "./dist/SideKick/SideKick.css",
     "./SideKick": {
       "types": "./dist/SideKick/index.d.ts",
       "import": "./dist/SideKick/index.mjs",
       "require": "./dist/SideKick/index.cjs"
     },
+    "./Spinner/styles.css": "./dist/Spinner/Spinner.css",
     "./Spinner": {
       "types": "./dist/Spinner/index.d.ts",
       "import": "./dist/Spinner/index.mjs",
       "require": "./dist/Spinner/index.cjs"
     },
+    "./StatusIndicator/styles.css": "./dist/StatusIndicator/StatusIndicator.css",
     "./StatusIndicator": {
       "types": "./dist/StatusIndicator/index.d.ts",
       "import": "./dist/StatusIndicator/index.mjs",
       "require": "./dist/StatusIndicator/index.cjs"
     },
+    "./StatusLabel/styles.css": "./dist/StatusLabel/StatusLabel.css",
     "./StatusLabel": {
       "types": "./dist/StatusLabel/index.d.ts",
       "import": "./dist/StatusLabel/index.mjs",
       "require": "./dist/StatusLabel/index.cjs"
     },
+    "./Stack/styles.css": "./dist/Stack/Stack.css",
     "./Stack": {
       "types": "./dist/Stack/index.d.ts",
       "import": "./dist/Stack/index.mjs",
       "require": "./dist/Stack/index.cjs"
     },
+    "./Switch/styles.css": "./dist/Switch/Switch.css",
     "./Switch": {
       "types": "./dist/Switch/index.d.ts",
       "import": "./dist/Switch/index.mjs",
       "require": "./dist/Switch/index.cjs"
     },
+    "./Table/styles.css": "./dist/Table/Table.css",
     "./Table": {
       "types": "./dist/Table/index.d.ts",
       "import": "./dist/Table/index.mjs",
       "require": "./dist/Table/index.cjs"
     },
+    "./Tabs/styles.css": "./dist/Tabs/Tabs.css",
     "./Tabs": {
       "types": "./dist/Tabs/index.d.ts",
       "import": "./dist/Tabs/index.mjs",
@@ -420,16 +473,19 @@
       "import": "./dist/Text/index.mjs",
       "require": "./dist/Text/index.cjs"
     },
+    "./Tiles/styles.css": "./dist/Tiles/Tiles.css",
     "./Tiles": {
       "types": "./dist/Tiles/index.d.ts",
       "import": "./dist/Tiles/index.mjs",
       "require": "./dist/Tiles/index.cjs"
     },
+    "./Toast/styles.css": "./dist/Toast/Toast.css",
     "./Toast": {
       "types": "./dist/Toast/index.d.ts",
       "import": "./dist/Toast/index.mjs",
       "require": "./dist/Toast/index.cjs"
     },
+    "./Tooltip/styles.css": "./dist/Tooltip/Tooltip.css",
     "./Tooltip": {
       "types": "./dist/Tooltip/index.d.ts",
       "import": "./dist/Tooltip/index.mjs",


### PR DESCRIPTION
## Motivations

1. Had a request to see if we could do anything about a big css file for consumers who don't use all of our components, or a very small subset of them.
2. This PR is a draft that shows the type of work we can do to our rollup file to generate css files based on css module input.

There are some issues in this PR that can be fixed with a bit more time spent (I timeboxed myself to an hour):

1. Right now we're generating all the input css modules based on a directory listing, which forces us to manually exclude entries that don't have CSS.
2. Also, some of our components don't follow the pattern setup in this PR that follows component/component.module.css, so we'll need something special for them.
3. I think a static list of all the input css module files would work, even if it's a bit clunky to setup. One output css file for each input css module?

## Changes

1. Modified the rollup config to generate a css file for each componet that fit the css module pattern (more details above)
2. Modified the package.json to expose those css files.

## Testing

This should have no effect on downstream consumers as they're not importing these new files (yet).
To test it's working, rebuild everything locally, and then you should be able to import `@jobber/components/Card/Card.css` and it should import and look okay.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
