### PR TITLE
feat(components-native): Add UNSAFE_style to Content

### DIFF
--- a/packages/components-native/src/Content/Content.test.tsx
+++ b/packages/components-native/src/Content/Content.test.tsx
@@ -21,7 +21,10 @@ function getContentChildren(contentView: ReactTestInstance) {
 const text = "🌚 I am the text 🌞";
 
 function setupContent(
-  props?: Pick<ContentProps, "spacing" | "childSpacing" | "direction">,
+  props?: Pick<
+    ContentProps,
+    "spacing" | "childSpacing" | "direction" | "UNSAFE_style"
+  >,
 ) {
   const container = render(
     <View accessibilityLabel="contentView">
@@ -29,6 +32,7 @@ function setupContent(
         spacing={props?.spacing}
         childSpacing={props?.childSpacing}
         direction={props?.direction}
+        UNSAFE_style={props?.UNSAFE_style}
       >
         <Text>{text}</Text>
         <Text>{text}</Text>
@@ -265,6 +269,80 @@ describe("Horizontal", () => {
       ]);
       expect(contentChildren[1].props.style).toContainEqual(
         horizontalStyles.smallestChildSpace,
+      );
+    });
+  });
+});
+
+describe("UNSAFE_style", () => {
+  it("applies custom styles to container", () => {
+    const customStyle = {
+      backgroundColor: "red",
+      padding: 16,
+    };
+
+    const { parentView } = setupContent({
+      UNSAFE_style: {
+        container: customStyle,
+      },
+    });
+
+    const contentView = getContentComponent(parentView);
+    expect(contentView.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(customStyle)]),
+    );
+  });
+
+  it("applies custom styles to child wrapper", () => {
+    const customStyle = {
+      backgroundColor: "blue",
+      marginLeft: 8,
+    };
+
+    const { parentView } = setupContent({
+      UNSAFE_style: {
+        childWrapper: customStyle,
+      },
+    });
+
+    const contentView = getContentComponent(parentView);
+    const contentChildren = getContentChildren(contentView);
+
+    contentChildren.forEach(child => {
+      expect(child.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining(customStyle)]),
+      );
+    });
+  });
+
+  it("applies custom styles to both container and child wrapper", () => {
+    const containerStyle = {
+      backgroundColor: "red",
+      padding: 16,
+    };
+
+    const childWrapperStyle = {
+      backgroundColor: "blue",
+      marginLeft: 8,
+    };
+
+    const { parentView } = setupContent({
+      UNSAFE_style: {
+        container: containerStyle,
+        childWrapper: childWrapperStyle,
+      },
+    });
+
+    const contentView = getContentComponent(parentView);
+    const contentChildren = getContentChildren(contentView);
+
+    expect(contentView.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(containerStyle)]),
+    );
+
+    contentChildren.forEach(child => {
+      expect(child.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining(childWrapperStyle)]),
       );
     });
   });

--- a/packages/components-native/src/Content/Content.tsx
+++ b/packages/components-native/src/Content/Content.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { View } from "react-native";
+import { View, ViewStyle } from "react-native";
 import { useHorizontalStyles } from "./ContentHorizontal.style";
 import { useVerticalStyles } from "./ContentVertical.style";
 import { useSpaceAroundStyles } from "./ContentSpaceAround.style";
@@ -29,6 +29,15 @@ export interface ContentProps {
   readonly childSpacing?: Spacing;
 
   readonly direction?: "horizontal" | "vertical";
+
+  /**
+   * **Use at your own risk:** Custom style for specific elements. This should only be used as a
+   * **last resort**. Using this may result in unexpected side effects.
+   */
+  readonly UNSAFE_style?: {
+    container?: ViewStyle;
+    childWrapper?: ViewStyle;
+  };
 }
 
 export function Content({
@@ -36,6 +45,7 @@ export function Content({
   spacing = "base",
   childSpacing = "base",
   direction = "vertical",
+  UNSAFE_style,
 }: ContentProps): JSX.Element {
   const horizontalStyles = useHorizontalStyles();
   const verticalStyles = useVerticalStyles();
@@ -46,7 +56,9 @@ export function Content({
   const containerStyle = spaceAroundStyles[styleName];
 
   return (
-    <View style={[styles.wrapper, containerStyle]}>{renderChildren()}</View>
+    <View style={[styles.wrapper, containerStyle, UNSAFE_style?.container]}>
+      {renderChildren()}
+    </View>
   );
 
   function renderChildren() {
@@ -57,12 +69,17 @@ export function Content({
     const childContainerStyle = styles[spaceName];
 
     return childArray.map((child, index) => {
-      // In order to get spacing between the children, we apply the child spacing on each of
-      // the children except for the first (top) child
       const childStyle = index !== 0 ? [childContainerStyle] : [];
 
       return (
-        <View key={index} style={[styles.childWrapper, ...childStyle]}>
+        <View
+          key={index}
+          style={[
+            styles.childWrapper,
+            ...childStyle,
+            UNSAFE_style?.childWrapper,
+          ]}
+        >
           {child}
         </View>
       );

--- a/packages/components-native/src/Content/Content.tsx
+++ b/packages/components-native/src/Content/Content.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { View, ViewStyle } from "react-native";
+import { StyleProp, View, ViewStyle } from "react-native";
 import { useHorizontalStyles } from "./ContentHorizontal.style";
 import { useVerticalStyles } from "./ContentVertical.style";
 import { useSpaceAroundStyles } from "./ContentSpaceAround.style";
@@ -11,6 +11,11 @@ export type Spacing =
   | "smaller"
   | "smallest"
   | "large";
+
+export interface ContentUnsafeStyle {
+  container?: StyleProp<ViewStyle>;
+  childWrapper?: StyleProp<ViewStyle>;
+}
 
 export interface ContentProps {
   /**
@@ -33,11 +38,9 @@ export interface ContentProps {
   /**
    * **Use at your own risk:** Custom style for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
+   * More information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).
    */
-  readonly UNSAFE_style?: {
-    container?: ViewStyle;
-    childWrapper?: ViewStyle;
-  };
+  readonly UNSAFE_style?: ContentUnsafeStyle;
 }
 
 export function Content({

--- a/packages/components-native/src/TextList/__snapshots__/TextList.test.tsx.snap
+++ b/packages/components-native/src/TextList/__snapshots__/TextList.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`TextList when the bulletItems is provided displays the text list 1`] = 
         {
           "padding": 0,
         },
+        undefined,
       ]
     }
   >
@@ -23,6 +24,7 @@ exports[`TextList when the bulletItems is provided displays the text list 1`] = 
       style={
         [
           {},
+          undefined,
         ]
       }
     >
@@ -114,6 +116,7 @@ exports[`TextList when the bulletItems is provided displays the text list 1`] = 
           {
             "padding": 0,
           },
+          undefined,
         ]
       }
     >

--- a/packages/site/src/content/Content/Content.props-mobile.json
+++ b/packages/site/src/content/Content/Content.props-mobile.json
@@ -66,7 +66,7 @@
       },
       "UNSAFE_style": {
         "defaultValue": null,
-        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.",
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
         "name": "UNSAFE_style",
         "parent": {
           "fileName": "../components-native/src/Content/Content.tsx",

--- a/packages/site/src/content/Content/Content.props-mobile.json
+++ b/packages/site/src/content/Content/Content.props-mobile.json
@@ -63,6 +63,19 @@
         "type": {
           "name": "\"horizontal\" | \"vertical\""
         }
+      },
+      "UNSAFE_style": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.",
+        "name": "UNSAFE_style",
+        "parent": {
+          "fileName": "../components-native/src/Content/Content.tsx",
+          "name": "ContentProps"
+        },
+        "required": false,
+        "type": {
+          "name": "ContentUnsafeStyle"
+        }
       }
     }
   }

--- a/packages/site/src/content/Content/ContentNotes.mdx
+++ b/packages/site/src/content/Content/ContentNotes.mdx
@@ -1,0 +1,24 @@
+## Component customization
+
+### UNSAFE_style (mobile)
+
+General information for using `UNSAFE_` props can be found
+[here](/guides/customizing-components).
+
+**Note**: Use of `UNSAFE_` props is **at your own risk** and should be
+considered a **last resort**. Future Content updates may lead to unintended
+breakages.
+
+The Content component has two elements that can be targeted to apply custom
+styles. These are the container and child wrapper.
+
+```tsx
+UNSAFE_style: {
+    container: {
+      paddingHorizontal: tokens["space-large"],
+    },
+    childWrapper: {
+      backgroundColor: tokens["color-surface--background"],
+    },
+  },
+```

--- a/packages/site/src/content/Content/index.tsx
+++ b/packages/site/src/content/Content/index.tsx
@@ -1,6 +1,7 @@
 import Content from "@atlantis/docs/components/Content/Content.stories.mdx";
 import Props from "./Content.props.json";
 import MobileProps from "./Content.props-mobile.json";
+import Notes from "./ContentNotes.mdx";
 import { ContentExport } from "../../types/content";
 import { getStorybookUrl } from "../../layout/getStorybookUrl";
 
@@ -60,4 +61,5 @@ export default {
       ),
     },
   ],
+  notes: () => <Notes />,
 } as const satisfies ContentExport;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
This PR adds `UNSAFE_style` customization capabilities to the mobile `Content` component. The main driver for this was to allow consumers the ability to set different spacing on the outer edges of `Content`.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added `ContentUnsafeStyle` interface with support for:
  - `container`: Customizes the main wrapper View
  - `childWrapper`: Customizes each child's wrapper View
- Added tests for `UNSAFE_style` functionality
- Added documentation in ContentNotes.mdx
- re-generated `Content.props-mobile.json`

## Testing

<!-- How to test your changes. -->

You can put the following in `docs/components/Content/Mobile.stories.tsx`:

```
export const WithCustomStyles = BasicTemplate.bind({});
WithCustomStyles.args = {
  direction: "vertical",
  spacing: "none",
  UNSAFE_style: {
    container: {
      backgroundColor: tokens["color-surface--background"],
      padding: tokens["space-base"],
      borderRadius: tokens["radius-base"],
    },
    childWrapper: {
      borderLeftWidth: tokens["border-base"],
      borderLeftColor: tokens["color-border"],
      paddingLeft: tokens["space-small"],
    },
  },
};
```

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
