### PR TITLE
feat(docx): Fixing "Show Code" examples with the weird numbers and dollar signs and such.

### DIFF
--- a/packages/site/src/components/RenderComponentShowCode.tsx
+++ b/packages/site/src/components/RenderComponentShowCode.tsx
@@ -15,7 +15,17 @@ export const RenderComponentShowCode = ({ children }: PropsWithChildren) => {
     setCodeVisible(!codeVisible);
   };
   const code = Children.map(children, child => {
-    return reactElementToJSXString(child);
+    return reactElementToJSXString(child, {
+      displayName: e => {
+        if (e && typeof e === "object" && "type" in e) {
+          if (typeof e.type === "function") {
+            return (e.type.name || "Anonymous").replace(/[\d$]+/g, "");
+          }
+        }
+
+        return "Anonymous";
+      },
+    });
   });
   useEffect(() => {
     prism.highlightAll();


### PR DESCRIPTION
## Motivations

1. The 'Show Code' examples would often show numbers or dollar signs. 
2. We can be displaying our component names better via reactElementToJSXString.
3. I've made an attempt at fixing that here.

## Changes
1. Hopefully, our component names don't have numbers or dollar signs in them anymore.

# Before
![image](https://github.com/user-attachments/assets/aae67939-6de1-4981-9ea6-e556e0b677a5)
![image](https://github.com/user-attachments/assets/4d6f6264-c819-4f45-8128-448a94c1600d)
![image](https://github.com/user-attachments/assets/cc1aa7cd-d1ec-4ceb-9705-168c8f2927b1)


# After
![image](https://github.com/user-attachments/assets/8db958ed-2d9f-46a7-aa81-be188100e674)


## Testing

Click on a "Show Code" example on the docs site. Especially some of the new layout ones. The code should be fully usable as an example instead of having to edit it.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
