### PR TITLE
docs: fix scaffolding Button spacing examples

### DIFF
--- a/packages/site/src/guides/scaffolding.stories.mdx
+++ b/packages/site/src/guides/scaffolding.stories.mdx
@@ -64,7 +64,7 @@ responsive behavior for free.
               <Emphasis variation="bold">Subtitle goes here</Emphasis>
             </Text>
           </Stack>
-          <Cluster justify="end" collapseBelow="1285px">
+          <Cluster justify="end" gap="small" collapseBelow="1285px">
             <Button label="Action 1" />
             <Button label="Action 2" type="secondary" />
             <Menu
@@ -103,7 +103,7 @@ responsive behavior for free.
             </Stack>
             <Box>
               <Container.Apply className={styles.actions}>
-                <Cluster justify="end">
+                <Cluster justify="end" gap="small">
                   <Button label="Action 1" />
                   <Button label="Action 2" type="secondary" />
                   <Menu


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We were not following spacing patterns in the scaffolding guide

## Changes

### Fixed

- gaps are small as per our spacing patterns

## Testing

Run locally/CF

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
