### PR TITLE
fix(components): Fix modal size not being respected in all cases

### DIFF
--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -8,7 +8,6 @@ import { InputText } from "@jobber/components/InputText";
 import {
   Autocomplete,
   Box,
-  Cluster,
   Combobox,
   Heading,
   Icon,
@@ -134,7 +133,6 @@ function CustomHeader() {
 
 const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
   const [modalOpen, setModalOpen] = useState(false);
-  const [modalOpen2, setModalOpen2] = useState(false);
   const [selectedOptions, setSelectedOptions] = useState<
     Array<{ id: string | number; label: string }>
   >([]);
@@ -151,7 +149,6 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
   const [autocompleteValue, setAutocompleteValue] = useState<
     AutocompleteOption | undefined
   >();
-  const [modalSize, setModalSize] = useState<"small" | "large" | undefined>();
 
   return (
     <Content>
@@ -161,17 +158,6 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
         after it has been closed. This is done with the Modal.Activator
         component
       </Text>
-      <Modal
-        open={modalOpen2}
-        onRequestClose={() => setModalOpen2(false)}
-        size={modalSize}
-        title={modalSize ? `${modalSize} Modal` : "Base modal"}
-      >
-        <Content>
-          <Text>It&apos;s harder, better, faster, and stronger! 🤖</Text>
-        </Content>
-      </Modal>
-      <Button label="Open Modal" onClick={() => setModalOpen2(true)} />
 
       <Button
         label="Open Modal with Custom Focus"
@@ -183,7 +169,6 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
           setModalOpen(false);
           setPopoverOpen(false);
         }}
-        size={modalSize}
       >
         <Modal.Content>
           <Modal.Header>
@@ -271,12 +256,6 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
           <InputText placeholder="Modal will return focus here" />
         </Modal.Activator>
       </Modal.Provider>
-
-      <Cluster>
-        <Button label="Small Modal" onClick={() => setModalSize("small")} />
-        <Button label="Large Modal" onClick={() => setModalSize("large")} />
-        <Button label="Base Modal" onClick={() => setModalSize(undefined)} />
-      </Cluster>
     </Content>
   );
 };

--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -8,6 +8,7 @@ import { InputText } from "@jobber/components/InputText";
 import {
   Autocomplete,
   Box,
+  Cluster,
   Combobox,
   Heading,
   Icon,
@@ -133,6 +134,7 @@ function CustomHeader() {
 
 const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
   const [modalOpen, setModalOpen] = useState(false);
+  const [modalOpen2, setModalOpen2] = useState(false);
   const [selectedOptions, setSelectedOptions] = useState<
     Array<{ id: string | number; label: string }>
   >([]);
@@ -149,6 +151,7 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
   const [autocompleteValue, setAutocompleteValue] = useState<
     AutocompleteOption | undefined
   >();
+  const [modalSize, setModalSize] = useState<"small" | "large" | undefined>();
 
   return (
     <Content>
@@ -158,6 +161,17 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
         after it has been closed. This is done with the Modal.Activator
         component
       </Text>
+      <Modal
+        open={modalOpen2}
+        onRequestClose={() => setModalOpen2(false)}
+        size={modalSize}
+        title={modalSize ? `${modalSize} Modal` : "Base modal"}
+      >
+        <Content>
+          <Text>It&apos;s harder, better, faster, and stronger! 🤖</Text>
+        </Content>
+      </Modal>
+      <Button label="Open Modal" onClick={() => setModalOpen2(true)} />
 
       <Button
         label="Open Modal with Custom Focus"
@@ -169,6 +183,7 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
           setModalOpen(false);
           setPopoverOpen(false);
         }}
+        size={modalSize}
       >
         <Modal.Content>
           <Modal.Header>
@@ -256,6 +271,12 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
           <InputText placeholder="Modal will return focus here" />
         </Modal.Activator>
       </Modal.Provider>
+
+      <Cluster>
+        <Button label="Small Modal" onClick={() => setModalSize("small")} />
+        <Button label="Large Modal" onClick={() => setModalSize("large")} />
+        <Button label="Base Modal" onClick={() => setModalSize(undefined)} />
+      </Cluster>
     </Content>
   );
 };

--- a/packages/components/src/Modal/ModalSizes.module.css
+++ b/packages/components/src/Modal/ModalSizes.module.css
@@ -1,9 +1,11 @@
 .small {
   --modal--padding: var(--space-base);
   --public-tab--inset: var(--space-base);
+  --modal--width: 400px;
   max-width: 400px;
 }
 
 .large {
+  --modal--width: 940px;
   max-width: 940px;
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There was an issue where sometimes the `modal.module.css` and `modalsizes.module.css` could be imported in different order causing the styling to not cascade consistently. This PR fixes that. This issue also caused the `Modal.Provider` method of using a modal to not respect the size prop.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- fix(components): Fix Modal.Rebuilt not respecting size prop consistently
- fix(components): Fix modal sometimes not respecting the size prop

### Security

- <!-- in case of vulnerabilities -->

## Testing

 - Verify the size prop is respected in the storybook example [here](https://b8334687.atlantis.pages.dev/storybook/?path=/story/components-overlays-modal-web--modal-with-provider-example)

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
