### PR TITLE
refactor(components-native): use interactive--background token in mobile components

### DIFF
--- a/packages/components-native/src/Chip/Chip.test.tsx
+++ b/packages/components-native/src/Chip/Chip.test.tsx
@@ -35,7 +35,7 @@ it("renders an inactive Chip with a default backgroundColor", () => {
     backgroundColor: tokens["color-surface--reverse"],
   });
   expect(getByTestId("chipTest").props.style).toContainEqual({
-    backgroundColor: tokens["color-surface--background"],
+    backgroundColor: tokens["color-interactive--background"],
   });
 });
 

--- a/packages/components-native/src/Chip/Chip.tsx
+++ b/packages/components-native/src/Chip/Chip.tsx
@@ -82,7 +82,7 @@ export function Chip({
         backgroundColor:
           inactiveBackgroundColor === "surface"
             ? tokens["color-surface"]
-            : tokens["color-surface--background"],
+            : tokens["color-interactive--background"],
       },
       isActive && { backgroundColor: accentColor },
     ];

--- a/packages/components-native/src/FormatFile/components/ProgressBar/ProgressBar.style.tsx
+++ b/packages/components-native/src/FormatFile/components/ProgressBar/ProgressBar.style.tsx
@@ -7,7 +7,7 @@ export const useStyles = buildThemedStyles(tokens => {
       height: 8,
       borderRadius: tokens["radius-circle"],
       overflow: "hidden",
-      backgroundColor: tokens["color-surface--background"],
+      backgroundColor: tokens["color-interactive--background"],
     },
     progress: {
       height: "100%",

--- a/packages/components-native/src/ProgressBar/ProgressBar.tsx
+++ b/packages/components-native/src/ProgressBar/ProgressBar.tsx
@@ -33,7 +33,9 @@ export function ProgressBar({
         <ProgressBarStepped
           total={total}
           current={current}
-          color={reverseTheme ? undefined : tokens["color-surface--background"]}
+          color={
+            reverseTheme ? undefined : tokens["color-interactive--background"]
+          }
           loading={loading}
           inProgress={inProgress}
         />
@@ -43,7 +45,7 @@ export function ProgressBar({
             width={100}
             animationDuration={0}
             color={
-              reverseTheme ? undefined : tokens["color-surface--background"]
+              reverseTheme ? undefined : tokens["color-interactive--background"]
             }
           />
           {!loading && (

--- a/packages/components-native/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/components-native/src/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`renders blue inProgress bar when 1 or more jobs is in progress 1`] = `
             "width": "100%",
           },
           {
-            "backgroundColor": "hsl(53, 21%, 93%)",
+            "backgroundColor": "hsl(51, 17%, 85%)",
             "width": "100%",
           },
         ]
@@ -116,7 +116,7 @@ exports[`renders green CompletedProgress bar when 1 or more jobs is completed 1`
             "width": "100%",
           },
           {
-            "backgroundColor": "hsl(53, 21%, 93%)",
+            "backgroundColor": "hsl(51, 17%, 85%)",
             "width": "100%",
           },
         ]

--- a/packages/components-native/src/Switch/components/BaseSwitch/BaseSwitch.tsx
+++ b/packages/components-native/src/Switch/components/BaseSwitch/BaseSwitch.tsx
@@ -60,7 +60,7 @@ export function BaseSwitch({
       } else if (internalValue) {
         return tokens["color-interactive"];
       } else {
-        return tokens["color-surface--background"];
+        return tokens["color-interactive--background"];
       }
     }
 
@@ -81,7 +81,7 @@ export function BaseSwitch({
       //iOS
       return {
         true: tokens["color-interactive"],
-        false: tokens["color-surface--background"],
+        false: tokens["color-interactive--background"],
       };
     }
   }
@@ -98,7 +98,7 @@ export function BaseSwitch({
       disabled={disabled}
       thumbColor={getThumbColor()}
       trackColor={getTrackColors()}
-      ios_backgroundColor={tokens["color-surface--background"]}
+      ios_backgroundColor={tokens["color-interactive--background"]}
       accessibilityLabel={accessibilityLabel}
       accessibilityRole={"switch"}
       accessibilityState={{

--- a/packages/components-native/src/Switch/components/BaseSwitch/__snapshots__/BaseSwitch.test.tsx.snap
+++ b/packages/components-native/src/Switch/components/BaseSwitch/__snapshots__/BaseSwitch.test.tsx.snap
@@ -26,12 +26,12 @@ exports[`renders a Switch with defaultValue false 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={false}
 />
 `;
@@ -62,12 +62,12 @@ exports[`renders a Switch with defaultValue true 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={true}
 />
 `;
@@ -98,12 +98,12 @@ exports[`renders a Switch with value false 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={false}
 />
 `;
@@ -134,12 +134,12 @@ exports[`renders a Switch with value true 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={true}
 />
 `;
@@ -170,12 +170,12 @@ exports[`renders a disabled Switch with value false 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={false}
 />
 `;
@@ -206,12 +206,12 @@ exports[`renders a disabled Switch with value true 1`] = `
         "width": 51,
       },
       {
-        "backgroundColor": "hsl(53, 21%, 93%)",
+        "backgroundColor": "hsl(51, 17%, 85%)",
         "borderRadius": 16,
       },
     ]
   }
-  tintColor="hsl(53, 21%, 93%)"
+  tintColor="hsl(51, 17%, 85%)"
   value={true}
 />
 `;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Standardize visual language of native components with web, leveraging the new token created in #2227 and implemented in web components in #2230 

## Changes

### Changed

- Background color in
  - Chip
  - ProgressBar
  - FormatFile internal ProgressBar
  - Switch

## Testing

In Storybook and run prerelease in mobile project (Android + iOS to test Switch)

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
