### PR TITLE
feat(components): Add clientColor to Card accent

### DIFF
--- a/packages/components/src/Card/cardcolors.module.css
+++ b/packages/components/src/Card/cardcolors.module.css
@@ -14,6 +14,10 @@
   --card--accent-color: var(--color-invoice);
 }
 
+.clientColor {
+  --card--accent-color: var(--color-client);
+}
+
 .blue {
   --card--accent-color: var(--color-blue);
 }

--- a/packages/components/src/Card/cardcolors.module.css.d.ts
+++ b/packages/components/src/Card/cardcolors.module.css.d.ts
@@ -3,6 +3,7 @@ declare const styles: {
   readonly "quoteColor": string;
   readonly "jobColor": string;
   readonly "invoiceColor": string;
+  readonly "clientColor": string;
   readonly "blue": string;
   readonly "blueLight": string;
   readonly "blueLighter": string;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
`Card` allowed `invoiceColor`, `requestColor`, `jobColor` & `quoteColor` as an `accent`. Now we need to add `clientColor` to round out all objects.

![Screenshot 2025-05-05 at 12 10 38 PM](https://github.com/user-attachments/assets/26107d5b-e8d9-4405-9ffa-c9d59cf78c46)



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `clientColor` is now available as a `Card` `accent`

## Testing

<!-- How to test your changes. -->
Select `clientColor` from the `accent` dropdown and see the change.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
