### PR TITLE
feat(design): Add surface and onSurface colors for color-client

### DIFF
--- a/packages/design/src/tokens/dark.tokens.json
+++ b/packages/design/src/tokens/dark.tokens.json
@@ -50,7 +50,7 @@
         },
         "destructive": {
             "$value": "{color.base.red-.500}",
-            "$description": "Use to signify that an interaction will destroy something in the users’ account or workflow."
+            "$description": "Use to signify that an interaction will destroy something in the users' account or workflow."
         },
         "destructive-": {
             "hover": {
@@ -149,7 +149,7 @@
         "text-": {
             "secondary": {
                 "$value": "{color.base.blue-.400}",
-                "$description": "Text that is relevant but less important can be lower-contrast to suggest its’ reduced importance."
+                "$description": "Text that is relevant but less important can be lower-contrast to suggest its' reduced importance."
             },
             "reverse": {
                 "$value": "{color.base.blue-.700}",
@@ -213,7 +213,7 @@
         },
         "overlay": {
             "$value": "rgba({color.black-.rgb}, 0.6)",
-            "$description": "Use to mask an area of the interface to promote focus to a foreground action, such as a Modal’s appearance."
+            "$description": "Use to mask an area of the interface to promote focus to a foreground action, such as a Modal's appearance."
         },
         "overlay-": {
             "dimmed": {
@@ -336,6 +336,16 @@
         "client": {
             "$value": "{color.base.blue-.200}",
             "$description": "Clients use a neutral value as they sit at the core of the workflow."
+        },
+        "client-": {
+            "surface": {
+                "$value": "{color.base.blue-.800}",
+                "$description": "Use for the surface of an element that has client status."
+            },
+            "onSurface": {
+                "$value": "{color.base.blue-.300}",
+                "$description": "Use for text or iconography that sits overtop a client background."
+            }
         }
     },
     "shadow": {

--- a/packages/design/src/tokens/workflow.tokens.json
+++ b/packages/design/src/tokens/workflow.tokens.json
@@ -117,6 +117,16 @@
     "client": {
       "$value": "{color.base.taupe-.700}",
       "$description": "Clients use a neutral value as they sit at the core of the workflow."
+    },
+    "client-": {
+      "surface": {
+        "$value": "{color.base.taupe-.200}",
+        "$description": "Use for the surface of an element that has client status."
+      },
+      "onSurface": {
+        "$value": "{color.base.taupe-.800}",
+        "$description": "Use for text or iconography that sits overtop a client background."
+      }
     }
   }
 }

--- a/packages/site/src/content/Box/Box.props.json
+++ b/packages/site/src/content/Box/Box.props.json
@@ -29,7 +29,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"base-grey--100\" | \"base-grey--200\" | \"base-grey--300\" | \"base-grey--400\" | \"base-grey--500\" | \"base-grey--600\" | \"base-grey--700\" | \"base-grey--800\" | \"base-grey--900\" | ... 272 more ... | \"client\""
+          "name": "\"base-grey--100\" | \"base-grey--200\" | \"base-grey--300\" | \"base-grey--400\" | \"base-grey--500\" | \"base-grey--600\" | \"base-grey--700\" | \"base-grey--800\" | \"base-grey--900\" | ... 274 more ... | \"client--onSurface\""
         }
       },
       "border": {
@@ -55,7 +55,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"base-grey--100\" | \"base-grey--200\" | \"base-grey--300\" | \"base-grey--400\" | \"base-grey--500\" | \"base-grey--600\" | \"base-grey--700\" | \"base-grey--800\" | \"base-grey--900\" | ... 272 more ... | \"client\""
+          "name": "\"base-grey--100\" | \"base-grey--200\" | \"base-grey--300\" | \"base-grey--400\" | \"base-grey--500\" | \"base-grey--600\" | \"base-grey--700\" | \"base-grey--800\" | \"base-grey--900\" | ... 274 more ... | \"client--onSurface\""
         }
       },
       "direction": {

--- a/packages/site/src/content/Typography/Typography.props.json
+++ b/packages/site/src/content/Typography/Typography.props.json
@@ -152,7 +152,7 @@
         },
         "required": false,
         "type": {
-          "name": "UnderlineStyle | \"solid color-indigo\" | \"solid color-indigo--light\" | \"solid color-indigo--lighter\" | \"solid color-indigo--lightest\" | \"solid color-indigo--dark\" | ... 634 more ... | \"dashed color-client\""
+          "name": "UnderlineStyle | \"solid color-indigo\" | \"solid color-indigo--light\" | \"solid color-indigo--lighter\" | \"solid color-indigo--lightest\" | \"solid color-indigo--dark\" | ... 642 more ... | \"dashed color-client--onSurface\""
         }
       },
       "UNSAFE_className": {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
When trying to assign `clientColor` to a `Card` in product, it wasn't appearing as the same taupe color that was displaying in Storybook. It was showing up as just grey. See this PR for the `Card` update https://github.com/GetJobber/atlantis/pull/2537

Looking through colors I noticed that `client` didn't have the same tokens as other objects. This PR fixes the `clientColor` issue in product.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `client-` tokens for `surface` & `onSurface` in `dark.tokens.json` and `workflow.tokens.json`

## Testing

<!-- How to test your changes. -->
Can put this in `docs/design/Colors.stories.mdx` to see the colors:

```
<Swatch
  colors={[
    "--color-client",
    "--color-client--surface",
    "--color-client--onSurface",
  ]}
/>
```

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
