### PR TITLE
refactor(components): Simplify ReactDatePicker state update

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -150,7 +150,11 @@ export function DatePicker({
         minDate={minDate}
         useWeekdaysShort={true}
         customInput={
-          <DatePickerActivator activator={activator} fullWidth={fullWidth} />
+          <DatePickerActivator
+            pickerRef={pickerRef}
+            activator={activator}
+            fullWidth={fullWidth}
+          />
         }
         renderCustomHeader={props => <DatePickerCustomHeader {...props} />}
         onCalendarOpen={handleCalendarOpen}

--- a/packages/components/src/DatePicker/DatePickerActivator.tsx
+++ b/packages/components/src/DatePicker/DatePickerActivator.tsx
@@ -2,11 +2,12 @@ import React, {
   ChangeEvent,
   ReactElement,
   Ref,
+  RefObject,
   cloneElement,
   forwardRef,
   isValidElement,
 } from "react";
-import { ReactDatePickerProps } from "react-datepicker";
+import ReactDatePicker, { ReactDatePickerProps } from "react-datepicker";
 import omit from "lodash/omit";
 import { Button } from "../Button";
 
@@ -33,6 +34,7 @@ export interface DatePickerActivatorProps
   onClick?(): void;
   onFocus?(): void;
   onKeyDown?(): void;
+  readonly pickerRef: RefObject<ReactDatePicker>;
 }
 
 export const DatePickerActivator = forwardRef(InternalActivator);

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -1,15 +1,12 @@
 import omit from "lodash/omit";
 import React, { useEffect, useRef, useState } from "react";
-import format from "date-fns/format";
 import isValid from "date-fns/isValid";
 import { InputDateProps } from "./InputDate.types";
 import { FieldActionsRef, FormField, Suffix } from "../FormField";
 import { DatePicker } from "../DatePicker";
-import { useAtlantisContext } from "../AtlantisContext";
 
 export function InputDate(inputProps: InputDateProps) {
   const formFieldActionsRef = useRef<FieldActionsRef>(null);
-  const { dateFormat } = useAtlantisContext();
 
   return (
     <DatePicker
@@ -22,7 +19,7 @@ export function InputDate(inputProps: InputDateProps) {
       maxDate={inputProps.maxDate}
       smartAutofocus={false}
       activator={activatorProps => {
-        const { onChange, onClick, value } = activatorProps;
+        const { onChange, onClick, value, pickerRef } = activatorProps;
         const newActivatorProps = omit(activatorProps, ["activator"]);
         const [isFocused, setIsFocused] = useState(false);
         const suffix =
@@ -76,12 +73,8 @@ export function InputDate(inputProps: InputDateProps) {
                  */
                 if (inputProps.restoreLastValueOnBlur) {
                   if ((!value || !isValid(value)) && inputProps.value) {
-                    onChange?.({
-                      // @ts-expect-error -- This is a hack to sync the value back to ReactDatePicker
-                      target: {
-                        value: format(inputProps.value, dateFormat),
-                      },
-                    });
+                    // @ts-expect-error -- ReactDatePicker types don't include setSelected
+                    pickerRef.current?.setSelected(inputProps.value);
                   }
                 }
               }}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Check out the original PR: https://github.com/GetJobber/atlantis/pull/2541

This simplifies the way we update the ReactDatePicker state.

## Changes

### Changed

- Simplify ReactDatePicker state update


## Testing

Test out this story locally in`docs/components/InputDate/Web.stories.tsx`

1. Click the textarea
2. Tab to focus the input date field
3. Backspace the value
4. Shift tab to go back to the textarea
    * Observe the form field input replaces the empty value with the previous value
5. Tab back into the input date field
6. Enter an invalid date string
7. Shift tab to go back to the textarea
    * Observe the form field input replaces the bad value with the previous value
8. Confirm the normal date picker works as expected (mouse click to focus which opens the date picker)

```jsx
const BasicTemplate: ComponentStory<typeof InputDate> = args => {
  const [date, setDate] = useState(new Date("11/11/2011"));

  return (
    <Content>
      <textarea />
      <InputDate
        value={date}
        restoreLastValueOnBlur
        onChange={d => {
          if (!d) return;
          setDate(d);
        }}
      />
    </Content>
  );
};
```

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

