### PR TITLE
feat(components): Update tiles to support alignment prop.

### DIFF
--- a/docs/components/Tiles/Web.stories.tsx
+++ b/docs/components/Tiles/Web.stories.tsx
@@ -91,6 +91,35 @@ const ContentTemplate: ComponentStory<typeof Tiles> = args => (
   </Tiles>
 );
 
+const AlignmentTemplate: ComponentStory<typeof Tiles> = () => (
+  <Box border="base" borderColor="border">
+    <Tiles gap="largest" align="center">
+      <Card>
+        <Box height={150} padding="base" justifyContent="center">
+          <Text>First tile</Text>
+        </Box>
+      </Card>
+      <Card>
+        <Box height={50} padding="base" justifyContent="center">
+          <Text>Second tile</Text>
+        </Box>
+      </Card>
+      <Card>
+        <Box height={20} padding="base" justifyContent="center">
+          <Text>Third tile</Text>
+        </Box>
+      </Card>
+      <Card>
+        <Box height={30} padding="base" justifyContent="center">
+          <Text>Forth tile</Text>
+        </Box>
+      </Card>
+    </Tiles>
+  </Box>
+);
+
+export const Alignment = AlignmentTemplate.bind({});
+
 export const WithContent = ContentTemplate.bind({});
 WithContent.args = {
   gap: "base",

--- a/packages/components/src/Tiles/Tiles.module.css
+++ b/packages/components/src/Tiles/Tiles.module.css
@@ -2,6 +2,7 @@
   display: grid;
   grid-gap: var(--public-tile-space);
   width: var(--public-tiles-width);
+  align-items: var(--public-tiles-align);
 }
 
 @supports (width: min(var(--public-tile-min-size), 100%)) {

--- a/packages/components/src/Tiles/Tiles.tsx
+++ b/packages/components/src/Tiles/Tiles.tsx
@@ -16,6 +16,7 @@ export function Tiles({
   id,
   UNSAFE_className,
   UNSAFE_style,
+  align = "start",
 }: TilesProps) {
   return (
     <Tag
@@ -28,6 +29,7 @@ export function Tiles({
           "--public-tile-min-size": minSize,
           "--public-tile-space": getMappedAtlantisSpaceToken(gap),
           "--public-tiles-width": autoWidth ? "auto" : "100%",
+          "--public-tiles-align": align,
           ...UNSAFE_style?.container,
         } as React.CSSProperties
       }

--- a/packages/components/src/Tiles/types.ts
+++ b/packages/components/src/Tiles/types.ts
@@ -6,14 +6,23 @@ import {
 
 export interface TilesProps extends CommonAtlantisProps {
   readonly children: React.ReactNode;
-  /** The minimum size of the tiles. */
-  readonly minSize: string;
-  /** The amount of space between the tiles. Semantic tokens are available. */
+  /** The minimum size of the tiles.
+   * @default "30ch"
+   */
+  readonly minSize?: string;
+  /** The amount of space between the tiles. Semantic tokens are available.
+   * @default "base"
+   */
   readonly gap?: GapSpacing;
   /** Whether to allow the tiles to take the width of the content. Defaults to 100% */
   readonly autoWidth?: boolean;
   /** The HTML tag to render the container as. Defaults to `div`. */
   as?: CommonAllowedElements;
+
+  /** The vertical alignment  of the tiles within the container.
+   * @default "start"
+   */
+  readonly align?: "start" | "center" | "end";
 
   /** **Use at your own risk:** Custom class names for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.

--- a/packages/site/src/content/Tiles/Tiles.mdx
+++ b/packages/site/src/content/Tiles/Tiles.mdx
@@ -123,18 +123,30 @@ The Tiles component supports vertically aligning the tiles within the container.
 
 <Canvas>
   <ContentBlock maxWidth="100%">
-    <Tiles gap="largest" align="center">
-      <Card>
-        <Box height={150} padding="base" justifyContent="center">
-          <Text>First tile</Text>
-        </Box>
-      </Card>
-      <Card>
-        <Box height={50} padding="base" justifyContent="center">
-          <Text>Second tile</Text>
-        </Box>
-      </Card>
-    </Tiles>
+    <Box border="base" borderColor="border" padding="small">
+      <Tiles gap="small" align="center" minSize="15ch">
+        <Card>
+          <Box height={150} width={90} justifyContent="center" padding="base">
+            <Text>First tile</Text>
+          </Box>
+        </Card>
+        <Card>
+          <Box height={50} width={90} padding="base" justifyContent="center">
+            <Text>Second tile</Text>
+          </Box>
+        </Card>
+        <Card>
+          <Box height={20} width={90} padding="base" justifyContent="center">
+            <Text>Third tile</Text>
+          </Box>
+        </Card>
+        <Card>
+          <Box height={50} width={90} padding="base" justifyContent="center">
+            <Text>Forth tile</Text>
+          </Box>
+        </Card>
+      </Tiles>
+    </Box>
   </ContentBlock>
 </Canvas>
 

--- a/packages/site/src/content/Tiles/Tiles.mdx
+++ b/packages/site/src/content/Tiles/Tiles.mdx
@@ -117,6 +117,27 @@ Controls the gap between tiles. Uses Jobber's spacing scale:
   </ContentBlock>
 </Canvas>
 
+### Alignment
+
+The Tiles component supports vertically aligning the tiles within the container.
+
+<Canvas>
+  <ContentBlock maxWidth="100%">
+    <Tiles gap="largest" align="center">
+      <Card>
+        <Box height={150} padding="base" justifyContent="center">
+          <Text>First tile</Text>
+        </Box>
+      </Card>
+      <Card>
+        <Box height={50} padding="base" justifyContent="center">
+          <Text>Second tile</Text>
+        </Box>
+      </Card>
+    </Tiles>
+  </ContentBlock>
+</Canvas>
+
 ## Accessibility
 
 The Tiles component:

--- a/packages/site/src/content/Tiles/Tiles.props.json
+++ b/packages/site/src/content/Tiles/Tiles.props.json
@@ -64,6 +64,21 @@
           "name": "CommonAllowedElements"
         }
       },
+      "align": {
+        "defaultValue": {
+          "value": "start"
+        },
+        "description": "The vertical alignment  of the tiles within the container.",
+        "name": "align",
+        "parent": {
+          "fileName": "packages/components/src/Tiles/types.ts",
+          "name": "TilesProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"start\" | \"center\" | \"end\""
+        }
+      },
       "UNSAFE_className": {
         "defaultValue": null,
         "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",


### PR DESCRIPTION
Fixed tiles having a default min size but forcing it to be required

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Tiles had 2 issues that I wanted to address.
1. Tiles had a default `minSize` in the component but still required it while using it. This marks the `minSize` as optional to match the implementation.
2. Updated Tiles to support vertical alignment of tiles

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Support vertical alignment of Tiles


### Fixed

- Fixed tiles requiring the `minSize` prop even though the implementation had a default value set

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
