### PR TITLE
feat(components): Chips Experiment

### DIFF
--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -3,6 +3,8 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Content } from "@jobber/components/Content";
 import { Chip, Chips } from "@jobber/components/Chips";
 import { Text } from "@jobber/components/Text";
+import { MenuItemsAPI } from "@jobber/components/Chips/ChipsTypes";
+import { ChipProps } from "@jobber/components/Chip/Chip.types";
 
 export default {
   title: "Components/Selections/Chips/Web",
@@ -212,6 +214,21 @@ const ControlledSelectionTemplate: ComponentStory<typeof Chips> = () => {
     setSelected(prev => [...prev, value]);
   };
 
+  const customRenderMenu = (
+    options: ChipProps[],
+    menuItemsAPI: MenuItemsAPI,
+  ) => {
+    return (
+      <div>
+        {options.map(option => (
+          <div onBlur={menuItemsAPI.handleCancelBlur} key={option.value}>
+            {option.label}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
   return (
     <>
       <Text>
@@ -231,6 +248,7 @@ const ControlledSelectionTemplate: ComponentStory<typeof Chips> = () => {
         onChange={handleSelect}
         onCustomAdd={handleCustomAdd}
         onSearch={handleSearch}
+        customRenderMenu={customRenderMenu}
       >
         {displayedOptions.map(name => (
           <Chip key={name} label={name} value={name} />

--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -75,31 +75,65 @@ export const MultiSelect = MultiSelectTemplate.bind({});
 MultiSelect.args = {};
 
 const SelectionTemplate: ComponentStory<typeof Chips> = args => {
-  const {
-    selected,
-    options,
-    loading,
-    handleLoadMore,
-    handleSearch,
-    handleSelect,
-    handleCustomAdd,
-  } = useFakeOptionQuery();
+  // const {
+  //   selected,
+  //   options,
+  //   loading,
+  //   handleLoadMore,
+  //   handleSearch,
+  //   handleSelect,
+  //   handleCustomAdd,
+  // } = useFakeOptionQuery();
+  const [selected, setSelected] = useState<string[]>(["Mando", "Darth Vader"]);
+  const [loading, setLoading] = useState(false);
+  const [options, setOptions] = useState<string[]>([
+    "Mando",
+    "Darth Vader",
+    "Yoda",
+    "Obi-Wan Kenobi",
+    "Anakin Skywalker",
+    "Padme Amidala",
+    "Mace Windu",
+  ]);
+  const [externalSearchValue, setExternalSearchValue] = useState("");
+
+  const handleSelect = (value: string[]) => {
+    setSelected(value);
+  };
+
+  const handleCustomAdd = (value: string) => {
+    setOptions(prev => [...prev, value]);
+    setSelected(prev => [...prev, value]);
+  };
+
+  const handleSearch = (value: string) => {
+    setExternalSearchValue(value);
+  };
+
+  const handleLoadMore = () => {
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+    }, 1000);
+  };
 
   return (
-    <Chips
-      {...args}
-      type="dismissible"
-      selected={selected}
-      onChange={handleSelect}
-      onCustomAdd={handleCustomAdd}
-      isLoadingMore={loading}
-      onSearch={handleSearch}
-      onLoadMore={handleLoadMore}
-    >
-      {options.map(name => (
-        <Chip key={name} label={name} value={name} />
-      ))}
-    </Chips>
+    <>
+      <Text>{externalSearchValue}</Text>
+      <Chips
+        type="dismissible"
+        selected={selected}
+        onChange={handleSelect}
+        onCustomAdd={handleCustomAdd}
+        isLoadingMore={loading}
+        onSearch={handleSearch}
+        onLoadMore={handleLoadMore}
+      >
+        {options.map(name => (
+          <Chip key={name} label={name} value={name} />
+        ))}
+      </Chips>
+    </>
   );
 };
 

--- a/docs/components/Chips/Web.stories.tsx
+++ b/docs/components/Chips/Web.stories.tsx
@@ -3,7 +3,6 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Content } from "@jobber/components/Content";
 import { Chip, Chips } from "@jobber/components/Chips";
 import { Text } from "@jobber/components/Text";
-import { useFakeOptionQuery } from "./utils/storyUtils";
 
 export default {
   title: "Components/Selections/Chips/Web",
@@ -74,16 +73,7 @@ const MultiSelectTemplate: ComponentStory<typeof Chips> = args => {
 export const MultiSelect = MultiSelectTemplate.bind({});
 MultiSelect.args = {};
 
-const SelectionTemplate: ComponentStory<typeof Chips> = args => {
-  // const {
-  //   selected,
-  //   options,
-  //   loading,
-  //   handleLoadMore,
-  //   handleSearch,
-  //   handleSelect,
-  //   handleCustomAdd,
-  // } = useFakeOptionQuery();
+const SelectionTemplate: ComponentStory<typeof Chips> = () => {
   const [selected, setSelected] = useState<string[]>(["Mando", "Darth Vader"]);
   const [loading, setLoading] = useState(false);
   const [options, setOptions] = useState<string[]>([
@@ -152,6 +142,133 @@ Selection.parameters = {
       files: {
         "/useFakeOptionQuery.ts": require("./utils/storyUtils").default,
       },
+    },
+  },
+};
+
+const ControlledSelectionTemplate: ComponentStory<typeof Chips> = () => {
+  const [selected, setSelected] = useState<string[]>([
+    "Luke Skywalker",
+    "Leia Organa",
+  ]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [displayedOptions, setDisplayedOptions] = useState([
+    "Luke Skywalker",
+    "Leia Organa",
+    "Han Solo",
+    "Chewbacca",
+    "R2-D2",
+    "C-3PO",
+    "Darth Vader",
+  ]);
+
+  // Full list of all available options
+  const allOptions = [
+    "Luke Skywalker",
+    "Leia Organa",
+    "Han Solo",
+    "Chewbacca",
+    "R2-D2",
+    "C-3PO",
+    "Darth Vader",
+    "Obi-Wan Kenobi",
+    "Yoda",
+    "Emperor Palpatine",
+    "Boba Fett",
+    "Lando Calrissian",
+    "Jabba the Hutt",
+    "Admiral Ackbar",
+    "Wedge Antilles",
+  ];
+
+  const handleSelect = (value: string[]) => {
+    setSelected(value);
+  };
+
+  // Handle search in controlled mode
+  // Here we manually filter our options based on search term
+  const handleSearch = (value: string) => {
+    setSearchTerm(value);
+
+    if (value === "") {
+      setDisplayedOptions(allOptions.slice(0, 7)); // Reset to initial set
+    } else {
+      // Filter options based on search term
+      // Note: We don't need to include selected options in the filtered list
+      // The component will ensure selected chips remain visible
+      const filteredOptions = allOptions.filter(option =>
+        option.toLowerCase().includes(value.toLowerCase()),
+      );
+      setDisplayedOptions(filteredOptions);
+    }
+  };
+
+  // Handle custom add in controlled mode
+  const handleCustomAdd = (value: string) => {
+    // Add to both our main options list and selected items
+    if (!allOptions.includes(value)) {
+      setDisplayedOptions([...displayedOptions, value]);
+    }
+    setSelected(prev => [...prev, value]);
+  };
+
+  return (
+    <>
+      <Text>
+        Controlled mode with search term: &ldquo;{searchTerm}&rdquo;
+        <br />
+        Selected: {selected.join(", ")}
+        <br />
+        <small style={{ color: "var(--color-text--subdued)" }}>
+          Try searching for &ldquo;Solo&rdquo; - notice how the selected chips
+          remain visible even when they don&apos;t match the search.
+        </small>
+      </Text>
+      <Chips
+        controlled={true}
+        type="dismissible"
+        selected={selected}
+        onChange={handleSelect}
+        onCustomAdd={handleCustomAdd}
+        onSearch={handleSearch}
+      >
+        {displayedOptions.map(name => (
+          <Chip key={name} label={name} value={name} />
+        ))}
+      </Chips>
+    </>
+  );
+};
+
+export const ControlledSelection = ControlledSelectionTemplate.bind({});
+ControlledSelection.args = {
+  type: "dismissible",
+};
+
+ControlledSelection.parameters = {
+  docs: {
+    description: {
+      story: `
+        This example demonstrates the controlled mode for dismissible chips.
+        
+        ## Controlled Mode Benefits
+        
+        When \`controlled={true}\` is set on dismissible chips:
+        
+        - **No internal filtering**: The component doesn't filter options based on search value
+        - **No debouncing**: Search events are immediately passed to the parent component
+        - **Consumer-driven filtering**: The parent component is responsible for filtering based on search
+        - **Better performance**: Avoid duplicate filtering logic and state
+        - **More flexibility**: Implement complex filtering logic (e.g., API requests, fuzzy search)
+        
+        ## Implementation Notes
+        
+        In controlled mode, you should:
+        
+        1. Maintain state for the options to display in your parent component
+        2. Handle filtering in your \`onSearch\` callback
+        3. Pass the filtered options as children to the Chips component
+      `,
     },
   },
 };

--- a/packages/components/src/Chips/ChipsTypes.tsx
+++ b/packages/components/src/Chips/ChipsTypes.tsx
@@ -68,6 +68,8 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
   readonly selected: string[];
   onChange(value: string[]): void;
 
+  readonly controlled?: boolean;
+
   /**
    * Use a custom activator to trigger the Chip option selector
    */

--- a/packages/components/src/Chips/ChipsTypes.tsx
+++ b/packages/components/src/Chips/ChipsTypes.tsx
@@ -1,6 +1,21 @@
 import { MouseEvent, ReactElement } from "react";
 import { ChipProps } from "./Chip";
 
+export interface MenuItemsAPI {
+  generateDescendantId: (index: number) => string;
+  handleSelectOption: (
+    option: ChipProps & {
+      readonly custom: boolean;
+    },
+  ) => void;
+  handleSetActiveOnMouseOver: (index: number) => () => void;
+  handleCancelBlur: () => void;
+  handleEnableBlur: () => void;
+  handleShowInput: () => void;
+  activeIndex: number;
+  menuListOptionStyles: string;
+  activeOptionStyles: string;
+}
 interface ChipFoundationProps {
   readonly children: ReactElement<ChipProps>[];
 
@@ -67,7 +82,10 @@ export interface ChipDismissibleProps extends ChipFoundationProps {
   readonly type: "dismissible";
   readonly selected: string[];
   onChange(value: string[]): void;
-
+  readonly customRenderMenu?: (
+    options: ChipProps[],
+    menuItemsAPI: MenuItemsAPI,
+  ) => ReactElement;
   readonly controlled?: boolean;
 
   /**

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
@@ -55,6 +55,7 @@ export function InternalChipDismissible(props: InternalChipDismissibleProps) {
         options={availableChipOptions}
         onOptionSelect={handleChipAdd}
         onCustomOptionSelect={handleCustomAdd}
+        customRenderMenu={props.customRenderMenu}
         onSearch={props.onSearch}
         onLoadMore={props.onLoadMore}
         onlyShowMenuOnSearch={props.onlyShowMenuOnSearch}

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissible.tsx
@@ -48,6 +48,7 @@ export function InternalChipDismissible(props: InternalChipDismissibleProps) {
       ))}
 
       <InternalChipDismissibleInput
+        controlled={props.controlled}
         activator={props.activator}
         attachTo={wrapperRef}
         isLoadingMore={props.isLoadingMore}

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -100,24 +100,36 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
             className={styles.menuList}
             data-testid="chip-menu"
           >
-            {allOptions.map((option, i) => (
-              <button
-                key={option.value}
-                role="option"
-                type="button"
-                id={generateDescendantId(i)}
-                className={classNames(styles.menuListOption, {
-                  [styles.activeOption]: activeIndex === i,
-                })}
-                onClick={() => handleSelectOption(option)}
-                onMouseEnter={handleSetActiveOnMouseOver(i)}
-                onMouseDown={handleCancelBlur}
-                onMouseUp={handleEnableBlur}
-              >
-                <span aria-hidden>{option.prefix}</span>
-                <Text>{option.label}</Text>
-              </button>
-            ))}
+            {props.customRenderMenu
+              ? props.customRenderMenu(allOptions, {
+                  generateDescendantId,
+                  handleSelectOption,
+                  handleSetActiveOnMouseOver,
+                  handleCancelBlur,
+                  handleEnableBlur,
+                  handleShowInput,
+                  activeIndex,
+                  menuListOptionStyles: styles.menuListOption,
+                  activeOptionStyles: styles.activeOption,
+                })
+              : allOptions.map((option, i) => (
+                  <button
+                    key={option.value}
+                    role="option"
+                    type="button"
+                    id={generateDescendantId(i)}
+                    className={classNames(styles.menuListOption, {
+                      [styles.activeOption]: activeIndex === i,
+                    })}
+                    onClick={() => handleSelectOption(option)}
+                    onMouseEnter={handleSetActiveOnMouseOver(i)}
+                    onMouseDown={handleCancelBlur}
+                    onMouseUp={handleEnableBlur}
+                  >
+                    <span aria-hidden>{option.prefix}</span>
+                    <Text>{option.label}</Text>
+                  </button>
+                ))}
 
             <div ref={visibleChildRef} />
 

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleInput.tsx
@@ -41,7 +41,6 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
     handleKeyDown,
     handleSelectOption,
     handleShowInput,
-    handleDebouncedSearch,
   } = useInternalChipDismissibleInput(props);
 
   const menuRef = useScrollToActive(activeIndex);
@@ -56,12 +55,6 @@ export function InternalChipDismissibleInput(props: ChipDismissibleInputProps) {
   useSafeLayoutEffect(() => {
     update?.();
   }, [allOptions, menuOpen, update, options]);
-
-  useEffect(() => {
-    handleDebouncedSearch(searchValue, options);
-
-    return handleDebouncedSearch.cancel;
-  }, [searchValue, options]);
 
   useEffect(() => {
     isInView && onLoadMore && onLoadMore(searchValue);

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
@@ -6,7 +6,12 @@ export type InternalChipDismissibleProps = Omit<ChipDismissibleProps, "type">;
 export interface ChipDismissibleInputProps
   extends Pick<
     InternalChipDismissibleProps,
-    "activator" | "isLoadingMore" | "onSearch" | "onLoadMore" | "controlled"
+    | "activator"
+    | "isLoadingMore"
+    | "onSearch"
+    | "onLoadMore"
+    | "controlled"
+    | "customRenderMenu"
   > {
   readonly attachTo: React.RefObject<Element | null>;
   readonly options: ChipProps[];

--- a/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/InternalChipDismissibleTypes.ts
@@ -6,7 +6,7 @@ export type InternalChipDismissibleProps = Omit<ChipDismissibleProps, "type">;
 export interface ChipDismissibleInputProps
   extends Pick<
     InternalChipDismissibleProps,
-    "activator" | "isLoadingMore" | "onSearch" | "onLoadMore"
+    "activator" | "isLoadingMore" | "onSearch" | "onLoadMore" | "controlled"
   > {
   readonly attachTo: React.RefObject<Element | null>;
   readonly options: ChipProps[];

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/__tests__/useInternalChipDismissibleInput.test.tsx
@@ -179,7 +179,6 @@ describe("handleBlur", () => {
       act(() => {
         result.current.handleOpenMenu();
         result.current.handleSearchChange(fakeChangeEvent(searchValue));
-        result.current.handleDebouncedSearch(searchValue, hookParams.options);
       });
       expect(result.current.searchValue).toBe(searchValue);
       expect(result.current.menuOpen).toBe(true);
@@ -336,7 +335,6 @@ describe("handleSearchChange", () => {
 
     act(() => {
       result.current.handleSearchChange(fakeChangeEvent("initial"));
-      result.current.handleDebouncedSearch("initial", hookParams.options);
     });
     act(() => jest.advanceTimersByTime(300));
     act(() => result.current.handleSearchChange(fakeChangeEvent("new search")));

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissible.ts
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissible.ts
@@ -1,7 +1,8 @@
-import { KeyboardEvent, MouseEvent, useRef } from "react";
+import { KeyboardEvent, MouseEvent, useEffect, useRef, useState } from "react";
 import sortBy from "lodash/sortBy";
 import { useLiveAnnounce } from "@jobber/hooks/useLiveAnnounce";
 import { InternalChipDismissibleProps } from "../InternalChipDismissibleTypes";
+import { ChipProps } from "../../Chip";
 
 /**
  * Recursively finds a focusable element (div or button) in the specified direction
@@ -37,15 +38,78 @@ export function useInternalChipDismissible({
   onChange,
   onClick,
   onCustomAdd,
+  controlled = false,
 }: InternalChipDismissibleProps) {
   const ref = useRef<HTMLDivElement>(null);
   const chipOptions = children.map(chip => chip.props);
-  const visibleChipOptions = chipOptions.filter(chip =>
-    selected.includes(chip.value),
-  );
+
+  // In controlled mode, we need to maintain a cache of all chip options we've seen
+  // to ensure selected chips are always displayed even when filtered out during search
+  const [chipOptionsCache, setChipOptionsCache] = useState<
+    Record<string, ChipProps>
+  >({});
+
+  // Update the cache whenever we see new chips
+  useEffect(() => {
+    if (controlled) {
+      let hasChanges = false;
+      const newCache = { ...chipOptionsCache };
+
+      // Only add new options to the cache
+      chipOptions.forEach(option => {
+        if (
+          !chipOptionsCache[option.value] ||
+          JSON.stringify(chipOptionsCache[option.value]) !==
+            JSON.stringify(option)
+        ) {
+          newCache[option.value] = option;
+          hasChanges = true;
+        }
+      });
+
+      // Only update state if we have new or changed options
+      if (hasChanges) {
+        setChipOptionsCache(newCache);
+      }
+    }
+  }, [controlled, chipOptions]);
+
+  // In controlled mode, determine visible chips from both current options and cache
+  const getVisibleChipOptions = () => {
+    if (!controlled) {
+      // Standard mode: filter current children to get visible chips
+      return chipOptions.filter(chip => selected.includes(chip.value));
+    }
+
+    // Controlled mode: ensure all selected chips are included
+    // First gather selected options from current children
+    const selectedOptionsMap: Record<string, ChipProps> = {};
+
+    // Add any options from current children that are selected
+    chipOptions.forEach(chip => {
+      if (selected.includes(chip.value)) {
+        selectedOptionsMap[chip.value] = chip;
+      }
+    });
+
+    // For any selected values not in current children, get from cache
+    selected.forEach(value => {
+      if (!selectedOptionsMap[value] && chipOptionsCache[value]) {
+        selectedOptionsMap[value] = chipOptionsCache[value];
+      }
+    });
+
+    // Convert to array and return
+    return Object.values(selectedOptionsMap);
+  };
+
+  const visibleChipOptions = getVisibleChipOptions();
   const sortedVisibleChipOptions = sortBy(visibleChipOptions, chip =>
     selected.indexOf(chip.value),
   );
+
+  // Always filter out selected items from available options
+  // Both in controlled and uncontrolled modes
   const availableChipOptions = chipOptions.filter(
     chip => !selected.includes(chip.value),
   );

--- a/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
+++ b/packages/components/src/Chips/InternalChipDismissible/hooks/useInternalChipDismissibleInput.tsx
@@ -6,8 +6,8 @@ import React, {
   useRef,
   useState,
 } from "react";
-import debounce from "lodash/debounce";
 import { useLiveAnnounce } from "@jobber/hooks/useLiveAnnounce";
+import { useDebounce } from "@jobber/components/utils/useDebounce";
 import {
   ChipDismissibleInputOptionProps,
   ChipDismissibleInputProps,
@@ -56,6 +56,7 @@ export function useInternalChipDismissibleInput({
     previousOptionIndex: activeIndex > 0 ? activeIndex - 1 : maxOptionIndex,
   };
 
+  // why do we need you?
   function handleSearch(newSearchValue: string, newOptions: ChipProps[] = []) {
     onSearch && onSearch(newSearchValue);
 
@@ -65,7 +66,7 @@ export function useInternalChipDismissibleInput({
     setShouldCancelEnter(false);
   }
 
-  const handleDebouncedSearch = debounce(handleSearch, SEARCH_DEBOUNCE_TIME);
+  const handleDebouncedSearch = useDebounce(handleSearch, SEARCH_DEBOUNCE_TIME);
 
   const actions = {
     generateDescendantId: (index: number) => `${computed.menuId}-${index}`,
@@ -130,6 +131,7 @@ export function useInternalChipDismissibleInput({
       if (onlyShowMenuOnSearch && newSearchValue.length === 0 && menuOpen) {
         actions.handleCloseMenu();
       }
+      handleDebouncedSearch(newSearchValue, options);
     },
 
     handleSetActiveOnMouseOver: (index: number) => {
@@ -192,7 +194,6 @@ export function useInternalChipDismissibleInput({
 
       handleKeydownEvents(callbacks, event);
     },
-    handleDebouncedSearch,
   };
 
   return {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

there's a request to support a custom template for the menu items in dismissible chips, and we've got a reasonably good idea of how to solve that with a custom render function. the only tricky part about that is if you want the render function to provide you with the data that corresponds to each item, you'll have to pass that in - meaning we have to update the types on `Chip` to accept a new prop that can have pretty much anything as a key. we've done this before on Menu and some other custom render function components

the next part is trickier though. we also want to be able to search and filter based on these arbitrary values. integrating that into Chip's search logic is not really an option. we have no idea what the data will be or if it's relevant to a search, we'd have no way of knowing. Chip's search works in a very complex way that I'd want to change if it was staying around, and there's a bug with it currently being called when it shouldn't and it's not actually debounced.

furthermore, there's a bunch of internal logic not only filtering, but using the search value and results of the filtering to decide if we should show the "+" button to add, and the content is based on the search term. note that this is NOT working with this example yet. we should be able to solve that with a `customRenderMenuItems` where you are responsible for rendering all the menu items yourself, and then you can include an extra one at the end. though that approach does also mean that you have to implement all the handlers yourself which is a lot.

with that in mind, it's best to delegate the search to the consumer. the only ways I see us doing that is either by providing some sort of search logic prop where we will have the search term as an argument, then you provide the function that it will use.

Or, what I've tried here. add a separate code path that just ignores almost all of the logic around filtering, searching, selected and defer the responsibilities to the consumer.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
