### PR TITLE
feat(components): Add semantic token support for Grid gap spacing

### DIFF
--- a/docs/components/Grid/Web.stories.tsx
+++ b/docs/components/Grid/Web.stories.tsx
@@ -6,6 +6,7 @@ import { Heading } from "@jobber/components/Heading";
 import { Text } from "@jobber/components/Text";
 import { Card } from "@jobber/components/Card";
 import { DescriptionList } from "@jobber/components/DescriptionList";
+import { Stack } from "@jobber/components/Stack";
 
 export default {
   title: "Components/Layouts and Structure/Grid/Web",
@@ -89,6 +90,92 @@ const ThreeColumnsTemplate: ComponentStory<typeof Grid> = args => (
     </Grid>
   </Content>
 );
+
+const SpacingTemplate: ComponentStory<typeof Grid> = () => (
+  <Stack gap="large">
+    <div>
+      <Text variation="subdued">gap=&quot;small&quot;</Text>
+      <Grid gap="small">
+        <Grid.Cell size={{ xs: 6 }}>
+          <Card>
+            <Content>
+              <Text>Column 1</Text>
+            </Content>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell size={{ xs: 6 }}>
+          <Card>
+            <Content>
+              <Text>Column 2</Text>
+            </Content>
+          </Card>
+        </Grid.Cell>
+      </Grid>
+    </div>
+
+    <div>
+      <Text variation="subdued">gap=true (default)</Text>
+      <Grid gap={true}>
+        <Grid.Cell size={{ xs: 6 }}>
+          <Card>
+            <Content>
+              <Text>Column 1</Text>
+            </Content>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell size={{ xs: 6 }}>
+          <Card>
+            <Content>
+              <Text>Column 2</Text>
+            </Content>
+          </Card>
+        </Grid.Cell>
+      </Grid>
+    </div>
+
+    <div>
+      <Text variation="subdued">gap=&quot;large&quot;</Text>
+      <Grid gap="large">
+        <Grid.Cell size={{ xs: 6 }}>
+          <Card>
+            <Content>
+              <Text>Column 1</Text>
+            </Content>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell size={{ xs: 6 }}>
+          <Card>
+            <Content>
+              <Text>Column 2</Text>
+            </Content>
+          </Card>
+        </Grid.Cell>
+      </Grid>
+    </div>
+
+    <div>
+      <Text variation="subdued">gap=false </Text>
+      <Grid gap={false}>
+        <Grid.Cell size={{ xs: 6 }}>
+          <Card>
+            <Content>
+              <Text>Column 1</Text>
+            </Content>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell size={{ xs: 6 }}>
+          <Card>
+            <Content>
+              <Text>Column 2</Text>
+            </Content>
+          </Card>
+        </Grid.Cell>
+      </Grid>
+    </div>
+  </Stack>
+);
+
+export const Spacing = SpacingTemplate.bind({});
 
 export const ThreeColumns = ThreeColumnsTemplate.bind({});
 ThreeColumns.args = {

--- a/packages/components/src/Grid/Grid.test.tsx
+++ b/packages/components/src/Grid/Grid.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { GRID_TEST_ID, Grid } from ".";
 import alignments from "./GridAlign.module.css";
+import { spaceTokens } from "../sharedHelpers/getMappedAtlantisSpaceToken";
 
 const children = [
   <Grid.Cell key="1" size={{ xs: 12, sm: 8, md: 6, lg: 4, xl: 3 }}>
@@ -19,20 +20,26 @@ describe("Grid", () => {
     render(<Grid>{children}</Grid>);
     const element = screen.getByTestId(GRID_TEST_ID);
     expect(element).toBeInTheDocument();
-    expect(element).toHaveClass("grid gap start");
+    expect(element).toHaveClass("grid start");
   });
 
   describe("gap", () => {
-    it("should have a gap by default", () => {
+    it("should have default gap spacing when gap is true", () => {
       render(<Grid>{children}</Grid>);
       const element = screen.getByTestId(GRID_TEST_ID);
-      expect(element).toHaveClass("gap");
+      expect(element).toHaveStyle({ gap: spaceTokens.base });
     });
 
-    it("should not have a gap when set", () => {
+    it("should have no gap when gap is false", () => {
       render(<Grid gap={false}>{children}</Grid>);
       const element = screen.getByTestId(GRID_TEST_ID);
-      expect(element).not.toHaveClass("gap");
+      expect(element).not.toHaveStyle({ gap: expect.any(String) });
+    });
+
+    it("should use custom gap spacing when provided a token", () => {
+      render(<Grid gap="small">{children}</Grid>);
+      const element = screen.getByTestId(GRID_TEST_ID);
+      expect(element).toHaveStyle({ gap: spaceTokens.small });
     });
   });
 

--- a/packages/components/src/Grid/Grid.tsx
+++ b/packages/components/src/Grid/Grid.tsx
@@ -3,12 +3,19 @@ import classNames from "classnames";
 import styles from "./Grid.module.css";
 import alignments from "./GridAlign.module.css";
 import { GridCell } from "./GridCell";
+import { GapSpacing } from "../sharedHelpers/types";
+import {
+  getMappedAtlantisSpaceToken,
+  spaceTokens,
+} from "../sharedHelpers/getMappedAtlantisSpaceToken";
 
 interface GridProps {
   /**
-   * Add spacing between elements.
+   * Add spacing between elements. Can be a boolean for default spacing,
+   * or a semantic token for custom spacing.
+   * @default true
    */
-  readonly gap?: boolean;
+  readonly gap?: boolean | GapSpacing;
 
   /**
    * Adjust the alignment of columns. We only support a few select properties
@@ -30,12 +37,24 @@ export function Grid({
   gap = true,
   children,
 }: GridProps) {
-  const classnames = classNames(styles.grid, alignments[alignItems], {
-    [styles.gap]: gap,
-  });
+  const gapValue = (() => {
+    if (typeof gap === "boolean") {
+      return gap ? spaceTokens.base : undefined;
+    }
+
+    return getMappedAtlantisSpaceToken(gap);
+  })();
+
+  const style: React.CSSProperties | undefined = gapValue
+    ? { gap: gapValue }
+    : undefined;
 
   return (
-    <div data-testid={GRID_TEST_ID} className={classnames}>
+    <div
+      data-testid={GRID_TEST_ID}
+      className={classNames(styles.grid, alignments[alignItems])}
+      style={style}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
This change improves the flexibility of the Grid component by allowing developers to use semantic tokens for spacing, maintaining consistency with our design system's spacing scale. The implementation aligns better with how we handle spacing across other components.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Support for semantic tokens (`small`, `base`, `large`, etc) in Grid gap spacing
- New Storybook examples demonstrating different gap spacing options
- Use of type `GapSpacing` for semantic token support

### Changed

- Grid gap implementation from CSS class-based to style-based using tokens
- Default gap behavior to use `spaceTokens.base` when `gap={true}`
- Grid component tests to verify token-based spacing

## Testing

<!-- How to test your changes. -->
Check out the new story http://localhost:6005/?path=/story/components-layouts-and-structure-grid-web--spacing to see that we can either allow the boolean/default base spacing or assign a different spacing token

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
