### PR TITLE
refactor(components): replace calcs to 12 with slim in web

### DIFF
--- a/packages/components/src/Banner/Banner.module.css
+++ b/packages/components/src/Banner/Banner.module.css
@@ -3,7 +3,7 @@
   --banner-textColor: var(--color-text);
   display: flex;
   position: relative;
-  padding: calc(var(--space-base) - var(--space-smaller)) var(--space-base);
+  padding: var(--space-slim) var(--space-base);
   border-radius: var(--radius-base);
   color: var(--banner-textColor);
   background-color: var(--banner-surface);

--- a/packages/components/src/Button/Button.module.css
+++ b/packages/components/src/Button/Button.module.css
@@ -183,7 +183,7 @@ a.button.disabled:hover {
 
 .small {
   --button--size: 32px;
-  padding: var(--space-smaller) calc(var(--space-base) - var(--space-smaller));
+  padding: var(--space-smaller) var(--space-slim);
 }
 
 .base {

--- a/packages/components/src/FormField/FormField.module.css
+++ b/packages/components/src/FormField/FormField.module.css
@@ -128,8 +128,8 @@
 }
 
 .small {
-  --field--padding-left: calc(var(--space-base) - var(--space-smaller));
-  --field--padding-right: calc(var(--space-base) - var(--space-smaller));
+  --field--padding-left: var(--space-slim);
+  --field--padding-right: var(--space-slim);
   --field--padding-top: var(--space-small);
   --field--padding-bottom: var(--space-small);
   --field--height: calc(var(--space-larger) + var(--space-smaller));

--- a/packages/components/src/InlineLabel/InlineLabel.module.css
+++ b/packages/components/src/InlineLabel/InlineLabel.module.css
@@ -12,7 +12,7 @@
 }
 
 .large {
-  padding: calc(var(--space-small) * 1.25) calc(var(--space-small) * 1.5);
+  padding: calc(var(--space-small) * 1.25) var(--space-slim);
   border-radius: var(--radius-larger);
 }
 
@@ -21,7 +21,7 @@
 }
 
 .larger {
-  padding: calc(var(--space-small) * 1.5) calc(var(--space-base));
+  padding: var(--space-slim) calc(var(--space-base));
   border-radius: var(--radius-larger);
 }
 

--- a/packages/components/src/MultiSelect/MultiSelect.module.css
+++ b/packages/components/src/MultiSelect/MultiSelect.module.css
@@ -48,8 +48,8 @@
 }
 
 .small {
-  --field--padding-left: calc(var(--space-base) - var(--space-smaller));
-  --field--padding-right: calc(var(--space-base) - var(--space-smaller));
+  --field--padding-left: var(--space-slim);
+  --field--padding-right: var(--space-slim);
   --field--height: calc(var(--space-larger) + var(--space-smaller));
 }
 

--- a/packages/components/src/SegmentedControl/SegmentedControl.module.css
+++ b/packages/components/src/SegmentedControl/SegmentedControl.module.css
@@ -29,7 +29,7 @@
 .container label {
   display: flex;
   z-index: 1;
-  padding: 0 calc(var(--space-base) - var(--space-smaller));
+  padding: 0 var(--space-slim);
   overflow: hidden;
   font-size: var(--typography--fontSize-base);
   font-weight: 600;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Since we've introduced a token for `slim` to meet needs that were being worked around repeatedly, let's clean up the old workarounds.

The most common was subtracting `smaller` (4) from `base` (16), but also found some multiplications. I checked for division like `large` (24) / `2`, but did not find anything 

## Changes

### Changed

- No visual changes
- Replacing calcs with the `--space-slim` token
  - Banner
  - Button
  - FormField
  - InlineLabel
  - MultiSelect
  - SegmentedControl

## Testing

Testing in Storybook should be sufficient - expect no visual diff

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

![Random photo of Atlantis](https://loremflickr.com/672/400/atlantis)
