### PR TITLE
chore(components): Use version range for hooks peerDep

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -518,7 +518,7 @@
   "peerDependencies": {
     "@apollo/client": "^3",
     "@jobber/design": "*",
-    "@jobber/hooks": "^2",
+    "@jobber/hooks": ">=2",
     "@tanstack/react-table": "^8",
     "axios": "^1",
     "classnames": "^2",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This is safer for when we do major version bumps. If we were to publish hooks v3.0.0, lerna's publish commit would fail in this case because components currently requires v2.x.x.

Using `>=2` allows any version above 2, including major version 3+.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Updated hooks peerDep version range 

## Before

This dry run shows that lerna would fail in the publish step because components requires a peerDep of v2.x.x

<img width="1268" alt="Screenshot 2025-05-12 at 11 15 18 AM" src="https://github.com/user-attachments/assets/b3d0b2f0-117d-4793-b3f2-a5dc88302ca5" />



## After

Now it's successful because v2 or above is allowed.

<img width="1225" alt="Screenshot 2025-05-12 at 11 16 37 AM" src="https://github.com/user-attachments/assets/cd03b2c2-e810-4568-81d3-c9b43edfd205" />


## Testing

No need to test anything.

Here's the dry run command if you really want to test it:

```bash
npx lerna version --no-push --no-git-tag-version --yes --no-private
```

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)
