### PR TITLE
chore: Skip versioning the atlantis-site which doesn't get published anyway

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "npm run build:all && npm run generate:sitemap",
     "build:all": "npm run storybook:build && npm run site:build && npm run merge:dist",
     "build:hooksIndex": "node scripts/createIndexFile.js ./packages/hooks/src",
-    "ci:release": "lerna publish --yes",
+    "ci:release": "lerna publish --yes --no-private",
     "clean": "rm -rf node_modules **/dist packages/**/.rollup.cache storybook-static",
     "generate": "plop -- --path='./packages/components/src/'",
     "generate:sitemap": "node sitemap-generator.js",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Lerna by default versions packages marked as `private: true` for some reason.

This PR prevents lerna from unnecessarily version bumping the atlantis-site (`packages/site`) on every publish commit.

So after this merges, this will no longer happen: 

<img width="439" alt="Screenshot 2025-05-12 at 11 27 46 AM" src="https://github.com/user-attachments/assets/98ba0247-29ce-4800-aa40-f86c73425f0e" />

## Changes

### Changed

- Configured lerna to skip private packages

## Before

Here's a dry run showing what happens when `--no-private` is not included.

<img width="1291" alt="Screenshot 2025-05-12 at 11 41 58 AM" src="https://github.com/user-attachments/assets/11ff1751-009d-4acf-9a2c-674ac54a2e85" />


## After

And here you'll see atlantis-site is skipped when `--no-private` is included.

<img width="1240" alt="Screenshot 2025-05-12 at 11 42 20 AM" src="https://github.com/user-attachments/assets/3de56688-efca-4bb3-b3ac-5dfcc354e460" />


## Testing

<!-- How to test your changes. -->

I wouldn't bother testing this, however if you want to... you can run a dry run with lerna:

```bash
npx lerna version --no-push --no-git-tag-version --yes --no-private
```

If you try without `--no-private`, you would see `atlantis-site` gets logged with a new version by lerna (assuming you actually have a change committed in one of the packages, like `components` for example). Reach out and I'll pass you a guide if you want more context here 👍 



Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)
