### PR TITLE
chore: Update package-lock.json due to recent change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43870,7 +43870,7 @@
       "peerDependencies": {
         "@apollo/client": "^3",
         "@jobber/design": "*",
-        "@jobber/hooks": "^2",
+        "@jobber/hooks": ">=2",
         "@tanstack/react-table": "^8",
         "axios": "^1",
         "classnames": "^2",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This change led to package-lock.json being updated upon install: https://github.com/GetJobber/atlantis/pull/2552

This PR just accepts that change that I missed yesterday.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Fixed our package-lock.json


## Testing

No testing necessary.

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)
