### PR TITLE
fix(components): stop showing focus ring on disabled and invalid components

### DIFF
--- a/packages/components/src/FormField/FormField.module.css
+++ b/packages/components/src/FormField/FormField.module.css
@@ -108,8 +108,8 @@
   overflow: auto;
 }
 
-.invalid,
-.invalid:focus-within {
+.invalid:not(.disabled),
+.invalid:not(.disabled):focus-within {
   --field--border-color: var(--color-critical);
   position: relative;
 }

--- a/packages/components/src/FormField/FormField.module.css
+++ b/packages/components/src/FormField/FormField.module.css
@@ -62,7 +62,7 @@
   box-sizing: border-box;
 }
 
-.wrapper:focus-within {
+.wrapper:not(.disabled):focus-within {
   position: relative;
   z-index: var(--field--base-elevation);
   box-shadow: var(--shadow-focus);

--- a/packages/components/src/FormField/FormField.module.css.d.ts
+++ b/packages/components/src/FormField/FormField.module.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles: {
   readonly "container": string;
   readonly "wrapper": string;
+  readonly "disabled": string;
   readonly "horizontalWrapper": string;
   readonly "textarea": string;
   readonly "safari": string;
@@ -9,7 +10,6 @@ declare const styles: {
   readonly "large": string;
   readonly "text": string;
   readonly "invalid": string;
-  readonly "disabled": string;
   readonly "small": string;
   readonly "inline": string;
   readonly "center": string;

--- a/packages/components/src/InputDate/InputDate.rebuilt.tsx
+++ b/packages/components/src/InputDate/InputDate.rebuilt.tsx
@@ -51,7 +51,7 @@ export const InputDateRebuilt = forwardRef(function InputDateInternal(
         ? ({
             icon: "calendar",
             ariaLabel: "Show calendar",
-            onClick: onClick && onClick,
+            onClick: !props.disabled && onClick && onClick,
           } as Suffix)
         : undefined;
 

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -27,7 +27,7 @@ export function InputDate(inputProps: InputDateProps) {
             ? ({
                 icon: "calendar",
                 ariaLabel: "Show calendar",
-                onClick: onClick && onClick,
+                onClick: !inputProps.disabled && onClick && onClick,
               } as Suffix)
             : undefined;
 


### PR DESCRIPTION
## Motivations
This fixes a few bugs where input fields show a focus ring (or in some cases their "invalid" border treatment) when they are disabled.

The Bugs:

https://github.com/user-attachments/assets/bea8dde1-9f22-4a70-86c6-887ac23425ea

https://github.com/user-attachments/assets/9ee2ec90-8300-4d73-bef1-a762b5c7b77a

The Fixes:

https://github.com/user-attachments/assets/a94cdebe-185c-435a-b122-d221a185ab4b



<img width="580" alt="image" src="https://github.com/user-attachments/assets/4969afdf-aed1-492c-b93d-81f2372e2c66" />



### Fixed
- Modify CSS to exclude focus ring on disabled fields 
- Modify CSS to exclude invalid border on disabled fields


## Testing
### Reproduction
To reproduce the bug, visit the current Atlantis site:

#### InputTime
1. View the [Atlantis InputTime "invalid" story with disabled set to true](https://atlantis.getjobber.com/storybook/?path=/story/components-forms-and-inputs-inputtime-web--invalid&args=disabled:!true). 
2. Click on the field. 
3. OBSERVE the focus ring appears around the disabled field.
4. OBSERVE the red invalid treatment also appears.
5. OBSERVE this bug is reproducible with both versions 1 & 2 of the component.

#### InputDate
1. View the [Atlantis InputDate "basic" story with disabled and invalid set to true](https://atlantis.getjobber.com/storybook/?path=/story/components-forms-and-inputs-inputdate-web--basic&args=invalid:!true;disabled:!true). 
2. Click on the field. 
3. OBSERVE the focus ring appears around the disabled field.
4. OBSERVE the red invalid treatment also appears.
5. Click on the calendar icon.
6. OBSERVE the focus ring appears around the disabled field.
7. OBSERVE the red invalid treatment also appears.
8. OBSERVE this bug is reproducible with both versions 1 & 2 of the component.

### Bug fix
To observe the bug fix, visit the site preview for this PR:

#### InputTime
1. View the [Atlantis InputTime "invalid" story with disabled set to true](https://cleanup-fix-disabled-inputs.atlantis.pages.dev/storybook/?path=/story/components-forms-and-inputs-inputtime-web--invalid&args=disabled:!true). 
2. Click on the field. 
3. OBSERVE that NO focus ring appears.
4. OBSERVE that NO red invalid treatment appears.
5. OBSERVE that the bug is fixed with both versions 1 & 2 of the component.

#### InputDate
1. View the [Atlantis InputDate "basic" story with disabled and invalid set to true](https://cleanup-fix-disabled-inputs.atlantis.pages.dev/storybook/?path=/story/components-forms-and-inputs-inputdate-web--basic&args=invalid:!true;disabled:!true). 
2. Click on the field. 
3. OBSERVE that NO focus ring appears around the disabled field.
4. OBSERVE that NO red invalid treatment appears.
5. Click on the calendar icon.
6. OBSERVE that NO focus ring appears.
7. OBSERVE that NO red invalid treatment appears.
8. OBSERVE that the bug is fixed with both versions 1 & 2 of the component.





Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
