### PR TITLE
fix(components-native): Fix bleeding corners for FormatFile

### DIFF
--- a/docs/components/FormatFile/Mobile.stories.tsx
+++ b/docs/components/FormatFile/Mobile.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/react";
 import { FormatFile } from "@jobber/components-native";
 
 export default {
@@ -11,9 +11,9 @@ export default {
     viewport: { defaultViewport: "mobile1" },
     showNativeOnWebDisclaimer: true,
   },
-} as ComponentMeta<typeof FormatFile>;
+} as Meta<typeof FormatFile>;
 
-const BasicTemplate: ComponentStory<typeof FormatFile> = args => (
+const BasicTemplate: StoryFn<typeof FormatFile> = args => (
   <FormatFile {...args} />
 );
 
@@ -26,6 +26,18 @@ Image.args = {
     thumbnailUrl: "https://picsum.photos/250",
     fileSize: 1024,
   },
+};
+
+export const ImageGrid = BasicTemplate.bind({});
+ImageGrid.args = {
+  file: {
+    fileName: "image.png",
+    contentType: "image/png",
+    url: "https://picsum.photos/250",
+    thumbnailUrl: "https://picsum.photos/250",
+    fileSize: 1024,
+  },
+  styleInGrid: true,
 };
 
 export const Video = BasicTemplate.bind({});

--- a/packages/components-native/package.json
+++ b/packages/components-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/components-native",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "license": "MIT",
   "description": "React Native implementation of Atlantis",
   "repository": {

--- a/packages/components-native/src/FormatFile/FormatFile.style.ts
+++ b/packages/components-native/src/FormatFile/FormatFile.style.ts
@@ -8,6 +8,8 @@ export const useStyles = buildThemedStyles(tokens => {
       borderColor: tokens["color-border"],
       borderRadius: tokens["radius-base"],
       marginBottom: tokens["space-small"],
+      // This is to prevent the image from overflowing the container's border radius, otherwise it can "bleed" out the corners
+      overflow: "hidden",
     },
     thumbnailContainerGrid: {
       width: tokens["space-extravagant"],

--- a/packages/components-native/src/ThumbnailList/__snapshots__/ThumbnailList.test.tsx.snap
+++ b/packages/components-native/src/ThumbnailList/__snapshots__/ThumbnailList.test.tsx.snap
@@ -75,6 +75,7 @@ exports[`renders a thumbnail component with attachments 1`] = `
                   "borderRadius": 8,
                   "borderWidth": 1,
                   "marginBottom": 8,
+                  "overflow": "hidden",
                 },
                 {
                   "height": 64,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

As noted in [JOB-122538](https://jobber.atlassian.net/browse/JOB-122538), there are currently bleeding corners seen when this is used with the `styleInGrid: true` configuration. This was discovered/prioritized after adding image attachments to job form submissions.

## Changes
- Fixes image corner bleeding when `styleInGrid: true`

### Added
- N/A

### Changed
- N/A

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Adds `overflow: "hidden"` to the thumbnail container styling for `FormatFile` to stop image corners from "bleeding" out of the border when `styleInGrid: true`

### Security
- N/A

## Testing
- Updated the story to contain an additional usage of FormatFile with the `styleInGrid: true` flag, which should help avoid this regressing

Testing can be done by [navigating to the `FormatFile > Mobile > Image Grid` story](http://localhost:6005/?path=/story/components-images-and-icons-formatfile-mobile--image-grid) when running storybook
- With the change you can see no image bleeding in the corners
![image](https://github.com/user-attachments/assets/e3ebfa87-cd63-44a8-92cd-69c0d96f6479)

- Without the change you can see image bleeding / not cropping the corners

It is worth noting that when `styleInGrid: true` is set in storybook, it causes the image to be cropped heavily to only the top ~25%. This is an existing bug in how it's being displayed in storybook. This can be seen with current `master` and in this PR. I'm not certain why and did not seem trivial to fix, but the usage in `jobber-mobile` with this fix does not have that issue nor does it have that issue currently (even with the bleeding corners).


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)


---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
