### PR TITLE
fix(components): Remove z-index from affix icons with actions [JOB-119173 ]

### DIFF
--- a/packages/components/src/FormField/FormField.module.css
+++ b/packages/components/src/FormField/FormField.module.css
@@ -352,11 +352,6 @@
   padding-left: var(--space-small);
 }
 
-.affixIcon.hasAction {
-  position: relative;
-  z-index: var(--field--postfix-action-elevation);
-}
-
 .affixLabel {
   display: flex;
   margin: 0 calc((var(--field--padding-left) - var(--space-smallest)) * -1) 0 0;

--- a/packages/components/src/FormField/FormField.module.css.d.ts
+++ b/packages/components/src/FormField/FormField.module.css.d.ts
@@ -25,7 +25,6 @@ declare const styles: {
   readonly "postfix": string;
   readonly "affixIcon": string;
   readonly "suffix": string;
-  readonly "hasAction": string;
   readonly "affixLabel": string;
   readonly "description": string;
   readonly "toolbar": string;

--- a/packages/components/src/FormField/FormFieldAffix.tsx
+++ b/packages/components/src/FormField/FormFieldAffix.tsx
@@ -47,7 +47,6 @@ export function AffixIcon({
 }: AffixIconProps & XOR<Affix, Suffix>) {
   const affixIconClass = classnames(styles.affixIcon, {
     [styles.suffix]: variation === "suffix",
-    [styles.hasAction]: onClick,
   });
 
   const iconSize = size === "small" ? "small" : "base";


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

[This bug](https://jobber.atlassian.net/browse/JOB-119173) was reported where the calendar from the date picker is overlapping with the save bar. 

![image-20250319-185030](https://github.com/user-attachments/assets/99dcebac-00df-41a3-a926-aa02c0eafb81)

Looking into it I can't determine the need for this z-index. I asked [here](https://getjobber.slack.com/archives/C03BKPST4KC/p1747244072043699) and Chris who was a reviewer on the original PR thinks it was to make sure that the icons are always above the input content (value/placeholder). I've done some testing though and it doesn't seem necessary for that. It's worth noting that only suffixes can have actions, so we only need to test this behaviour for suffixes and not prefixes.

### Removed

The z-index for affix icons with actions has been removed.

## Testing

To do some initial testing I added the following to one of the stories for form field:
```
  suffix: {
    icon: "googlePlay",
    onClick: () => console.log("clicked suffix"),
    ariaLabel: "Suffix button",
  },
```
To ensure that at various screen sizes the placeholder text/input value don't overlap with the suffix button. I have also created a pre-release for testing the behaviour on JO and JFE on various inputs. I recognize that my solution is based on not seeing issues with the style removed so it is important that we test this thoroughly.

![Screenshot 2025-05-14 at 1 11 11 PM](https://github.com/user-attachments/assets/4963bbae-4ea2-4150-8282-9e539c30a32f)


![Screenshot 2025-05-14 at 1 11 25 PM](https://github.com/user-attachments/assets/f822cfff-fc38-4e2f-b85c-8150c8ef13eb)



Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
