### PR TITLE
fix(components): Allowing error passthrough on <Select version={2} />

### DIFF
--- a/docs/components/Select/Web.stories.tsx
+++ b/docs/components/Select/Web.stories.tsx
@@ -156,12 +156,14 @@ export const VersionComparison = () => {
   const [invalid, setInvalid] = useState<boolean | undefined>(undefined);
   const [disabled, setDisabled] = useState(false);
   const [description, setDescription] = useState<string>("");
+  const [error, setError] = useState<string>("");
 
   const extraProps = {
     invalid,
     inline,
     disabled,
     description,
+    error,
   };
 
   const handleChange = (field: keyof typeof values) => (value: string) => {
@@ -346,6 +348,12 @@ export const VersionComparison = () => {
             onClick={() => {
               setDescription(description ? "" : "This is a description");
             }}
+          />
+        </Grid.Cell>
+        <Grid.Cell size={{ xs: 6 }}>
+          <Button
+            label="Toggle Error"
+            onClick={() => setError(error ? "" : "This is an error")}
           />
         </Grid.Cell>
       </Grid>

--- a/packages/components/src/Select/Select.rebuilt.tsx
+++ b/packages/components/src/Select/Select.rebuilt.tsx
@@ -60,7 +60,7 @@ export function SelectRebuilt(props: SelectRebuiltProps) {
       autofocus={props.autofocus}
       name={name}
       wrapperRef={wrapperRef}
-      error={""}
+      error={props.error ?? ""}
       invalid={props.invalid}
       identifier={id}
       descriptionIdentifier={descriptionIdentifier}

--- a/packages/components/src/Select/Select.types.ts
+++ b/packages/components/src/Select/Select.types.ts
@@ -54,4 +54,5 @@ export interface SelectRebuiltProps
   readonly value?: string | number;
   onChange?(newValue?: string | number): void;
   version: 2;
+  error?: string;
 }


### PR DESCRIPTION
## Motivations

We want to allow the error to be passed through to the `SelectRebuilt` component.

## Changes

1. The error is now passed through to the SelectRebuilt component.

## Testing

You should be able to add an 'error' prop to the `SelectRebuilt` component and see the error displayed

"Version comparison" story's Toggle Error verifies `error` prop is being passed through

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
