### PR TITLE
fix(components): stop minilabel from responding on empty disabled InputTime

### DIFF
--- a/packages/components/src/FormField/FormField.module.css
+++ b/packages/components/src/FormField/FormField.module.css
@@ -78,6 +78,11 @@
   margin-right: var(--field--padding-right);
 }
 
+/* When there's placeholder text on an EMPTY time input
+  - we hide the field value when the input is:
+  - not focused or disabled
+*/
+.timeInputLabel input:disabled,
 .timeInputLabel:not(:focus-within) input {
   color: var(--field--background-color);
   -webkit-text-fill-color: var(--field--background-color);

--- a/packages/components/src/FormField/FormField.module.css
+++ b/packages/components/src/FormField/FormField.module.css
@@ -83,7 +83,7 @@
   -webkit-text-fill-color: var(--field--background-color);
 }
 
-.timeInputLabel:focus-within,
+.timeInputLabel:not(.disabled):focus-within,
 .miniLabel {
   --field--placeholder-color: var(--color-text--secondary);
   --field--placeholder-offset: var(--space-smallest);
@@ -92,7 +92,7 @@
   --field--padding-bottom: var(--space-small);
 }
 
-.timeInputLabel.large:focus-within,
+.timeInputLabel:not(.disabled).large:focus-within,
 .miniLabel.large {
   --field--padding-top: calc(var(--space-large) + var(--space-smaller));
 }
@@ -299,9 +299,12 @@
   padding-right: var(--field--padding-right);
 }
 
-.miniLabel .label,
-.timeInputLabel:focus-within .label {
+.miniLabel .label {
   font-size: var(--typography--fontSize-small);
+}
+
+.small.miniLabel .label {
+  display: none;
 }
 
 .text.miniLabel .label {
@@ -312,15 +315,18 @@
   background-color: var(--field--background-color);
 }
 
-.small.miniLabel .label,
-.timeInputLabel.small.miniLabel:focus-within .label {
+.timeInputLabel:focus-within:not(.disabled) .label {
+  font-size: var(--typography--fontSize-small);
+}
+
+.timeInputLabel.small.miniLabel:focus-within:not(.disabled) .label {
   display: none;
 }
 
 /**This is valid cascading order **/
 /* stylelint-disable-next-line no-descending-specificity */
 .large.miniLabel .label,
-.timeInputLabel.large.miniLabel:focus-within .label {
+.timeInputLabel.large.miniLabel:focus-within:not(.disabled) .label {
   padding-top: var(--space-small);
 }
 


### PR DESCRIPTION
## Motivations
InputTime should not show interaction when disabled. 
This fixes a case where a blank disabled InputTime would show interaction when clicked on.

Bug:

https://github.com/user-attachments/assets/6b7e4168-002d-4547-9930-b867b398b23a

No regressions:
When the disabled field has a value, it should also continue to not show interaction when clicked on.

https://github.com/user-attachments/assets/f0309504-761b-4ba3-b0f2-a75d58dd48c8



## Changes
Modifies the FormField CSS to include a few more cases of handling focus on InputTime.

### Fixed
- InputTime no longer responds to focus to animate minilabel when disabled.

## Testing
### Bug Reproduction:
1. Navigate to https://atlantis.getjobber.com/storybook/?path=/story/components-forms-and-inputs-inputtime-web--uncontrolled
2. Set a placeholder value on the field and set it to disabled.
3. Click within the field.
4. OBSERVE that the minilabel moves up and the blank time field "--:--" appears.

### Fix
1. Navigate to https://cleanup-fix-disabled-input-t.atlantis.pages.dev/?path=/story/components-forms-and-inputs-inputtime-web--controlled
2. Set a placeholder value on the field and set it to disabled.
4. Click within the field.
5. OBSERVE that the minilabel moves up and the blank time field "--:--" appears.

https://github.com/user-attachments/assets/4db962fd-53a3-4c63-97c7-08854adabd5f




Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).

