### PR TITLE
fix(components): Adjusting Date & Time handling in FormatRelativeDateTime

### DIFF
--- a/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
+++ b/packages/components/src/FormatRelativeDateTime/FormatRelativeDateTime.tsx
@@ -7,10 +7,16 @@ interface FormatRelativeDateTimeProps {
    * A `string` should be an ISO 8601 format date string.
    */
   readonly date: Date | string;
+
+  /**
+   * Whether to show the date and time on day rollover.
+   */
+  readonly showDateAndTimeOnDayRollover?: boolean;
 }
 
 export function FormatRelativeDateTime({
   date: inputDate,
+  showDateAndTimeOnDayRollover = false,
 }: FormatRelativeDateTimeProps) {
   let dateObject: Date;
 
@@ -21,8 +27,13 @@ export function FormatRelativeDateTime({
   }
 
   const now = Date.now() / 1000; //seconds
+  const today = new Date();
   const date = dateObject;
   const delta = now - date.getTime() / 1000; //seconds;
+  const additionalOptions: object =
+    showDateAndTimeOnDayRollover && today.getDate() !== date.getDate()
+      ? { weekday: "short", hour: "numeric", minute: "numeric" }
+      : {};
 
   switch (relativeTimeRange(delta)) {
     case "less than an hour":
@@ -33,13 +44,24 @@ export function FormatRelativeDateTime({
           {date.toLocaleTimeString(undefined, {
             hour: "numeric",
             minute: "numeric",
+            ...additionalOptions,
           })}
         </>
       );
     case "less than a week":
-      return <>{strFormatDate(date, { weekday: "short" })}</>;
+      return (
+        <>{strFormatDate(date, { weekday: "short", ...additionalOptions })}</>
+      );
     case "less than a year":
-      return <>{strFormatDate(date, { month: "short", day: "numeric" })}</>;
+      return (
+        <>
+          {strFormatDate(date, {
+            month: "short",
+            day: "numeric",
+            ...additionalOptions,
+          })}
+        </>
+      );
     default:
       return (
         <>


### PR DESCRIPTION
## Motivations

1. We had some reports that the way this component was managing dates from yesterday, but still within 24 hours, was causing some confusion.
2. This PR introduces a new prop to enable including the date when the day rolls over to the next.
3. The prop was introduced because this is ~5 year old code, so didn't want to surprise long-term consumers with a breaking change.

## Changes

1. Adds a new prop to force FormatRelativeDateTime to show the date on day rollover.

### Before
![image](https://github.com/user-attachments/assets/db684ae1-c3ee-4618-86e9-ded5c1b8a127)

### After

![image](https://github.com/user-attachments/assets/fa6f36e8-0bf9-4d85-82f7-ee74109724d0)

### Additional Thoughts
This was one of the component we tagged during our Atomic work as potentially being rebuilt as a hook, and I would still agree with that path forward.

It might be as simple as extracting the logic in this component into a new hook and exporting that.

## Testing

1. When adding the new 'showDateAndTimeOnDayRollver' prop, you should see the Date along with the Time is the date passed's day does not match the current day.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
