### PR TITLE
only one failing test and it seems unrelated

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -35,6 +35,7 @@ function AutocompleteInternal<
     onFocus,
     validations,
     customRenderMenu,
+    version = 1,
     ...inputProps
   }: AutocompleteProps<
     GenericOption,
@@ -68,6 +69,7 @@ function AutocompleteInternal<
       <InputText
         ref={mergeRefs([ref, inputRef])}
         autocomplete={false}
+        version={version as 1 | undefined}
         size={size}
         value={inputText}
         onChange={handleInputChange}

--- a/packages/components/src/Autocomplete/Autocomplete.types.ts
+++ b/packages/components/src/Autocomplete/Autocomplete.types.ts
@@ -102,6 +102,13 @@ export interface AutocompleteProps<
       GenericOptionValue
     >,
   ) => React.ReactElement;
+
+  /**
+   * The version of the autocomplete.
+   *
+   * @default 1
+   */
+  version?: 1 | 2;
 }
 
 export type CustomOptionsMenuType<GenericOption extends AnyOption = AnyOption> =


### PR DESCRIPTION

## Motivations

1. Needed a V2 for the Autocomplete. This just allows passthrough of the prop to the InputText currently. 
2. This needs to be tested properly.

## Changes

1. Added a 'version' prop to Autocomplete, which allows passthrough to the InputText.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
