### PR TITLE
fix(components): rename InputNumberProps type and improve mutual exclusivity

### DIFF
--- a/packages/components/src/InputNumber/index.tsx
+++ b/packages/components/src/InputNumber/index.tsx
@@ -10,12 +10,16 @@ import {
   InputNumberRebuiltRef,
 } from "./InputNumber.rebuilt.types";
 
-export type InputNumberShimProps =
-  | InputNumberLegacyProps
-  | InputNumberRebuiltProps;
+export type InputNumberProps =
+  | ({
+      version: 2;
+    } & InputNumberRebuiltProps)
+  | ({
+      version?: 1;
+    } & InputNumberLegacyProps);
 
 function isNewInputNumberProps(
-  props: InputNumberShimProps,
+  props: InputNumberProps,
 ): props is InputNumberRebuiltProps {
   return props.version === 2;
 }
@@ -23,7 +27,7 @@ function isNewInputNumberProps(
 type InputNumberRef = InputNumberRebuiltRef | InputNumberLegacyRef;
 
 export const InputNumber = forwardRef(function InputNumberShim(
-  props: InputNumberShimProps,
+  props: InputNumberProps,
   ref: ForwardedRef<InputNumberRef>,
 ) {
   if (isNewInputNumberProps(props)) {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
This pull request updates the `InputNumber` component to improve type safety and clarify versioning. 

### Fixed
The main change involves replacing the `InputNumberShimProps` type with a new `InputNumberProps` type  explicitly distinguishes between version 1 and version 2 props.

### Changes to `InputNumber` component:
* Renamed `InputNumberShimProps` with `InputNumberProps` for backward compatibiltiy. 
* Restructure exported props to more clearly provide mutually exclusive types based on  `version` field.

## Testing
- in the Storybook file for InputNumber Web (`docs/components/InputNumber/Web.stories.tsx`), replace the BasicTemplate with the following and play with the types to confirm that the `defaultValue` prop behaves as expected depending on the version being set to 2, 1 or undefined.
```
const BasicTemplate: ComponentStory<typeof InputNumber> = args => {
  return (
    <>
      <InputNumber defaultValue={10} version={2} />
      <InputNumber defaultValue={"10"} />
    </>
  );
};
```



Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
