### PR TITLE
feat(components): add ref to Checkbox v2

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
+++ b/packages/components/src/Checkbox/Checkbox.rebuilt.tsx
@@ -1,24 +1,27 @@
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, forwardRef } from "react";
 import classnames from "classnames";
 import styles from "./Checkbox.module.css";
 import { CheckboxRebuiltProps } from "./Checkbox.types";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
 
-export function CheckboxRebuilt({
-  checked,
-  defaultChecked,
-  disabled,
-  label,
-  name,
-  value,
-  indeterminate = false,
-  description,
-  id,
-  onBlur,
-  onChange,
-  onFocus,
-}: CheckboxRebuiltProps) {
+export const CheckboxRebuilt = forwardRef(function CheckboxRebuiltInternal(
+  {
+    checked,
+    defaultChecked,
+    disabled,
+    label,
+    name,
+    value,
+    indeterminate = false,
+    description,
+    id,
+    onBlur,
+    onChange,
+    onFocus,
+  }: CheckboxRebuiltProps,
+  ref: React.Ref<HTMLInputElement>,
+) {
   const wrapperClassName = classnames(
     styles.wrapper,
     disabled && styles.disabled,
@@ -48,6 +51,7 @@ export function CheckboxRebuilt({
       <label className={wrapperClassName}>
         <span className={styles.checkHolder}>
           <input
+            ref={ref}
             type="checkbox"
             id={id}
             className={inputClassName}
@@ -72,4 +76,6 @@ export function CheckboxRebuilt({
       )}
     </div>
   );
-}
+});
+
+CheckboxRebuilt.displayName = "CheckboxRebuilt";

--- a/packages/components/src/Checkbox/Checkbox.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.test.tsx
@@ -134,4 +134,12 @@ describe("Checkbox", () => {
       expect(onBlur).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("ref", () => {
+    it("should be forwarded to the input element", () => {
+      const ref = React.createRef<HTMLInputElement>();
+      render(<Checkbox version={2} ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
+  });
 });

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { CheckboxLegacy } from "./Checkbox";
 import { CheckboxRebuilt } from "./Checkbox.rebuilt";
 import { CheckboxLegacyProps, CheckboxRebuiltProps } from "./Checkbox.types";
@@ -11,12 +11,17 @@ function isNewCheckboxProps(
   return props.version === 2;
 }
 
-export function Checkbox(props: CheckboxShimProps) {
+export const Checkbox = forwardRef(function CheckboxShim(
+  props: CheckboxShimProps,
+  ref: React.Ref<HTMLInputElement>,
+) {
   if (isNewCheckboxProps(props)) {
-    return <CheckboxRebuilt {...props} />;
+    return <CheckboxRebuilt {...props} ref={ref} />;
   }
 
   return <CheckboxLegacy {...props} />;
-}
+});
+
+Checkbox.displayName = "Checkbox";
 
 export type { CheckboxLegacyProps, CheckboxRebuiltProps };


### PR DESCRIPTION
Adds the forwarding of a ref to v2 to enable programatic control

## Motivations
With the move to v2, we lost the ability to programmatically focus/interact with the input directly.

## Changes

1. Adds a `ref` of `HTMLInputElement` to be forwarded through the shim

## Testing
1. Adding a ref should not have a type error by accurately exposing an HTMLInputElement.
2. Should be able to set `.focus()` the ref.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
