### PR TITLE
fix(components): Fix Composable modal actions not supporting overrides on Buttons

### DIFF
--- a/packages/components/src/Modal/Modal.rebuilt.test.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.test.tsx
@@ -26,9 +26,18 @@ describe("Composable Modal", () => {
     expect(header).toBeDefined();
     expect(header).toHaveTextContent("Modal Title");
     expect(screen.getByText("This is some extra content")).toBeInTheDocument();
-    expect(screen.getByText("Submit")).toBeInTheDocument();
-    expect(screen.getByText("Cancel")).toBeInTheDocument();
-    expect(screen.getByText("Delete")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit" })).toHaveClass(
+      "primary",
+    );
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveClass(
+      "primary subtle",
+    );
+    expect(screen.getByRole("button", { name: "Delete" })).toHaveClass(
+      "secondary destructive",
+    );
   });
 
   it("should allow overriding of action buttons", () => {
@@ -44,7 +53,7 @@ describe("Composable Modal", () => {
             }}
             secondary={{
               label: "Cancel",
-              variation: "subtle",
+              variation: "work",
               type: "tertiary",
             }}
             tertiary={{
@@ -60,7 +69,7 @@ describe("Composable Modal", () => {
       "secondary destructive",
     );
     expect(screen.getByRole("button", { name: "Cancel" })).toHaveClass(
-      "tertiary subtle",
+      "tertiary work",
     );
     expect(screen.getByRole("button", { name: "Delete" })).toHaveClass(
       "secondary destructive",

--- a/packages/components/src/Modal/Modal.rebuilt.test.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.test.tsx
@@ -31,6 +31,41 @@ describe("Composable Modal", () => {
     expect(screen.getByText("Delete")).toBeInTheDocument();
   });
 
+  it("should allow overriding of action buttons", () => {
+    render(
+      <Modal.Provider open={true}>
+        <Modal.Content>
+          <Modal.Header title="Modal Title" />
+          <Modal.Actions
+            primary={{
+              label: "Submit",
+              variation: "destructive",
+              type: "secondary",
+            }}
+            secondary={{
+              label: "Cancel",
+              variation: "subtle",
+              type: "tertiary",
+            }}
+            tertiary={{
+              label: "Delete",
+              variation: "destructive",
+              type: "secondary",
+            }}
+          />
+        </Modal.Content>
+      </Modal.Provider>,
+    );
+    expect(screen.getByRole("button", { name: "Submit" })).toHaveClass(
+      "secondary destructive",
+    );
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveClass(
+      "tertiary subtle",
+    );
+    expect(screen.getByRole("button", { name: "Delete" })).toHaveClass(
+      "secondary destructive",
+    );
+  });
   it('modal contains aria role of "dialog"', async () => {
     render(
       <Modal.Provider open={true}>

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -55,12 +55,12 @@ export function ModalActions({
           <div className={rightAction}>
             {primary && <Button {...primary} />}
             {secondary && (
-              <Button {...secondary} type="primary" variation="subtle" />
+              <Button type="primary" variation="subtle" {...secondary} />
             )}
           </div>
           {tertiary && (
             <div className={leftAction}>
-              <Button {...tertiary} type="secondary" variation="destructive" />
+              <Button type="secondary" variation="destructive" {...tertiary} />
             </div>
           )}
         </div>


### PR DESCRIPTION


## Motivations

During the creation of composable modal actions a mistake was added that prevented overriding the button types which was present in the non-composable version. This PR aims to fix that

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- fix(components): Allow overriding of button type and button variation in `Modal.Actions`

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
