### PR TITLE
fix(components-native): Cleanup form on submit success v2

### DIFF
--- a/packages/components-native/src/Form/Form.test.tsx
+++ b/packages/components-native/src/Form/Form.test.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
 import { Alert, Keyboard } from "react-native";
 import { Host } from "react-native-portalize";
+import { FieldValues, SubmitHandler } from "react-hook-form";
 import { Form, FormBannerMessage, FormBannerMessageType } from ".";
 import { FormBannerErrors, FormSubmitErrorType } from "./types";
+import * as useInternalFormModule from "./hooks/useInternalForm";
 import { atlantisContextDefaultValues } from "../AtlantisContext";
 import * as atlantisContext from "../AtlantisContext/AtlantisContext";
 import { Text } from "../Text";
@@ -300,30 +302,67 @@ describe("Form", () => {
       });
     });
 
-    it("should call onSubmitSuccess after submit promise resolves", async () => {
+    function mockUseInternalForm() {
+      const originalUseInternalForm = useInternalFormModule.useInternalForm;
+      let resolveInternalPromise: () => void;
+
+      const mockSubmitHandler = jest
+        .spyOn(useInternalFormModule, "useInternalForm")
+        .mockImplementation(formMethods => {
+          const originalHookValues = originalUseInternalForm(formMethods);
+
+          function handleSubmitWrapper(fn: SubmitHandler<FieldValues>) {
+            return async () => {
+              await originalHookValues.handleSubmit(fn)();
+
+              return new Promise<void>(resolve => {
+                resolveInternalPromise = resolve;
+              });
+            };
+          }
+
+          return {
+            ...originalHookValues,
+            handleSubmit: handleSubmitWrapper,
+          };
+        });
+
+      return {
+        mockSubmitHandler,
+        resolveFormSubmitPromise: () => {
+          resolveInternalPromise?.();
+        },
+      };
+    }
+
+    it("should call onSubmitSuccess after form submit promise resolves", async () => {
+      const formMock = mockUseInternalForm();
       onSubmitMock.mockImplementationOnce(() => {
         return Promise.resolve({
           resolvedPromiseData: "passed",
         });
       });
       const { getByLabelText } = render(<FormTest onSubmit={onSubmitMock} />);
-      const saveButton = getByLabelText(saveButtonText);
 
-      const newValue = "New Value";
-      fireEvent.changeText(getByLabelText(testInputTextPlaceholder), newValue);
-      expect(onChangeMock).toHaveBeenCalled();
-
-      fireEvent(getByLabelText(switchLabel), "onValueChange", true);
-      expect(onChangeSwitchMock).toHaveBeenCalled();
-
-      fireEvent.press(saveButton);
+      fireEvent.changeText(
+        getByLabelText(testInputTextPlaceholder),
+        "New Value",
+      );
+      fireEvent.press(getByLabelText(saveButtonText));
 
       await waitFor(() => {
         expect(onSubmitMock).toHaveBeenCalled();
       });
-      expect(onSuccessMock).toHaveBeenCalledWith({
-        resolvedPromiseData: "passed",
+      expect(onSuccessMock).not.toHaveBeenCalled();
+
+      act(() => formMock.resolveFormSubmitPromise());
+
+      await waitFor(() => {
+        expect(onSuccessMock).toHaveBeenCalledWith({
+          resolvedPromiseData: "passed",
+        });
       });
+      formMock.mockSubmitHandler.mockRestore();
     });
 
     it("should dismiss keyboard when form is saved", async () => {

--- a/packages/components-native/src/Form/Form.tsx
+++ b/packages/components-native/src/Form/Form.tsx
@@ -251,11 +251,10 @@ function InternalForm<T extends FieldValues, S>({
     let result: S | undefined;
 
     await handleSubmit(async data => {
-      const saveResult = await internalSubmit(data);
-      result = saveResult as S;
+      result = (await internalSubmit(data)) as S;
+      removeListenerRef.current?.();
     })();
 
-    removeListenerRef.current?.();
     onSubmitSuccess(result as S);
   }
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations
We have had to make a few PRs into jobber-mobile to work around onSubmit being called before the form is fully submitted. 

https://github.com/GetJobber/jobber-mobile/pull/10437
https://github.com/GetJobber/jobber-mobile/pull/10214
https://github.com/GetJobber/jobber-mobile/pull/9974

Tickets resolved by above PRs. All talking about the cache data sticking around
https://jobber.atlassian.net/browse/JOB-126732
https://jobber.atlassian.net/browse/OPS-23103
https://jobber.atlassian.net/browse/OPS-22226

Outstanding ticket
Extra issues are caused when deleting line items if they are dirty
https://jobber.atlassian.net/browse/JOB-125243

We are calling onSubmitSuccess before react-hook-form thinks the form is submitted.

The function passed to handleSubmit(react-hook-form) returns a promise. If that promise succeeds then the the form is considered successfully submitted. We have been including onSubmitSuccess in that inner promise, meaning it is being called as part of the submission which also means if it fails then the form will tell the user that the save didn't happen. However, the save did happen because internalSubmit is already called.

I feel like this would be a more robust longer term fix to move `onSubmitSuccess` after the form is submitted.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

Moved calling of the onSaveSuccess parameter to after the react-hook-form handle submit promise resolves. Meaning the form is considered submitted when the function is called.

## Testing

Undo the specific patch fixes in jobber-mobile in the PRs above and install the pre-release. The navigation and cache issues aren't reintroduced. 
eg:
Create a quote then create a second quote immediately after. You shouldn't see any cached data pre-populate in the form from the previous quote.

Dirty a line item before deleting it and you won't get confirmation before back.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
