### PR TITLE
fix(components): Clean up size and placement of FormatFile delete button

### DIFF
--- a/packages/components/src/FormatFile/FormatFile.module.css
+++ b/packages/components/src/FormatFile/FormatFile.module.css
@@ -83,6 +83,12 @@
   z-index: var(--elevation-base);
 }
 
+.compact .customDeleteButton {
+  max-width: 24px;
+  min-height: 24px;
+  border-radius: var(--radius-small);
+}
+
 .expanded .thumbnail {
   border-right: none;
   border-bottom-left-radius: var(--radius-base);
@@ -137,6 +143,7 @@
   position: absolute;
   top: var(--space-smaller);
   right: var(--space-smaller);
+  box-shadow: var(--shadow-base);
 }
 
 @media (--medium-screens-and-up) {

--- a/packages/components/src/FormatFile/FormatFile.module.css
+++ b/packages/components/src/FormatFile/FormatFile.module.css
@@ -84,9 +84,12 @@
 }
 
 .compact .customDeleteButton {
+  border-radius: var(--radius-small);
+}
+
+.compact.base .customDeleteButton {
   max-width: 24px;
   min-height: 24px;
-  border-radius: var(--radius-small);
 }
 
 .expanded .thumbnail {
@@ -144,6 +147,11 @@
   top: var(--space-smaller);
   right: var(--space-smaller);
   box-shadow: var(--shadow-base);
+}
+
+.compact.large .deleteButton {
+  top: var(--space-small);
+  right: var(--space-small);
 }
 
 @media (--medium-screens-and-up) {

--- a/packages/components/src/FormatFile/FormatFile.module.css
+++ b/packages/components/src/FormatFile/FormatFile.module.css
@@ -154,7 +154,7 @@
   right: var(--space-small);
 }
 
-@media (--medium-screens-and-up) {
+@media (any-pointer: fine) {
   .deleteable ~ .deleteButton {
     visibility: hidden;
   }

--- a/packages/components/src/FormatFile/FormatFile.module.css.d.ts
+++ b/packages/components/src/FormatFile/FormatFile.module.css.d.ts
@@ -7,6 +7,7 @@ declare const styles: {
   readonly "base": string;
   readonly "thumbnail": string;
   readonly "deleteButton": string;
+  readonly "customDeleteButton": string;
   readonly "clickable": string;
   readonly "hoverable": string;
   readonly "progress": string;

--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -216,6 +216,9 @@ FormatFile.DeleteButton = function FormatFileDeleteButton({
   return (
     <>
       <Button
+        UNSAFE_className={{
+          container: size === "base" ? styles.customDeleteButton : undefined,
+        }}
         onClick={onDelete}
         variation="destructive"
         type="tertiary"

--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -202,20 +202,18 @@ FormatFile.Wrapper = function FormatFileWrapper({
 
 FormatFile.DeleteButton = function FormatFileDeleteButton({
   onDelete,
-  size = "base",
   children,
 }: {
   readonly onDelete?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => void;
-  readonly size?: "base" | "large";
   readonly children?: React.ReactNode;
 }) {
   return (
     <>
       <Button
         UNSAFE_className={{
-          container: size === "base" ? styles.customDeleteButton : undefined,
+          container: styles.customDeleteButton,
         }}
         onClick={onDelete}
         variation="destructive"

--- a/packages/components/src/FormatFile/FormatFile.tsx
+++ b/packages/components/src/FormatFile/FormatFile.tsx
@@ -211,8 +211,6 @@ FormatFile.DeleteButton = function FormatFileDeleteButton({
   readonly size?: "base" | "large";
   readonly children?: React.ReactNode;
 }) {
-  const buttonSize = size === "base" ? "small" : "base";
-
   return (
     <>
       <Button
@@ -224,7 +222,7 @@ FormatFile.DeleteButton = function FormatFileDeleteButton({
         type="tertiary"
         icon="trash"
         ariaLabel="Delete File"
-        size={buttonSize}
+        size={"small"}
       />
       {children}
     </>

--- a/packages/site/src/content/FormatFile/FormatFile.props.json
+++ b/packages/site/src/content/FormatFile/FormatFile.props.json
@@ -281,15 +281,6 @@
         "type": {
           "name": "(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void"
         }
-      },
-      "size": {
-        "defaultValue": null,
-        "description": "",
-        "name": "size",
-        "required": false,
-        "type": {
-          "name": "\"base\" | \"large\""
-        }
       }
     }
   }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The delete button on a thumbnail in FormatFile is
- too big on the base size (covers way too much surface area) and arguably doesn't need to be as large as it is in the large size thumbnail either
- too close to the edge on the large size (focus state has a just-off overlap with the border)
- the radius of the button looks awkward against the corner of the thumbnail
- delete button was not visible on larger touch devices like an iPad

Base
![image](https://github.com/user-attachments/assets/077abbff-a20d-495b-bfb0-61c917150434)
![image](https://github.com/user-attachments/assets/03c50778-8fed-4f64-993b-8802edb3b4a7)
Focus state does overlap but I think it's an acceptable trade-off for the reduction in image covered

Large
![image](https://github.com/user-attachments/assets/70303dc3-f5bc-4e19-bbca-a94b4abdafff)
![image](https://github.com/user-attachments/assets/c51e0836-deed-405c-babb-ee81580f0fc9)

Touch emulator with a large viewport
![image](https://github.com/user-attachments/assets/5865838a-6bfc-4ebd-b3f0-4cd5ec66a8bd)

Mouse with a small viewport
![image](https://github.com/user-attachments/assets/b8565c63-4f02-4db8-96e6-cc50bb7b57da)

## Changes

### Changed

- Delete button is always `small`
- On base size thumbnail, custom styling is applied to reduce size further
- No changes to Expanded state
- Added a shadow to give button slightly more distinction from background in always-visible (small-screen) states
- Query to show delete button is based on cursor, not viewport so that larger touch devices see the delete button

### Fixed

- focus state on large size of thumbnail no longer overlaps
- delete button on base size of thumbnail no longer covers >25% of surface area

## Testing

Can test locally/CF/in Notes or Quotes in Jobber

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
