### PR TITLE
fix(components): DataList Header Fixes

### DIFF
--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -27,6 +27,10 @@ import {
 } from "./components/DataListLoadingState";
 import { MAX_DATA_COUNT } from "./components/DataListLoadMore";
 import { SORTING_ICON_TEST_ID } from "./components/DataListHeaderTile/DataListSortingArrows";
+import {
+  DATA_LIST_HEADER_BATCH_SELECT_TEST_ID,
+  DATA_LIST_HEADER_CHECKBOX_TEST_ID,
+} from "./components/DataListHeader/DataListHeaderCheckbox";
 import { GLIMMER_TEST_ID } from "../Glimmer";
 import { Button } from "../Button";
 
@@ -440,7 +444,16 @@ describe("DataList", () => {
 
     it("should render the sorting arrows when sorting is specified", () => {
       renderLayout(undefined, {
-        sortable: [{ key: "name" }],
+        sortable: [
+          {
+            key: "name",
+            sortType: "toggle",
+            options: [
+              { id: "nameAsc", label: "Ascending", order: "asc" },
+              { id: "nameDesc", label: "Descending", order: "desc" },
+            ],
+          },
+        ],
         onSort: jest.fn(),
         state: undefined,
       });
@@ -720,6 +733,194 @@ describe("DataList", () => {
       );
 
       expect(screen.getByText(bannerText)).toBeInTheDocument();
+    });
+  });
+
+  describe("Header Checkbox", () => {
+    const checkboxMockData = [
+      { id: 1, name: "John", email: "john@doe.com" },
+      { id: 2, name: "Jane", email: "jane@doe.com" },
+    ];
+    const checkboxMockHeaders = {
+      name: "Name",
+      email: "Email",
+    };
+
+    it("should render checkbox for layout but not be visible when onSelectAll is absent", () => {
+      const mockOnSelect = jest.fn();
+      render(
+        <DataList
+          data={checkboxMockData}
+          headers={checkboxMockHeaders}
+          onSelect={mockOnSelect}
+          selected={[]}
+        >
+          <DataList.Layout>
+            {(item: DataListItemType<typeof checkboxMockData>) => (
+              <div>{item.name}</div>
+            )}
+          </DataList.Layout>
+        </DataList>,
+      );
+
+      const headerCheckbox = screen.queryByTestId(
+        DATA_LIST_HEADER_CHECKBOX_TEST_ID,
+      );
+      expect(headerCheckbox).toBeInTheDocument();
+      expect(headerCheckbox).not.toHaveClass("visible");
+    });
+
+    it("should not show checkbox or select-all UI when item is selected and onSelectAll is absent", () => {
+      const mockOnSelect = jest.fn();
+      render(
+        <DataList
+          data={checkboxMockData}
+          headers={checkboxMockHeaders}
+          onSelect={mockOnSelect}
+          selected={[checkboxMockData[0].id]}
+        >
+          <DataList.Layout>
+            {(item: DataListItemType<typeof checkboxMockData>) => (
+              <div>{item.name}</div>
+            )}
+          </DataList.Layout>
+        </DataList>,
+      );
+
+      expect(screen.getByText(checkboxMockHeaders.name)).toBeInTheDocument();
+
+      expect(
+        screen.queryByTestId(DATA_LIST_HEADER_BATCH_SELECT_TEST_ID),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show headers or checkbox on small screens when onSelectAll is absent", () => {
+      // Override the media query mock to simulate small screens
+      // The headerVisibility prop defaulting to visible might override our media query
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+          matches: query.includes("(min-width: 0px)"), // Only match xs breakpoint
+          media: query,
+          onchange: null,
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+          dispatchEvent: jest.fn(),
+        })),
+      });
+
+      const mockOnSelect = jest.fn();
+      render(
+        <DataList
+          data={checkboxMockData}
+          headers={checkboxMockHeaders}
+          onSelect={mockOnSelect}
+          selected={[checkboxMockData[0].id]}
+          headerVisibility={{ xs: false }}
+        >
+          <DataList.Layout size="xs">
+            {(item: DataListItemType<typeof checkboxMockData>) => (
+              <div>{item.name}</div>
+            )}
+          </DataList.Layout>
+        </DataList>,
+      );
+
+      expect(
+        screen.queryByText(checkboxMockHeaders.name),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show select-all UI when items are selected and onSelectAll is provided", async () => {
+      const mockOnSelect = jest.fn();
+      const mockOnSelectAll = jest.fn();
+
+      const { rerender } = render(
+        <DataList
+          data={checkboxMockData}
+          headers={checkboxMockHeaders}
+          onSelect={mockOnSelect}
+          onSelectAll={mockOnSelectAll}
+          selected={[]}
+        >
+          <DataList.Layout>
+            {(item: DataListItemType<typeof checkboxMockData>) => (
+              <div>{item.name}</div>
+            )}
+          </DataList.Layout>
+        </DataList>,
+      );
+
+      const headerCheckbox = screen.getByTestId(
+        DATA_LIST_HEADER_CHECKBOX_TEST_ID,
+      );
+      expect(headerCheckbox).toBeInTheDocument();
+      expect(headerCheckbox).toHaveClass("visible");
+
+      // Rerender with a selected item
+      rerender(
+        <DataList
+          data={checkboxMockData}
+          headers={checkboxMockHeaders}
+          onSelect={mockOnSelect}
+          onSelectAll={mockOnSelectAll}
+          selected={[checkboxMockData[0].id]}
+        >
+          <DataList.Layout>
+            {(item: DataListItemType<typeof checkboxMockData>) => (
+              <div>{item.name}</div>
+            )}
+          </DataList.Layout>
+        </DataList>,
+      );
+
+      const batchSelectUI = await screen.findByTestId(
+        DATA_LIST_HEADER_BATCH_SELECT_TEST_ID,
+      );
+      expect(batchSelectUI).toBeInTheDocument();
+    });
+
+    it("should show select-all UI on small screens when item is selected and onSelectAll is present", async () => {
+      // Override media query to ensure small screen
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+          matches: query.includes("(min-width: 0px)"), // Only match xs breakpoint
+          media: query,
+          onchange: null,
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+          dispatchEvent: jest.fn(),
+        })),
+      });
+
+      const mockOnSelect = jest.fn();
+      const mockOnSelectAll = jest.fn();
+
+      render(
+        <DataList
+          data={checkboxMockData}
+          headers={checkboxMockHeaders}
+          onSelect={mockOnSelect}
+          onSelectAll={mockOnSelectAll}
+          selected={[checkboxMockData[0].id]}
+          headerVisibility={{ xs: false }}
+        >
+          <DataList.Layout size="xs">
+            {(item: DataListItemType<typeof checkboxMockData>) => (
+              <div data-testid={`item-${item.id}`}>{item.name}</div>
+            )}
+          </DataList.Layout>
+        </DataList>,
+      );
+
+      expect(
+        screen.queryByText(checkboxMockHeaders.name),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeader.test.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeader.test.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { DataListHeader } from "./DataListHeader";
+import { useDataListContext } from "../../context/DataListContext";
+import { useBatchSelect } from "../../hooks/useBatchSelect";
+import { useActiveLayout } from "../../hooks/useActiveLayout";
+import { useResponsiveSizing } from "../../hooks/useResponsiveSizing";
+
+// Mock the hooks
+jest.mock("../../context/DataListContext", () => ({
+  useDataListContext: jest.fn(),
+}));
+
+jest.mock("../../hooks/useBatchSelect", () => ({
+  useBatchSelect: jest.fn(),
+}));
+
+jest.mock("../../hooks/useActiveLayout", () => ({
+  useActiveLayout: jest.fn(),
+}));
+
+jest.mock("../../hooks/useResponsiveSizing", () => ({
+  useResponsiveSizing: jest.fn(),
+}));
+
+describe("DataListHeader", () => {
+  const mockUseDataListContext = useDataListContext as jest.Mock;
+  const mockUseBatchSelect = useBatchSelect as jest.Mock;
+  const mockUseActiveLayout = useActiveLayout as jest.Mock;
+  const mockUseResponsiveSizing = useResponsiveSizing as jest.Mock;
+
+  const mockLayout = jest.fn(data => (
+    <div data-testid="mock-header">{data.label}</div>
+  ));
+  const mockHeaders = { label: "Test Header" };
+
+  beforeEach(() => {
+    // Default mock settings
+    mockUseResponsiveSizing.mockReturnValue({ xs: true });
+
+    mockUseDataListContext.mockReturnValue({
+      headerVisibility: { xs: true, sm: true, md: true, lg: true, xl: true },
+      headers: mockHeaders,
+      layoutBreakpoints: ["xs"],
+      data: [{ id: 1 }, { id: 2 }],
+      selected: [],
+    });
+
+    mockUseBatchSelect.mockReturnValue({
+      hasAtLeastOneSelected: false,
+      canSelect: false,
+      canSelectAll: false,
+    });
+
+    mockUseActiveLayout.mockReturnValue({
+      layout: mockLayout,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when headerVisibility is true", () => {
+    it("should render the header when layout is defined", () => {
+      render(<DataListHeader />);
+      expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    });
+
+    it("should render header when layout is defined and no items are selected", () => {
+      mockUseBatchSelect.mockReturnValue({
+        hasAtLeastOneSelected: false,
+        canSelect: true,
+        canSelectAll: true,
+      });
+
+      render(<DataListHeader />);
+      expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    });
+
+    it("should render header when no items are selected and selection is disabled", () => {
+      mockUseBatchSelect.mockReturnValue({
+        hasAtLeastOneSelected: false,
+        canSelect: false,
+        canSelectAll: false,
+      });
+
+      render(<DataListHeader />);
+      expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    });
+
+    it("should not render when layout is undefined", () => {
+      mockUseActiveLayout.mockReturnValue({ layout: undefined });
+
+      render(<DataListHeader />);
+      expect(screen.queryByTestId("mock-header")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when headerVisibility is false", () => {
+    beforeEach(() => {
+      mockUseDataListContext.mockReturnValue({
+        headerVisibility: {
+          xs: false,
+          sm: false,
+          md: false,
+          lg: false,
+          xl: false,
+        },
+        headers: mockHeaders,
+        layoutBreakpoints: ["xs"],
+      });
+    });
+
+    it("should not render when no items are selected and selection is disabled", () => {
+      mockUseBatchSelect.mockReturnValue({
+        hasAtLeastOneSelected: false,
+        canSelect: false,
+        canSelectAll: false,
+      });
+
+      render(<DataListHeader />);
+      expect(screen.queryByTestId("mock-header")).not.toBeInTheDocument();
+    });
+
+    it("should not render when no items are selected, selection is enabled but canSelectAll is false", () => {
+      mockUseBatchSelect.mockReturnValue({
+        hasAtLeastOneSelected: false,
+        canSelect: true,
+        canSelectAll: false,
+      });
+
+      render(<DataListHeader />);
+      expect(screen.queryByTestId("mock-header")).not.toBeInTheDocument();
+    });
+
+    it("should render when at least one item is selected", () => {
+      mockUseBatchSelect.mockReturnValue({
+        hasAtLeastOneSelected: true,
+        canSelect: false,
+        canSelectAll: false,
+      });
+
+      render(<DataListHeader />);
+      expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    });
+
+    it("should not render when no items selected even if selection is enabled and canSelectAll is true", () => {
+      mockUseBatchSelect.mockReturnValue({
+        hasAtLeastOneSelected: false,
+        canSelect: true,
+        canSelectAll: true,
+      });
+
+      render(<DataListHeader />);
+      expect(screen.queryByTestId("mock-header")).not.toBeInTheDocument();
+    });
+
+    it("should not render when layout is undefined regardless of selection state", () => {
+      mockUseActiveLayout.mockReturnValue({ layout: undefined });
+      mockUseBatchSelect.mockReturnValue({
+        hasAtLeastOneSelected: true,
+        canSelect: true,
+        canSelectAll: true,
+      });
+
+      render(<DataListHeader />);
+      expect(screen.queryByTestId("mock-header")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("with different responsive sizes", () => {
+    it("should use the first available breakpoint when current size is not in headerVisibility", () => {
+      // Mock a scenario where we're at a medium breakpoint but only small is defined in visibility
+      mockUseResponsiveSizing.mockReturnValue({
+        xs: false,
+        sm: false,
+        md: true,
+      });
+      mockUseDataListContext.mockReturnValue({
+        headerVisibility: { xs: true, sm: true }, // Only xs and sm defined
+        headers: mockHeaders,
+        layoutBreakpoints: ["xs", "sm", "md"],
+      });
+
+      render(<DataListHeader />);
+      expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    });
+
+    it("should respect headerVisibility for the current breakpoint", () => {
+      // Set medium breakpoint to false in visibility
+      mockUseResponsiveSizing.mockReturnValue({
+        xs: false,
+        sm: false,
+        md: true,
+      });
+      mockUseDataListContext.mockReturnValue({
+        headerVisibility: { xs: true, sm: true, md: false },
+        headers: mockHeaders,
+        layoutBreakpoints: ["xs", "sm", "md"],
+      });
+
+      render(<DataListHeader />);
+      expect(screen.queryByTestId("mock-header")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeader.test.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeader.test.tsx
@@ -64,7 +64,7 @@ describe("DataListHeader", () => {
   describe("when headerVisibility is true", () => {
     it("should render the header when layout is defined", () => {
       render(<DataListHeader />);
-      expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+      expect(screen.getByTestId("mock-header")).toBeVisible();
     });
 
     it("should render header when layout is defined and no items are selected", () => {

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
@@ -63,9 +63,13 @@ function isHeaderHidden(
   canSelect: boolean,
   canSelectAll: boolean,
 ) {
-  return (
-    (!visible && !hasAtLeastOneSelected) ||
-    !layout ||
-    (!visible && canSelect && !canSelectAll)
-  );
+  // When the horizontal area is too small and the data starts to wrap
+  // we want to hide the headers that will no longer align with the content
+
+  // The exception is when we have onSelectAll AND one or more are selected
+  // because then we show the "header" in its select-all UI variation state
+  const isHiddenForSelect = !visible && canSelect && !canSelectAll;
+  const isHiddenForSelectAll = !visible && !hasAtLeastOneSelected;
+
+  return !layout || isHiddenForSelect || isHiddenForSelectAll;
 }

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
@@ -10,6 +10,7 @@ import { DataListHeaderCheckbox } from "./DataListHeaderCheckbox";
 import { useActiveLayout } from "../../hooks/useActiveLayout";
 import { useBatchSelect } from "../../hooks/useBatchSelect";
 import styles from "../../DataList.module.css";
+import { DataListObject, LayoutRenderer } from "../../DataList.types";
 
 export function DataListHeader() {
   const breakpoints = useResponsiveSizing();
@@ -18,14 +19,24 @@ export function DataListHeader() {
     headers,
     layoutBreakpoints,
   } = useDataListContext();
-  const { hasAtLeastOneSelected } = useBatchSelect();
+  const { hasAtLeastOneSelected, canSelect, canSelectAll } = useBatchSelect();
 
   const size = getVisibleSize();
   const { layout } = useActiveLayout();
 
   const visible = headerVisibility[size];
 
-  if ((!visible && !hasAtLeastOneSelected) || !layout) return null;
+  if (
+    getVisibility(
+      visible,
+      hasAtLeastOneSelected,
+      layout,
+      canSelect,
+      canSelectAll,
+    )
+  ) {
+    return null;
+  }
 
   const headerData = generateHeaderElements(headers);
   if (!headerData) return null;
@@ -43,4 +54,18 @@ export function DataListHeader() {
 
     return visibleHeaderSize || layoutBreakpoints[0];
   }
+}
+
+function getVisibility(
+  visible: boolean | undefined,
+  hasAtLeastOneSelected: boolean,
+  layout: LayoutRenderer<DataListObject> | undefined,
+  canSelect: boolean,
+  canSelectAll: boolean,
+) {
+  return (
+    (!visible && !hasAtLeastOneSelected) ||
+    !layout ||
+    (!visible && canSelect && !canSelectAll)
+  );
 }

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
@@ -27,7 +27,7 @@ export function DataListHeader() {
   const visible = headerVisibility[size];
 
   if (
-    getVisibility(
+    isHeaderHidden(
       visible,
       hasAtLeastOneSelected,
       layout,
@@ -56,7 +56,7 @@ export function DataListHeader() {
   }
 }
 
-function getVisibility(
+function isHeaderHidden(
   visible: boolean | undefined,
   hasAtLeastOneSelected: boolean,
   layout: LayoutRenderer<DataListObject> | undefined,

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeader.tsx
@@ -39,7 +39,7 @@ export function DataListHeader() {
   }
 
   const headerData = generateHeaderElements(headers);
-  if (!headerData) return null;
+  if (!headerData || !layout) return null;
 
   return (
     <div className={styles.headerTitles}>

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.test.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.test.tsx
@@ -7,7 +7,11 @@ import {
   DataListContext,
   defaultValues,
 } from "@jobber/components/DataList/context/DataListContext";
-import { DataListHeaderCheckbox } from "./DataListHeaderCheckbox";
+import {
+  DATA_LIST_HEADER_BATCH_SELECT_TEST_ID,
+  DATA_LIST_HEADER_CHECKBOX_TEST_ID,
+  DataListHeaderCheckbox,
+} from "./DataListHeaderCheckbox";
 
 const handleSelect = jest.fn();
 const handleSelectAll = jest.fn();
@@ -17,76 +21,129 @@ beforeEach(() => {
   handleSelectAll.mockReset();
 });
 
-const withSelectedContext = {
+const withBothHandlersContext = {
   ...defaultValues,
   selected: ["1"],
   onSelect: handleSelect,
   onSelectAll: handleSelectAll,
+  data: [{ id: "1" }, { id: "2" }],
 };
 
-const withoutSelectedContext = {
+const withOnlySelectContext = {
   ...defaultValues,
-  ...withSelectedContext,
+  selected: ["1"],
+  onSelect: handleSelect,
+  data: [{ id: "1" }, { id: "2" }],
+};
+
+const withoutHandlersContext = {
+  ...defaultValues,
+  data: [{ id: "1" }, { id: "2" }],
+};
+
+const withNoSelectedItemsContext = {
+  ...withBothHandlersContext,
   selected: [],
 };
 
 const deselectAllLabel = "Deselect All";
 
 describe("DataListHeaderCheckbox", () => {
-  it("should only render the checkbox and children when there are no selected items", () => {
-    const textToBeFound = "Find me";
-    render(
-      <DataListContext.Provider value={withoutSelectedContext}>
-        <DataListHeaderCheckbox>
-          <p>{textToBeFound}</p>
-        </DataListHeaderCheckbox>
-      </DataListContext.Provider>,
-    );
+  describe("when neither onSelect nor onSelectAll are provided", () => {
+    it("should only render the children without checkbox or AnimatedSwitcher", () => {
+      const childText = "Find me";
+      render(
+        <DataListContext.Provider value={withoutHandlersContext}>
+          <DataListHeaderCheckbox>
+            <p data-testid="child-element">{childText}</p>
+          </DataListHeaderCheckbox>
+        </DataListContext.Provider>,
+      );
 
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: deselectAllLabel }),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText(textToBeFound)).toBeInTheDocument();
+      expect(screen.getByTestId("child-element")).toBeInTheDocument();
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it("should only render the checkbox and deselect all button when there are selected items", () => {
-    const textToBeFound = "Find me";
-    render(
-      <DataListContext.Provider value={withSelectedContext}>
-        <DataListHeaderCheckbox>
-          <p>{textToBeFound}</p>
-        </DataListHeaderCheckbox>
-      </DataListContext.Provider>,
-    );
+  describe("when only onSelect is provided", () => {
+    it("should render an invisible checkbox with children (no AnimatedSwitcher)", () => {
+      const childText = "Find me";
+      render(
+        <DataListContext.Provider value={withOnlySelectContext}>
+          <DataListHeaderCheckbox>
+            <p data-testid="child-element">{childText}</p>
+          </DataListHeaderCheckbox>
+        </DataListContext.Provider>,
+      );
 
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: deselectAllLabel }),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(textToBeFound)).not.toBeInTheDocument();
+      expect(screen.getByTestId("child-element")).toBeInTheDocument();
+      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+      expect(
+        screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
+      ).not.toHaveClass("visible");
+    });
   });
 
-  it("should only render the children when none of the required props are implemented", () => {
-    const textToBeFound = "Find me";
-    render(
-      <DataListContext.Provider value={defaultValues}>
-        <DataListHeaderCheckbox>
-          <p>{textToBeFound}</p>
-        </DataListHeaderCheckbox>
-      </DataListContext.Provider>,
-    );
+  describe("when both onSelect and onSelectAll are provided", () => {
+    it("should render a visible checkbox and children when no items are selected", () => {
+      const childText = "Find me";
+      render(
+        <DataListContext.Provider value={withNoSelectedItemsContext}>
+          <DataListHeaderCheckbox>
+            <p data-testid="child-element">{childText}</p>
+          </DataListHeaderCheckbox>
+        </DataListContext.Provider>,
+      );
 
-    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: deselectAllLabel }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByText(textToBeFound)).toBeInTheDocument();
+      expect(screen.getByTestId("child-element")).toBeInTheDocument();
+      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+      expect(
+        screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID)).toHaveClass(
+        "visible",
+      );
+      expect(
+        screen.queryByTestId(DATA_LIST_HEADER_BATCH_SELECT_TEST_ID),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render the batch select UI when items are selected", () => {
+      const childText = "Find me";
+      render(
+        <DataListContext.Provider value={withBothHandlersContext}>
+          <DataListHeaderCheckbox>
+            <p data-testid="child-element">{childText}</p>
+          </DataListHeaderCheckbox>
+        </DataListContext.Provider>,
+      );
+
+      expect(screen.queryByTestId("child-element")).not.toBeInTheDocument();
+      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+      expect(
+        screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID)).toHaveClass(
+        "visible",
+      );
+      expect(
+        screen.getByTestId(DATA_LIST_HEADER_BATCH_SELECT_TEST_ID),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: deselectAllLabel }),
+      ).toBeInTheDocument();
+    });
   });
 
-  it("should fire the onSelectAll when the checkbox have been clicked", async () => {
+  it("should fire the onSelectAll when the checkbox has been clicked", async () => {
     render(
-      <DataListContext.Provider value={withSelectedContext}>
+      <DataListContext.Provider value={withBothHandlersContext}>
         <DataListHeaderCheckbox>
           <div />
         </DataListHeaderCheckbox>
@@ -98,9 +155,9 @@ describe("DataListHeaderCheckbox", () => {
     expect(handleSelectAll).toHaveBeenCalledTimes(1);
   });
 
-  it("should return an empty array on onSelect when deselect all have been clicked", async () => {
+  it("should return an empty array on onSelect when deselect all has been clicked", async () => {
     render(
-      <DataListContext.Provider value={withSelectedContext}>
+      <DataListContext.Provider value={withBothHandlersContext}>
         <DataListHeaderCheckbox>
           <div />
         </DataListHeaderCheckbox>
@@ -156,11 +213,11 @@ describe("DataListHeaderCheckbox", () => {
       it.each([
         [
           "is not the same as totalCount",
-          { ...withSelectedContext, totalCount: 2 },
+          { ...withBothHandlersContext, totalCount: 2 },
         ],
         [
           "is less than the length of data",
-          { ...withSelectedContext, data: [{ id: 1 }, { id: 2 }] },
+          { ...withBothHandlersContext, data: [{ id: 1 }, { id: 2 }] },
         ],
       ])("should be indeterminate when the selected items %s", (_, context) => {
         render(
@@ -176,10 +233,13 @@ describe("DataListHeaderCheckbox", () => {
     });
 
     it.each([
-      ["is the same as totalCount", { ...withSelectedContext, totalCount: 1 }],
+      [
+        "is the same as totalCount",
+        { ...withBothHandlersContext, totalCount: 1 },
+      ],
       [
         "is greater than or equal to the length of data",
-        { ...withSelectedContext, data: [{ id: 1 }] },
+        { ...withBothHandlersContext, data: [{ id: 1 }] },
       ],
     ])("should be a checkmark when the selected items %s", (_, context) => {
       render(

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.tsx
@@ -122,9 +122,7 @@ function ColumnHeaderContent({
   readonly hasAtLeastOneSelected: boolean;
   readonly selectedCount: number;
   readonly deselectText: string;
-  readonly onSelect:
-    | ((selected: DataListSelectedType<string | number>) => void)
-    | undefined;
+  readonly onSelect?: (selected: DataListSelectedType<string | number>) => void;
 }) {
   if (canSelectAll) {
     return (

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.tsx
@@ -16,6 +16,10 @@ interface DataListHeaderCheckbox {
   readonly children: ReactElement;
 }
 
+export const DATA_LIST_HEADER_CHECKBOX_TEST_ID = "ATL-DataList-header-checkbox";
+export const DATA_LIST_HEADER_BATCH_SELECT_TEST_ID =
+  "ATL-DataList-header-batch-select";
+
 export function DataListHeaderCheckbox({ children }: DataListHeaderCheckbox) {
   const { sm } = useResponsiveSizing();
   const { data, totalCount } = useDataListContext();
@@ -41,6 +45,7 @@ export function DataListHeaderCheckbox({ children }: DataListHeaderCheckbox) {
   return (
     <div className={styles.selectable}>
       <div
+        data-testid={DATA_LIST_HEADER_CHECKBOX_TEST_ID}
         className={classNames(styles.selectAllCheckbox, {
           [styles.visible]: canSelectAll,
         })}
@@ -127,7 +132,10 @@ function ColumnHeaderContent({
         switched={hasAtLeastOneSelected}
         initialChild={children}
         switchTo={
-          <div className={styles.batchSelectContainer}>
+          <div
+            data-testid={DATA_LIST_HEADER_BATCH_SELECT_TEST_ID}
+            className={styles.batchSelectContainer}
+          >
             <div className={styles.headerBatchSelect}>
               {Boolean(selectedCount) && <Text>{selectedCount} selected</Text>}
               <Button


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

we had 2 somewhat related issues with DataList headers, both happening in the situation where your DataList has an `onSelect` and `selected` props implemented but NO `onSelectAll`

**the first issue**

because we aren't rendering the checkbox to select all, everything shifts to the left - causing misalignment in all your columns with the header. this is very hard, or awkward to solve at the consumer level because you don't have access to the checkbox. the best you can do is some not great workaround checking for `!item.id` in the `DataList.Layout` to give the header the exact amount of spacing as the Checkbox would occupy

![image](https://github.com/user-attachments/assets/11b44a23-6948-4db6-92eb-91867101b9bd)




**second issue**
on mobile/small screens, the headers would show up if you have a selection
![image](https://github.com/user-attachments/assets/9ef0516a-8604-4780-bf21-bb1c051aa69c)

this isn't desirable because the headers don't make any sense due to the content no longer being in columns that line up with the headers. also if you click on a header that has a dropdown it's just borked.
![image](https://github.com/user-attachments/assets/b3843b4e-d47b-4067-a20d-99d71117301a)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

no longer showing headers on single-select + mobile. the logic wasn't account for this case, updated it.

the checkbox is now always being rendered as long as we have either `onSelect` or `onSelectAll`. admittedly it's a bit weird because in the `onSelect` case it is never used nor visible, but it'll provide the correct spacing. open to different ideas on how to approach this.

### Security

- <!-- in case of vulnerabilities -->

## Testing

we should test a handful of cases around the header's visibility, wether that's the standard header or the select-all version of the header

- no onSelect nor onSelect all
- onSelect with no onSelectAll
- onSelect and no onSelectAll

then in each one, try out the "normal" screen sizes, mobile screen size, and manually passed in HeaderVisibility config

ALSO when trying out the select versions, make sure we have the select all UI when we expect to (1+ selections, onSelectAll present), and that it's not there for `onSelect` only implementations. 

alignment of the headers and columns should be correct for all cases too

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
