### PR TITLE
fix(components): Adding optional strategy prop to popovers to fix scrolling layout issue

### DIFF
--- a/packages/components/src/Popover/Popover.types.ts
+++ b/packages/components/src/Popover/Popover.types.ts
@@ -20,6 +20,12 @@ export interface PopoverProps {
   readonly open: boolean;
 
   /**
+   * The strategy to use for the Popover.
+   * @default 'absolute'
+   */
+  readonly strategy?: "absolute" | "fixed";
+
+  /**
    * Callback executed when the user wants to close/dismiss the Popover
    */
   readonly onRequestClose?: () => void;
@@ -54,7 +60,10 @@ export interface PopoverProps {
 }
 
 export type PopoverProviderProps = PropsWithChildren<
-  Pick<PopoverProps, "preferredPlacement" | "attachTo" | "open"> & {
+  Pick<
+    PopoverProps,
+    "preferredPlacement" | "attachTo" | "open" | "strategy"
+  > & {
     /**
      * **Use at your own risk:** Custom class names for specific elements. This should only be used as a
      * **last resort**. Using this may result in unexpected side effects.

--- a/packages/components/src/Popover/PopoverContext.tsx
+++ b/packages/components/src/Popover/PopoverContext.tsx
@@ -29,12 +29,14 @@ export function PopoverProvider({
   open,
   UNSAFE_className,
   UNSAFE_style,
+  strategy,
 }: PopoverProviderProps) {
   const { setPopperElement, setArrowElement, popperStyles, attributes } =
     usePopover({
       preferredPlacement,
       attachTo,
       open,
+      strategy,
     });
 
   if (!open) return null;

--- a/packages/components/src/Popover/usePopover.tsx
+++ b/packages/components/src/Popover/usePopover.tsx
@@ -7,7 +7,11 @@ export const usePopover = ({
   preferredPlacement,
   attachTo,
   open,
-}: Pick<PopoverProps, "preferredPlacement" | "attachTo" | "open">) => {
+  strategy = "absolute",
+}: Pick<
+  PopoverProps,
+  "preferredPlacement" | "attachTo" | "open" | "strategy"
+>) => {
   const [popperElement, setPopperElement] = useState<HTMLElement | null>();
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>();
 
@@ -21,6 +25,13 @@ export const usePopover = ({
         name: "offset",
         options: {
           offset: [0, 10],
+        },
+      },
+      {
+        name: "preventOverflow",
+        options: {
+          boundary: "viewport",
+          padding: 8,
         },
       },
       {
@@ -38,11 +49,17 @@ export const usePopover = ({
     {
       modifiers,
       placement: preferredPlacement,
+      strategy,
     },
   );
   useRefocusOnActivator(open);
 
-  return { setPopperElement, setArrowElement, popperStyles, attributes };
+  return {
+    setPopperElement,
+    setArrowElement,
+    popperStyles,
+    attributes,
+  };
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/site/src/content/Popover/Popover.props.json
+++ b/packages/site/src/content/Popover/Popover.props.json
@@ -45,6 +45,21 @@
           "name": "boolean"
         }
       },
+      "strategy": {
+        "defaultValue": {
+          "value": "'absolute'"
+        },
+        "description": "The strategy to use for the Popover.",
+        "name": "strategy",
+        "parent": {
+          "fileName": "packages/components/src/Popover/Popover.types.ts",
+          "name": "PopoverProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"absolute\" | \"fixed\""
+        }
+      },
       "onRequestClose": {
         "defaultValue": null,
         "description": "Callback executed when the user wants to close/dismiss the Popover",
@@ -147,6 +162,21 @@
         "required": true,
         "type": {
           "name": "boolean"
+        }
+      },
+      "strategy": {
+        "defaultValue": {
+          "value": "'absolute'"
+        },
+        "description": "The strategy to use for the Popover.",
+        "name": "strategy",
+        "parent": {
+          "fileName": "packages/components/src/Popover/Popover.types.ts",
+          "name": "PopoverProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"absolute\" | \"fixed\""
         }
       },
       "UNSAFE_className": {


### PR DESCRIPTION
## Motivations

There is an issue with the popovers when they scroll outside of the viewport in the sidenav, as it leads to the screen being larger and you can scroll down to this weird white space.

## Changes

- Introduced a new optional `strategy` prop to the Popover component, allowing users to specify the positioning strategy ('absolute' or 'fixed').
- Updated PopoverProvider and usePopover hooks to support the new strategy prop.

- Also added some padding so the popover wouldn't sit right on the bottom of the page.

https://github.com/user-attachments/assets/73d224d0-389d-46d5-92a1-699ff0f70863


### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

This is the issue that's being fixed

https://github.com/user-attachments/assets/6bdbd58e-aa81-49de-bf67-3a1c089ae39b

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
