### PR TITLE
fix(components-native): fix placement of assistive text on Checkbox [JOB-125934]

### DIFF
--- a/packages/components-native/src/Checkbox/Checkbox.style.ts
+++ b/packages/components-native/src/Checkbox/Checkbox.style.ts
@@ -12,7 +12,7 @@ export const useStyles = buildThemedStyles(tokens => {
       width: "100%",
       justifyContent: "space-between",
       flexDirection: "row",
-      alignItems: "start",
+      alignItems: "flex-start",
       paddingVertical: tokens["space-small"],
     },
 

--- a/packages/components-native/src/Checkbox/Checkbox.style.ts
+++ b/packages/components-native/src/Checkbox/Checkbox.style.ts
@@ -18,6 +18,7 @@ export const useStyles = buildThemedStyles(tokens => {
 
     label: {
       flex: 1,
+      gap: tokens["space-smallest"],
     },
 
     checkbox: {

--- a/packages/components-native/src/Checkbox/Checkbox.style.ts
+++ b/packages/components-native/src/Checkbox/Checkbox.style.ts
@@ -12,7 +12,7 @@ export const useStyles = buildThemedStyles(tokens => {
       width: "100%",
       justifyContent: "space-between",
       flexDirection: "row",
-      alignItems: "center",
+      alignItems: "start",
       paddingVertical: tokens["space-small"],
     },
 

--- a/packages/components-native/src/Checkbox/Checkbox.style.ts
+++ b/packages/components-native/src/Checkbox/Checkbox.style.ts
@@ -18,7 +18,7 @@ export const useStyles = buildThemedStyles(tokens => {
 
     label: {
       flex: 1,
-      gap: tokens["space-smallest"],
+      gap: tokens["space-smaller"],
     },
 
     checkbox: {

--- a/packages/components-native/src/Checkbox/Checkbox.tsx
+++ b/packages/components-native/src/Checkbox/Checkbox.tsx
@@ -152,6 +152,15 @@ function CheckboxInternal({
             <Text variation={textVariation} align="start">
               {label}
             </Text>
+            {assistiveText && (
+              <Text
+                level="textSupporting"
+                align="start"
+                variation={textVariation}
+              >
+                {assistiveText}
+              </Text>
+            )}
           </View>
         )}
         <View
@@ -168,11 +177,6 @@ function CheckboxInternal({
           )}
         </View>
       </View>
-      {assistiveText && (
-        <Text level="textSupporting" align="start" variation={textVariation}>
-          {assistiveText}
-        </Text>
-      )}
     </Pressable>
   );
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Assistive text on Checkbox does not match intended designs

**Actual**
![image](https://github.com/user-attachments/assets/7870ce47-6b27-41fe-ac56-88ebfeb23c46)

**Design**
![image](https://github.com/user-attachments/assets/6f18b915-109e-480c-8e99-d0d7097745a0)


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Mobile checkbox now matches designs

**Short text**
![image](https://github.com/user-attachments/assets/29c6ebaf-07f3-47aa-b851-15e208a4d527)

**Wrapping text**
![image](https://github.com/user-attachments/assets/bb4b8dd5-11b6-4c35-aad9-5ebc96557b8e)

## Testing

Can test locally, limited usage in the app

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
