### PR TITLE
fix(components-native): Do not render Select's label element when no label is provided [JOB-125934]

### DIFF
--- a/packages/components-native/src/Select/Select.tsx
+++ b/packages/components-native/src/Select/Select.tsx
@@ -153,14 +153,15 @@ export function Select({
           <View
             style={[styles.container, (invalid || !!error) && styles.invalid]}
           >
-            <Text
-              level="textSupporting"
-              variation={textVariation}
-              hideFromScreenReader={true}
-            >
-              {label}
-            </Text>
-
+            {label && (
+              <Text
+                level="textSupporting"
+                variation={textVariation}
+                hideFromScreenReader={true}
+              >
+                {label}
+              </Text>
+            )}
             <View style={styles.input}>
               <View style={styles.value}>
                 <Text


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

When no label is provided to Select, there's still an element rendered that occupies space
![image](https://github.com/user-attachments/assets/ca1f90ab-e8cc-4c51-a137-3b42761905ad)

## Changes

### Changed

- wrapped the Text for the label in a conditional so it only show up when present

### Fixed

- Select now looks nicer when you don't pass it a label

## Testing

Because of web differences, you have to test this one in the app (job forms or requests have examples of this use case)

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
