### PR TITLE
fix(components): Fix InputDate and InputTime v2 Issues

### DIFF
--- a/packages/components/src/InputDate/InputDate.rebuilt.tsx
+++ b/packages/components/src/InputDate/InputDate.rebuilt.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef } from "react";
-import omit from "lodash/omit";
 import { useInputDateActivatorActions } from "./useInputDateActivatorActions";
 import { InputDateRebuiltProps } from "./InputDate.types";
 import { Suffix } from "../FormField";
@@ -31,18 +30,19 @@ export const InputDateRebuilt = forwardRef(function InputDateInternal(
 
   function InputDateActivator(activatorProps: DatePickerActivatorProps) {
     const { onClick, value } = activatorProps;
-    const newActivatorProps = omit(activatorProps, ["activator", "fullWidth"]);
+
+    const datePickerId = activatorProps.id;
 
     const { handleChange, handleFocus, handleBlur, isFocused } =
       useInputDateActivatorActions({
-        onChange: newActivatorProps.onChange,
+        onChange: activatorProps.onChange,
         onFocus: event => {
           props.onFocus?.(event);
-          newActivatorProps.onFocus?.();
+          activatorProps.onFocus?.();
         },
         onBlur: event => {
           props.onBlur?.(event);
-          newActivatorProps.onBlur?.();
+          activatorProps.onBlur?.();
         },
       });
 
@@ -61,8 +61,18 @@ export const InputDateRebuilt = forwardRef(function InputDateInternal(
       // We prevent the picker from opening on focus for keyboard navigation, so to maintain a good UX for mouse users we want to open the picker on click
       <div onClick={onClick}>
         <InputText
-          {...newActivatorProps}
-          {...props}
+          // Only pass specific props we know are valid and needed
+          id={datePickerId}
+          disabled={props.disabled}
+          error={props.error}
+          readOnly={props.readOnly}
+          placeholder={props.placeholder}
+          size={props.size}
+          inline={props.inline}
+          align={props.align}
+          description={props.description}
+          invalid={props.invalid}
+          name={props.name}
           version={2}
           value={
             showEmptyValueLabel ? props.emptyValueLabel || "" : value || ""

--- a/packages/components/src/InputDate/InputDate.rebuilt.tsx
+++ b/packages/components/src/InputDate/InputDate.rebuilt.tsx
@@ -31,8 +31,6 @@ export const InputDateRebuilt = forwardRef(function InputDateInternal(
   function InputDateActivator(activatorProps: DatePickerActivatorProps) {
     const { onClick, value } = activatorProps;
 
-    const datePickerId = activatorProps.id;
-
     const { handleChange, handleFocus, handleBlur, isFocused } =
       useInputDateActivatorActions({
         onChange: activatorProps.onChange,
@@ -61,8 +59,11 @@ export const InputDateRebuilt = forwardRef(function InputDateInternal(
       // We prevent the picker from opening on focus for keyboard navigation, so to maintain a good UX for mouse users we want to open the picker on click
       <div onClick={onClick}>
         <InputText
-          // Only pass specific props we know are valid and needed
-          id={datePickerId}
+          aria-describedby={activatorProps.ariaDescribedBy}
+          aria-invalid={activatorProps.ariaInvalid === "true" ? true : false}
+          aria-labelledby={activatorProps.ariaLabelledBy}
+          aria-required={activatorProps.ariaRequired === "true" ? true : false}
+          id={activatorProps.id}
           disabled={props.disabled}
           error={props.error}
           readOnly={props.readOnly}

--- a/packages/components/src/InputTime/InputTime.rebuilt.tsx
+++ b/packages/components/src/InputTime/InputTime.rebuilt.tsx
@@ -46,6 +46,7 @@ export function InputTimeRebuilt({
         name={params.name}
         className={inputStyle}
         onBlur={handleBlur}
+        id={id}
         disabled={params.disabled}
         readOnly={params.readonly}
         onChange={handleChangeEvent}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

InputTime v2 has a problem where the input and label are not associated, because we are not giving the input the corresponding id

InputDate has a plethora of issues stemming from the way its types are defined with the immediate, blocking issue being that it is attempting to spread `readonly` and `showIcon` onto an html element

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

passed the id we have onto the InputTime

stopped spreading all of `props` onto the InputText inside InputDate, instead only applying the specific props we want to use. also stopped spreading the `activatorProps`/`newActivatorProps` since there are a handful of problems with those too.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
