### PR TITLE
fix(components): Manage Checkbox Visibility Inline for Improved Testing

### DIFF
--- a/packages/components/src/DataList/DataList.module.css
+++ b/packages/components/src/DataList/DataList.module.css
@@ -154,14 +154,9 @@
 
 .selectAllCheckbox {
   display: flex;
-  visibility: hidden;
 
   /* To compensate the Checkbox's label margin that we are using for screen-readers */
   margin-right: calc(var(--space-base) * -1);
-}
-
-.selectAllCheckbox.visible {
-  visibility: visible;
 }
 
 .listItem .selectable > :first-child {

--- a/packages/components/src/DataList/DataList.module.css.d.ts
+++ b/packages/components/src/DataList/DataList.module.css.d.ts
@@ -10,7 +10,6 @@ declare const styles: {
   readonly "active": string;
   readonly "selectable": string;
   readonly "selectAllCheckbox": string;
-  readonly "visible": string;
   readonly "selected": string;
   readonly "filtering": string;
   readonly "filteringSpinner": string;

--- a/packages/components/src/DataList/DataList.test.tsx
+++ b/packages/components/src/DataList/DataList.test.tsx
@@ -763,11 +763,14 @@ describe("DataList", () => {
         </DataList>,
       );
 
-      const headerCheckbox = screen.queryByTestId(
+      const checkboxContainer = screen.getByTestId(
         DATA_LIST_HEADER_CHECKBOX_TEST_ID,
       );
+      const headerCheckbox = within(checkboxContainer).getByRole("checkbox", {
+        hidden: true,
+      });
       expect(headerCheckbox).toBeInTheDocument();
-      expect(headerCheckbox).not.toHaveClass("visible");
+      expect(headerCheckbox).not.toBeVisible();
     });
 
     it("should not show checkbox or select-all UI when item is selected and onSelectAll is absent", () => {
@@ -852,12 +855,12 @@ describe("DataList", () => {
           </DataList.Layout>
         </DataList>,
       );
-
-      const headerCheckbox = screen.getByTestId(
+      const checkboxContainer = screen.getByTestId(
         DATA_LIST_HEADER_CHECKBOX_TEST_ID,
       );
+      const headerCheckbox = within(checkboxContainer).getByRole("checkbox");
       expect(headerCheckbox).toBeInTheDocument();
-      expect(headerCheckbox).toHaveClass("visible");
+      expect(headerCheckbox).toBeVisible();
 
       // Rerender with a selected item
       rerender(

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.test.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.test.tsx
@@ -9,7 +9,6 @@ import {
 } from "@jobber/components/DataList/context/DataListContext";
 import {
   DATA_LIST_HEADER_BATCH_SELECT_TEST_ID,
-  DATA_LIST_HEADER_CHECKBOX_TEST_ID,
   DataListHeaderCheckbox,
 } from "./DataListHeaderCheckbox";
 
@@ -61,15 +60,14 @@ describe("DataListHeaderCheckbox", () => {
       );
 
       expect(screen.getByTestId("child-element")).toBeInTheDocument();
-      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
       expect(
-        screen.queryByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
+        screen.queryByRole("checkbox", { hidden: true }),
       ).not.toBeInTheDocument();
     });
   });
 
   describe("when only onSelect is provided", () => {
-    it("should render an invisible checkbox with children (no AnimatedSwitcher)", () => {
+    it("should render a hidden checkbox with children (no AnimatedSwitcher)", () => {
       const childText = "Find me";
       render(
         <DataListContext.Provider value={withOnlySelectContext}>
@@ -80,13 +78,13 @@ describe("DataListHeaderCheckbox", () => {
       );
 
       expect(screen.getByTestId("child-element")).toBeInTheDocument();
-      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+      const checkbox = screen.queryByRole("checkbox");
+
+      expect(checkbox).not.toBeInTheDocument();
+      // Use hidden: true to find elements even if they are not visible to accessibility API
       expect(
-        screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
+        screen.getByRole("checkbox", { hidden: true }),
       ).toBeInTheDocument();
-      expect(
-        screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
-      ).not.toHaveClass("visible");
     });
   });
 
@@ -102,13 +100,11 @@ describe("DataListHeaderCheckbox", () => {
       );
 
       expect(screen.getByTestId("child-element")).toBeInTheDocument();
-      expect(screen.getByRole("checkbox")).toBeInTheDocument();
-      expect(
-        screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID)).toHaveClass(
-        "visible",
-      );
+
+      const checkbox = screen.getByRole("checkbox");
+
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toBeVisible();
       expect(
         screen.queryByTestId(DATA_LIST_HEADER_BATCH_SELECT_TEST_ID),
       ).not.toBeInTheDocument();
@@ -126,12 +122,11 @@ describe("DataListHeaderCheckbox", () => {
 
       expect(screen.queryByTestId("child-element")).not.toBeInTheDocument();
       expect(screen.getByRole("checkbox")).toBeInTheDocument();
-      expect(
-        screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId(DATA_LIST_HEADER_CHECKBOX_TEST_ID)).toHaveClass(
-        "visible",
-      );
+
+      const checkbox = screen.getByRole("checkbox");
+
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toBeVisible();
       expect(
         screen.getByTestId(DATA_LIST_HEADER_BATCH_SELECT_TEST_ID),
       ).toBeInTheDocument();
@@ -228,7 +223,9 @@ describe("DataListHeaderCheckbox", () => {
           </DataListContext.Provider>,
         );
 
-        expect(screen.getByRole("checkbox")).toHaveClass("indeterminate");
+        expect(screen.getByRole("checkbox", { hidden: true })).toHaveClass(
+          "indeterminate",
+        );
       });
     });
 
@@ -250,7 +247,7 @@ describe("DataListHeaderCheckbox", () => {
         </DataListContext.Provider>,
       );
 
-      expect(screen.getByRole("checkbox")).toBeChecked();
+      expect(screen.getByRole("checkbox", { hidden: true })).toBeChecked();
     });
   });
 });

--- a/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.tsx
+++ b/packages/components/src/DataList/components/DataListHeader/DataListHeaderCheckbox.tsx
@@ -46,9 +46,10 @@ export function DataListHeaderCheckbox({ children }: DataListHeaderCheckbox) {
     <div className={styles.selectable}>
       <div
         data-testid={DATA_LIST_HEADER_CHECKBOX_TEST_ID}
-        className={classNames(styles.selectAllCheckbox, {
-          [styles.visible]: canSelectAll,
-        })}
+        style={{
+          visibility: canSelectAll ? "visible" : "hidden",
+        }}
+        className={classNames(styles.selectAllCheckbox)}
       >
         <Checkbox
           checked={isAllSelected()}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

running into some issues with the hidden checkbox in testing environments

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

right now since the `visibility: hidden` is managed through a CSS module, RTL can't/doesn't know about that, meaning that tests that do

`screen.getAllByRole("checkbox")` or `screen.getByRole("checkbox")` will find the checkbox that we expect to be hidden. this is causing some tests to fail, and it just isn't great really to have tests see an element that users won't.

it's just a limitation of RTL, one that from what I can tell they have no intention of addressing since it would just be a lot to factor in how a project is managing its styles.

to get around this, I'm just going to move that visibility toggle inline. the `visible` style was only ever adjusting that single property based on `canSelectAll`, so I think it's a fair approach to move it.

**thoughts**
having the checkbox be there but invisible isn't great. the layout is just very finicky, and difficult to create the same alignment without rendering it in some way. we do have future plans to handle this scenario more holistically, so when we do that this can be removed.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
