### PR TITLE
fix(components): Fix InputTime v2 clearable while-editing 

### DIFF
--- a/packages/components/src/InputTime/InputTime.rebuilt.tsx
+++ b/packages/components/src/InputTime/InputTime.rebuilt.tsx
@@ -19,6 +19,7 @@ export function InputTimeRebuilt({
 
   const { inputStyle } = useFormFieldWrapperStyles(params);
 
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
   const id = getId(params);
 
   return (
@@ -39,6 +40,7 @@ export function InputTimeRebuilt({
       readonly={params.readonly}
       placeholder={params.placeholder}
       value={dateToTimeString(value)}
+      wrapperRef={wrapperRef}
     >
       <input
         ref={ref}

--- a/packages/components/src/InputTime/InputTime.tsx
+++ b/packages/components/src/InputTime/InputTime.tsx
@@ -12,6 +12,7 @@ export function InputTime({
   ...params
 }: InputTimeProps) {
   const ref = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const { setTypedTime } = useTimePredict({ value, handleChange });
 
   const fieldProps: FormFieldProps = omit(
@@ -34,6 +35,7 @@ export function InputTime({
         fieldProps.onKeyUp?.(e);
         !isNaN(parseInt(e.key, 10)) && setTypedTime(prev => prev + e.key);
       }}
+      wrapperRef={wrapperRef}
     />
   );
 


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

clearable while-editing does not work in InputTime. This is caused by missing `wrapperRef` prop into `FormFieldWrapper`, which results in the focus event listeners not getting registered in `useFormFieldFocus`. clearable while-editing relies on the focus state to show/hide the clear icon button

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Pass `wrapperRef` into `FormFieldWrapper` in `InputTime.rebuilt`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- InputTime v2 can now be cleared while-editing

### Security

- <!-- in case of vulnerabilities -->

## Testing

- In one of the existing stories, set `clearable="while-editing"`
- Confirm that clear icon button is visible while editing.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
