### PR TITLE
chore(components): add edit to allowed chip suffix icons

### DIFF
--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -69,6 +69,7 @@ export interface ChipSuffixProps extends PropsWithChildren {
 export const allowedSuffixIcons = [
   "cross",
   "add",
+  "edit",
   "checkmark",
   "remove",
   "arrowDown",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

An additional icon type is required for chip suffixes as per these designs: https://www.figma.com/design/WpthXbRKRnR47XOc8sPy1U/AI-Receptionist-V2?node-id=143-12610&t=3MTHUIH3iD9AmVcw-4

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

- Added "edit" icon to allow listed chip suffix icons

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Replace "cross" with "edit" on ln 27 of docs/components/Chip/Chip.stories.mdx, check that it renders properly in the docs

<img width="281" height="129" alt="Screenshot 2025-07-17 at 10 08 10 AM" src="https://github.com/user-attachments/assets/624186be-e3a1-42b3-a911-14a61a8f0c0b" />

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
