### PR TITLE
feat(components): Replace Popper with FloatingUI in Autocomplete

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.module.css
+++ b/packages/components/src/Autocomplete/Autocomplete.module.css
@@ -29,7 +29,6 @@
   visibility: visible;
   width: 100%;
   height: auto;
-  max-height: 300px;
   opacity: 1;
 }
 

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -51,7 +51,9 @@ function AutocompleteInternal<
     useState<Array<GenericOption | GenericGetOptionsValue>>(initialOptionsMemo);
   const [inputFocused, setInputFocused] = useState(false);
   const [inputText, setInputText] = useState(value?.label ?? "");
-  const autocompleteRef = useRef(null);
+  const [autocompleteRef, setAutocompleteRef] = useState<HTMLDivElement | null>(
+    null,
+  );
   const delayedSearch = useDebounce(updateSearch, debounceRate);
   const inputRef = useRef<InputTextRef | null>(null);
 
@@ -64,7 +66,7 @@ function AutocompleteInternal<
   }, [value]);
 
   return (
-    <div className={styles.autocomplete} ref={autocompleteRef}>
+    <div className={styles.autocomplete} ref={setAutocompleteRef}>
       <InputText
         ref={mergeRefs([ref, inputRef])}
         autocomplete={false}

--- a/packages/components/src/Autocomplete/Autocomplete.types.ts
+++ b/packages/components/src/Autocomplete/Autocomplete.types.ts
@@ -118,7 +118,7 @@ export interface MenuProps<
   /**
    * Element that the menu is attached to when the menu opens.
    */
-  readonly attachTo: RefObject<Element | null>;
+  readonly attachTo: HTMLDivElement | null;
   /**
    * Ref to the TextInput element.
    */

--- a/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
+++ b/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
@@ -31,7 +31,6 @@ export function DefaultMenu({
     menuRef,
     setMenuRef,
     styles: floatStyles,
-    attributes,
     targetWidth,
   } = useRepositionMenu(attachTo);
 
@@ -48,7 +47,7 @@ export function DefaultMenu({
 
   return (
     <BaseAutocompleteMenuWrapper
-      {...{ setMenuRef, floatStyles, attributes, targetWidth, visible }}
+      {...{ setMenuRef, floatStyles, targetWidth, visible }}
     >
       {options?.map((option, index) => {
         return (

--- a/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
+++ b/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
@@ -30,7 +30,7 @@ export function DefaultMenu({
   const {
     menuRef,
     setMenuRef,
-    styles: popperStyles,
+    styles: floatStyles,
     attributes,
     targetWidth,
   } = useRepositionMenu(attachTo);
@@ -48,7 +48,7 @@ export function DefaultMenu({
 
   return (
     <BaseAutocompleteMenuWrapper
-      {...{ setMenuRef, popperStyles, attributes, targetWidth, visible }}
+      {...{ setMenuRef, floatStyles, attributes, targetWidth, visible }}
     >
       {options?.map((option, index) => {
         return (

--- a/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
+++ b/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject } from "react";
+import React from "react";
 import { BaseAutocompleteMenuWrapper } from "./MenuWrapper";
 import { AnyOption, Option } from "../Autocomplete.types";
 import { isOptionSelected } from "../Autocomplete.utils";
@@ -12,7 +12,7 @@ export interface DefaultMenuProps {
   /**
    * Element that it's attached to when the menu opens.
    */
-  readonly attachTo: RefObject<Element | null>;
+  readonly attachTo: HTMLDivElement | null;
   onOptionSelect(chosenOption?: Option): void;
   readonly visible?: boolean;
 }

--- a/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
+++ b/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
@@ -14,7 +14,7 @@ export interface DefaultMenuProps {
    */
   readonly attachTo: HTMLDivElement | null;
   onOptionSelect(chosenOption?: Option): void;
-  readonly visible?: boolean;
+  readonly visible: boolean;
 }
 
 /**
@@ -32,7 +32,7 @@ export function DefaultMenu({
     setMenuRef,
     styles: floatStyles,
     targetWidth,
-  } = useRepositionMenu(attachTo);
+  } = useRepositionMenu(attachTo, visible, false);
 
   const detectSeparatorCondition = (option: Option) =>
     option.description || option.details;

--- a/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
+++ b/packages/components/src/Autocomplete/Menu/DefaultMenu.tsx
@@ -33,7 +33,7 @@ export function DefaultMenu({
     styles: popperStyles,
     attributes,
     targetWidth,
-  } = useRepositionMenu(attachTo, visible);
+  } = useRepositionMenu(attachTo);
 
   const detectSeparatorCondition = (option: Option) =>
     option.description || option.details;

--- a/packages/components/src/Autocomplete/Menu/Menu.tsx
+++ b/packages/components/src/Autocomplete/Menu/Menu.tsx
@@ -1,6 +1,5 @@
 import React, { RefObject } from "react";
 import { InputTextRef } from "@jobber/components/InputText";
-import { useModalContext } from "@jobber/components/Modal";
 import { DefaultMenu, DefaultMenuProps } from "./DefaultMenu";
 import { useAutocompleteMenu } from "./MenuWrapper";
 import {
@@ -22,25 +21,6 @@ export function Menu<
   inputRef,
   customRenderMenu,
 }: MenuProps<GenericOption, GenericOptionValue>) {
-  const { open: isWithinOpenModal } = useModalContext();
-
-  /**
-   * Experimental/temporary workaround for Autocompletes within Modals. This is only necessary
-   * when an Autocomplete uses `customRenderMenu` and is rendered within the composable version
-   * of Modal (aka Modal.Provider).
-   *
-   * If `customRenderMenu` contains clickable elements such as Buttons, the consumer must ALSO
-   * replace any `onClick` handlers with `onMouseDown` handlers on those Buttons.
-   *
-   * The check below prevents Autocomplete from rendering the `customRenderMenu` when it's not visible
-   * (when the input isn't focused). This prevents Modals (FloatingUI) from marking the Autocomplete's
-   * menu as data-floating-ui-inert and aria-hidden="true". As a result, this prevents the bug where clicking
-   * within its menu would cause FloatingUI to close the parent Modal because it determined the click was
-   * outside of the Modal.
-   */
-  const specialModalWorkaround = isWithinOpenModal && customRenderMenu;
-  if (specialModalWorkaround && !inputFocused) return null;
-
   if (customRenderMenu) {
     return (
       <CustomMenu

--- a/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
+++ b/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren, useCallback, useEffect } from "react";
 import classNames from "classnames";
 import { useIsMounted } from "@jobber/hooks/useIsMounted";
-import { createPortal } from "react-dom";
+import { FloatingPortal } from "@floating-ui/react";
 import styles from "../Autocomplete.module.css";
 import { UseRepositionMenu, useRepositionMenu } from "../useRepositionMenu";
 
@@ -77,5 +77,5 @@ export function BaseAutocompleteMenuWrapper(
   const mounted = useIsMounted();
   const menu = <BaseAutocompleteMenuWrapperInternal {...props} />;
 
-  return mounted.current ? createPortal(menu, document.body) : menu;
+  return mounted.current ? <FloatingPortal>{menu}</FloatingPortal> : menu;
 }

--- a/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
+++ b/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
@@ -8,7 +8,6 @@ import { UseRepositionMenu, useRepositionMenu } from "../useRepositionMenu";
 export interface BaseAutocompleteMenuWrapperInternalProps {
   readonly setMenuRef: UseRepositionMenu["setMenuRef"];
   readonly floatStyles: UseRepositionMenu["styles"];
-  readonly attributes: UseRepositionMenu["attributes"];
   readonly targetWidth: UseRepositionMenu["targetWidth"];
   readonly visible?: boolean;
 }
@@ -16,7 +15,6 @@ export interface BaseAutocompleteMenuWrapperInternalProps {
 function BaseAutocompleteMenuWrapperInternal({
   setMenuRef,
   floatStyles,
-  attributes,
   targetWidth,
   visible,
   children,
@@ -27,7 +25,6 @@ function BaseAutocompleteMenuWrapperInternal({
       ref={setMenuRef}
       style={{ ...floatStyles.float, width: targetWidth }}
       data-elevation={"elevated"}
-      {...attributes.float}
     >
       {children}
     </div>
@@ -59,7 +56,6 @@ export function useAutocompleteMenu({
 
       return (
         <BaseAutocompleteMenuWrapper
-          attributes={menuFloatProps.attributes}
           floatStyles={menuFloatProps.styles}
           setMenuRef={menuFloatProps.setMenuRef}
           targetWidth={menuFloatProps.targetWidth}

--- a/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
+++ b/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
@@ -23,7 +23,10 @@ function BaseAutocompleteMenuWrapperInternal({
     <div
       className={classNames(styles.options, { [styles.visible]: visible })}
       ref={setMenuRef}
-      style={{ ...floatStyles.float, width: targetWidth }}
+      style={{
+        ...floatStyles.float,
+        width: targetWidth,
+      }}
       data-elevation={"elevated"}
     >
       {children}

--- a/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
+++ b/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
@@ -52,7 +52,7 @@ export function useAutocompleteMenu({
       children?: React.ReactNode;
       visible: boolean;
     }): React.ReactElement => {
-      const menuPopperProps = useRepositionMenu(attachTo, visible);
+      const menuPopperProps = useRepositionMenu(attachTo);
       useEffect(() => {
         setMenuRef(menuPopperProps.menuRef);
       }, [menuPopperProps.menuRef]);

--- a/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
+++ b/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
@@ -38,7 +38,7 @@ function BaseAutocompleteMenuWrapperInternal({
 export function useAutocompleteMenu({
   attachTo,
 }: {
-  attachTo: React.RefObject<Element | null>;
+  attachTo: HTMLDivElement | null;
 }) {
   const [menuRef, setMenuRef] = React.useState<HTMLElement | null>(null);
   const AutocompleteMenuWrapper = useCallback(

--- a/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
+++ b/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
@@ -49,7 +49,7 @@ export function useAutocompleteMenu({
       children?: React.ReactNode;
       visible: boolean;
     }): React.ReactElement => {
-      const menuFloatProps = useRepositionMenu(attachTo);
+      const menuFloatProps = useRepositionMenu(attachTo, visible, true);
       useEffect(() => {
         setMenuRef(menuFloatProps.menuRef);
       }, [menuFloatProps.menuRef]);

--- a/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
+++ b/packages/components/src/Autocomplete/Menu/MenuWrapper.tsx
@@ -7,7 +7,7 @@ import { UseRepositionMenu, useRepositionMenu } from "../useRepositionMenu";
 
 export interface BaseAutocompleteMenuWrapperInternalProps {
   readonly setMenuRef: UseRepositionMenu["setMenuRef"];
-  readonly popperStyles: UseRepositionMenu["styles"];
+  readonly floatStyles: UseRepositionMenu["styles"];
   readonly attributes: UseRepositionMenu["attributes"];
   readonly targetWidth: UseRepositionMenu["targetWidth"];
   readonly visible?: boolean;
@@ -15,7 +15,7 @@ export interface BaseAutocompleteMenuWrapperInternalProps {
 
 function BaseAutocompleteMenuWrapperInternal({
   setMenuRef,
-  popperStyles,
+  floatStyles,
   attributes,
   targetWidth,
   visible,
@@ -25,9 +25,9 @@ function BaseAutocompleteMenuWrapperInternal({
     <div
       className={classNames(styles.options, { [styles.visible]: visible })}
       ref={setMenuRef}
-      style={{ ...popperStyles.popper, width: targetWidth }}
+      style={{ ...floatStyles.float, width: targetWidth }}
       data-elevation={"elevated"}
-      {...attributes.popper}
+      {...attributes.float}
     >
       {children}
     </div>
@@ -52,17 +52,17 @@ export function useAutocompleteMenu({
       children?: React.ReactNode;
       visible: boolean;
     }): React.ReactElement => {
-      const menuPopperProps = useRepositionMenu(attachTo);
+      const menuFloatProps = useRepositionMenu(attachTo);
       useEffect(() => {
-        setMenuRef(menuPopperProps.menuRef);
-      }, [menuPopperProps.menuRef]);
+        setMenuRef(menuFloatProps.menuRef);
+      }, [menuFloatProps.menuRef]);
 
       return (
         <BaseAutocompleteMenuWrapper
-          attributes={menuPopperProps.attributes}
-          popperStyles={menuPopperProps.styles}
-          setMenuRef={menuPopperProps.setMenuRef}
-          targetWidth={menuPopperProps.targetWidth}
+          attributes={menuFloatProps.attributes}
+          floatStyles={menuFloatProps.styles}
+          setMenuRef={menuFloatProps.setMenuRef}
+          targetWidth={menuFloatProps.targetWidth}
           visible={visible}
         >
           {children}

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`Autocomplete should display headers when headers are passed in 1`] = `
           >
             <label
               class="label"
-              for=":r3:"
+              for=":r4:"
             >
               placeholder_name
             </label>
@@ -75,7 +75,7 @@ exports[`Autocomplete should display headers when headers are passed in 1`] = `
               <input
                 autocomplete="off"
                 class="input"
-                id=":r3:"
+                id=":r4:"
                 type="text"
                 value=""
               />

--- a/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/components/src/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`Autocomplete should display headers when headers are passed in 1`] = `
           >
             <label
               class="label"
-              for=":r4:"
+              for=":r5:"
             >
               placeholder_name
             </label>
@@ -75,7 +75,7 @@ exports[`Autocomplete should display headers when headers are passed in 1`] = `
               <input
                 autocomplete="off"
                 class="input"
-                id=":r4:"
+                id=":r5:"
                 type="text"
                 value=""
               />

--- a/packages/components/src/Autocomplete/constants.ts
+++ b/packages/components/src/Autocomplete/constants.ts
@@ -1,1 +1,2 @@
 export const AUTOCOMPLETE_MAX_HEIGHT = 300;
+export const AUTCOMPLETE_MIN_HEIGHT = 100;

--- a/packages/components/src/Autocomplete/constants.ts
+++ b/packages/components/src/Autocomplete/constants.ts
@@ -1,0 +1,1 @@
+export const AUTOCOMPLETE_MAX_HEIGHT = 300;

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -1,4 +1,3 @@
-import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
 import { autoUpdate, flip, offset, useFloating } from "@floating-ui/react";
 import { MenuProps } from "./Autocomplete.types";
 
@@ -16,11 +15,10 @@ export interface UseRepositionMenu {
 
 export function useRepositionMenu(
   attachTo: MenuProps["attachTo"],
-  visible = false,
 ): UseRepositionMenu {
   const referenceElement = attachTo.current;
 
-  const { refs, floatingStyles, update } = useFloating({
+  const { refs, floatingStyles } = useFloating({
     placement: "bottom",
     middleware: [offset(8), flip({ fallbackPlacements: ["top"] })],
     elements: {
@@ -28,12 +26,6 @@ export function useRepositionMenu(
     },
     whileElementsMounted: autoUpdate,
   });
-
-  useSafeLayoutEffect(() => {
-    if (visible && update) {
-      update();
-    }
-  }, [visible, update]);
 
   const targetWidth = attachTo.current?.clientWidth;
 

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -53,6 +53,8 @@ export function useRepositionMenu(
       : {}),
   });
 
+  // While DefaultMenu leverages conditional rendering, CustomMenu is hidden with CSS
+  // We need to apply the correct update method to each case
   useSafeLayoutEffect(() => {
     if (cssManagedVisibility && visible && attachTo && refs.floating.current) {
       const cleanup = autoUpdate(attachTo, refs.floating.current, update);

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -6,10 +6,10 @@ export interface UseRepositionMenu {
   readonly setMenuRef: (ref: HTMLElement | null) => void;
   readonly targetWidth: number | undefined;
   readonly styles: {
-    popper: React.CSSProperties;
+    float: React.CSSProperties;
   };
   readonly attributes: {
-    popper: Record<string, string>;
+    float: Record<string, string>;
   };
 }
 
@@ -34,8 +34,8 @@ export function useRepositionMenu(
     setMenuRef: refs.setFloating,
     targetWidth,
     styles: {
-      popper: floatingStyles,
+      float: floatingStyles,
     },
-    attributes: { popper: {} },
+    attributes: { float: {} },
   };
 }

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -63,7 +63,14 @@ export function useRepositionMenu(
     }
 
     return undefined;
-  }, [cssManagedVisibility, visible, attachTo, refs.floating.current]);
+  }, [
+    cssManagedVisibility,
+    visible,
+    attachTo,
+    refs.floating.current,
+    update,
+    autoUpdate,
+  ]);
 
   const targetWidth = attachTo?.clientWidth;
 

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -6,7 +6,6 @@ import {
   useFloating,
 } from "@floating-ui/react";
 import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
-import { useCallback } from "react";
 import { MenuProps } from "./Autocomplete.types";
 import { AUTOCOMPLETE_MAX_HEIGHT } from "./constants";
 
@@ -54,7 +53,7 @@ export function useRepositionMenu(
       : {}),
   });
 
-  const conditionalUpdate = useCallback(() => {
+  useSafeLayoutEffect(() => {
     if (cssManagedVisibility && visible && attachTo && refs.floating.current) {
       const cleanup = autoUpdate(attachTo, refs.floating.current, update);
 
@@ -62,11 +61,7 @@ export function useRepositionMenu(
     }
 
     return undefined;
-  }, [update, cssManagedVisibility, visible, attachTo, refs.floating.current]);
-
-  useSafeLayoutEffect(() => {
-    conditionalUpdate();
-  }, [conditionalUpdate, visible]);
+  }, [cssManagedVisibility, visible, attachTo, refs.floating.current]);
 
   const targetWidth = attachTo?.clientWidth;
 

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -13,18 +13,16 @@ export interface UseRepositionMenu {
 export function useRepositionMenu(
   attachTo: MenuProps["attachTo"],
 ): UseRepositionMenu {
-  const referenceElement = attachTo.current;
-
   const { refs, floatingStyles } = useFloating({
     placement: "bottom",
     middleware: [offset(8), flip({ fallbackPlacements: ["top"] })],
     elements: {
-      reference: referenceElement || null,
+      reference: attachTo,
     },
     whileElementsMounted: autoUpdate,
   });
 
-  const targetWidth = attachTo.current?.clientWidth;
+  const targetWidth = attachTo?.clientWidth;
 
   return {
     menuRef: refs.floating.current,

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -7,7 +7,7 @@ import {
 } from "@floating-ui/react";
 import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
 import { MenuProps } from "./Autocomplete.types";
-import { AUTOCOMPLETE_MAX_HEIGHT } from "./constants";
+import { AUTCOMPLETE_MIN_HEIGHT, AUTOCOMPLETE_MAX_HEIGHT } from "./constants";
 
 export interface UseRepositionMenu {
   readonly menuRef: HTMLElement | null;
@@ -27,6 +27,7 @@ export function useRepositionMenu(
     placement: "bottom",
     middleware: [
       offset(8),
+      flip({ fallbackPlacements: ["top"] }),
       size({
         apply({ availableHeight, elements }) {
           // Limit the height for a true maximum
@@ -34,14 +35,13 @@ export function useRepositionMenu(
           const maxHeight =
             availableHeight > AUTOCOMPLETE_MAX_HEIGHT
               ? AUTOCOMPLETE_MAX_HEIGHT
-              : Math.max(0, availableHeight);
+              : Math.max(AUTCOMPLETE_MIN_HEIGHT, availableHeight);
 
           Object.assign(elements.floating.style, {
             maxHeight: `${maxHeight}px`,
           });
         },
       }),
-      flip({ fallbackPlacements: ["top"] }),
     ],
     elements: {
       reference: attachTo,

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -1,7 +1,14 @@
-import { autoUpdate, flip, offset, useFloating } from "@floating-ui/react";
+import {
+  autoUpdate,
+  flip,
+  offset,
+  size,
+  useFloating,
+} from "@floating-ui/react";
 import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
 import { useCallback } from "react";
 import { MenuProps } from "./Autocomplete.types";
+import { AUTOCOMPLETE_MAX_HEIGHT } from "./constants";
 
 export interface UseRepositionMenu {
   readonly menuRef: HTMLElement | null;
@@ -19,7 +26,24 @@ export function useRepositionMenu(
 ): UseRepositionMenu {
   const { refs, floatingStyles, update } = useFloating({
     placement: "bottom",
-    middleware: [offset(8), flip({ fallbackPlacements: ["top"] })],
+    middleware: [
+      offset(8),
+      size({
+        apply({ availableHeight, elements }) {
+          // Limit the height for a true maximum
+          // However if we have less space than that, then reduce it to allow scrolling
+          const maxHeight =
+            availableHeight > AUTOCOMPLETE_MAX_HEIGHT
+              ? AUTOCOMPLETE_MAX_HEIGHT
+              : Math.max(0, availableHeight);
+
+          Object.assign(elements.floating.style, {
+            maxHeight: `${maxHeight}px`,
+          });
+        },
+      }),
+      flip({ fallbackPlacements: ["top"] }),
+    ],
     elements: {
       reference: attachTo,
     },

--- a/packages/components/src/Autocomplete/useRepositionMenu.ts
+++ b/packages/components/src/Autocomplete/useRepositionMenu.ts
@@ -8,9 +8,6 @@ export interface UseRepositionMenu {
   readonly styles: {
     float: React.CSSProperties;
   };
-  readonly attributes: {
-    float: Record<string, string>;
-  };
 }
 
 export function useRepositionMenu(
@@ -36,6 +33,5 @@ export function useRepositionMenu(
     styles: {
       float: floatingStyles,
     },
-    attributes: { float: {} },
   };
 }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

React-popper is deprecated, and we've chosen FloatingUI as its successor.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

new `size` behavior both prevents the Autocomplete menu from being inaccessible and also avoids "pushing" the limits of its container (the document body) beyond, resulting in a broken layout. instead it will shrink to the available size, and allow scrolling.

### Changed

Replaced the Popper code responsible for positioning the Autocomplete's dropdown menu with FloatingUI.

Replaced the `react-dom` `createPortal` with `FloatingPortal` which handles a bunch of stuff for us and solves the same problem that `createPortal` does
https://floating-ui.com/docs/floatingportal#floatingportal

Removed the workaround with Modal because I believe the FloatingPortal solves the problem.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

This change should be completely imperceptible. It should do the exact same thing as it did before which is:
- position the menu below the input with the correct width and placement such that the input is not obstructed, and there isn't a huge gap between the input and the menu
- if there is insufficient space below the Autocomplete, the menu instead goes above. we never want it to go to the sides 
- try placing an Autocomplete somewhere where we can scroll and see it reposition

the custom menu setup should also work. it makes use of some of the "refs" we pass around.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
