### PR TITLE
fix(components): Undo ComboboxSelection type for callback props

### DIFF
--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -371,7 +371,9 @@ describe("Combobox Multiselect", () => {
     expect(handleSelect).toHaveBeenCalledWith([]);
   });
 
-  it("should call onSelectAll when clicking Select all", async () => {
+  it("should call onSelectAll with options with only id and label when clicking Select all", async () => {
+    const mockOnClick = jest.fn();
+
     render(
       <Combobox
         label={activatorLabel}
@@ -381,8 +383,8 @@ describe("Combobox Multiselect", () => {
         onSelectAll={handleSelectAll}
         onClear={handleClear}
       >
-        <Combobox.Option id="1" label="Bilbo Baggins" />
-        <Combobox.Option id="2" label="Frodo Baggins" />
+        <Combobox.Option id="1" label="Bilbo Baggins" onClick={mockOnClick} />
+        <Combobox.Option id="2" label="Frodo Baggins" onClick={mockOnClick} />
       </Combobox>,
     );
 

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -372,6 +372,7 @@ describe("Combobox Multiselect", () => {
   });
 
   it("should call onSelectAll with options with only id and label when clicking Select all", async () => {
+    // Not directly using mockOnClick, it is used to confirm its absence in the onSelectAll callback argument
     const mockOnClick = jest.fn();
 
     render(

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -27,13 +27,13 @@ export interface ComboboxProps {
   /**
    * Callback function invoked upon the selection of an option. Provides the selected option(s) as an argument.
    */
-  readonly onSelect: (selection: ComboboxSelection[]) => void;
+  readonly onSelect: (selection: ComboboxOption[]) => void;
 
   /**
    * Callback function invoked upon the selection of all options. Provides the selected option(s) as an argument.
    * This is only available when `multiSelect` is `true`.
    */
-  readonly onSelectAll?: (selection: ComboboxSelection[]) => void;
+  readonly onSelectAll?: (selection: ComboboxOption[]) => void;
 
   /**
    * Callback function invoked upon the clearing of all options.
@@ -155,8 +155,6 @@ export interface ComboboxOptionProps {
 }
 
 export type ComboboxOption = ComboboxOptionProps;
-
-export type ComboboxSelection = Pick<ComboboxOptionProps, "id" | "label">;
 
 export interface ComboboxContentProps {
   /**

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import classnames from "classnames";
 import { FloatingNode, FloatingPortal, FloatingTree } from "@floating-ui/react";
 import ReactDOM from "react-dom";
@@ -26,6 +26,15 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
       props.open,
       props.wrapperRef,
     );
+
+  // options that are passed back to consumers via onSelectAll callback
+  // should only contain id and label
+  const consumerOptions = useMemo(() => {
+    return props.options.map(option => ({
+      id: option.id,
+      label: option.label,
+    }));
+  }, [props.options]);
 
   const content = (
     <div
@@ -59,7 +68,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
           }}
           onSelectAll={() => {
             props.selectedStateSetter(props.options);
-            onSelectAll?.(props.options);
+            onSelectAll?.(consumerOptions);
           }}
         />
       )}

--- a/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
+++ b/packages/components/src/Combobox/components/ComboboxContent/ComboboxContent.tsx
@@ -29,7 +29,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
 
   // options that are passed back to consumers via onSelectAll callback
   // should only contain id and label
-  const consumerOptions = useMemo(() => {
+  const optionsData = useMemo(() => {
     return props.options.map(option => ({
       id: option.id,
       label: option.label,
@@ -68,7 +68,7 @@ export function ComboboxContent(props: ComboboxContentProps): JSX.Element {
           }}
           onSelectAll={() => {
             props.selectedStateSetter(props.options);
-            onSelectAll?.(consumerOptions);
+            onSelectAll?.(optionsData);
           }}
         />
       )}

--- a/packages/components/src/Combobox/index.ts
+++ b/packages/components/src/Combobox/index.ts
@@ -1,7 +1,3 @@
 export * from "./Combobox";
 export { ComboboxContextProvider } from "./ComboboxProvider";
-export {
-  ComboboxOption,
-  ComboboxCustomActivatorProps,
-  ComboboxSelection,
-} from "./Combobox.types";
+export { ComboboxOption, ComboboxCustomActivatorProps } from "./Combobox.types";

--- a/packages/site/src/content/Combobox/Combobox.props.json
+++ b/packages/site/src/content/Combobox/Combobox.props.json
@@ -57,7 +57,7 @@
         },
         "required": true,
         "type": {
-          "name": "(selection: ComboboxSelection[]) => void"
+          "name": "(selection: ComboboxOptionProps[]) => void"
         }
       },
       "onSelectAll": {
@@ -70,7 +70,7 @@
         },
         "required": false,
         "type": {
-          "name": "(selection: ComboboxSelection[]) => void"
+          "name": "(selection: ComboboxOptionProps[]) => void"
         }
       },
       "onClear": {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We deliberately chose to create a new ComboboxSelection type in this [PR](https://github.com/GetJobber/atlantis/pull/2615#discussion_r2205377698) in order to better reflect the combobox options being passed back to the consumers via callbacks (only `id` and `label` of ComboboxOption). However, digging deeper I found these callbacks (onSelect) to be passed through layers of hooks and internal components. Going through each usage and changing the type quickly becomes messy, although all CI jobs are passing. We will have to come back and tackle a full cleanup in a separate ticket. This PR will undo the addition of ComboboxSelection type and also only return `id` and `label` in each option of `onSelectAll`

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- Undo the addition of ComboboxSelection and revert `onSelect` and `onSelectAll` type to `ComboboxOption[]`
- `onSelectAll` now only passes back `id` and `label` of each option

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Add `onSelectAll` callback prop to `ComboboxMultiSelection` story and confirm options only contain id and label

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
