### PR TITLE
feat(components): Remove Chip.Suffix icon allowed list check

### DIFF
--- a/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
+++ b/packages/components/src/Chip/components/ChipSuffix/Chip.Suffix.tsx
@@ -12,7 +12,7 @@ export function ChipSuffix({
   testID,
   ariaLabel,
 }: ChipSuffixProps) {
-  let singleChild = useChildComponent(
+  const singleChild = useChildComponent(
     children,
     d => d.type === Icon || d.type == InternalChipButton,
   );
@@ -29,12 +29,6 @@ export function ChipSuffix({
     event.stopPropagation();
     onClick(event);
   };
-
-  const iconName = singleChild?.props?.name || singleChild?.props?.icon;
-
-  if (!allowedSuffixIcons.includes(iconName)) {
-    singleChild = undefined;
-  }
 
   return (
     <span
@@ -65,12 +59,3 @@ export interface ChipSuffixProps extends PropsWithChildren {
       | React.KeyboardEvent<HTMLSpanElement>,
   ) => void;
 }
-
-export const allowedSuffixIcons = [
-  "cross",
-  "add",
-  "edit",
-  "checkmark",
-  "remove",
-  "arrowDown",
-];


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

There was icon allowed list check in `Chip.Suffix` that only allowed some action-type icons to be used. This limited consumer flexibility in choosing the icon that fits their workflow the best. We also did not have any indication of why an icon would not render, nor documentation on the allowed list. A consumer had to debug into Atlantis code to find out and submit [contribution PR](https://github.com/GetJobber/atlantis/pull/2618) to get the edit icon added .

With this change, we want to provide consumers more flexibility in picking their icon, so they don't have to depend on us releasing a new code change every time a new icon needs to be used. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `Chip.Suffix` now allows any icon to be used.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Confirm any icon that was not on the allowed list can render in Chip.Suffix

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
