### PR TITLE
chore: Fix test:visual command

### DIFF
--- a/packages/site/.gitignore
+++ b/packages/site/.gitignore
@@ -5,6 +5,7 @@ public/foundation.css
 public/dark.mode.css
 public/styles.css
 node_modules/
+node_modules.e2e/
 test-results/
 playwright-report/
 blob-report/

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -4,6 +4,10 @@
 cd ../..
 
 # NOTES:
+# This line prevents mounting the site's node_modules. We need to install those inside the container
+# because linux requires different modules compared to macOS.
+#     -v $(pwd)/packages/site/node_modules.e2e:/atlantis/packages/site/node_modules \
+#
 # The bash script does the following:
 # 1. Install dependencies for this linux container environment
 # 2. Bundle and copyFiles (part of npm run dev)
@@ -14,9 +18,11 @@ cd ../..
 # See packages/site/package.json for the npm commands where this script is called from.
 PLAYWRIGHT_COMMAND="$@"
 
+echo "Running e2e tests inside a docker container..."
 # Run the e2e tests
 docker run --rm -it \
     -v $(pwd):/atlantis \
+    -v $(pwd)/packages/site/node_modules.e2e:/atlantis/packages/site/node_modules \
     -w /atlantis/packages/site \
     mcr.microsoft.com/playwright:v1.52.0-noble \
-    bash -c "npm run bundle && npm run copyFiles && (npx vite &) && sleep 3 && npx $PLAYWRIGHT_COMMAND"
+    bash -c "npm install --ignore-scripts && npm run bundle && npm run copyFiles && (npx vite &) && sleep 3 && npx $PLAYWRIGHT_COMMAND"


### PR DESCRIPTION

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

It was failing because some of the build scripts require npm deps that are properly compiled for the docker container's linux environment. Your local node_modules directory contains both js scripts as well as pre-compiled architecture-specific dependencies for macOS. When you run `npm install` inside a linux environment, you end up getting pre-compiled deps for that architecture instead, and that's exactly what we needed here.

This is actually something I had in place back in May (as part of Scott's original PR) but I [reverted it](https://github.com/GetJobber/atlantis/pull/2566/commits/b2fb538ea4c591408f0572de9e8b97bed70e9f91) because it started working without the npm install step.

I think something possibly recently changed regarding deps we have, or I was just hitting a weird cache at the time which made me think it was unnecessary and working fine.




## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Fixed test:visual for our local environments


## Testing

1. cd packages/site
2. `npm run test:visual`
    * observe it fails
3. Pull this branch
4. `npm run test:visual`
    * observe it succeeds!

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
