### PR TITLE
build: Prevent stale vite cache for docs site & e2e visual tests

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -4,7 +4,7 @@
   "version": "0.60.0",
   "type": "module",
   "scripts": {
-    "dev": "npm run bundle && npm run copyFiles && vite",
+    "dev": "npm run bundle && npm run copyFiles && vite --force",
     "bundle": "rollup -c editorBundle.rollup.config.js && rollup -c editorMobileBundle.rollup.config.js",
     "copyFiles": "cp ../design/dist/foundation.css ./public/foundation.css && cp ../components/dist/styles.css ./public/styles.css && cp ../design/dist/dark.mode.css ./public/dark.mode.css && cp ./node_modules/axios/dist/esm/axios.js ./public",
     "build": "npm run bundle && npm run copyFiles && tsc -b && vite build",

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -11,7 +11,7 @@ cd ../..
 # The bash script does the following:
 # 1. Install dependencies for this linux container environment
 # 2. Bundle and copyFiles (part of npm run dev)
-# 3. Start the vite dev server in the background
+# 3. Start the vite dev server in the background. Use --force to clear the vite cache.
 # 4. Wait for 3 seconds to ensure the server is ready
 # 5. Run the playwright tests
 
@@ -25,4 +25,4 @@ docker run --rm -it \
     -v $(pwd)/packages/site/node_modules.e2e:/atlantis/packages/site/node_modules \
     -w /atlantis/packages/site \
     mcr.microsoft.com/playwright:v1.52.0-noble \
-    bash -c "npm install --ignore-scripts && npm run bundle && npm run copyFiles && (npx vite &) && sleep 3 && npx $PLAYWRIGHT_COMMAND"
+    bash -c "npm install --ignore-scripts && npm run bundle && npm run copyFiles && (npx vite --force &) && sleep 3 && npx $PLAYWRIGHT_COMMAND"


### PR DESCRIPTION

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The docs site has a vite cache which sometimes causes problems and doesn't load the latest code after rebuilding components.

On another branch I was adding visual tests for the first time. I made a test modification to a component (Banner), rebuilt with bootstrap and then re-ran the visual e2e tests and it was still showing me the outdated Banner from before my change. This went on for awhile before I realized it was vite's cache. 

This PR forces vite to rebuild the cache when it's started up. The performance impact is minimal, I can't even tell. The win is avoiding vite's inconsistent cache.


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Always rebuild vite's cache for the docs site

## Testing

1. `cd packages/site && npm run test:visual`
2. Modify a component such as Spinner (Banner doesn't have tests on master yet)
3. Re-run bootstrap
4. `cd packages/site && npm run test:visual`
5. Observe it correctly fails due to the e2e screenshot being different ✅ 
    * Before this change, this was unreliable

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
