### PR TITLE
fix(components): Fixing DataList title styling on loadingState filtering [JOB-130817]

### DIFF
--- a/packages/components/src/DataList/DataList.module.css
+++ b/packages/components/src/DataList/DataList.module.css
@@ -21,8 +21,10 @@
   display: flex;
   position: relative;
   z-index: var(--elevation-base);
-  margin-bottom: var(--space-small);
+  margin-bottom: 0;
+  padding-bottom: var(--space-small);
   align-items: center;
+  background-color: var(--color-surface);
 }
 
 .headerFilters {

--- a/packages/components/src/DataList/DataList.module.css
+++ b/packages/components/src/DataList/DataList.module.css
@@ -21,7 +21,6 @@
   display: flex;
   position: relative;
   z-index: var(--elevation-base);
-  margin-bottom: 0;
   padding-bottom: var(--space-small);
   align-items: center;
   background-color: var(--color-surface);


### PR DESCRIPTION


## Motivations
The `title` prop on the `DataList` component was receiving the background colour change as part of `loadingState=filtering` erroneously. We want this to stay the same.

## Changes
I explicitly set the title background to have the correct background (none existed previously), and changed the margin to padding.

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
