### PR TITLE
fix(components): Fixing up eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,6 @@
-node_modules
+node_modules/
+**/node_modules/
+**/node_modules/**/*
 dist
 .rpt2_cache
 packages/design/colors.js
@@ -9,4 +11,5 @@ packages/generators/templates
 storybook-static
 
 *.css.d.ts
+*.css
 *.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,39 @@
 packages/generators/templates
-packages/components/dist/styles.css
 packages/design/icons/
 **/CHANGELOG.md
+.storybook/**
+
+# Ignore all built/compiled files
+**/dist/**
+**/build/**
+**/.rollup.cache/**
+storybook-static/**
+
+# Ignore configuration and data files
+*.json
+
+# Ignore auto-generated files
+**/*.css.d.ts
+**/*.module.css.d.ts
+**/tokens.*.ts
+**/icon.map.ts
+**/iconMap.ts
+
+# Ignore public assets and bundles
+**/public/**/*.js
+**/public/**/*.css
+**/public/**/*.html
+
+# Ignore test reports
+**/playwright-report/**
+**/test-results/**
+
+# Ignore HTML files (often generated)
+**/*.html
+
+# Ignore YAML files
+**/*.yml
+**/*.yaml
+
+# Ignore VS Code snippets
+**/*.code-snippets

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   proseWrap: "always",
-  arrowParens: "avoid"
+  arrowParens: "avoid",
+  trailingComma: "all",
 };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,25 @@
 {
-  // Set eslint as the default Formatter for TS/TSX
+  // Set prettier as the default Formatter for TS/TSX and ESLint for linting
   "[typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[javascript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.stylelint": "explicit"
+    }
   },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",
     "source.fixAll.stylelint": "explicit"
   },
+  "editor.formatOnSave": true,
   "eslint.enable": true,
   "eslint.format.enable": true,
   "eslint.options": {
@@ -34,7 +41,7 @@
     "typescriptreact"
   ],
   "peacock.color": "#F4E465",
-  "prettier.enable": false,
+  "prettier.enable": true,
   "workbench.colorCustomizations": {
     "statusBar.background": "#f4e465",
     "statusBarItem.hoverBackground": "#f1dc35",

--- a/docs/design/Borders.stories.mdx
+++ b/docs/design/Borders.stories.mdx
@@ -35,7 +35,7 @@ export function Example({ of: size }) {
 
 export function BorderSize({ of: size }) {
   return getComputedStyle(document.documentElement).getPropertyValue(
-    `--border-${size}`
+    `--border-${size}`,
   );
 }
 

--- a/docs/hooks/useStepper.stories.mdx
+++ b/docs/hooks/useStepper.stories.mdx
@@ -66,7 +66,7 @@ interface UseStepOptions<StepName extends string> {
 
 function useStepper<StepName extends string>(
   steps: readonly StepName[],
-  options: UseStepOptions<StepName> = {}
+  options: UseStepOptions<StepName> = {},
 );
 ```
 

--- a/docs/patterns/errors.stories.mdx
+++ b/docs/patterns/errors.stories.mdx
@@ -29,7 +29,7 @@ set it right whenever possible.
 > Good error messages are important, but the best designs carefully prevent
 > problems from occurring in the first place. Either eliminate error-prone
 > conditions, or check for them and present users with a confirmation option
-> before they commit to the action.<br/>
+> before they commit to the action.
 > [– 10 Usability Heuristics for User Interface Design](https://www.nngroup.com/articles/ten-usability-heuristics/#toc-5-error-prevention-5)
 
 While avoiding errors is the ideal, it’s largely impossible to avoid _all_ of

--- a/package-lock.json
+++ b/package-lock.json
@@ -21963,6 +21963,7 @@
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
@@ -38055,6 +38056,7 @@
     },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-diff": "^1.1.2"
@@ -47033,11 +47035,9 @@
         "@rushstack/eslint-patch": "^1.2.0",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
-        "eslint-config-prettier": "^8.7.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-jest": "^27.2.1",
-        "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.33.2",
         "prettier": "^2.8.4"
       },
@@ -47279,16 +47279,6 @@
         "node": ">=0.10.0"
       }
     },
-    "packages/eslint-config/node_modules/eslint-config-prettier": {
-      "version": "8.7.0",
-      "license": "MIT",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
     "packages/eslint-config/node_modules/eslint-import-resolver-typescript": {
       "version": "3.6.1",
       "license": "ISC",
@@ -47397,25 +47387,6 @@
           "optional": true
         },
         "jest": {
-          "optional": true
-        }
-      }
-    },
-    "packages/eslint-config/node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lerna:clean": "lerna run clean && lerna clean --y && npm run clean",
     "lint:css": "stylelint 'packages/**/*.css' --allow-empty-input --ignore-pattern 'packages/**/dist/**/*.css'",
     "lint:fix": "npm run lint:js -- --fix && npm run lint:css -- --fix && npm run lint:markdown -- --write",
-    "lint:js": "eslint --ext .js,.jsx,.ts,.tsx,.mjs,.cjs . --report-unused-disable-directives",
+    "lint:js": "eslint --ext .js,.jsx,.ts,.tsx,.mjs,.cjs packages docs scripts  --report-unused-disable-directives",
     "lint:markdown": "prettier --check '**/*.{md,mdx}' --write",
     "merge:dist": "mv storybook-static packages/site/dist/storybook && mv packages/site/dist storybook-static",
     "pack": "npm run bootstrap && npm pack -w",

--- a/packages/components/src/DataList/components/DataListSearch/DataListSearch.module.css
+++ b/packages/components/src/DataList/components/DataListSearch/DataListSearch.module.css
@@ -16,10 +16,8 @@
   background-color: var(--color-surface);
   opacity: 0;
   transform: translateY(-50%);
-  transition:
-    opacity var(--transition-properties),
-    width var(--transition-properties),
-    visibility var(--transition-properties);
+  transition: opacity var(--transition-properties),
+    width var(--transition-properties), visibility var(--transition-properties);
 
   @media not (--medium-screens-and-up) {
     overflow: hidden;

--- a/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.module.css
+++ b/packages/components/src/DataList/components/DataListStickyHeader/DataListStickyHeader.module.css
@@ -27,15 +27,14 @@
   height: 0;
   background-color: var(--color-border);
   transform: translateX(-50%);
-  transition:
-    height var(--sticky-header-transition-properties) var(--timing-quick),
+  transition: height var(--sticky-header-transition-properties)
+      var(--timing-quick),
     width var(--sticky-header-transition-properties);
 }
 
 .stuck::before {
   width: 100%;
   height: var(--border-thick);
-  transition:
-    height var(--sticky-header-transition-properties),
+  transition: height var(--sticky-header-transition-properties),
     width var(--sticky-header-transition-properties) var(--timing-quick);
 }

--- a/packages/components/src/Disclosure/Disclosure.module.css
+++ b/packages/components/src/Disclosure/Disclosure.module.css
@@ -15,8 +15,7 @@
   list-style: none;
   cursor: pointer;
   outline-color: transparent;
-  transition:
-    background-color var(--timing-base) ease-out,
+  transition: background-color var(--timing-base) ease-out,
     box-shadow var(--timing-base);
 }
 

--- a/packages/components/src/InputFile/InputFile.module.css
+++ b/packages/components/src/InputFile/InputFile.module.css
@@ -16,8 +16,7 @@
   border: var(--border-base) dashed var(--color-border--interactive);
   border-radius: var(--radius-base);
   text-align: center;
-  transition:
-    border-color var(--timing-quick) ease-out,
+  transition: border-color var(--timing-quick) ease-out,
     background-color var(--timing-base) ease-out;
 }
 

--- a/packages/components/src/LightBox/LightBox.module.css
+++ b/packages/components/src/LightBox/LightBox.module.css
@@ -190,8 +190,7 @@
   height: 64px;
   border-radius: var(--radius-small);
   background-color: var(--color-surface);
-  transition:
-    border var(--timing-base) ease-in,
+  transition: border var(--timing-base) ease-in,
     border-radius var(--timing-quick) ease-in,
     transform var(--timing-quick) ease-in-out;
   flex-shrink: 0;

--- a/packages/components/src/Menu/Menu.module.css
+++ b/packages/components/src/Menu/Menu.module.css
@@ -71,8 +71,7 @@
   cursor: pointer;
   gap: var(--menu-space);
   align-items: center;
-  transition:
-    background-color var(--timing-base) ease-out,
+  transition: background-color var(--timing-base) ease-out,
     box-shadow var(--timing-base) ease-out;
 }
 

--- a/packages/components/src/SideDrawer/SideDrawer.module.css
+++ b/packages/components/src/SideDrawer/SideDrawer.module.css
@@ -41,8 +41,7 @@
   z-index: var(--elevation-base);
   padding: var(--sideDrawer--base-padding);
   background-color: var(--sideDrawer--background);
-  transition:
-    box-shadow var(--timing-base) ease-in-out,
+  transition: box-shadow var(--timing-base) ease-in-out,
     filter var(--timing-base) ease-in-out;
 }
 
@@ -65,8 +64,7 @@
 }
 
 .footer.hasShadow {
-  box-shadow:
-    0px var(--space-minuscule) var(--space-smaller) 0px
+  box-shadow: 0px var(--space-minuscule) var(--space-smaller) 0px
       rgba(var(--color-black--rgb), 0.1),
     0px -2px 12px 0px rgba(var(--color-black--rgb), 0.05);
 }
@@ -155,9 +153,7 @@
   width: 0;
   opacity: 0;
   transform: translateX(-8px);
-  transition:
-    width var(--transition),
-    transform var(--transition),
+  transition: width var(--transition), transform var(--transition),
     opacity var(--transition);
 
   &.backButtonVisible {

--- a/packages/design/.eslintrc
+++ b/packages/design/.eslintrc
@@ -1,10 +1,10 @@
 {
-    "rules": {
-        "import/no-internal-modules": "off",
-        "eslint-plugin-import/no-default-export": "off",
-        "import/no-default-export": "off"
-    },
-    "env": {
-        "jest": true
-    }
+  "rules": {
+    "import/no-internal-modules": "off",
+    "eslint-plugin-import/no-default-export": "off",
+    "import/no-default-export": "off"
+  },
+  "env": {
+    "jest": true
+  }
 }

--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -5,15 +5,17 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
-    "prettier",
-    "plugin:prettier/recommended",
     "plugin:jest/recommended",
     "plugin:import/typescript",
   ],
-  plugins: ["@typescript-eslint", "react", "prettier", "import", "jest"],
+  plugins: ["@typescript-eslint", "react", "import", "jest"],
   settings: {
     react: { version: "detect" },
-    "import/resolver": { typescript: {} },
+    "import/resolver": {
+      node: {
+        extensions: [".js", ".jsx", ".ts", ".tsx"],
+      },
+    },
   },
   parserOptions: {
     ecmaFeatures: { jsx: true },
@@ -29,7 +31,12 @@ module.exports = {
       },
     ],
     "import/no-default-export": "error",
-    "import/no-unresolved": ["error", { ignore: [".css$"] }],
+    "import/no-unresolved": [
+      "error",
+      {
+        ignore: [".css$", "react-native", "react-native-.*"],
+      },
+    ],
     "import/namespace": "error",
     "import/default": "error",
     "import/export": "error",
@@ -45,11 +52,6 @@ module.exports = {
     "import/newline-after-import": "error",
     "jest/no-jasmine-globals": "error",
     "react/no-danger": "error",
-    "prettier/prettier": [
-      "error",
-      { trailingComma: "all", arrowParens: "avoid" },
-      { usePrettierrc: false },
-    ],
     "@typescript-eslint/consistent-type-assertions": [
       "error",
       {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,11 +10,9 @@
     "@rushstack/eslint-patch": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
-    "eslint-config-prettier": "^8.7.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jest": "^27.2.1",
-    "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.33.2",
     "prettier": "^2.8.4"
   },

--- a/packages/site/src/components/VisibleWhenFocused.module.css
+++ b/packages/site/src/components/VisibleWhenFocused.module.css
@@ -1,14 +1,14 @@
 .container {
-    pointer-events: none;
-    position: absolute;
-    top: 0;
-    opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  opacity: 0;
 }
 
 .container:focus-within {
-    pointer-events: auto;
-    z-index: var(--elevation-modal);
-    margin-top: var(--space-base);
-    padding: var(--space-smaller);
-    opacity: 1;
+  pointer-events: auto;
+  z-index: var(--elevation-modal);
+  margin-top: var(--space-base);
+  padding: var(--space-smaller);
+  opacity: 1;
 }

--- a/packages/site/src/content/Container/Container.module.css
+++ b/packages/site/src/content/Container/Container.module.css
@@ -1,38 +1,38 @@
 @container example (min-width: 600px) {
-    .item {
-        background-color: var(--color-surface--background);
-        padding: var(--space-large);
-        padding-right: var(--space-largest);
-        border-radius: var(--radius-base);
-    }
+  .item {
+    background-color: var(--color-surface--background);
+    padding: var(--space-large);
+    padding-right: var(--space-largest);
+    border-radius: var(--radius-base);
+  }
 
-    .item>* {
-        padding: var(--space-small);
-    }
+  .item > * {
+    padding: var(--space-small);
+  }
 }
 
 @container first (min-width: 0px) {
-    .item {
-        background-color: var(--color-surface--background);
-        padding: var(--space-large);
-        padding-right: var(--space-largest);
-        border-radius: var(--radius-base);
-    }
+  .item {
+    background-color: var(--color-surface--background);
+    padding: var(--space-large);
+    padding-right: var(--space-largest);
+    border-radius: var(--radius-base);
+  }
 
-    .item>* {
-        padding: var(--space-small);
-    }
+  .item > * {
+    padding: var(--space-small);
+  }
 }
 
 @container second (min-width: 0px) {
-    .item {
-        background-color: var(--color-success);
-        padding: var(--space-large);
-        padding-right: var(--space-largest);
-        border-radius: var(--radius-base);
-    }
+  .item {
+    background-color: var(--color-success);
+    padding: var(--space-large);
+    padding-right: var(--space-largest);
+    border-radius: var(--radius-base);
+  }
 
-    .item>* {
-        padding: var(--space-small);
-    }
+  .item > * {
+    padding: var(--space-small);
+  }
 }

--- a/packages/site/src/content/DataList/DataListNotes.mdx
+++ b/packages/site/src/content/DataList/DataListNotes.mdx
@@ -330,12 +330,12 @@ DataList.Search adds a search input to the list. This is debounced by 500ms.
 
 #### Controlling the search input
 
-By default, DataList.Search is uncontrolled and internally manages its value.
-If you need the ability to control it, you can pass in a `value` prop and use
-the `onSearch` prop to handle updating your state with the latest value. In
-this case `onSearch` will *not* be debounced. Be sure to gracefully handle
-rapid key presses and avoid over-triggering expensive operations, like network
-requests for example.
+By default, DataList.Search is uncontrolled and internally manages its value. If
+you need the ability to control it, you can pass in a `value` prop and use the
+`onSearch` prop to handle updating your state with the latest value. In this
+case `onSearch` will _not_ be debounced. Be sure to gracefully handle rapid key
+presses and avoid over-triggering expensive operations, like network requests
+for example.
 
 ```tsx
 const [searchValue, setSearchValue] = useState("");
@@ -347,12 +347,12 @@ const debouncedRequest = useDebounce((search: string) => {
 <DataList>
   <DataList.Search
     value={searchValue}
-    onSearch={(search) => {
+    onSearch={search => {
       setSearchValue(search);
       debouncedRequest(search);
     }}
   />
-</DataList>
+</DataList>;
 ```
 
 ### Empty state

--- a/packages/site/src/content/Popover/PopoverNotes.mdx
+++ b/packages/site/src/content/Popover/PopoverNotes.mdx
@@ -1,6 +1,5 @@
 ## Component customization
 
-
 ### Composable usage
 
 Popover exposes its internal building blocks as subcomponents:
@@ -15,20 +14,17 @@ Here's a basic example of how our current non-composable Popover is used:
   open={showPopover}
   onRequestClose={() => setShowPopover(false)}
 >
-  <Content>
-    Popover content goes here
-  </Content>
+  <Content>Popover content goes here</Content>
 </Popover>
 ```
 
-Using Popover's built-in subcomponents, this UI can alternatively be expressed as:
+Using Popover's built-in subcomponents, this UI can alternatively be expressed
+as:
 
 ```tsx
 <Popover.Provider attachTo={elementRef} open={showPopover}>
   <Popover.DismissButton onClick={() => setShowPopover(false)} />
-  <Content>
-    Popover content goes here
-  </Content>
+  <Content>Popover content goes here</Content>
   <Popover.Arrow />
 </Popover.Provider>
 ```
@@ -38,9 +34,7 @@ so:
 
 ```tsx
 <Popover.Provider attachTo={elementRef} open={showPopover}>
-  <Content>
-    Popover content goes here
-  </Content>
+  <Content>Popover content goes here</Content>
 </Popover.Provider>
 ```
 
@@ -54,9 +48,7 @@ component into `Popover.DismissButton`:
       <Button.Icon name="eyeCrossed" />
     </Button>
   </Popover.DismissButton>
-  <Content>
-    Popover content goes here
-  </Content>
+  <Content>Popover content goes here</Content>
   <Popover.Arrow />
 </Popover.Provider>
 ```
@@ -124,9 +116,7 @@ If you're using Popover with its composable subcomponents, you'll need to pass
       dismissButtonContainer: styles.customDismissButton,
     }}
   />
-  <Content>
-    Popover content goes here
-  </Content>
+  <Content>Popover content goes here</Content>
   <Popover.Arrow
     UNSAFE_className={{
       arrow: styles.customArrow,
@@ -134,7 +124,6 @@ If you're using Popover with its composable subcomponents, you'll need to pass
   />
 </Popover.Provider>
 ```
-
 
 #### UNSAFE_style
 
@@ -169,9 +158,7 @@ If you're using Popover with its composable subcomponents, you'll need to pass
       },
     }}
   />
-  <Content>
-    Popover content goes here
-  </Content>
+  <Content>Popover content goes here</Content>
   <Popover.Arrow
     UNSAFE_style={{
       arrow: {

--- a/packages/site/src/guides/page-layouts.module.css
+++ b/packages/site/src/guides/page-layouts.module.css
@@ -1,39 +1,39 @@
 @container container-items (min-width:0px) {
-    .item>* {
-        --color-border: var(--color-critical);
-        --border-base: var(--border-thick);
-    }
+  .item > * {
+    --color-border: var(--color-critical);
+    --border-base: var(--border-thick);
+  }
 
-    .itemDotted>* {
-        --color-border: var(--color-task);
-        border-style: dotted;
-        --border-base: var(--border-thicker);
-    }
+  .itemDotted > * {
+    --color-border: var(--color-task);
+    border-style: dotted;
+    --border-base: var(--border-thicker);
+  }
 
-    .itemUpsideDown>* {
-        --color-border: var(--color-critical);
-        --border-base: var(--border-thicker);
-    }
+  .itemUpsideDown > * {
+    --color-border: var(--color-critical);
+    --border-base: var(--border-thicker);
+  }
 }
 
 @container container-items (max-width: 600px) {
-    .item>* {
-        --color-border: var(--color-success);
-        --border-base: var(--border-thicker);
-    }
+  .item > * {
+    --color-border: var(--color-success);
+    --border-base: var(--border-thicker);
+  }
 }
 
 @container container-items (max-width: 650px) {
-    .itemDotted>* {
-        --color-border: var(--color-visit);
-        border-style: dotted;
-        --border-base: var(--border-thicker);
-    }
+  .itemDotted > * {
+    --color-border: var(--color-visit);
+    border-style: dotted;
+    --border-base: var(--border-thicker);
+  }
 }
 
 @container container-items (max-width: 700px) {
-    .itemUpsideDown>* {
-        --color-border: var(--color-event);
-        --border-base: var(--border-thick);
-    }
+  .itemUpsideDown > * {
+    --color-border: var(--color-event);
+    --border-base: var(--border-thick);
+  }
 }

--- a/packages/site/src/guides/scaffolding.module.css
+++ b/packages/site/src/guides/scaffolding.module.css
@@ -1,13 +1,13 @@
 @media (max-width: 1285px) {
-    .actions>div> :first-child {
-        width: 100%;
-    }
+  .actions > div > :first-child {
+    width: 100%;
+  }
 
-    .actions>div> :nth-child(2) {
-        flex-grow: 1;
-    }
+  .actions > div > :nth-child(2) {
+    flex-grow: 1;
+  }
 
-    .actions>div> :nth-child(3) {
-        flex-grow: 1;
-    }
+  .actions > div > :nth-child(3) {
+    flex-grow: 1;
+  }
 }

--- a/packages/site/src/layout/NavMenu.module.css
+++ b/packages/site/src/layout/NavMenu.module.css
@@ -15,7 +15,7 @@
   }
 }
 
-.navMenuContainer>* {
+.navMenuContainer > * {
   padding-left: var(--space-base);
   padding-right: var(--space-base);
   padding-bottom: var(--space-base);
@@ -53,7 +53,6 @@
   background-color: var(--color-surface);
   border-radius: var(--radius-small);
 }
-
 
 .navMenuLink {
   color: var(--color-text);

--- a/packages/site/src/layout/SearchBox.module.css
+++ b/packages/site/src/layout/SearchBox.module.css
@@ -1,8 +1,8 @@
 .searchBoxResults {
-    width: 100%;
-    height: 600px;
-    max-height: calc(100vh - 240px);
-    overflow-y: scroll;
-    padding: var(--space-smallest);
-    box-sizing: border-box;
+  width: 100%;
+  height: 600px;
+  max-height: calc(100vh - 240px);
+  overflow-y: scroll;
+  padding: var(--space-smallest);
+  box-sizing: border-box;
 }

--- a/packages/site/src/layout/SearchButton.module.css
+++ b/packages/site/src/layout/SearchButton.module.css
@@ -10,8 +10,8 @@
   transition: all var(--timing-base) ease-out;
 
   &:focus-visible {
-      box-shadow: var(--shadow-focus);
-      background-color: var(--color-surface--background--hover);
+    box-shadow: var(--shadow-focus);
+    background-color: var(--color-surface--background--hover);
   }
 }
 

--- a/packages/site/src/main.css
+++ b/packages/site/src/main.css
@@ -51,7 +51,6 @@ h6 {
   text-transform: uppercase;
 }
 
-
 a {
   margin: calc(-1 * var(--space-smallest));
   padding: var(--space-smallest);
@@ -130,7 +129,6 @@ section[role="tabpanel"] {
     margin: 0;
     padding: var(--space-base);
   }
-
 }
 
 pre,
@@ -164,7 +162,7 @@ pre.root-pre {
   padding: var(--space-large);
 }
 
-section[role="tabpanel"]>div>h1:first-of-type {
+section[role="tabpanel"] > div > h1:first-of-type {
   display: none;
 }
 

--- a/packages/site/src/pages/NotFoundPage.module.css
+++ b/packages/site/src/pages/NotFoundPage.module.css
@@ -1,24 +1,29 @@
+.container {
+  display: flex;
+  align-items: flex-start;
+  background: var(--color-informative--surface);
+  height: 100%;
+  justify-content: center;
+  box-sizing: border-box;
+  position: relative;
+  padding-top: var(--space-largest);
+}
 
+@media screen and (min-width: 1024px) {
   .container {
-    display: flex;
-    align-items: flex-start;
-    background: var(--color-informative--surface);
-    height: 100%;
-    justify-content: center;
-    box-sizing: border-box;
-    position: relative;
-    padding-top: var(--space-largest);
-  }
+    align-items: center;
+    background: var(--color-informative--onSurface);
+    background: linear-gradient(
+      to bottom,
+      var(--color-informative--onSurface) 0%,
+      var(--color-surface) 40%
+    );
 
-  @media screen and (min-width: 1024px) {
-    .container {
-        align-items: center;
-        background: var(--color-informative--onSurface);
-        background: linear-gradient(to bottom, var(--color-informative--onSurface) 0%, var(--color-surface) 40% );
-    
-        /* The Wavy part */
-        mask: radial-gradient(64px at 50% 90px, #000 99%, #0000 101%) calc(50% - 100px) 0 / 200px 100%, 
-              radial-gradient(64px at 50% -40px, #0000 99%, #000 101%) 50% 50px / 200px 100% repeat-x;
+    /* The Wavy part */
+    mask: radial-gradient(64px at 50% 90px, #000 99%, #0000 101%)
+        calc(50% - 100px) 0 / 200px 100%,
+      radial-gradient(64px at 50% -40px, #0000 99%, #000 101%) 50% 50px / 200px
+        100% repeat-x;
   }
 
   .content {
@@ -29,19 +34,20 @@
     padding: var(--space-largest);
   }
 
-  @keyframes swim
-  {
-    0% { 
-      display: block; 
-      margin-right: -100%; 
+  @keyframes swim {
+    0% {
+      display: block;
+      margin-right: -100%;
     }
-    100% { 
-      margin-right: 150%; 
+    100% {
+      margin-right: 150%;
     }
   }
 
   @keyframes bounce {
-    0%, 50%, 100% {
+    0%,
+    50%,
+    100% {
       transform: translateY(0);
     }
     25% {
@@ -55,17 +61,15 @@
   .fish {
     display: none;
   }
-  
+
   @media screen and (min-width: 1024px) {
-  .fish {
-    display: block;
+    .fish {
+      display: block;
       margin-top: -200px;
       margin-right: -100%;
-      position: absolute;	
+      position: absolute;
       animation: swim 30s linear infinite, bounce 2s infinite;
       font-size: var(--typography--fontSize-jumbo);
+    }
   }
-}
-  
-
 }

--- a/packages/stylelint-config/stylelint.config.js
+++ b/packages/stylelint-config/stylelint.config.js
@@ -2,12 +2,10 @@
 module.exports = {
   extends: ["stylelint-config-recommended", "stylelint-config-css-modules"],
   plugins: [
-    "stylelint-prettier",
     "stylelint-order",
     "stylelint-declaration-block-no-ignored-properties",
   ],
   rules: {
-    "prettier/prettier": true,
     "color-named": "never",
     "color-no-hex": true,
     "plugin/declaration-block-no-ignored-properties": true,


### PR DESCRIPTION

## Motivations

Some of our eslint plugins are outdated, so this PR removes them in favour of cleaner prettier/eslint/stylelint approaches. Each tool now operates on their own, and we no longer prevent prettier from running.

## Changes

1. Removed eslint plugs that mixed with prettier
2. Re-enabled Prettier in the repo.



## Testing

1. Linting should still work properly
2. Prettier should work in the repo

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
