### PR TITLE
feat(components): Use FloatingUI for Tooltip

### DIFF
--- a/packages/components/src/Tooltip/Tooltip.test.tsx
+++ b/packages/components/src/Tooltip/Tooltip.test.tsx
@@ -3,10 +3,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Tooltip } from ".";
 
-// We automatically mock popper (__mocks__/@popperjs/core.js), but in this test suite
-// we are verifying certain behaviours that require popper to be active.
-jest.unmock("@popperjs/core");
-
 it("shouldn't show the tooltip", async () => {
   const message = "Imma not tip the tool";
   const content = "Don't show my tooltip";
@@ -143,7 +139,7 @@ describe("with a preferred placement", () => {
 
       const tooltip = screen.getByRole("tooltip");
 
-      expect(tooltip).toHaveAttribute("data-popper-placement", placement);
+      expect(tooltip).toHaveAttribute("data-placement", placement);
       expect(tooltip).toHaveClass(placement);
     },
   );

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -1,9 +1,8 @@
-import React, { ReactElement, ReactNode, useState } from "react";
+import React, { ReactElement, useState } from "react";
 import classnames from "classnames";
-import ReactDOM from "react-dom";
+import { FloatingPortal } from "@floating-ui/react";
 import { motion } from "framer-motion";
 import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
-import { useIsMounted } from "@jobber/hooks/useIsMounted";
 import styles from "./Tooltip.module.css";
 import { useTooltipPositioning } from "./useTooltipPositioning";
 import { Placement } from "./Tooltip.types";
@@ -40,7 +39,7 @@ export function Tooltip({
     attributes,
     placement,
     shadowRef,
-    styles: popperStyles,
+    styles: floatingStyles,
     setArrowRef,
     setTooltipRef,
   } = useTooltipPositioning({ preferredPlacement: preferredPlacement });
@@ -59,13 +58,14 @@ export function Tooltip({
     <>
       <span className={styles.shadowActivator} ref={shadowRef} />
       {children}
-      <TooltipPortal>
+      <FloatingPortal>
         {show && Boolean(message) && (
           <div
             className={toolTipClassNames}
-            style={popperStyles.popper}
+            style={floatingStyles.popper}
             ref={setTooltipRef}
             role="tooltip"
+            data-placement={placement}
             {...attributes.popper}
           >
             <motion.div
@@ -83,13 +83,23 @@ export function Tooltip({
               <p className={styles.tooltipMessage}>{message}</p>
               <div
                 ref={setArrowRef}
-                style={popperStyles.arrow}
+                style={{
+                  position: "absolute",
+                  left:
+                    floatingStyles.arrow?.x != null
+                      ? `${floatingStyles.arrow?.x}px`
+                      : "",
+                  top:
+                    floatingStyles.arrow?.y != null
+                      ? `${floatingStyles.arrow?.y}px`
+                      : "",
+                }}
                 className={styles.arrow}
               />
             </motion.div>
           </div>
         )}
-      </TooltipPortal>
+      </FloatingPortal>
     </>
   );
 
@@ -146,18 +156,4 @@ export function Tooltip({
       };
     }, []);
   }
-}
-
-interface TooltipPortalProps {
-  readonly children: ReactNode;
-}
-
-function TooltipPortal({ children }: TooltipPortalProps) {
-  const mounted = useIsMounted();
-
-  if (!mounted?.current) {
-    return null;
-  }
-
-  return ReactDOM.createPortal(children, document.body);
 }

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -76,7 +76,7 @@ export function Tooltip({
         {show && Boolean(message) && (
           <div
             className={toolTipClassNames}
-            style={floatingStyles.popper}
+            style={floatingStyles.float}
             ref={setTooltipRef}
             role="tooltip"
             data-placement={placement}

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -53,6 +53,17 @@ export function Tooltip({
     placement === "right" && styles.right,
   );
 
+  const arrowStyles: React.CSSProperties = {
+    position: "absolute",
+    // only left or top will be defined at a time
+    left: Number.isFinite(floatingStyles.arrow?.x)
+      ? `${floatingStyles.arrow?.x}px`
+      : "",
+    top: Number.isFinite(floatingStyles.arrow?.y)
+      ? `${floatingStyles.arrow?.y}px`
+      : "",
+  };
+
   return (
     <>
       <span className={styles.shadowActivator} ref={shadowRef} />
@@ -81,17 +92,7 @@ export function Tooltip({
               <p className={styles.tooltipMessage}>{message}</p>
               <div
                 ref={setArrowRef}
-                style={{
-                  position: "absolute",
-                  left:
-                    floatingStyles.arrow?.x != null
-                      ? `${floatingStyles.arrow?.x}px`
-                      : "",
-                  top:
-                    floatingStyles.arrow?.y != null
-                      ? `${floatingStyles.arrow?.y}px`
-                      : "",
-                }}
+                style={arrowStyles}
                 className={styles.arrow}
               />
             </motion.div>

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -53,15 +53,18 @@ export function Tooltip({
     placement === "right" && styles.right,
   );
 
+  const arrowX = floatingStyles.arrow?.x;
+  const arrowY = floatingStyles.arrow?.y;
   const arrowStyles: React.CSSProperties = {
     position: "absolute",
-    // only left or top will be defined at a time
-    left: Number.isFinite(floatingStyles.arrow?.x)
-      ? `${floatingStyles.arrow?.x}px`
-      : "",
-    top: Number.isFinite(floatingStyles.arrow?.y)
-      ? `${floatingStyles.arrow?.y}px`
-      : "",
+    left:
+      arrowX !== null && arrowX !== undefined
+        ? `${floatingStyles.arrow?.x}px`
+        : "",
+    top:
+      arrowY !== null && arrowY !== undefined
+        ? `${floatingStyles.arrow?.y}px`
+        : "",
   };
 
   return (

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement, useState } from "react";
+import React, { ReactElement, ReactNode, useState } from "react";
 import classnames from "classnames";
 import { FloatingPortal } from "@floating-ui/react";
 import { motion } from "framer-motion";
 import { useSafeLayoutEffect } from "@jobber/hooks/useSafeLayoutEffect";
+import { useIsMounted } from "@jobber/hooks/useIsMounted";
 import styles from "./Tooltip.module.css";
 import { useTooltipPositioning } from "./useTooltipPositioning";
 import { Placement } from "./Tooltip.types";
@@ -71,7 +72,7 @@ export function Tooltip({
     <>
       <span className={styles.shadowActivator} ref={shadowRef} />
       {children}
-      <FloatingPortal>
+      <TooltipPortal>
         {show && Boolean(message) && (
           <div
             className={toolTipClassNames}
@@ -101,7 +102,7 @@ export function Tooltip({
             </motion.div>
           </div>
         )}
-      </FloatingPortal>
+      </TooltipPortal>
     </>
   );
 
@@ -158,4 +159,18 @@ export function Tooltip({
       };
     }, []);
   }
+}
+
+interface TooltipPortalProps {
+  readonly children: ReactNode;
+}
+
+function TooltipPortal({ children }: TooltipPortalProps) {
+  const mounted = useIsMounted();
+
+  if (!mounted?.current) {
+    return null;
+  }
+
+  return <FloatingPortal>{children}</FloatingPortal>;
 }

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -36,7 +36,6 @@ export function Tooltip({
   const [show, setShow] = useState(false);
 
   const {
-    attributes,
     placement,
     shadowRef,
     styles: floatingStyles,
@@ -66,7 +65,6 @@ export function Tooltip({
             ref={setTooltipRef}
             role="tooltip"
             data-placement={placement}
-            {...attributes.popper}
           >
             <motion.div
               className={styles.tooltip}

--- a/packages/components/src/Tooltip/useTooltipPositioning.ts
+++ b/packages/components/src/Tooltip/useTooltipPositioning.ts
@@ -48,7 +48,7 @@ export function useTooltipPositioning({
 
   return {
     styles: {
-      popper: floatingStyles,
+      float: floatingStyles,
       arrow: middlewareData.arrow,
     },
     placement: placement,

--- a/packages/components/src/Tooltip/useTooltipPositioning.ts
+++ b/packages/components/src/Tooltip/useTooltipPositioning.ts
@@ -9,7 +9,6 @@ import {
 } from "@floating-ui/react";
 import { Placement } from "./Tooltip.types";
 
-const DEFAULT_PLACEMENT: Placement = "top";
 const TOOLTIP_SHIFT_PADDING = 8;
 const TOOLTIP_ARROW_PADDING = 6;
 
@@ -52,8 +51,7 @@ export function useTooltipPositioning({
       popper: floatingStyles,
       arrow: middlewareData.arrow,
     },
-    attributes: { popper: {} },
-    placement: placement || DEFAULT_PLACEMENT,
+    placement: placement,
     shadowRef,
     setArrowRef,
     setTooltipRef: refs.setFloating,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Popper is deprecated. replaced by FloatingUI.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

shift middleware allows it to sort of follow you along as you scroll for example

this will be impossible to do with the hover trigger but focusing can happen. also added the shiftLimiter to prevent it from showing up off screen.

### Changed

- replaced usePopper with useFloating
- renamed anything referencing popper
- swapped the ReactDOM portal for FloatingPortal


### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

**shift + limitshift** 

since tooltips respond to focus, focus the activator element then scroll. the tooltip should shift along with the movement, and the arrow should move along with you BUT hit the edge at such a point that doesn't look bad with the rounded border radius.

furthermore the shift should not apply to things fully off screen. so if you have a tooltip on something, focus it, then scroll it completely out of view it shouldn't be stuck at the X/Y coordinates where it would have been if it were in view.

**arrow position**
should be correct and look good

**placement**
preferred placement should be respected

it should adjust based on available space and use sensible fallbacks

**portal**

if you put it inside something with `overflow:hidden` it should still show because it's out on the body



Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
