### PR TITLE
fix(components): Fix InputNumber v2 to not wrap react node description in Text

### DIFF
--- a/packages/components/src/InputNumber/InputNumber.rebuilt.test.tsx
+++ b/packages/components/src/InputNumber/InputNumber.rebuilt.test.tsx
@@ -82,3 +82,23 @@ test("it should clamp value to minValue when value is below minValue", () => {
   expect(input).toBeVisible();
   expect(input).toHaveValue("10");
 });
+
+test("it should render element description directly without wrapping in paragraph", () => {
+  const customDescription = (
+    <div data-testid="custom-description">Custom element description</div>
+  );
+
+  const { getByTestId } = render(
+    <InputNumber
+      version={2}
+      placeholder="Number"
+      description={customDescription}
+    />,
+  );
+
+  const descriptionElement = getByTestId("custom-description");
+  expect(descriptionElement).toBeVisible();
+  expect(descriptionElement.parentElement).not.toBeInstanceOf(
+    HTMLParagraphElement,
+  );
+});

--- a/packages/components/src/InputNumber/InputNumber.rebuilt.tsx
+++ b/packages/components/src/InputNumber/InputNumber.rebuilt.tsx
@@ -73,6 +73,8 @@ export const InputNumberRebuilt = forwardRef(
       ...ariaNumberFieldProps
     } = props;
 
+    const stringDescription = typeof description === "string";
+
     return (
       <AriaNumberField
         {...ariaNumberFieldProps}
@@ -119,9 +121,13 @@ export const InputNumberRebuilt = forwardRef(
             elementType="div"
             slot="description"
           >
-            <Text size="small" variation="subdued">
-              {description}
-            </Text>
+            {stringDescription ? (
+              <Text size="small" variation="subdued">
+                {description}
+              </Text>
+            ) : (
+              description
+            )}
           </AriaText>
         )}
         {error && (


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Recently we allowed react nodes for all form field description props: https://github.com/GetJobber/atlantis/pull/2633

@ZakaryH found that InputNumber v2 was incorrectly passing react node descriptions into a `<Text>` wrapper still.

This PR fixes that.



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- Fix InputNumber v2 to not wrap react node descriptions in Text


## Testing

1. Pull this branch, npm run bootstrap, run storybook
2. Modify the basic story template in `docs/components/InputNumber/Web.stories.tsx`
    * set `version={2}`
    * set `description={<div>This is a description</div>}`
3. View the story and confirm it's not wrapped inside a `<p>` tag
4. Change description to a raw string
5. Confirm the story renders it inside a `<p>` tag


Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
