### PR TITLE
fix(components): Don't import directly from the hooks barrel file

### DIFF
--- a/packages/components/src/FormField/FormFieldTypes.ts
+++ b/packages/components/src/FormField/FormFieldTypes.ts
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, ReactNode, RefObject } from "react";
 import { RegisterOptions } from "react-hook-form";
 import { XOR } from "ts-xor";
-import { type Clearable } from "@jobber/hooks/useShowClear";
+import { Clearable } from "@jobber/hooks";
 import { IconNames } from "../Icon";
 
 export type FormFieldTypes =

--- a/packages/components/src/InputEmail/InputEmail.types.ts
+++ b/packages/components/src/InputEmail/InputEmail.types.ts
@@ -1,4 +1,4 @@
-import { type Clearable } from "@jobber/hooks/useShowClear";
+import { Clearable } from "@jobber/hooks";
 import { CommonFormFieldProps, FormFieldProps } from "../FormField";
 
 export type InputEmailLegacyProps = CommonFormFieldProps &

--- a/packages/components/src/InputText/InputText.types.ts
+++ b/packages/components/src/InputText/InputText.types.ts
@@ -1,4 +1,4 @@
-import { type Clearable } from "@jobber/hooks/useShowClear";
+import { Clearable } from "@jobber/hooks";
 import { XOR } from "ts-xor";
 import {
   AutocompleteTypes,


### PR DESCRIPTION

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This led to a production build error due to the way vite's rollup bundles our app. In vite dev mode, powered by esbuild, we didn't see this issue, but production builds use rollup which behaves differently.

The hooks package is lacking support for esm, so we suspect that's what caused rollup to build things differently.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Changed

- Fix import to be direct


## Testing

* Make a prerelease
* Install that in the app
* Run `pnpm dedupe && pnpm run build && pnpm run preview`

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
