### PR TITLE
feat(components): Custom ESLintr Rule for Hook Imports

### DIFF
--- a/packages/components/.eslintrc.cjs
+++ b/packages/components/.eslintrc.cjs
@@ -1,4 +1,14 @@
+require("@jobber/eslint-config/patch-eslint-plugin-resolution.js");
+
 module.exports = {
+  root: true,
+  env: { browser: true, es6: true, node: true },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaFeatures: { jsx: true },
+    ecmaVersion: 2018,
+    sourceType: "module",
+  },
   rules: {
     "import/no-internal-modules": [
       "error",
@@ -6,5 +16,8 @@ module.exports = {
         allow: ["**"],
       },
     ],
+    // Custom rule to enforce specific @jobber/hooks imports
+    "jobber/prefer-specific-hooks-import": "error",
   },
+  plugins: ["jobber", "import"],
 };

--- a/packages/eslint-config/eslint-plugin-jobber.js
+++ b/packages/eslint-config/eslint-plugin-jobber.js
@@ -1,0 +1,19 @@
+/**
+ * ESLint plugin for @jobber packages
+ *
+ * This plugin provides custom rules specific to Jobber's codebase
+ */
+
+const rules = require("./rules");
+
+module.exports = {
+  rules,
+  configs: {
+    recommended: {
+      plugins: ["jobber"],
+      rules: {
+        "jobber/prefer-specific-hooks-import": "error",
+      },
+    },
+  },
+};

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,9 @@
   "main": ".eslintrc.js",
   "license": "MIT",
   "files": [
-    "patch-eslint-plugin-resolution.js"
+    "patch-eslint-plugin-resolution.js",
+    "rules/",
+    "eslint-plugin-jobber.js"
   ],
   "dependencies": {
     "@rushstack/eslint-patch": "^1.2.0",

--- a/packages/eslint-config/patch-eslint-plugin-resolution.js
+++ b/packages/eslint-config/patch-eslint-plugin-resolution.js
@@ -1,2 +1,16 @@
 // eslint-disable-next-line import/no-internal-modules
 require("@rushstack/eslint-patch/modern-module-resolution");
+
+// Register our custom plugin
+const Module = require("module");
+const path = require("path");
+
+const originalResolveFilename = Module._resolveFilename;
+
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (request === "eslint-plugin-jobber") {
+    return path.resolve(__dirname, "eslint-plugin-jobber.js");
+  }
+
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};

--- a/packages/eslint-config/rules/index.js
+++ b/packages/eslint-config/rules/index.js
@@ -1,0 +1,7 @@
+/**
+ * Custom ESLint rules for @jobber packages
+ */
+
+module.exports = {
+  "prefer-specific-hooks-import": require("./prefer-specific-hooks-import"),
+};

--- a/packages/eslint-config/rules/prefer-specific-hooks-import.js
+++ b/packages/eslint-config/rules/prefer-specific-hooks-import.js
@@ -1,0 +1,99 @@
+/**
+ * Custom ESLint rule to enforce specific import patterns for @jobber/hooks
+ *
+ * This rule enforces that imports from "@jobber/hooks" should use specific
+ * hook imports like "@jobber/hooks/useBool" instead of named imports from
+ * the main package.
+ *
+ * ❌ Bad:  import { useBool } from "@jobber/hooks";
+ * ✅ Good: import { useBool } from "@jobber/hooks/useBool";
+ */
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "enforce specific import paths for @jobber/hooks",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      preferSpecificImport:
+        "Import '{{hookName}}' from '@jobber/hooks/{{hookName}}' instead of '@jobber/hooks'",
+    },
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        // Only check imports from "@jobber/hooks"
+        if (node.source.value !== "@jobber/hooks") {
+          return;
+        }
+
+        // Only check named imports (not default or namespace imports)
+        const namedImports = node.specifiers.filter(
+          spec => spec.type === "ImportSpecifier",
+        );
+
+        if (namedImports.length === 0) {
+          return;
+        }
+
+        // Check each named import
+        namedImports.forEach(specifier => {
+          const hookName = specifier.imported.name;
+
+          // Verify it follows the "use" pattern (hooks should start with "use")
+          if (!hookName.startsWith("use")) {
+            return;
+          }
+
+          context.report({
+            node: specifier,
+            messageId: "preferSpecificImport",
+            data: {
+              hookName,
+            },
+            fix(fixer) {
+              // If there's only one named import, replace the entire import
+              if (namedImports.length === 1) {
+                return fixer.replaceText(
+                  node,
+                  `import { ${hookName} } from "@jobber/hooks/${hookName}";`,
+                );
+              }
+
+              // If there are multiple named imports, we need to split them
+              // This is more complex, so for now we'll handle the simple case
+              // and let the user manually fix complex cases
+              const otherImports = namedImports
+                .filter(spec => spec !== specifier)
+                .map(spec => spec.imported.name);
+
+              if (otherImports.length > 0) {
+                // Create two separate import statements
+                const remainingImports = `import { ${otherImports.join(
+                  ", ",
+                )} } from "@jobber/hooks";`;
+                const specificImport = `import { ${hookName} } from "@jobber/hooks/${hookName}";`;
+
+                return [
+                  fixer.replaceText(node, remainingImports),
+                  fixer.insertTextAfter(node, `\n${specificImport}`),
+                ];
+              }
+
+              return fixer.replaceText(
+                node,
+                `import { ${hookName} } from "@jobber/hooks/${hookName}";`,
+              );
+            },
+          });
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
