### PR TITLE
fix(components): Add missing slim class for Content spacing

### DIFF
--- a/packages/components/src/Content/Spacing.module.css
+++ b/packages/components/src/Content/Spacing.module.css
@@ -1,7 +1,3 @@
-.slim > :not(:last-child) {
-  margin-bottom: var(--space-slim);
-}
-
 .minuscule > :not(:last-child) {
   margin-bottom: var(--space-minuscule);
 }
@@ -16,6 +12,10 @@
 
 .small > :not(:last-child) {
   margin-bottom: var(--space-small);
+}
+
+.slim > :not(:last-child) {
+  margin-bottom: var(--space-slim);
 }
 
 .base > :not(:last-child) {

--- a/packages/components/src/Content/Spacing.module.css.d.ts
+++ b/packages/components/src/Content/Spacing.module.css.d.ts
@@ -1,9 +1,9 @@
 declare const styles: {
-  readonly "slim": string;
   readonly "minuscule": string;
   readonly "smallest": string;
   readonly "smaller": string;
   readonly "small": string;
+  readonly "slim": string;
   readonly "base": string;
   readonly "large": string;
   readonly "larger": string;


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Just noticed that `Content` spacing was missing the `slim` class. This PR adds that.

<img width="1510" height="839" alt="Screenshot 2025-08-06 at 11 14 29 AM" src="https://github.com/user-attachments/assets/dfcde348-50f6-4aa6-8826-cd4f8fcc86ce" />


## Changes

### Fixed

- Add missing slim class for Content


## Testing

* Check the storybook preview: https://cleanup-add-missing-slim-cla.atlantis.pages.dev/storybook/?path=/story/components-layouts-and-structure-content-web--basic&args=spacing:slim
* Confirm `slim` is now an option

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
