### PR TITLE
feat(components): Add numberOfLines prop to Heading [132044]

### DIFF
--- a/docs/components/Heading/Web.stories.tsx
+++ b/docs/components/Heading/Web.stories.tsx
@@ -36,26 +36,102 @@ Levels.args = { level: 1 };
 
 const TruncationTemplate: ComponentStory<typeof Heading> = () => {
   return (
-    <div style={{ width: "300px", border: "1px dashed #ccc", padding: "16px" }}>
-      <Content>
-        <Heading level={3} numberOfLines={1}>
-          numberOfLines=1: This heading demonstrates single line truncation and
-          will cut off any text that exceeds the container width with ellipsis
-        </Heading>
-        <Divider />
-        <Heading level={3} numberOfLines={2}>
-          numberOfLines=2: This heading shows two line truncation behavior and
-          will allow text to wrap to exactly two lines before truncating with an
-          ellipsis at the end
-        </Heading>
-        <Divider />
-        <Heading level={3}>
-          No numberOfLines prop: This heading will wrap naturally without any
-          truncation limits and can span as many lines as needed to display all
-          the content
-        </Heading>
-      </Content>
-    </div>
+    <Content spacing="large">
+      <div>
+        <Heading level={2}>Fixed Width Container</Heading>
+        <div
+          style={{ width: "300px", border: "1px dashed #ccc", padding: "16px" }}
+        >
+          <Content>
+            <Heading level={3} maxLines="single">
+              maxLines=&quot;single&quot;: This heading demonstrates single line
+              truncation and will cut off any text that exceeds the container
+              width with ellipsis
+            </Heading>
+            <Divider />
+            <Heading level={3} maxLines="small">
+              maxLines=&quot;small&quot;: This heading shows two line truncation
+              behavior and will allow text to wrap to exactly two lines before
+              truncating with an ellipsis at the end
+            </Heading>
+            <Divider />
+            <Heading level={3}>
+              No maxLines prop: This heading will wrap naturally without any
+              truncation limits and can span as many lines as needed to display
+              all the content
+            </Heading>
+          </Content>
+        </div>
+      </div>
+
+      <div>
+        <Heading level={2}>Flex Layout (70% width)</Heading>
+        <div
+          style={{
+            display: "flex",
+            border: "1px dashed #999",
+            padding: "16px",
+            gap: "16px",
+          }}
+        >
+          <div
+            style={{
+              flex: "0 0 70%",
+              border: "1px solid #ddd",
+              padding: "12px",
+            }}
+          >
+            <Content>
+              <Heading level={3} maxLines="single">
+                maxLines=&quot;single&quot;: Flex item with 70% width showing
+                truncation works with flexible layouts and responsive design
+              </Heading>
+              <Divider />
+              <Heading level={3} maxLines="small">
+                maxLines=&quot;small&quot;: This heading in a flex container
+                demonstrates that truncation works perfectly with CSS flexbox
+                and dynamic width calculations
+              </Heading>
+            </Content>
+          </div>
+          <div style={{ flex: "1", border: "1px solid #ddd", padding: "12px" }}>
+            <Heading level={4}>Sidebar</Heading>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <Heading level={2}>Grid Layout (2fr + 1fr)</Heading>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "2fr 1fr",
+            gap: "16px",
+            border: "1px dashed #999",
+            padding: "16px",
+          }}
+        >
+          <div style={{ border: "1px solid #ddd", padding: "12px" }}>
+            <Content>
+              <Heading level={3} maxLines="single">
+                maxLines=&quot;single&quot;: Grid item with 2fr showing that
+                truncation adapts to CSS Grid fractional units automatically
+              </Heading>
+              <Divider />
+              <Heading level={3} maxLines="base">
+                maxLines=&quot;base&quot;: This heading demonstrates truncation
+                in CSS Grid layouts with fractional units, showing how the
+                component adapts to dynamic widths calculated by the grid
+                algorithm without needing explicit pixel values
+              </Heading>
+            </Content>
+          </div>
+          <div style={{ border: "1px solid #ddd", padding: "12px" }}>
+            <Heading level={4}>1fr column</Heading>
+          </div>
+        </div>
+      </div>
+    </Content>
   );
 };
 

--- a/docs/components/Heading/Web.stories.tsx
+++ b/docs/components/Heading/Web.stories.tsx
@@ -33,3 +33,31 @@ const LevelsTemplate: ComponentStory<typeof Heading> = args => {
 
 export const Levels = LevelsTemplate.bind({});
 Levels.args = { level: 1 };
+
+const TruncationTemplate: ComponentStory<typeof Heading> = () => {
+  return (
+    <div style={{ width: "300px", border: "1px dashed #ccc", padding: "16px" }}>
+      <Content>
+        <Heading level={3} numberOfLines={1}>
+          numberOfLines=1: This heading demonstrates single line truncation and
+          will cut off any text that exceeds the container width with ellipsis
+        </Heading>
+        <Divider />
+        <Heading level={3} numberOfLines={2}>
+          numberOfLines=2: This heading shows two line truncation behavior and
+          will allow text to wrap to exactly two lines before truncating with an
+          ellipsis at the end
+        </Heading>
+        <Divider />
+        <Heading level={3}>
+          No numberOfLines prop: This heading will wrap naturally without any
+          truncation limits and can span as many lines as needed to display all
+          the content
+        </Heading>
+      </Content>
+    </div>
+  );
+};
+
+export const Truncation = TruncationTemplate.bind({});
+Truncation.args = {};

--- a/packages/components/src/Heading/Heading.test.tsx
+++ b/packages/components/src/Heading/Heading.test.tsx
@@ -87,15 +87,24 @@ it("renders a non heading inline element", () => {
 it("renders with maxLines prop", () => {
   const { container } = render(
     <Heading level={2} maxLines="small">
-      This text should be truncated
+      This is a very long heading text that would likely be truncated when the
+      maxLines prop is set to small, which corresponds to 2 lines maximum
     </Heading>,
   );
+
+  const heading = container.querySelector("h2");
+  expect(heading).toHaveClass("textTruncate");
+
+  expect(heading).toHaveTextContent(
+    "This is a very long heading text that would likely be truncated when the maxLines prop is set to small, which corresponds to 2 lines maximum",
+  );
+
   expect(container).toMatchInlineSnapshot(`
     <div>
       <h2
         class="base bold largest heading textTruncate"
       >
-        This text should be truncated
+        This is a very long heading text that would likely be truncated when the maxLines prop is set to small, which corresponds to 2 lines maximum
       </h2>
     </div>
   `);

--- a/packages/components/src/Heading/Heading.test.tsx
+++ b/packages/components/src/Heading/Heading.test.tsx
@@ -84,6 +84,23 @@ it("renders a non heading inline element", () => {
   `);
 });
 
+it("renders with numberOfLines prop", () => {
+  const { container } = render(
+    <Heading level={2} numberOfLines={2}>
+      This text should be truncated
+    </Heading>,
+  );
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <h2
+        class="base bold largest heading textTruncate"
+      >
+        This text should be truncated
+      </h2>
+    </div>
+  `);
+});
+
 describe("UNSAFE_props", () => {
   it("should apply the UNSAFE_className to the element", () => {
     render(

--- a/packages/components/src/Heading/Heading.test.tsx
+++ b/packages/components/src/Heading/Heading.test.tsx
@@ -84,9 +84,9 @@ it("renders a non heading inline element", () => {
   `);
 });
 
-it("renders with numberOfLines prop", () => {
+it("renders with maxLines prop", () => {
   const { container } = render(
-    <Heading level={2} numberOfLines={2}>
+    <Heading level={2} maxLines="small">
       This text should be truncated
     </Heading>,
   );

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -14,7 +14,13 @@ export interface HeadingProps {
    */
   readonly element?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
 
-  readonly numberOfLines?: number;
+  readonly maxLines?:
+    | "single"
+    | "small"
+    | "base"
+    | "large"
+    | "larger"
+    | "unlimited";
 
   /**
    * **Use at your own risk:** Custom classNames for specific elements. This should only be used as a
@@ -37,7 +43,7 @@ export function Heading({
   level = 5,
   children,
   element,
-  numberOfLines,
+  maxLines = "unlimited",
   UNSAFE_className,
   UNSAFE_style,
 }: HeadingProps) {
@@ -81,11 +87,20 @@ export function Heading({
     },
   };
 
+  const maxLineToNumber = {
+    single: 1,
+    small: 2,
+    base: 4,
+    large: 8,
+    larger: 16,
+    unlimited: undefined,
+  };
+
   return (
     <Typography
       {...levelMap[level]}
       element={element || levelMap[level].element}
-      numberOfLines={numberOfLines}
+      numberOfLines={maxLineToNumber[maxLines]}
       UNSAFE_className={UNSAFE_className}
       UNSAFE_style={UNSAFE_style}
     >

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -14,6 +14,8 @@ export interface HeadingProps {
    */
   readonly element?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
 
+  readonly numberOfLines?: number;
+
   /**
    * **Use at your own risk:** Custom classNames for specific elements. This should only be used as a
    * **last resort**. Using this may result in unexpected side effects.
@@ -35,6 +37,7 @@ export function Heading({
   level = 5,
   children,
   element,
+  numberOfLines,
   UNSAFE_className,
   UNSAFE_style,
 }: HeadingProps) {
@@ -82,6 +85,7 @@ export function Heading({
     <Typography
       {...levelMap[level]}
       element={element || levelMap[level].element}
+      numberOfLines={numberOfLines}
       UNSAFE_className={UNSAFE_className}
       UNSAFE_style={UNSAFE_style}
     >

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -14,6 +14,10 @@ export interface HeadingProps {
    */
   readonly element?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
 
+  /**
+   * The maximum amount of lines the text can occupy before being truncated with "...".
+   * Uses predefined string values that correspond to a doubling scale for the amount of lines.
+   */
   readonly maxLines?:
     | "single"
     | "small"

--- a/packages/site/src/content/Heading/Heading.props.json
+++ b/packages/site/src/content/Heading/Heading.props.json
@@ -34,17 +34,19 @@
           "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"span\""
         }
       },
-      "numberOfLines": {
-        "defaultValue": null,
+      "maxLines": {
+        "defaultValue": {
+          "value": "unlimited"
+        },
         "description": "",
-        "name": "numberOfLines",
+        "name": "maxLines",
         "parent": {
           "fileName": "../components/src/Heading/Heading.tsx",
           "name": "HeadingProps"
         },
         "required": false,
         "type": {
-          "name": "number"
+          "name": "\"single\" | \"small\" | \"base\" | \"large\" | \"larger\" | \"unlimited\""
         }
       },
       "UNSAFE_className": {

--- a/packages/site/src/content/Heading/Heading.props.json
+++ b/packages/site/src/content/Heading/Heading.props.json
@@ -38,7 +38,7 @@
         "defaultValue": {
           "value": "unlimited"
         },
-        "description": "",
+        "description": "The maximum amount of lines the text can occupy before being truncated with \"...\".\nUses predefined string values that correspond to a doubling scale for the amount of lines.",
         "name": "maxLines",
         "parent": {
           "fileName": "../components/src/Heading/Heading.tsx",

--- a/packages/site/src/content/Heading/Heading.props.json
+++ b/packages/site/src/content/Heading/Heading.props.json
@@ -34,6 +34,19 @@
           "name": "\"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"p\" | \"span\""
         }
       },
+      "numberOfLines": {
+        "defaultValue": null,
+        "description": "",
+        "name": "numberOfLines",
+        "parent": {
+          "fileName": "../components/src/Heading/Heading.tsx",
+          "name": "HeadingProps"
+        },
+        "required": false,
+        "type": {
+          "name": "number"
+        }
+      },
       "UNSAFE_className": {
         "defaultValue": null,
         "description": "**Use at your own risk:** Custom classNames for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",


### PR DESCRIPTION
- Introduced numberOfLines prop to Heading component to control text truncation.
- Updated Heading stories to demonstrate single and multi-line truncation.
- Added test case for rendering Heading with numberOfLines prop

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

As discussed [here](https://github.com/GetJobber/jobber-frontend/pull/4169#discussion_r2257751592), Tanner was looking for a way to truncate text within our `Heading` component. This PR exposes the `numberOfLines` prop on `Typography` to the `Heading` component to allow for this truncation 

### Added

`numberOfLines` prop for Heading

## Testing

You can take a look at the new story I added

<img width="361" height="346" alt="Screenshot 2025-08-07 at 1 57 19 PM" src="https://github.com/user-attachments/assets/9c5df1fd-82a7-4e43-a862-6f43c050a1cb" />


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
