### PR TITLE
Job 130436/remove popper

### DIFF
--- a/docs/components/Popover/Popover.stories.mdx
+++ b/docs/components/Popover/Popover.stories.mdx
@@ -53,7 +53,7 @@ To add an inline informational element that the user can dismiss, consider if
 
 - Popover text content should be concise and clear. Try not to go over three
   lines so the user can get back to what they were doing!
-- In "informational" usage, Popper may have a CTA that allows the user to
+- In "informational" usage, Popover may have a CTA that allows the user to
   "acknowledge" and dismiss the Popover; this does not replace the need for the
   dismiss button.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45855,7 +45855,6 @@
       "dependencies": {
         "@floating-ui/react": "^0.27.5",
         "@jobber/formatters": "^0.4.0",
-        "@popperjs/core": "^2.0.6",
         "@tanstack/react-table": "8.5.13",
         "@types/color": "^3.0.1",
         "@types/lodash": "^4.14.136",
@@ -45874,7 +45873,6 @@
         "react-dropzone": "^11.0.2",
         "react-hook-form": "^7.43.7",
         "react-markdown": "^8.0.3",
-        "react-popper": "^2.2.5",
         "react-router-dom": "^5.3.4",
         "ts-xor": "^1.0.8"
       },
@@ -45917,7 +45915,6 @@
         "react": "^18.2.0",
         "react-dom": "^18",
         "react-hook-form": "^7",
-        "react-popper": "^2",
         "react-router-dom": "^6"
       }
     },

--- a/packages/components/__mocks__/@popperjs/core.js
+++ b/packages/components/__mocks__/@popperjs/core.js
@@ -1,8 +1,0 @@
-// Mock popper to avoid forceUpdate causing act warnings with testing-library.
-export function createPopper() {
-  return {
-    destroy: jest.fn(),
-    forceUpdate: jest.fn(),
-    update: jest.fn(),
-  };
-}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -472,7 +472,6 @@
   "dependencies": {
     "@floating-ui/react": "^0.27.5",
     "@jobber/formatters": "^0.4.0",
-    "@popperjs/core": "^2.0.6",
     "@tanstack/react-table": "8.5.13",
     "@types/color": "^3.0.1",
     "@types/lodash": "^4.14.136",
@@ -491,7 +490,6 @@
     "react-dropzone": "^11.0.2",
     "react-hook-form": "^7.43.7",
     "react-markdown": "^8.0.3",
-    "react-popper": "^2.2.5",
     "react-router-dom": "^5.3.4",
     "ts-xor": "^1.0.8"
   },
@@ -534,7 +532,6 @@
     "react": "^18.2.0",
     "react-dom": "^18",
     "react-hook-form": "^7",
-    "react-popper": "^2",
     "react-router-dom": "^6"
   },
   "browserslist": [

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -155,7 +155,6 @@ export default {
     "react-hook-form",
     "react-router-dom",
     "react-dom",
-    "react-popper",
     "react-dom/client",
     "axios",
     "lodash",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

getting rid of the dependency of popper

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

fixed a typo that said "popper" that was showing up in my search results

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

removed the packages from our direct dependencies

though the package will continue to be included  due to `react-datepicker` still using `@popperjs/core` and `react-popper`

that's also the only remaining real reference to `popper` is react datepicker props, css rules and tests. can't get rid of these until we upgrade, and presumably they've gotten off popper too.

removed a mock for popper in tests

removed the rollupconfig entry for popper too

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
