### PR TITLE
fix(docs): fix mobile preview not working on the docs site

### DIFF
--- a/packages/site/editorMobileBundle.rollup.config.js
+++ b/packages/site/editorMobileBundle.rollup.config.js
@@ -63,6 +63,11 @@ export default {
           find: "@react-native-picker/picker",
           replacement: path.resolve(dirname, "./src/MobileOverrides.jsx"),
         },
+        {
+          find: /@jobber\/hooks\/(.*)/,
+          replacement: (_, p1) =>
+            path.resolve(dirname, `../hooks/dist/${p1}/${p1}.js`),
+        },
       ],
     }),
     babel({

--- a/packages/site/src/editorMobileBundle.js
+++ b/packages/site/src/editorMobileBundle.js
@@ -3,7 +3,8 @@ import ReactDOM from "react-dom/client";
 import { View } from "react-native-web";
 import { Modalize } from "react-native-modalize";
 import { IntlProvider } from "react-intl";
-import { useFormState, useIsMounted } from "@jobber/hooks";
+import { useFormState } from "@jobber/hooks/useFormState";
+import { useIsMounted } from "@jobber/hooks/useIsMounted";
 
 window.React = React;
 window.ReactDOM = ReactDOM;


### PR DESCRIPTION
 Copy how jobber/components bundles hooks package on the docs site to fix the RN editor not rendering


## Motivations

<!-- Why did you do what you did? -->
The mobile preview for the docs site was broken this PR fixes that by copying how hooks for the mobile editor rendering.

I decided to go with the quick fix because I know we have updates to our hooks package bundling coming soon

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
