### PR TITLE
docs: Revert Link formatting in DataTableNotes

### DIFF
--- a/packages/site/src/content/DataTable/DataTableNotes.mdx
+++ b/packages/site/src/content/DataTable/DataTableNotes.mdx
@@ -13,15 +13,8 @@ with libraries like [TanStack Table](https://tanstack.com/table) to handle
 complex data management.
 
 To see examples of how the atomic DataTable components can be configured, see
-
-<a
-  href={getStorybookUrl(
-    "?path=/story/components-lists-and-tables-datatable-web-composable--basic"
-  )}
->
-  this section of storybook
-</a>
-. These are just starting points, the components are fully composable and can
+[this section of storybook](../?path=/story/components-lists-and-tables-datatable-web-composable--basic).
+These are just starting points, the components are fully composable and can
 support a wide range of use cases.
 
 ### Basic Structure
@@ -65,15 +58,7 @@ more.
 
 Rows and cells support fully custom content, including other components,
 enabling rich, interactive table layouts. See an example
-
-<a
-  href={getStorybookUrl(
-    "?path=/story/components-lists-and-tables-datatable-web-composable--advanced-filtering"
-  )}
->
-  here
-</a>
-.
+[here](../?path=/story/components-lists-and-tables-datatable-web-composable--advanced-filtering).
 
 ```tsx
 <DataTable.Row>
@@ -108,16 +93,9 @@ enabling rich, interactive table layouts. See an example
 ### Row Actions
 
 Use `DataTable.RowActions` to render
-
-<a
-  href={getStorybookUrl(
-    "?path=/story/components-lists-and-tables-datatable-web-composable--row-actions"
-  )}
->
-  per-row controls
-</a>
-like buttons or menus. The content is fully custom; wire up events and state in your
-app.
+[per-row controls](../?path=/story/components-lists-and-tables-datatable-web-composable--row-actions)
+like buttons or menus. The content is fully custom; wire up events and state in
+your app.
 
 ```tsx
 <DataTable.Row>
@@ -135,16 +113,10 @@ app.
 
 ### Bulk Actions
 
-<a
-  href={getStorybookUrl(
-    "?path=/story/components-lists-and-tables-datatable-web-composable--bulk-selection"
-  )}
->
-  Bulk actions
-</a>
-are composed by adding a selection column and showing actions in the the `DataTable.Actions`
-area when one or more rows are selected. State and behavior are controlled by your
-app or a table library.
+[Bulk actions](../?path=/story/components-lists-and-tables-datatable-web-composable--bulk-selection)
+are composed by adding a selection column and showing actions in the the
+`DataTable.Actions` area when one or more rows are selected. State and behavior
+are controlled by your app or a table library.
 
 Selection column with checkboxes:
 
@@ -200,15 +172,8 @@ Show a bulk action bar when there are selected rows:
 ### Sortable Headers
 
 For
-
-<a
-  href={getStorybookUrl(
-    "?path=/story/components-lists-and-tables-datatable-web-composable--sortable"
-  )}
->
-  sortable columns
-</a>
-, use DataTable.SortableHeader with the required props:
+[sortable columns](../?path=/story/components-lists-and-tables-datatable-web-composable--sortable),
+use DataTable.SortableHeader with the required props:
 
 ```tsx
 <DataTable.Header>
@@ -244,15 +209,8 @@ equilibrium) based on your application's logic.
 ### Pagination
 
 For
-
-<a
-  href={getStorybookUrl(
-    "?path=/story/components-lists-and-tables-datatable-web-composable--with-pagination"
-  )}
->
-  pagination functionality
-</a>
-, use DataTable.Pagination and DataTable.PaginationButton:
+[pagination functionality](../?path=/story/components-lists-and-tables-datatable-web-composable--with-pagination),
+use DataTable.Pagination and DataTable.PaginationButton:
 
 ```tsx
 <DataTable.Footer>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Used `getStorybookUrl` in a `<a>` but it formats the `mdx` file with extra space and therefore, also created space in the Implement tab. This PR goes back to Markdown linking format.


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Before

<img width="658" height="283" alt="Screenshot 2025-08-13 at 11 20 19 PM" src="https://github.com/user-attachments/assets/43b61cde-2f61-49bb-9355-2b8839da7ffd" />


### After

<img width="741" height="141" alt="Screenshot 2025-08-13 at 11 21 01 PM" src="https://github.com/user-attachments/assets/47ef1f30-2ae4-41bd-9e5d-5c6b0c226d37" />


## Testing

Clicking the link opens a new window to the correct spot and formatting isn't borked!

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
