### PR TITLE
build: Ignore site build dirs to make eslint run fast locally

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,9 @@ packages/design/src/assets/**
 packages/design/src/icons/iconStyles.*
 packages/design/icons
 packages/generators/templates
+packages/site/playwright-report
+packages/site/public
+packages/site/test-results
 storybook-static
 
 *.css.d.ts


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This ignores a few site build dirs for eslint.

Before this change, eslint would hang for me when running locally. Waited over 15mins and still hadn't completed.

After this change, eslint actually completes in under 30 seconds.

## Changes


### Fixed

- Ignore site build dirs to make eslint run fast locally


## Testing

* run `npm run lint:js` locally
* watch it complete 

Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
