### PR TITLE
feat(components): Add additional gap spacings to Flex [JOB-133026]

### DIFF
--- a/packages/components/src/Flex/Flex.module.css
+++ b/packages/components/src/Flex/Flex.module.css
@@ -4,6 +4,10 @@
   flex: 1;
 }
 
+.minusculeGap {
+  gap: var(--space-minuscule);
+}
+
 .smallestGap {
   gap: var(--space-smallest);
 }
@@ -16,12 +20,28 @@
   gap: var(--space-small);
 }
 
+.slimGap {
+  gap: var(--space-slim);
+}
+
 .baseGap {
   gap: var(--space-base);
 }
 
 .largeGap {
   gap: var(--space-large);
+}
+
+.largerGap {
+  gap: var(--space-larger);
+}
+
+.largestGap {
+  gap: var(--space-largest);
+}
+
+.extravagantGap {
+  gap: var(--space-extravagant);
 }
 
 .noneGap {

--- a/packages/components/src/Flex/Flex.module.css.d.ts
+++ b/packages/components/src/Flex/Flex.module.css.d.ts
@@ -1,10 +1,15 @@
 declare const styles: {
   readonly "flexible": string;
+  readonly "minusculeGap": string;
   readonly "smallestGap": string;
   readonly "smallerGap": string;
   readonly "smallGap": string;
+  readonly "slimGap": string;
   readonly "baseGap": string;
   readonly "largeGap": string;
+  readonly "largerGap": string;
+  readonly "largestGap": string;
+  readonly "extravagantGap": string;
   readonly "noneGap": string;
   readonly "startAlign": string;
   readonly "centerAlign": string;

--- a/packages/components/src/Flex/Flex.types.ts
+++ b/packages/components/src/Flex/Flex.types.ts
@@ -4,11 +4,16 @@ export type Direction = "row" | "column";
 
 export const spacing = [
   "none",
+  "minuscule",
   "smallest",
   "smaller",
   "small",
+  "slim",
   "base",
   "large",
+  "larger",
+  "largest",
+  "extravagant",
 ] as const;
 
 type ValuesOfSpacing<T extends typeof spacing> = T[number];

--- a/packages/site/src/content/Flex/Flex.props.json
+++ b/packages/site/src/content/Flex/Flex.props.json
@@ -46,7 +46,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"none\" | \"smallest\" | \"smaller\" | \"small\" | \"base\" | \"large\""
+          "name": "\"none\" | \"minuscule\" | \"smallest\" | \"smaller\" | \"small\" | \"slim\" | \"base\" | \"large\" | \"larger\" | \"largest\" | \"extravagant\""
         }
       },
       "direction": {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Adds all of our spacing sizes as gap options for `Flex` in response to a request for `largest` to be made an option. If it is a spacing that we document and make available for gaps on other layout components I can't think of any reason why it shouldn't be available for Flex. 

### Added

<img width="704" height="417" alt="Screenshot 2025-08-18 at 15 55 10" src="https://github.com/user-attachments/assets/fb9bc5e4-0e4a-4216-9e68-43e339e538f9" />


## Testing

Take a look in Storybook. I slotted the new gaps in, in order of their sizes but they don't display in Storybook in exactly that order. This doesn't seem to be anything new because some were out of order before but if anyone knows how to change this I am happy to fix it.

<img width="326" height="283" alt="Screenshot 2025-08-18 at 15 58 08" src="https://github.com/user-attachments/assets/b125b72f-4af3-42c2-857a-bd55467826f2" />


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
