### PR TITLE
docs: Add useStepper to Docs Site

### DIFF
--- a/docs/hooks/useStepper.stories.mdx
+++ b/docs/hooks/useStepper.stories.mdx
@@ -78,10 +78,10 @@ function useStepper<StepName extends string>(
   currentStep: StepName;
 
   // Move to next step
-  nextStep: () => void;
+  goToNextStep: () => void;
 
   // Move to previous step
-  previousStep: () => void;
+  goToPreviousStep: () => void;
 
   // Navigate to specific step
   goToStep: (step: StepName) => void;

--- a/packages/site/src/hooksList.ts
+++ b/packages/site/src/hooksList.ts
@@ -70,6 +70,11 @@ export const hooksList = [
     sections: ["Window & Layout"],
   },
   {
+    title: "useStepper",
+    to: "/hooks/useStepper",
+    sections: ["React Utilities"],
+  },
+  {
     title: "useWindowDimensions",
     to: "/hooks/useWindowDimensions",
     sections: ["Window & Layout"],

--- a/packages/site/src/maps/hooksContent.tsx
+++ b/packages/site/src/maps/hooksContent.tsx
@@ -12,6 +12,7 @@ import UseOnKeyDownDocs from "@atlantis/docs/hooks/useOnKeyDown.stories.mdx";
 import UseOnMountDocs from "@atlantis/docs/hooks/useOnMount.stories.mdx";
 import UseRefocusOnActivatorDocs from "@atlantis/docs/hooks/useRefocusOnActivator.stories.mdx";
 import UseResizeObserverDocs from "@atlantis/docs/hooks/useResizeObserver.stories.mdx";
+import UseStepperDocs from "@atlantis/docs/hooks/useStepper.stories.mdx";
 import UseWindowDimensionsDocs from "@atlantis/docs/hooks/useWindowDimensions.stories.mdx";
 import { ContentMapItems } from "../types/maps";
 
@@ -85,6 +86,11 @@ export const hooksContentMap: ContentMapItems = {
     intro: "useResizeObserver",
     title: "useResizeObserver",
     content: () => <UseResizeObserverDocs />,
+  },
+  useStepper: {
+    intro: "useStepper",
+    title: "useStepper",
+    content: () => <UseStepperDocs />,
   },
   useWindowDimensions: {
     intro: "useWindowDimensions",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Add `useStepper` to new docs site

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- `useStepper` docs are in new docs site


## Testing

<!-- How to test your changes. -->
Make sure `useStepper` page is viewable via sidenav, main hooks page and via search modal

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
