### PR TITLE
fix(docx): fix typo on DatePicker url in InputDate docs

### DIFF
--- a/docs/components/Datepicker/Datepicker.stories.mdx
+++ b/docs/components/Datepicker/Datepicker.stories.mdx
@@ -13,18 +13,18 @@ multi-mode opportunity to select a date.
 
 ## Design & usage guidelines
 
-Use Datepicker when you are looking to provide the user with a highly visual
+Use DatePicker when you are looking to provide the user with a highly visual
 interface for intuitive date selections.
 
-A classic use case for a standalone Datepicker would be as a means to navigate
+A classic use case for a standalone DatePicker would be as a means to navigate
 within a larger calendar interface.
 
-It may be beneficial to supplement the Datepicker with alternate means of
+It may be beneficial to supplement the DatePicker with alternate means of
 entering their date selection, such as providing a `date` input.
 
 ### Inline
 
-Use an inline Datepicker when you have sufficient space in the interface to have
+Use an inline DatePicker when you have sufficient space in the interface to have
 a permanent date selection fixture, or when date selection is the primary
 function of the interface, such as a stepped flow where the user is asked a
 series of scheduling questions individually, in sequence.
@@ -44,7 +44,7 @@ accessibility of the component is handled by the `React DatePicker` component.
 Users can operate all of the controls by keyboard, including the `tab` to cycle
 between Next/Previous month and the calendar, arrow keys to navigate between
 dates, and `space` and/or `return` to make selections. Pressing `escape` will
-close the Datepicker.
+close the DatePicker.
 
 The date available for selection is read aloud to assistive technology in the
 format "Choose \{date\} (button)". For example, "Choose December 1st, 2021

--- a/docs/components/InputDate/InputDate.stories.mdx
+++ b/docs/components/InputDate/InputDate.stories.mdx
@@ -52,7 +52,7 @@ available amount of space left by any other inputs in the group.
 ## Related components
 
 - On web if you do not need an accompanying form field, you can use the
-  [Datepicker](/components/DatePicker) on its own
+  [DatePicker](/components/DatePicker) on its own
 - If you need to allow the user to enter time, use
   [InputTime](/components/InputTime)
 - If you just need a text input, use [InputText](/components/InputText)

--- a/docs/components/InputDate/InputDate.stories.mdx
+++ b/docs/components/InputDate/InputDate.stories.mdx
@@ -52,7 +52,7 @@ available amount of space left by any other inputs in the group.
 ## Related components
 
 - On web if you do not need an accompanying form field, you can use the
-  [Datepicker](/components/Datepicker) on its own
+  [Datepicker](/components/DatePicker) on its own
 - If you need to allow the user to enter time, use
   [InputTime](/components/InputTime)
 - If you just need a text input, use [InputText](/components/InputText)


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

URL to DatePicker docs is broken, generates 404

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Fixed

- casing of Datepicker -> DatePicker in link, no longer 404s

## Testing

Run InputDate docs locally / CF

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
