### PR TITLE
fix(components): make InlineLabels without associated semantic colors look good in dark mode

### DIFF
--- a/packages/components/src/InlineLabel/InlineLabel.module.css
+++ b/packages/components/src/InlineLabel/InlineLabel.module.css
@@ -40,8 +40,13 @@
 }
 
 .orange {
-  color: var(--color-orange--dark);
-  background-color: var(--color-orange--lightest);
+  color: var(--color-base-orange--600);
+  background-color: var(--color-base-orange--200);
+}
+
+[data-theme="dark"] .orange {
+  color: var(--color-base-orange--200);
+  background-color: var(--color-base-orange--600);
 }
 
 .green,
@@ -69,8 +74,13 @@
 }
 
 .lime {
-  color: var(--color-lime--dark);
-  background-color: var(--color-lime--lightest);
+  color: var(--color-base-lime--700);
+  background-color: var(--color-base-lime--200);
+}
+
+[data-theme="dark"] .lime {
+  color: var(--color-base-lime--200);
+  background-color: var(--color-base-lime--700);
 }
 
 .purple,
@@ -86,8 +96,13 @@
 }
 
 .teal {
-  color: var(--color-teal--dark);
-  background-color: var(--color-teal--lightest);
+  color: var(--color-base-teal--700);
+  background-color: var(--color-base-teal--200);
+}
+
+[data-theme="dark"] .teal {
+  color: var(--color-base-teal--200);
+  background-color: var(--color-base-teal--700);
 }
 
 .yellowGreen,


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Most InlineLabels map back to semantic colors (success, critical, etc)

However, orange teal and lime do not, and as such do not happily adapt to dark mode

## Changes

### Fixed

- Orange, teal, and lime InlineLabels adapt to dark mode

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
