### PR TITLE
feat(components): Provide Default Content to Combobox CustomRender

### DIFF
--- a/docs/components/Combobox/Web.stories.tsx
+++ b/docs/components/Combobox/Web.stories.tsx
@@ -536,6 +536,9 @@ const ComboboxCustomRenderOptions: ComponentStory<typeof Combobox> = args => {
   const [selectedLineItems, setSelectedLineItems] = useState<ComboboxOption[]>(
     [],
   );
+  const [selectedLineItems2, setSelectedLineItems2] = useState<
+    ComboboxOption[]
+  >([]);
 
   const teamMemberOptions = [
     {
@@ -899,6 +902,33 @@ const ComboboxCustomRenderOptions: ComponentStory<typeof Combobox> = args => {
                     </Box>
                   </Flex>
                 );
+              }}
+            />
+          );
+        })}
+
+        <Combobox.Action
+          label="+ Add new line item"
+          onClick={() => {
+            alert("Added a new line item ✅");
+          }}
+        />
+      </Combobox>
+      <Combobox
+        label="Add line item with default content"
+        subjectNoun="line items"
+        {...args}
+        onSelect={setSelectedLineItems2}
+        selected={selectedLineItems2}
+      >
+        {lineItemOptions.map(o => {
+          return (
+            <Combobox.Option
+              key={o.id}
+              id={`${o.id}`}
+              label={o.label}
+              customRender={({ DefaultContent }) => {
+                return <DefaultContent />;
               }}
             />
           );

--- a/packages/components/src/Combobox/Combobox.test.tsx
+++ b/packages/components/src/Combobox/Combobox.test.tsx
@@ -157,7 +157,9 @@ describe("Combobox", () => {
 
   it("should fire the onSelect when clicking an option", async () => {
     await userEvent.click(screen.getByRole("combobox"));
-    await userEvent.click(screen.getByText("Bilbo Baggins"));
+    await userEvent.click(
+      screen.getByRole("option", { name: "Bilbo Baggins" }),
+    );
 
     expect(handleSelect).toHaveBeenCalledTimes(1);
     expect(handleSelect).toHaveBeenCalledWith([
@@ -245,7 +247,9 @@ describe("Combobox Multiselect", () => {
     await userEvent.click(screen.getByRole("combobox"));
     expect(screen.getByTestId(MENU_TEST_ID)).not.toHaveClass("hidden");
 
-    await userEvent.click(screen.getByText("Bilbo Baggins"));
+    await userEvent.click(
+      screen.getByRole("option", { name: "Bilbo Baggins" }),
+    );
     expect(screen.getByTestId(MENU_TEST_ID)).not.toHaveClass("hidden");
   });
 
@@ -315,7 +319,9 @@ describe("Combobox Multiselect", () => {
 
     await userEvent.click(screen.getByRole("combobox"));
     await userEvent.type(searchInput, "Bilbo");
-    await userEvent.click(screen.getByText("Bilbo Baggins"));
+    await userEvent.click(
+      screen.getByRole("option", { name: "Bilbo Baggins" }),
+    );
 
     expect(searchInput).toHaveValue("Bilbo");
   });
@@ -590,6 +596,65 @@ describe("Infinite scroll", () => {
       observer.enterNode(loadMoreTrigger);
     });
     expect(mockLoadMore).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Combobox DefaultContent via customRender", () => {
+  it("should render DefaultContent and behave like the default option in single-select", async () => {
+    render(
+      <Combobox label={activatorLabel} selected={[]} onSelect={handleSelect}>
+        <Combobox.Option
+          id="1"
+          label="Bilbo Baggins"
+          customRender={({ DefaultContent }) => <DefaultContent />}
+        />
+        <Combobox.Option id="2" label="Frodo Baggins" />
+      </Combobox>,
+    );
+
+    await userEvent.click(screen.getByRole("combobox"));
+    // Default content shows the label as usual
+    expect(screen.getByText("Bilbo Baggins")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("option", { name: "Bilbo Baggins" }),
+    );
+    // Behaves like default: calls onSelect and closes menu in single-select
+    expect(handleSelect).toHaveBeenCalledWith([
+      { id: "1", label: "Bilbo Baggins" },
+    ]);
+    expect(screen.getByTestId(MENU_TEST_ID)).toHaveClass("hidden");
+  });
+
+  it("should render DefaultContent and show selected state (checkmark) in multi-select", async () => {
+    render(
+      <Combobox
+        label={activatorLabel}
+        multiSelect
+        selected={[{ id: "1", label: "Bilbo Baggins" }]}
+        onSelect={handleSelect}
+      >
+        <Combobox.Option
+          id="1"
+          label="Bilbo Baggins"
+          customRender={({ DefaultContent }) => <DefaultContent />}
+        />
+        <Combobox.Option id="2" label="Frodo Baggins" />
+      </Combobox>,
+    );
+
+    await userEvent.click(screen.getByRole("combobox"));
+    // Default content reflects selection state
+    expect(
+      screen.getByRole("option", { name: "Bilbo Baggins" }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("checkmark")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("option", { name: "Bilbo Baggins" }),
+    );
+    // Multiselect: menu remains open
+    expect(screen.getByTestId(MENU_TEST_ID)).not.toHaveClass("hidden");
   });
 });
 

--- a/packages/components/src/Combobox/Combobox.types.ts
+++ b/packages/components/src/Combobox/Combobox.types.ts
@@ -145,6 +145,7 @@ export interface ComboboxOptionProps {
   readonly customRender?: (
     option: Omit<ComboboxOptionProps, "customRender"> & {
       isSelected: boolean;
+      DefaultContent: () => ReactElement;
     },
   ) => React.ReactNode;
 

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.pom.tsx
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.pom.tsx
@@ -70,3 +70,8 @@ export const customRender: ComboboxOptionProps["customRender"] = ({
     </div>
   );
 };
+
+export const customRenderDefaultContent: ComboboxOptionProps["customRender"] =
+  ({ DefaultContent }) => {
+    return <DefaultContent />;
+  };

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.test.tsx
@@ -199,6 +199,41 @@ describe("ComboboxOption", () => {
         label: "Michael",
       });
     });
+
+    it("provides DefaultContent and renders it identically to default", () => {
+      const option: ComboboxOptionProps = {
+        id: "1",
+        label: "Michael",
+        customRender: POM.customRenderDefaultContent,
+      };
+
+      POM.renderOption({
+        ...option,
+        selected: [],
+      });
+
+      // default content renders the label
+      expect(POM.getOption("Michael")).toBeInTheDocument();
+      // not selected, so no checkmark
+      expect(POM.queryCheckmark()).not.toBeInTheDocument();
+    });
+
+    it("DefaultContent reflects selection state (shows checkmark when selected)", () => {
+      const option: ComboboxOptionProps = {
+        id: "1",
+        label: "Michael",
+        customRender: POM.customRenderDefaultContent,
+      };
+
+      POM.renderOption({
+        ...option,
+        selected: [option],
+      });
+
+      // default content renders the label and checkmark when selected
+      expect(POM.getOption("Michael")).toBeInTheDocument();
+      expect(POM.getCheckmark()).toBeInTheDocument();
+    });
   });
 
   describe("onClick callback", () => {

--- a/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.tsx
+++ b/packages/components/src/Combobox/components/ComboboxOption/ComboboxOption.tsx
@@ -34,6 +34,9 @@ export function ComboboxOption(props: ComboboxOptionProps) {
         customRender({
           ...contentProps,
           isSelected,
+          DefaultContent: () => (
+            <InternalDefaultContent {...contentProps} isSelected={isSelected} />
+          ),
         })
       ) : (
         <InternalDefaultContent {...contentProps} isSelected={isSelected} />


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

there are times when you want to enhance or wrap a Combobox option, yet you don't want to change the layout.

additionally, there is complexity added from the portalling meaning that if you try to wrap the `<Combobox>` invocation, since the menu itself ends up elsewhere on the DOM - it might not behave as expected

to deal with both problems, we are going to provide what we would have rendered as an arg to the custom render render prop

this way a consumer can wrap the option, it will be directly around the option sidestepping the portal issue, and there's no need to make a fragile re-creation of the default content that may change

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

DefaultContent arg provided to customRender on Combobox 

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
