### PR TITLE
use library to format phone numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
       "dependencies": {
         "@storybook/blocks": "^7.6.20",
         "@storybook/components": "^7.6.20",
-        "jest-environment-jsdom": "^29.5.0"
+        "jest-environment-jsdom": "^29.5.0",
+        "libphonenumber-js": "^1.12.15"
       },
       "devDependencies": {
         "@apollo/client": "^3.7.10",
@@ -28776,6 +28777,12 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.15",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.15.tgz",
+      "integrity": "sha512-TMDCtIhWUDHh91wRC+wFuGlIzKdPzaTUHHVrIZ3vPUEoNaXFLrsIQ1ZpAeZeXApIF6rvDksMTvjrIQlLKaYxqQ==",
+      "license": "MIT"
     },
     "node_modules/liftoff": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,8 @@
   "dependencies": {
     "@storybook/blocks": "^7.6.20",
     "@storybook/components": "^7.6.20",
-    "jest-environment-jsdom": "^29.5.0"
+    "jest-environment-jsdom": "^29.5.0",
+    "libphonenumber-js": "^1.12.15"
   },
   "engines": {
     "node": "22",

--- a/packages/formatters/phoneNumber.ts
+++ b/packages/formatters/phoneNumber.ts
@@ -1,0 +1,18 @@
+import { parsePhoneNumberFromString } from "libphonenumber-js";
+
+export function formatPhoneNumberForDisplay(
+  phoneNumber: string,
+  international = false,
+) {
+  const parsed = parsePhoneNumberFromString(phoneNumber);
+
+  if (!parsed) {
+    return phoneNumber;
+  }
+
+  if (international) {
+    return parsed.formatInternational();
+  }
+
+  return parsed.formatNational();
+}


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

NOTE this is a proof-of-concept.

## Motivations
Couldn't find a standardized formatter for phone numbers
<!-- Why did you do what you did? -->

## Changes
Added a new utility function formatPhoneNumberForDisplay to the Atlantis formatters package that provides consistent phone number formatting across the application.

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added
Uses libphonenumber-js for robust phone number parsing and validation
Supports both national and international formatting via optional parameter
Gracefully handles invalid phone numbers by returning the original input
Defaults to national format for better user experience in most regions

## Testing
QA Instructions:
- [ ] Test with valid phone numbers in different formats
Enter phone numbers like "+1-555-123-4567", "5551234567", "(555) 123-4567"
Verify national formatting works correctly
Verify international formatting works correctly
- [ ] Test with invalid phone numbers
Enter invalid formats like "abc123", "123", empty string
Verify function returns original input unchanged
- [ ] Test edge cases
Test with very long phone numbers
Test with special characters
Verify no crashes or errors occur
<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
