### PR TITLE
fix(hooks): Prevent mockViewportWidth from accessing window until necessary

### DIFF
--- a/packages/hooks/src/useBreakpoints/mockViewportWidth/mockViewportWidth.ts
+++ b/packages/hooks/src/useBreakpoints/mockViewportWidth/mockViewportWidth.ts
@@ -1,8 +1,12 @@
-const defaultMatchMedia = window.matchMedia;
-const defaultResizeTo = window.resizeTo;
-const defaultInnerWidth = window.innerWidth;
+let defaultMatchMedia: typeof window.matchMedia;
+let defaultResizeTo: typeof window.resizeTo;
+let defaultInnerWidth: typeof window.innerWidth;
 
 export function mockViewportWidth() {
+  defaultMatchMedia = window.matchMedia;
+  defaultResizeTo = window.resizeTo;
+  defaultInnerWidth = window.innerWidth;
+
   return { cleanup, setViewportWidth };
 }
 


### PR DESCRIPTION

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

This was causing some problems with vitest suites that use `node` env instead of the default jsdom environment. During the test suite bootup process (before tests run), imports of `@jobber/hooks` barrel file cause this file to load and in the vitest `node` environment, `window` doesn't exist so it crashes the suite.



## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->



### Fixed

- Only access window when necessary


Changes can be [tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
