### PR TITLE
fix(components): Fix DatePicker onChange to not restore deleted value

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -149,11 +149,7 @@ export function DatePicker({
         minDate={minDate}
         useWeekdaysShort={true}
         customInput={
-          <DatePickerActivator
-            pickerRef={pickerRef}
-            activator={activator}
-            fullWidth={fullWidth}
-          />
+          <DatePickerActivator activator={activator} fullWidth={fullWidth} />
         }
         renderCustomHeader={props => <DatePickerCustomHeader {...props} />}
         onCalendarOpen={handleCalendarOpen}

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -183,7 +183,8 @@ export function DatePicker({
    * fail).
    */
   function handleChange(value: Date | null) {
-    if (value) onChange(value);
+    // TODO: Ticket created to update all DatePicker and InputDate usages to accept Date | null
+    onChange(value as Date);
   }
 
   function handleCalendarOpen() {

--- a/packages/components/src/DatePicker/DatePickerActivator.tsx
+++ b/packages/components/src/DatePicker/DatePickerActivator.tsx
@@ -1,7 +1,6 @@
-import type { ChangeEvent, ReactElement, Ref, RefObject } from "react";
+import type { ChangeEvent, ReactElement, Ref } from "react";
 import React, { cloneElement, forwardRef, isValidElement } from "react";
 import type { DatePickerProps as ReactDatePickerProps } from "react-datepicker";
-import type ReactDatePicker from "react-datepicker";
 import omit from "lodash/omit";
 import { Button } from "../Button";
 
@@ -28,7 +27,6 @@ export interface DatePickerActivatorProps
   onClick?(): void;
   onFocus?(): void;
   onKeyDown?(): void;
-  readonly pickerRef: RefObject<ReactDatePicker>;
 }
 
 export const DatePickerActivator = forwardRef(InternalActivator);

--- a/packages/components/src/InputDate/InputDate.test.tsx
+++ b/packages/components/src/InputDate/InputDate.test.tsx
@@ -354,7 +354,7 @@ describe("InputDate V1", () => {
     );
   }
 
-  describe("when restoreLastValueOnBlur is true", () => {
+  describe("when onChange skips empty or invalid dates", () => {
     it("restores the last value when the input is empty", async () => {
       const originalValue = "11/11/2011";
       const placeholder = "placeholder";
@@ -362,7 +362,6 @@ describe("InputDate V1", () => {
         <>
           <textarea data-testid="textarea" />
           <InputDateWithStateTest
-            restoreLastValueOnBlur
             initialValue={originalValue}
             placeholder={placeholder}
           />
@@ -391,7 +390,6 @@ describe("InputDate V1", () => {
         <>
           <textarea data-testid="textarea" />
           <InputDateWithStateTest
-            restoreLastValueOnBlur
             initialValue={originalValue}
             placeholder={placeholder}
           />

--- a/packages/components/src/InputDate/InputDate.tsx
+++ b/packages/components/src/InputDate/InputDate.tsx
@@ -1,6 +1,5 @@
 import omit from "lodash/omit";
 import React, { useEffect, useRef, useState } from "react";
-import isValid from "date-fns/isValid";
 import type { InputDateProps } from "./InputDate.types";
 import type { FieldActionsRef, Suffix } from "../FormField";
 import { FormField } from "../FormField";
@@ -20,7 +19,7 @@ export function InputDate(inputProps: InputDateProps) {
       maxDate={inputProps.maxDate}
       smartAutofocus={false}
       activator={activatorProps => {
-        const { onChange, onClick, value, pickerRef } = activatorProps;
+        const { onChange, onClick, value } = activatorProps;
         const newActivatorProps = omit(activatorProps, ["activator"]);
         const [isFocused, setIsFocused] = useState(false);
         const suffix =
@@ -56,27 +55,6 @@ export function InputDate(inputProps: InputDateProps) {
                 inputProps.onBlur && inputProps.onBlur();
                 activatorProps.onBlur && activatorProps.onBlur();
                 setIsFocused(false);
-
-                /**
-                 * This is an experimental workaround to solve a specific UX problem we have under certain conditions.
-                 * When you click to focus InputDate, ReactDatePicker becomes visible. If you delete the current date and blur
-                 * the input field by clicking away, ReactDatePicker will automatically set the date to whatever date was
-                 * currently selected.
-                 *
-                 * The above works great and is the expected user experience. ReactDatePicker fills in the empty value for us.
-                 *
-                 * However, there's a specific scenario where ReactDatePicker isn't visible: when you tab into the input date.
-                 * When you tab into it, clear the value, and tab away to blur, ReactDatePicker doesn't automatically fill in
-                 * the empty value because it wasn't visible/active.
-                 *
-                 * To solve this, we need to handle the blur event here and check if the value is empty or invalid. If it is,
-                 * we have to call onChange with the original input value which informs ReactDatePicker that is the current value.
-                 */
-                if (inputProps.restoreLastValueOnBlur) {
-                  if ((!value || !isValid(value)) && inputProps.value) {
-                    pickerRef.current?.setSelected(inputProps.value);
-                  }
-                }
               }}
               onFocus={() => {
                 inputProps.onFocus && inputProps.onFocus();

--- a/packages/components/src/InputDate/InputDate.types.ts
+++ b/packages/components/src/InputDate/InputDate.types.ts
@@ -91,17 +91,4 @@ export interface InputDateProps
    * Text to display instead of a date value
    */
   readonly emptyValueLabel?: string;
-
-  /**
-   * Experimental:
-   * Whether to replace empty/invalid values with the original value on blur.
-   *
-   * This solves an immediate UX problem and is likely to change in the future.
-   * It prevents the input from retaining empty/invalid values when the user tabs
-   * into it, clears the value, and tabs away. In this scenario, the original
-   * value will be restored.
-   *
-   * @default false
-   */
-  readonly restoreLastValueOnBlur?: boolean;
 }

--- a/packages/site/src/content/InputDate/InputDate.props.json
+++ b/packages/site/src/content/InputDate/InputDate.props.json
@@ -86,21 +86,6 @@
           "name": "string"
         }
       },
-      "restoreLastValueOnBlur": {
-        "defaultValue": {
-          "value": "false"
-        },
-        "description": "Experimental:\nWhether to replace empty/invalid values with the original value on blur.\n\nThis solves an immediate UX problem and is likely to change in the future.\nIt prevents the input from retaining empty/invalid values when the user tabs\ninto it, clears the value, and tabs away. In this scenario, the original\nvalue will be restored.",
-        "name": "restoreLastValueOnBlur",
-        "parent": {
-          "fileName": "packages/components/src/InputDate/InputDate.types.ts",
-          "name": "InputDateProps"
-        },
-        "required": false,
-        "type": {
-          "name": "boolean"
-        }
-      },
       "id": {
         "defaultValue": null,
         "description": "A unique identifier for the input.",


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

In https://github.com/GetJobber/atlantis/pull/2688 where react-datepicker was upgraded, `handleChange` was set to accept `(value: Date | null) => void`, and onChange is only fired when value is not null. This causes an issue in `InputDate` where if you open the date picker, delete the value, then click away to blur, it "restores" back to the previous value. We need to make sure the value is not restored and onChange is called unless consumers specifically choose to. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `handleChange` calls `onChange` with `onChange(value as Date)` for possible null value. A ticket has been created to update all usages of InputDate and DatePicker to accept `(value: Date | null) => void` and remove this type assertion.
- Removed `restoreLastValueOnBlur` prop from `InputDate`. value can be restored by doing null check in onChange
- Removed `pickerRef` prop from `DatePickerActivator` that was used by restoreLastValueOnBlur

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Open datepicker from InputDate, remove the value, then click away -> input value should not be "restored"
- Tab into InputDate, remove the value, then tab away -> input value should not be restored
- Add null check and early return in InputDate `onChange`: `if (!d) return;`, tab into InputDate, remove the value, then tab away -> input value is restored.

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
