### PR TITLE
docs(components): Add AutocompleteV2 Docs

### DIFF
--- a/docs/components/Autocomplete/WebV2.stories.tsx
+++ b/docs/components/Autocomplete/WebV2.stories.tsx
@@ -355,27 +355,6 @@ const TemplateFreeForm: ComponentStory<typeof Autocomplete> = () => {
   );
 };
 
-const TemplateDebounce0: ComponentStory<typeof Autocomplete> = () => {
-  const [value, setValue] = useState<OptionLike | undefined>();
-  const [inputValue, setInputValue] = useState("");
-
-  return (
-    <Content>
-      <Heading level={4}>Debounce disabled</Heading>
-      <Autocomplete
-        version={2}
-        placeholder="Search"
-        value={value}
-        onChange={setValue}
-        inputValue={inputValue}
-        onInputChange={setInputValue}
-        debounce={0}
-        menu={[{ type: "options", options: simpleOptions }]}
-      />
-    </Content>
-  );
-};
-
 // Helpers for async story
 const withKeys = (opts: OptionLike[], prefix: string): OptionLike[] =>
   opts.map((o, i) => ({ ...o, key: o.key ?? `${prefix}-${o.label}-${i}` }));
@@ -522,5 +501,4 @@ export const Loading = TemplateLoading.bind({});
 export const CustomRenderOption = TemplateCustomRenderOption.bind({});
 export const HeaderFooter = TemplateHeaderFooter.bind({});
 export const FreeForm = TemplateFreeForm.bind({});
-export const DebounceDisabled = TemplateDebounce0.bind({});
 export const AsyncUserManaged = TemplateAsyncUserManaged.bind({});

--- a/docs/components/Autocomplete/WebV2.stories.tsx
+++ b/docs/components/Autocomplete/WebV2.stories.tsx
@@ -7,6 +7,9 @@ import { Content } from "@jobber/components/Content";
 import { Heading } from "@jobber/components/Heading";
 import { Text } from "@jobber/components/Text";
 import { Icon } from "@jobber/components/Icon";
+import { InputText } from "@jobber/components/InputText";
+import { Modal } from "@jobber/components/Modal";
+import { Button } from "@jobber/components/Button";
 import { AutocompleteV2Docgen } from "./V2.docgen";
 
 export default {
@@ -167,11 +170,25 @@ const TemplateWithActions: ComponentStory<typeof Autocomplete> = () => {
             type: "section" as const,
             label: "Outdoor",
             options: simpleOptionsSecondSection,
+            actions: [
+              {
+                type: "action" as const,
+                label: "Add Outdoor Service",
+                onClick: () => alert("Add Outdoor Service"),
+              },
+            ],
           },
           {
             type: "section" as const,
             label: "Extras",
             options: simpleOptionsThirdSection,
+            actions: [
+              {
+                type: "action" as const,
+                label: "Add Extras Service",
+                onClick: () => alert("Add Extras Service"),
+              },
+            ],
           },
         ]}
       />
@@ -184,28 +201,42 @@ const TemplateEmptyStateAndActions: ComponentStory<
 > = () => {
   const [value, setValue] = useState<OptionLike | undefined>();
   const [inputValue, setInputValue] = useState("zzz");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [serviceValue, setServiceValue] = useState("");
 
   return (
-    <Content>
-      <Heading level={4}>Empty state with actions</Heading>
-      <Autocomplete
-        version={2}
-        placeholder="Try a term with no matches"
-        value={value}
-        onChange={setValue}
-        inputValue={inputValue}
-        onInputChange={setInputValue}
-        emptyStateMessage="No services found"
-        emptyActions={[
-          {
-            type: "action",
-            label: "Create service",
-            onClick: () => alert("Create"),
-          },
-        ]}
-        menu={[{ type: "options", options: [] }]}
-      />
-    </Content>
+    <>
+      <Content>
+        <Heading level={4}>Empty state with empty action</Heading>
+        <Autocomplete
+          version={2}
+          placeholder="Try a term with no matches"
+          value={value}
+          onChange={setValue}
+          inputValue={inputValue}
+          onInputChange={setInputValue}
+          emptyStateMessage="No services found"
+          emptyActions={[
+            {
+              type: "action",
+              label: "Create service",
+              onClick: () => setModalOpen(true),
+            },
+          ]}
+          menu={[{ type: "options", options: [] }]}
+        />
+      </Content>
+      <Modal open={modalOpen} onRequestClose={() => setModalOpen(false)}>
+        <Content>
+          <Heading level={4}>Create service</Heading>
+          <InputText
+            value={serviceValue}
+            onChange={(val: string) => setServiceValue(val)}
+          />
+          <Button label="Create" onClick={() => setModalOpen(false)} />
+        </Content>
+      </Modal>
+    </>
   );
 };
 

--- a/docs/components/Autocomplete/WebV2.stories.tsx
+++ b/docs/components/Autocomplete/WebV2.stories.tsx
@@ -1,16 +1,24 @@
 import React, { useRef, useState } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { useDebounce } from "@jobber/hooks";
-import { Autocomplete } from "@jobber/components/Autocomplete";
-import type { OptionLike } from "@jobber/components/Autocomplete";
+import {
+  Autocomplete,
+  type MenuAction,
+  type MenuFooter,
+  type MenuHeader,
+  type OptionLike,
+  defineMenu,
+} from "@jobber/components/Autocomplete";
 import { Content } from "@jobber/components/Content";
 import { Heading } from "@jobber/components/Heading";
 import { Text } from "@jobber/components/Text";
-import { Icon } from "@jobber/components/Icon";
+import { Icon, type IconNames } from "@jobber/components/Icon";
 import { InputText } from "@jobber/components/InputText";
 import { Modal } from "@jobber/components/Modal";
 import { Button } from "@jobber/components/Button";
 import { Emphasis } from "@jobber/components/Emphasis";
+import { Flex } from "@jobber/components/Flex";
+import { Typography } from "@jobber/components/Typography";
 import { AutocompleteV2Docgen } from "./V2.docgen";
 
 export default {
@@ -86,19 +94,19 @@ const flatOptions: OptionLike[] = [
   { label: "Window Cleaning" },
 ];
 
-const sectionedMenu = [
-  { type: "section" as const, label: "Indoor", options: simpleOptions },
+const sectionedMenu = defineMenu<OptionLike>([
+  { type: "section", label: "Indoor", options: simpleOptions },
   {
-    type: "section" as const,
+    type: "section",
     label: "Outdoor",
     options: simpleOptionsSecondSection,
   },
   {
-    type: "section" as const,
+    type: "section",
     label: "Extras",
     options: simpleOptionsThirdSection,
   },
-];
+]);
 
 const TemplateFlat: ComponentStory<typeof Autocomplete> = () => {
   const [value, setValue] = useState<OptionLike | undefined>();
@@ -154,44 +162,44 @@ const TemplateWithActions: ComponentStory<typeof Autocomplete> = () => {
         onChange={setValue}
         inputValue={inputValue}
         onInputChange={setInputValue}
-        menu={[
+        menu={defineMenu<OptionLike>([
           {
-            type: "section" as const,
+            type: "section",
             label: "Services",
             options: simpleOptions,
             actions: [
               {
-                type: "action" as const,
+                type: "action",
                 label: "Add Service",
                 onClick: () => alert("Add Service"),
               },
             ],
           },
           {
-            type: "section" as const,
+            type: "section",
             label: "Outdoor",
             options: simpleOptionsSecondSection,
             actions: [
               {
-                type: "action" as const,
+                type: "action",
                 label: "Add Outdoor Service",
                 onClick: () => alert("Add Outdoor Service"),
               },
             ],
           },
           {
-            type: "section" as const,
+            type: "section",
             label: "Extras",
             options: simpleOptionsThirdSection,
             actions: [
               {
-                type: "action" as const,
+                type: "action",
                 label: "Add Extras Service",
                 onClick: () => alert("Add Extras Service"),
               },
             ],
           },
-        ]}
+        ])}
       />
     </Content>
   );
@@ -201,7 +209,7 @@ const TemplateEmptyStateAndActions: ComponentStory<
   typeof Autocomplete
 > = () => {
   const [value, setValue] = useState<OptionLike | undefined>();
-  const [inputValue, setInputValue] = useState("zzz");
+  const [inputValue, setInputValue] = useState("");
   const [modalOpen, setModalOpen] = useState(false);
   const [serviceValue, setServiceValue] = useState("");
 
@@ -224,7 +232,7 @@ const TemplateEmptyStateAndActions: ComponentStory<
               onClick: () => setModalOpen(true),
             },
           ]}
-          menu={[{ type: "options", options: [] }]}
+          menu={[{ type: "options", options: simpleOptions }]}
         />
       </Content>
       <Modal open={modalOpen} onRequestClose={() => setModalOpen(false)}>
@@ -240,24 +248,6 @@ const TemplateEmptyStateAndActions: ComponentStory<
     </>
   );
 };
-
-const noop = () => undefined;
-
-const TemplateLoading: ComponentStory<typeof Autocomplete> = () => (
-  <Content>
-    <Heading level={4}>Loading</Heading>
-    <Autocomplete
-      version={2}
-      placeholder="Loading..."
-      value={undefined}
-      onChange={noop}
-      inputValue={"Loading..."}
-      onInputChange={noop}
-      loading
-      menu={[]}
-    />
-  </Content>
-);
 
 const TemplateCustomRenderOption: ComponentStory<typeof Autocomplete> = () => {
   const [value, setValue] = useState<ServiceOption | undefined>();
@@ -278,7 +268,9 @@ const TemplateCustomRenderOption: ComponentStory<typeof Autocomplete> = () => {
             borderBottom: "1px solid var(--color-border)",
           },
         }}
-        menu={[{ type: "options", options: serviceOptions }]}
+        menu={defineMenu<ServiceOption>([
+          { type: "options", options: serviceOptions },
+        ])}
         customRenderOption={({ value: v, isSelected }) => (
           <div
             style={{
@@ -317,7 +309,7 @@ const TemplateHeaderFooter: ComponentStory<typeof Autocomplete> = () => {
         onChange={setValue}
         inputValue={inputValue}
         onInputChange={setInputValue}
-        menu={[
+        menu={defineMenu<OptionLike>([
           { type: "header", label: "Pinned header", shouldClose: false },
           { type: "options", options: simpleOptions },
           {
@@ -325,7 +317,7 @@ const TemplateHeaderFooter: ComponentStory<typeof Autocomplete> = () => {
             label: "Pinned footer",
             onClick: () => alert("Footer"),
           },
-        ]}
+        ])}
       />
     </Content>
   );
@@ -347,7 +339,9 @@ const TemplateFreeForm: ComponentStory<typeof Autocomplete> = () => {
         onInputChange={setInputValue}
         allowFreeForm
         createFreeFormValue={label => ({ label })}
-        menu={[{ type: "options", options: simpleOptions }]}
+        menu={defineMenu<OptionLike>([
+          { type: "options", options: simpleOptions },
+        ])}
       />
       <Text>Try typing an option not in the list, and blurring the input</Text>
       <Heading level={5}>Selected value: {value?.label}</Heading>
@@ -487,7 +481,229 @@ const TemplateAsyncUserManaged: ComponentStory<typeof Autocomplete> = () => {
         loading={loading}
         emptyStateMessage="No services found"
         isOptionEqualToValue={(option, selected) => option.key === selected.key}
-        menu={[{ type: "options", options }]}
+        menu={defineMenu<OptionLike>([{ type: "options", options }])}
+      />
+    </Content>
+  );
+};
+
+interface CustomOption extends OptionLike {
+  description: string;
+}
+
+interface ActionExtraProps {
+  icon?: IconNames;
+}
+
+const customOptions: CustomOption[] = [
+  {
+    label: "Drain Cleaning",
+    description: "Clear drains of accumulated debris and build up",
+  },
+  {
+    label: "Pipe Replacement",
+    description: "Replace old poly-b pipes with new PVC",
+  },
+  { label: "Sewer Line Repair", description: "Repair damaged sewer lines" },
+  {
+    label: "Window Cleaning",
+    description: "Clean windows of accumulated debris and build up",
+  },
+  {
+    label: "Roof Inspection",
+    description: "Inspect roofs for damage and wear",
+  },
+];
+
+const customOptions2: CustomOption[] = [
+  {
+    label: "Lawn Mowing",
+    description: "Mow the lawn",
+  },
+  {
+    label: "Gutter Repair",
+    description: "Repair damaged gutters",
+  },
+  { label: "Pressure Washing", description: "Pressure wash the house" },
+  {
+    label: "Fence Painting",
+    description: "Paint the fence",
+  },
+  {
+    label: "Garage Cleanup",
+    description: "Clean the garage",
+  },
+];
+
+const customActions: MenuAction<ActionExtraProps>[] = [
+  {
+    type: "action",
+    label: "Add Service",
+    icon: "plus",
+    onClick: () => alert("Add"),
+  },
+];
+
+const customActions2: MenuAction<ActionExtraProps>[] = [
+  {
+    type: "action",
+    label: "Add Other",
+    icon: "plus",
+    onClick: () => alert("Add"),
+  },
+];
+
+const customHeader: MenuHeader<ActionExtraProps> = {
+  type: "header",
+  label: "The prices of each service is in CAD",
+};
+
+const emptyActions: MenuAction<ActionExtraProps>[] = [
+  {
+    type: "action",
+    label: "Favorite",
+    icon: "star",
+    onClick: () => alert("Add"),
+  },
+];
+
+const customFooter: MenuFooter<ActionExtraProps> = {
+  type: "footer",
+  label: "Adjust prices",
+  icon: "edit",
+  onClick: () => alert("Footer"),
+};
+
+interface SectionExtraProps {
+  icon: IconNames;
+}
+
+const sectionedMenuCustomized = defineMenu<
+  CustomOption,
+  SectionExtraProps,
+  ActionExtraProps
+>([
+  {
+    type: "section",
+    label: "Indoor",
+    icon: "home",
+    options: customOptions,
+    actions: customActions,
+  },
+  {
+    type: "section",
+    label: "Off-site",
+    icon: "fuel",
+    options: customOptions2,
+    actions: customActions2,
+  },
+  customHeader,
+  customFooter,
+]);
+
+const TemplateEverythingCustomized: ComponentStory<
+  typeof Autocomplete
+> = () => {
+  const [value, setValue] = useState<CustomOption | undefined>();
+  const [inputValue, setInputValue] = useState("");
+
+  return (
+    <Content>
+      <Heading level={4}>Everything customized</Heading>
+      <Autocomplete
+        version={2}
+        placeholder="Search"
+        value={value}
+        onChange={setValue}
+        inputValue={inputValue}
+        onInputChange={setInputValue}
+        menu={sectionedMenuCustomized}
+        emptyActions={emptyActions}
+        filterOptions={(options, searchTerm) => {
+          return options.filter(option => {
+            // Search both label and description
+            return (
+              option.label.toLowerCase().includes(searchTerm.toLowerCase()) ||
+              option.description
+                .toLowerCase()
+                .includes(searchTerm.toLowerCase())
+            );
+          });
+        }}
+        customRenderAction={({ origin, value: actionValue }) => {
+          if (origin === "empty") {
+            return (
+              <Flex template={["shrink", "grow"]}>
+                {actionValue.icon ? <Icon name={actionValue.icon} /> : null}
+                <Typography textColor="interactive">
+                  {actionValue.label}
+                </Typography>
+              </Flex>
+            );
+          }
+
+          const iconName = actionValue.icon;
+
+          return (
+            <Flex template={["shrink", "grow"]}>
+              {iconName ? <Icon name={iconName} /> : null}
+              <Typography textColor="interactive">
+                {actionValue.label}
+              </Typography>
+            </Flex>
+          );
+        }}
+        customRenderHeader={({ value: headerValue }) => {
+          return <Emphasis variation="italic">{headerValue.label}</Emphasis>;
+        }}
+        customRenderFooter={({ value: footerValue }) => {
+          return (
+            <Flex template={["shrink", "grow"]}>
+              {footerValue.icon ? <Icon name={footerValue.icon} /> : null}
+              <Typography textColor="interactive">
+                {footerValue.label}
+              </Typography>
+            </Flex>
+          );
+        }}
+        customRenderSection={sectionValue => {
+          return (
+            <Flex template={["shrink", "grow"]}>
+              <Icon name={sectionValue.icon} />
+              <Typography fontWeight="bold">{sectionValue.label}</Typography>
+            </Flex>
+          );
+        }}
+        customRenderOption={({ value: optionValue, isSelected }) => {
+          return (
+            <Flex template={["grow", "shrink"]}>
+              {isSelected ? (
+                <Emphasis variation="bold">{optionValue.label}</Emphasis>
+              ) : (
+                <Text>{optionValue.label}</Text>
+              )}
+              {isSelected ? (
+                <Emphasis variation="bold">{optionValue.description}</Emphasis>
+              ) : (
+                <Text>{optionValue.description}</Text>
+              )}
+            </Flex>
+          );
+        }}
+        customRenderInput={({ inputRef, inputProps }) => {
+          return (
+            <InputText
+              ref={inputRef}
+              {...inputProps}
+              size="small"
+              suffix={{
+                icon: "search",
+                ariaLabel: "Search",
+                onClick: () => alert("Search"),
+              }}
+            />
+          );
+        }}
       />
     </Content>
   );
@@ -497,8 +713,8 @@ export const Flat = TemplateFlat.bind({});
 export const Sectioned = TemplateSectioned.bind({});
 export const WithActions = TemplateWithActions.bind({});
 export const EmptyStateAndActions = TemplateEmptyStateAndActions.bind({});
-export const Loading = TemplateLoading.bind({});
 export const CustomRenderOption = TemplateCustomRenderOption.bind({});
 export const HeaderFooter = TemplateHeaderFooter.bind({});
 export const FreeForm = TemplateFreeForm.bind({});
 export const AsyncUserManaged = TemplateAsyncUserManaged.bind({});
+export const EverythingCustomized = TemplateEverythingCustomized.bind({});

--- a/docs/components/Autocomplete/WebV2.stories.tsx
+++ b/docs/components/Autocomplete/WebV2.stories.tsx
@@ -10,6 +10,7 @@ import { Icon } from "@jobber/components/Icon";
 import { InputText } from "@jobber/components/InputText";
 import { Modal } from "@jobber/components/Modal";
 import { Button } from "@jobber/components/Button";
+import { Emphasis } from "@jobber/components/Emphasis";
 import { AutocompleteV2Docgen } from "./V2.docgen";
 
 export default {
@@ -259,7 +260,7 @@ const TemplateLoading: ComponentStory<typeof Autocomplete> = () => (
 );
 
 const TemplateCustomRenderOption: ComponentStory<typeof Autocomplete> = () => {
-  const [value, setValue] = useState<OptionLike | undefined>();
+  const [value, setValue] = useState<ServiceOption | undefined>();
   const [inputValue, setInputValue] = useState("");
 
   return (
@@ -272,11 +273,29 @@ const TemplateCustomRenderOption: ComponentStory<typeof Autocomplete> = () => {
         onChange={setValue}
         inputValue={inputValue}
         onInputChange={setInputValue}
+        UNSAFE_styles={{
+          option: {
+            borderBottom: "1px solid var(--color-border)",
+          },
+        }}
         menu={[{ type: "options", options: serviceOptions }]}
-        customRenderOption={({ value: v, isActive, isSelected }) => (
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        customRenderOption={({ value: v, isSelected }) => (
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+            }}
+          >
             {isSelected && <Icon name="checkmark" />}
-            <Text variation={isActive ? "info" : "default"}>{v.label}</Text>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              <Text variation={"default"}>{v.label}</Text>
+              <Text variation="subdued">{v.details}</Text>
+              <Emphasis variation="bold">${v.price}</Emphasis>
+            </div>
+            <div style={{ marginLeft: "auto" }}>
+              <Text variation="subdued">{v.description}</Text>
+            </div>
           </div>
         )}
       />

--- a/docs/components/Autocomplete/WebV2.stories.tsx
+++ b/docs/components/Autocomplete/WebV2.stories.tsx
@@ -330,6 +330,8 @@ const TemplateFreeForm: ComponentStory<typeof Autocomplete> = () => {
         createFreeFormValue={label => ({ label })}
         menu={[{ type: "options", options: simpleOptions }]}
       />
+      <Text>Try typing an option not in the list, and blurring the input</Text>
+      <Heading level={5}>Selected value: {value?.label}</Heading>
     </Content>
   );
 };

--- a/packages/components/src/Autocomplete/Autocomplete.rebuilt.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.rebuilt.test.tsx
@@ -337,6 +337,35 @@ describe("AutocompleteRebuilt", () => {
       expect(secondAction?.textContent).toContain("First Section Action");
     });
 
+    it("does not render section header or actions when section has no filtered options", async () => {
+      render(
+        <Wrapper
+          menu={[
+            menuSection<OptionLike>(
+              "Indoor",
+              [{ label: "Drain Cleaning" }],
+              [{ type: "action", label: "Add Service", onClick: jest.fn() }],
+            ),
+            menuSection<OptionLike>(
+              "Off-site",
+              [{ label: "Tree Removal" }],
+              [{ type: "action", label: "Add Other", onClick: jest.fn() }],
+            ),
+          ]}
+        />,
+      );
+
+      await openAutocomplete();
+      await typeInInput("Drain");
+
+      await expectMenuShown();
+      // Indoor has a matching option, so header is visible
+      expect(screen.queryByText("Indoor")).toBeVisible();
+      // Off-site has no matching options; header and its actions should not render
+      expect(screen.queryByText("Off-site")).not.toBeInTheDocument();
+      expect(screen.queryByText("Add Other")).not.toBeInTheDocument();
+    });
+
     it("does not render empty sections", async () => {
       render(
         <Wrapper
@@ -372,6 +401,35 @@ describe("AutocompleteRebuilt", () => {
 
       await expectMenuShown();
       expect(screen.queryByText("O Letter Section")).not.toBeInTheDocument();
+    });
+
+    it("only renders sections that have options", async () => {
+      render(
+        <Wrapper
+          menu={[
+            menuSection<OptionLike>(
+              "Section One Header Label",
+              [{ label: "Section 1 Option" }],
+              [],
+            ),
+            menuSection<OptionLike>(
+              "Section Two Header Label",
+              [{ label: "Section 2 Option" }],
+              [],
+            ),
+          ]}
+        />,
+      );
+
+      await openAutocomplete();
+      await typeInInput("Section 1");
+
+      await expectMenuShown();
+      expect(screen.queryByText("Section One Header Label")).toBeVisible();
+      expect(
+        screen.queryByText("Section Two Header Label"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Section 2 Option")).not.toBeInTheDocument();
     });
   });
 

--- a/packages/components/src/Autocomplete/Autocomplete.types.ts
+++ b/packages/components/src/Autocomplete/Autocomplete.types.ts
@@ -594,7 +594,6 @@ interface AutocompleteRebuiltBaseProps<
 
   /**
    * Custom equality for option to value mapping.
-   * TODO: decide if we wanna keep this
    */
   readonly isOptionEqualToValue?: (option: Value, value: Value) => boolean;
 }

--- a/packages/components/src/Autocomplete/index.tsx
+++ b/packages/components/src/Autocomplete/index.tsx
@@ -30,6 +30,14 @@ export {
   type GroupOption,
   type OptionCollection,
   type Option,
+  type MenuItem,
+  type MenuSection,
+  type MenuOptions,
+  type MenuHeader,
+  type MenuFooter,
+  type MenuAction,
+  type ExtraProps,
+  defineMenu,
 } from "./Autocomplete.types";
 
 export {

--- a/packages/components/src/Autocomplete/utils/menuModel.ts
+++ b/packages/components/src/Autocomplete/utils/menuModel.ts
@@ -54,10 +54,9 @@ export function buildItemsForGroup<
   const filtered = optionsFilter ? optionsFilter(group.options) : group.options;
   const actions = group.actions ?? [];
   const result: Array<RenderItem<Value, S, A>> = [];
-  const sectionHasContent =
-    isSection && (filtered.length > 0 || actions.length > 0);
 
-  if (sectionHasContent) {
+  // Only render a section header when that section has at least one option after filtering
+  if (isSection && filtered.length > 0) {
     result.push({
       kind: "section",
       section: group,
@@ -73,7 +72,8 @@ export function buildItemsForGroup<
     );
   }
 
-  if (actions.length > 0) {
+  // Only render actions for a group when that group has at least one option after filtering
+  if (actions.length > 0 && filtered.length > 0) {
     result.push(
       ...actions.map<RenderItem<Value, S, A>>(action => ({
         kind: "action",

--- a/packages/site/generateDocs.mjs
+++ b/packages/site/generateDocs.mjs
@@ -142,3 +142,11 @@ const buildMobileComponentDocs = name => {
 ListOfGeneratedWebComponents.forEach(buildComponentDocs);
 
 ListOfGeneratedMobileComponents.forEach(buildMobileComponentDocs);
+
+// Custom generation for components that don't follow the standard
+// <Component>/<Component>.tsx convention.
+// Autocomplete v2 (rebuilt) lives alongside v1 but uses a different filename.
+parseAndWriteDocs(
+  `${baseComponentDir}/Autocomplete/Autocomplete.rebuilt.tsx`,
+  `${baseOutputDir}/AutocompleteV2/AutocompleteV2.props.json`,
+);

--- a/packages/site/src/componentList.ts
+++ b/packages/site/src/componentList.ts
@@ -54,6 +54,13 @@ export const componentList = [
     additionalMatches: ["Search", "Typeahead", "Suggest"],
   },
   {
+    title: "Autocomplete (v2)",
+    to: "/components/Autocomplete (v2)",
+    imageURL: "/Autocomplete.png",
+    sections: ["Forms & Inputs"],
+    additionalMatches: ["Search", "Typeahead", "Suggest", "Rebuilt"],
+  },
+  {
     title: "AutoLink",
     to: "/components/AutoLink",
     imageURL: "/AutoLink.png",

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2.props.json
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2.props.json
@@ -1,0 +1,23 @@
+[
+  {
+    "tags": {},
+    "filePath": "../components/src/Autocomplete/Autocomplete.rebuilt.tsx",
+    "description": "",
+    "displayName": "Autocomplete",
+    "methods": [],
+    "props": {
+      "version": {
+        "defaultValue": {
+          "value": "2"
+        },
+        "description": "Version of the component to use.",
+        "name": "version",
+        "required": false,
+        "type": {
+          "name": "2"
+        }
+      }
+    }
+  }
+]
+

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2.props.json
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2.props.json
@@ -3,21 +3,559 @@
     "tags": {},
     "filePath": "../components/src/Autocomplete/Autocomplete.rebuilt.tsx",
     "description": "",
-    "displayName": "Autocomplete",
+    "displayName": "AutocompleteRebuilt",
     "methods": [],
     "props": {
       "version": {
-        "defaultValue": {
-          "value": "2"
-        },
-        "description": "Version of the component to use.",
+        "defaultValue": null,
+        "description": "",
         "name": "version",
-        "required": false,
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": true,
         "type": {
           "name": "2"
+        }
+      },
+      "multiple": {
+        "defaultValue": null,
+        "description": "Whether the autocomplete allows multiple selections.\nWARNING: This is currently incomplete and will not display selections, only data is returned.\nDo not use this prop unless you are sure you know what you are doing.",
+        "name": "multiple",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "value": {
+        "defaultValue": null,
+        "description": "The currently selected value of the Autocomplete.\nSingle-select: undefined indicates no selection",
+        "name": "value",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": true,
+        "type": {
+          "name": "Value[] | OptionLike"
+        }
+      },
+      "inputValue": {
+        "defaultValue": null,
+        "description": "The current input value of the Autocomplete.",
+        "name": "inputValue",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": true,
+        "type": {
+          "name": "string"
+        }
+      },
+      "onInputChange": {
+        "defaultValue": null,
+        "description": "Callback invoked when the input value changes.",
+        "name": "onInputChange",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": true,
+        "type": {
+          "name": "(value: string) => void"
+        }
+      },
+      "onBlur": {
+        "defaultValue": null,
+        "description": "Callback invoked when the input is blurred.",
+        "name": "onBlur",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      },
+      "onFocus": {
+        "defaultValue": null,
+        "description": "Callback invoked when the input is focused.",
+        "name": "onFocus",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      },
+      "inputEqualsOption": {
+        "defaultValue": null,
+        "description": "Custom equality for input text to option mapping.\nDefaults to case-sensitive label equality via getOptionLabel.",
+        "name": "inputEqualsOption",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(input: string, option: Value) => boolean"
+        }
+      },
+      "menu": {
+        "defaultValue": null,
+        "description": "Data structure for the menu.\nObserves a data hierarchy to determine elements, order, and grouping.\nAccepts Sections, Options as top level objects in the array.\nActions may appear in both sections and options.",
+        "name": "menu",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": true,
+        "type": {
+          "name": "MenuItem<Value, ExtraProps, ExtraProps>[]"
+        }
+      },
+      "filterOptions": {
+        "defaultValue": null,
+        "description": "Controls how options are filtered in response to the current input value.\n- Omit to use the default case-insensitive substring match against labels using getOptionLabel\n- Provide a function to implement custom filtering logic\n- Set to `false` to opt out of filtering entirely (useful for async options)",
+        "name": "filterOptions",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "false | ((options: Value[], inputValue: string) => Value[])"
+        }
+      },
+      "getOptionLabel": {
+        "defaultValue": null,
+        "description": "Used to determine the label for a given option, useful for custom data for options.\nDefaults to  option.label.",
+        "name": "getOptionLabel",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(option: Value) => string"
+        }
+      },
+      "debounce": {
+        "defaultValue": {
+          "value": "300"
+        },
+        "description": "Debounce in milliseconds for input-driven filtering and search render.\nSet to 0 to disable debouncing.",
+        "name": "debounce",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "number"
+        }
+      },
+      "customRenderOption": {
+        "defaultValue": null,
+        "description": "Render prop to customize the rendering of an option.\n@param args.value - The option value including all extra keys from the menu item\n@param args.isActive - Whether the option is currently highlighted/active\n@param args.isSelected - Whether the option is currently selected",
+        "name": "customRenderOption",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(args: { value: Value; isActive: boolean; isSelected: boolean; }) => ReactNode"
+        }
+      },
+      "customRenderSection": {
+        "defaultValue": null,
+        "description": "Render prop to customize the rendering of a section.\n@param args.section - The section value including all extra keys from the menu item",
+        "name": "customRenderSection",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(section: MenuSection<Value, ExtraProps, ExtraProps>) => ReactNode"
+        }
+      },
+      "customRenderAction": {
+        "defaultValue": null,
+        "description": "Render prop to customize the rendering of an action.\n@param args.value - The action value including all extra keys from the menu item\n@param args.isActive - Whether the action is currently highlighted/active\n@param args.origin - The origin of the action (\"menu\" or \"empty\")",
+        "name": "customRenderAction",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(args: { value: MenuAction<ExtraProps>; isActive: boolean; origin?: ActionOrigin; }) => ReactNode"
+        }
+      },
+      "customRenderHeader": {
+        "defaultValue": null,
+        "description": "Render prop to customize the rendering of header items.",
+        "name": "customRenderHeader",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(args: { value: MenuHeader<ExtraProps>; isActive?: boolean; }) => ReactNode"
+        }
+      },
+      "customRenderFooter": {
+        "defaultValue": null,
+        "description": "Render prop to customize the rendering of footer items.",
+        "name": "customRenderFooter",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(args: { value: MenuFooter<ExtraProps>; isActive?: boolean; }) => ReactNode"
+        }
+      },
+      "customRenderInput": {
+        "defaultValue": null,
+        "description": "Render prop to customize the rendering of the input.\n@param props.inputRef - The ref to the input element\n@param props.inputProps - The props to pass to the input element\nNote that you must pass the inputRef to the input",
+        "name": "customRenderInput",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(props: { inputRef: Ref<HTMLInputElement | HTMLTextAreaElement>; inputProps: InputTextRebuiltProps; }) => ReactNode"
+        }
+      },
+      "UNSAFE_className": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom class names for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_className",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ menu?: string; option?: string; section?: string; action?: string; input?: string; header?: string; footer?: string; }"
+        }
+      },
+      "UNSAFE_styles": {
+        "defaultValue": null,
+        "description": "**Use at your own risk:** Custom style for specific elements. This should only be used as a\n**last resort**. Using this may result in unexpected side effects.\nMore information in the [Customizing components Guide](https://atlantis.getjobber.com/guides/customizing-components).",
+        "name": "UNSAFE_styles",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ menu?: CSSProperties; option?: CSSProperties; section?: CSSProperties; action?: CSSProperties; input?: CSSProperties; header?: CSSProperties; footer?: CSSProperties; }"
+        }
+      },
+      "emptyStateMessage": {
+        "defaultValue": {
+          "value": "string \"No options\""
+        },
+        "description": "Render a custom empty state when the menu is empty.\nNOTE: Do not put interactive elements in the empty state, it will break accessibility.\nIf you require interactive elements in the empty state, use the `emptyActions` prop.\nTo opt out of the default empty state message entirely use \"false\".",
+        "name": "emptyStateMessage",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "ReactNode"
+        }
+      },
+      "emptyActions": {
+        "defaultValue": null,
+        "description": "Actions to display when there are no options to render after filtering.\nCan be a static list or a function that derives actions from the current input value.\nWhen provided and options are empty, these are rendered as navigable actions. Compatible with or without `emptyStateMessage`.",
+        "name": "emptyActions",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "MenuAction<ExtraProps>[] | ((args: { inputValue: string; }) => MenuAction<ExtraProps>[])"
+        }
+      },
+      "openOnFocus": {
+        "defaultValue": {
+          "value": "true"
+        },
+        "description": "Whether the menu should open when the input gains focus.",
+        "name": "openOnFocus",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "placeholder": {
+        "defaultValue": null,
+        "description": "The placeholder text for the input.",
+        "name": "placeholder",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "disabled": {
+        "defaultValue": null,
+        "description": "Whether the input is disabled.",
+        "name": "disabled",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "error": {
+        "defaultValue": null,
+        "description": "Error message to display below the input\nWhen present, invalid appearance applied to the input",
+        "name": "error",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "invalid": {
+        "defaultValue": null,
+        "description": "Whether the input is invalid. Receives invalid appearance.",
+        "name": "invalid",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "readOnly": {
+        "defaultValue": {
+          "value": "false"
+        },
+        "description": "Whether the input is read-only.",
+        "name": "readOnly",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "description": {
+        "defaultValue": null,
+        "description": "Description to display below the input",
+        "name": "description",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "name": {
+        "defaultValue": null,
+        "description": "Name of the input for form submission",
+        "name": "name",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
+      "size": {
+        "defaultValue": null,
+        "description": "Size of the input",
+        "name": "size",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "\"small\" | \"large\""
+        }
+      },
+      "suffix": {
+        "defaultValue": null,
+        "description": "",
+        "name": "suffix",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "{ onClick: () => void; readonly ariaLabel: string; readonly icon: IconNames; readonly label?: string; } | { onClick?: never; ariaLabel?: never; readonly label?: string; readonly icon?: IconNames; }"
+        }
+      },
+      "prefix": {
+        "defaultValue": null,
+        "description": "",
+        "name": "prefix",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "Affix"
+        }
+      },
+      "onOpen": {
+        "defaultValue": null,
+        "description": "Callback invoked when the menu opens.",
+        "name": "onOpen",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      },
+      "onClose": {
+        "defaultValue": null,
+        "description": "Callback invoked when the menu closes.",
+        "name": "onClose",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "() => void"
+        }
+      },
+      "loading": {
+        "defaultValue": null,
+        "description": "Whether the menu is loading.\nDisplays glimmers in the menu",
+        "name": "loading",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "customRenderLoading": {
+        "defaultValue": null,
+        "description": "Custom render prop for content to render when `loading` is true.",
+        "name": "customRenderLoading",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "ReactNode"
+        }
+      },
+      "isOptionEqualToValue": {
+        "defaultValue": null,
+        "description": "Custom equality for option to value mapping.",
+        "name": "isOptionEqualToValue",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "AutocompleteRebuiltBaseProps"
+        },
+        "required": false,
+        "type": {
+          "name": "(option: Value, value: Value) => boolean"
+        }
+      },
+      "allowFreeForm": {
+        "defaultValue": null,
+        "description": "Whether the autocomplete allows free-form input.\nWhen true, the input value is not restricted to the options * in the menu. Input can be used to create a new value.\nWhen false, the input value must match an option in the menu.\nInput value will be cleared if no selection is made and\nWhether the autocomplete allows free-form input.\nWhen true, the input value is not restricted to the options in the menu. Input can be used to create a new value.\nWhen false, the input value must match an option in the menu.\nInput value will be cleared if no selection is made and focus is lost.\nWhether the autocomplete allows free-form input.\nWhen true, the input value is not restricted to the options in the menu. Input can be used to create a new value.\nWhen false, the input value must match an option in the menu.\nInput value will be cleared if no selection is made and focus is lost.",
+        "name": "allowFreeForm",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "FreeFormOn"
+        },
+        "required": false,
+        "type": {
+          "name": "boolean"
+        }
+      },
+      "createFreeFormValue": {
+        "defaultValue": null,
+        "description": "Factory used to create a Value from free-form input when committing. Necessary with complex option values. The only value the input can produce is a string.\n@param input - The input value",
+        "name": "createFreeFormValue",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "FreeFormOn"
+        },
+        "required": true,
+        "type": {
+          "name": "(input: string) => Value"
+        }
+      },
+      "onChange": {
+        "defaultValue": null,
+        "description": "Callback invoked when the selection value changes.\nThis is called when we consider a selection \"committed\"\n- The user presses enter\n- The user clicks outside the menu with a selection typed\n- The user clicks the clear button\nThe user clears a previous selection by deleting the input value\n- The user selects an option with click or enter\n- The user types a value that matches an option\n- The user types a value that does not match an option and allowFreeForm is true\nCallback invoked when the selection value changes.",
+        "name": "onChange",
+        "parent": {
+          "fileName": "packages/components/src/Autocomplete/Autocomplete.types.ts",
+          "name": "FreeFormOn"
+        },
+        "required": true,
+        "type": {
+          "name": "((value: AutocompleteValue<Value, Multiple>) => void) | ((value: AutocompleteValue<Value, Multiple>) => void)"
+        }
+      },
+      "ref": {
+        "defaultValue": null,
+        "description": "",
+        "name": "ref",
+        "required": false,
+        "type": {
+          "name": "Ref<HTMLInputElement | HTMLTextAreaElement>"
         }
       }
     }
   }
 ]
-

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
@@ -18,10 +18,9 @@ that the user can select. These options should be presented in a way that makes
 it easy for the user to find the value they are looking for. There are a few
 ways to achieve this.
 
-[Section headings](../?path=/story/components-forms-and-inputs-autocomplete-web--section-heading)
-can be added to an Autocomplete to break up the options into groups. This can be
-useful if there are a lot of options or if the options are related to different
-things.
+Section headings can be added to an Autocomplete to break up the options into
+groups. This can be useful if there are a lot of options or if the options are
+related to different things.
 
 Headers and Footers can be used to present persistent information or actions
 that should always be available regardless of results, or scroll location in the
@@ -32,17 +31,23 @@ focus of the Autocomplete.
 Empty actions can be used to present a user with relevant actions to take when
 no options exist.
 
+### FreeForm
+
 The "free form" allows for using a text value that does not already exist in the
 list of options. This works best when the content of an option is simply a word.
 When the content is more complex, we have to consider what to populate the
 additional fields with.
 
-An alternate approach when the data is complex is to leverage the empty actions,
+An alternate approach with complex data, is to leverage the empty actions,
 actions, or header/footer actions to launch a creation flow to populate the
 fields.
 
+### Stay Open Behavior
+
 Actions can be individually configured to keep the menu open when used if
 desired.
+
+### Interactive Content
 
 Content in options, actions, headers, footers, and sections can all be
 customized, however it is imperative to avoid putting additional interactive
@@ -51,8 +56,12 @@ elements inside any of these. Because focus remains in the input, and we
 is impossible to Tab to any nested interactive elements such as a button inside
 of a row. Instead, use the provided action interfaces.
 
+### Content Complexity
+
 When providing complex content in each option, it is recommended to separate the
 options with a border bottom to improve readability of the options.
+
+### Content Consistency
 
 Items of the same type should appear consistently ie. if an Autocomplete has
 options, sections and actions avoid making the apperance of some options

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
@@ -22,11 +22,12 @@ that the user can select. These options should be presented in a way that makes
 it easy for the user to find the value they are looking for. There are a few
 ways to achieve this.
 
+
+### Sectioned
+
 Section headings can be added to an Autocomplete to break up the options into
 groups. This can be useful if there are a lot of options or if the options are
 related to different things.
-
-### Sectioned
 
 export const AutocompleteV2SectionedExample = () => {
   const [value, setValue] = useState();
@@ -63,7 +64,8 @@ export const AutocompleteV2SectionedExample = () => {
     },
   ];
 
-return ( <Autocomplete
+  return (
+    <Autocomplete
       version={2}
       placeholder="Search"
       value={value}
@@ -71,11 +73,15 @@ return ( <Autocomplete
       inputValue={inputValue}
       onInputChange={setInputValue}
       menu={menu}
-    /> ); };
+    />
+  );
+};
 
 <Canvas>
   <AutocompleteV2SectionedExample />
 </Canvas>
+
+### Header and Footers
 
 Headers and Footers can be used to present persistent information or actions
 that should always be available regardless of results, or scroll location in the
@@ -83,26 +89,118 @@ list of options. While there is no limit to how many can be present, it is
 advisable to use them sparringly to prevent the options from being the primary
 focus of the Autocomplete.
 
+
 export const AutocompleteV2HeaderFooterExample = () => {
   const [value, setValue] = useState();
   const [inputValue, setInputValue] = useState("");
 
-return ( <Content> <Heading level={5}>Header/Footer</Heading> <Autocomplete
-version={2} placeholder="Search" value={value} onChange={setValue}
-inputValue={inputValue} onInputChange={setInputValue} menu={[ { type: "header",
-label: "Pinned header", shouldClose: false }, { type: "options", options: [ {
-label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label: "Sewer Line
-Repair" }, { label: "Window Cleaning" }, { label: "Roof Inspection" }, { label:
-"Lawn Mowing" }, { label: "Hedge Trimming" }, ], }, { type: "footer", label:
-"Interactive footer", onClick: () => { alert("Clicked") } }, ]} /> </Content> );
+  return (
+    <Content>
+      <Heading level={5}>Header/Footer</Heading>
+      <Autocomplete
+        version={2}
+        placeholder="Search"
+        value={value}
+        onChange={setValue}
+        inputValue={inputValue}
+        onInputChange={setInputValue}
+        menu={[
+          { type: "header", label: "Pinned header", shouldClose: false },
+          {
+            type: "options",
+            options: [
+              { label: "Drain Cleaning" },
+              { label: "Pipe Replacement" },
+              { label: "Sewer Line Repair" },
+              { label: "Window Cleaning" },
+              { label: "Roof Inspection" },
+              { label: "Lawn Mowing" },
+              { label: "Hedge Trimming" },
+            ],
+          },
+          { type: "footer", label: "Interactive footer", onClick: () => { alert("Clicked") } },
+        ]}
+      />
+    </Content>
+  );
 };
 
 <Canvas>
   <AutocompleteV2HeaderFooterExample />
 </Canvas>
 
+### Actions
+
+Actions may be placed either on the "flat" list of options or in individual sections. They are accessible by keyboard using arrow keys and Enter to select the highlighted action.
+
+
+export const AutocompleteV2ActionsExample = () => {
+  const [value, setValue] = useState();
+  const [inputValue, setInputValue] = useState("");
+  const [open, setOpen] = useState(false);
+  const [newService, setNewService] = useState("");
+
+  return (
+    <Content>
+      <Heading level={5}>Actions</Heading>
+      <Autocomplete
+        version={2}
+        placeholder="Options and actions"
+        value={value}
+        onChange={setValue}
+        inputValue={inputValue}
+        onInputChange={setInputValue}
+        emptyStateMessage="No services found"
+        menu={[
+          {
+            type: "section",
+            label: "Indoor",
+            options: [
+              { label: "Drain Cleaning" },
+              { label: "Pipe Replacement" },
+              { label: "Sewer Line Repair" },
+              { label: "Window Cleaning" },
+            ],
+            actions: [
+              {
+                type: "action",
+                label: "New Indoor",
+                onClick: () => { alert("Adding indoor service") }
+              }
+            ],
+          },
+          {
+            type: "section",
+            label: "Outdoor",
+            options: [
+              { label: "Window Cleaning" },
+              { label: "Roof Inspection" },
+              { label: "Lawn Mowing" },
+              { label: "Hedge Trimming" },
+            ],
+            actions: [
+              {
+                type: "action",
+                label: "New Outdoor",
+                onClick: () => { alert("Adding outdoor service") }
+              }
+            ],
+          },  
+        ]}
+      />
+    </Content>
+  );
+};
+
+<Canvas>
+  <AutocompleteV2ActionsExample />
+</Canvas>
+
+### Empty Actions
+
 Empty actions can be used to present a user with relevant actions to take when
-no options exist.
+no options exist. They will not be visible otherwise.
+
 
 export const AutocompleteV2EmptyActionsExample = () => {
   const [value, setValue] = useState();
@@ -110,19 +208,98 @@ export const AutocompleteV2EmptyActionsExample = () => {
   const [open, setOpen] = useState(false);
   const [newService, setNewService] = useState("");
 
-return ( <Content> <Heading level={5}>Empty actions</Heading> <Autocomplete
-version={2} placeholder="Try a term with no matches" value={value}
-onChange={setValue} inputValue={inputValue} onInputChange={setInputValue}
-emptyStateMessage="No services found" emptyActions={[ { type: "action", label:
-"Create service", onClick: () => setOpen(true), }, ]} menu={[ { type: "options",
-options: [ { label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label:
-"Sewer Line Repair" }, ], }, ]} /> {open ? ( <Content> <Heading level={5}>Create
-service</Heading> <input value={newService} onChange={e =>
-setNewService(e.target.value)} /> <Button label="Create" onClick={() =>
-setOpen(false)} /> </Content> ) : null} </Content> ); };
+  return (
+    <Content>
+      <Heading level={5}>Empty actions</Heading>
+      <Autocomplete
+        version={2}
+        placeholder="Try a term with no matches"
+        value={value}
+        onChange={setValue}
+        inputValue={inputValue}
+        onInputChange={setInputValue}
+        emptyStateMessage="No services found"
+        emptyActions={[
+          {
+            type: "action",
+            label: "Create service",
+            onClick: () => setOpen(true),
+          },
+        ]}
+        menu={[
+          {
+            type: "options",
+            options: [
+              { label: "Drain Cleaning" },
+              { label: "Pipe Replacement" },
+              { label: "Sewer Line Repair" },
+            ],
+          },
+        ]}
+      />
+      {open ? (
+        <Content>
+          <Heading level={5}>Create service</Heading>
+          <input
+            value={newService}
+            onChange={e => setNewService(e.target.value)}
+          />
+          <Button label="Create" onClick={() => setOpen(false)} />
+        </Content>
+      ) : null}
+    </Content>
+  );
+};
 
 <Canvas>
   <AutocompleteV2EmptyActionsExample />
+</Canvas>
+
+### Stay Open Behavior
+
+All interactive elements (actions, headers, footers, empty actions) can be individually configured to keep the menu open when used if
+desired.
+
+
+export const AutocompleteV2StayOpenExample = () => {
+  const [value, setValue] = useState();
+  const [inputValue, setInputValue] = useState("");
+
+  return (
+    <Content>
+      <Heading level={5}>Stay Open Action</Heading>
+      <Autocomplete
+        version={2}
+        placeholder="Search"
+        value={value}
+        onChange={setValue}
+        inputValue={inputValue}
+        onInputChange={setInputValue}
+        menu={[
+          {
+            type: "options",
+            options: [
+              { label: "Drain Cleaning" },
+              { label: "Pipe Replacement" },
+              { label: "Sewer Line Repair" },
+            ],
+            actions: [
+              {
+                type: "action",
+                label: "Add Service (stays open)",
+                shouldClose: false,
+                onClick: () => alert("Add Service"),
+              },
+            ],
+          },
+        ]}
+      />
+    </Content>
+  );
+};
+
+<Canvas>
+  <AutocompleteV2StayOpenExample />
 </Canvas>
 
 ### FreeForm
@@ -146,34 +323,26 @@ export const AutocompleteV2FreeFormExample = () => {
     { label: "Window Cleaning" },
   ];
 
-return ( <> <p>Your selection is: {value?.label ?? "" }</p> <Autocomplete
-version={2} placeholder="Type anything" value={value} onChange={setValue}
-inputValue={inputValue} onInputChange={setInputValue} allowFreeForm
-createFreeFormValue={label => ({ label })} menu={[{ type: "options", options }]}
-/> </> ); };
+  return (
+    <>
+    <p>Your selection is: {value?.label ?? "" }</p>
+    <Autocomplete
+      version={2}
+      placeholder="Type anything"
+      value={value}
+      onChange={setValue}
+      inputValue={inputValue}
+      onInputChange={setInputValue}
+      allowFreeForm
+      createFreeFormValue={label => ({ label })}
+      menu={[{ type: "options", options }]}
+    />
+    </>
+  );
+};
 
 <Canvas>
   <AutocompleteV2FreeFormExample />
-</Canvas>
-### Stay Open Behavior
-
-Actions can be individually configured to keep the menu open when used if
-desired.
-
-export const AutocompleteV2StayOpenExample = () => {
-  const [value, setValue] = useState();
-  const [inputValue, setInputValue] = useState("");
-
-return ( <Content> <Heading level={5}>Stay Open Action</Heading> <Autocomplete
-version={2} placeholder="Search" value={value} onChange={setValue}
-inputValue={inputValue} onInputChange={setInputValue} menu={[ { type: "options",
-options: [ { label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label:
-"Sewer Line Repair" }, ], actions: [ { type: "action", label: "Add Service
-(stays open)", shouldClose: false, onClick: () => alert("Add Service"), }, ], },
-]} /> </Content> ); };
-
-<Canvas>
-  <AutocompleteV2StayOpenExample />
 </Canvas>
 
 ### Interactive Content

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
@@ -8,8 +8,61 @@ import { Autocomplete } from "@jobber/components/Autocomplete";
 
 # Autocomplete (v2)
 
-This is the rebuilt Autocomplete. Dedicated docs live here for the new
-implementation.
+An Autocomplete component allows a user to quickly pick a preset value from a
+larger list of possible options.
 
-- Differences from v1 will be documented here.
--
+## Design & usage guidelines
+
+The options in an Autocomplete component should be a list of possible values
+that the user can select. These options should be presented in a way that makes
+it easy for the user to find the value they are looking for. There are a few
+ways to achieve this.
+
+[Section headings](../?path=/story/components-forms-and-inputs-autocomplete-web--section-heading)
+can be added to an Autocomplete to break up the options into groups. This can be
+useful if there are a lot of options or if the options are related to different
+things.
+
+Headers and Footers can be used to present persistent information or actions
+that should always be available regardless of results, or scroll location in the
+list of options. While there is no limit to how many can be present, it is
+advisable to use them sparringly to prevent the options from being the primary
+focus of the Autocomplete.
+
+Empty actions can be used to present a user with relevant actions to take when
+no options exist.
+
+The "free form" allows for using a text value that does not already exist in the
+list of options. This works best when the content of an option is simply a word.
+When the content is more complex, we have to consider what to populate the
+additional fields with.
+
+An alternate approach when the data is complex is to leverage the empty actions,
+actions, or header/footer actions to launch a creation flow to populate the
+fields.
+
+Actions can be individually configured to keep the menu open when used if
+desired.
+
+Content in options, actions, headers, footers, and sections can all be
+customized, however it is imperative to avoid putting additional interactive
+elements inside any of these. Because focus remains in the input, and we
+"virtually" move the highlighted item with arrow keys on keyboard navigation, it
+is impossible to Tab to any nested interactive elements such as a button inside
+of a row. Instead, use the provided action interfaces.
+
+When providing complex content in each option, it is recommended to separate the
+options with a border bottom to improve readability of the options.
+
+Items of the same type should appear consistently ie. if an Autocomplete has
+options, sections and actions avoid making the apperance of some options
+different from the rest.
+
+## Related components
+
+- If you want to present a list of predefined options without text input, or the
+  number of options is smaller, use a [Select](/components/Select)
+- If autocompleted results are not required for the text input, use
+  [InputText](/components/InputText)
+- If a text input appearance is not required, and options can only be from a
+  predefined set then a Combobox can be used

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
@@ -1,0 +1,15 @@
+import { Meta } from "@storybook/addon-docs";
+import { Autocomplete } from "@jobber/components/Autocomplete";
+
+<Meta
+  title="Components/Forms and Inputs/Autocomplete/Web (v2)"
+  component={Autocomplete}
+/>
+
+# Autocomplete (v2)
+
+This is the rebuilt Autocomplete. Dedicated docs live here for the new
+implementation.
+
+- Differences from v1 will be documented here.
+-

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2.stories.mdx
@@ -1,5 +1,9 @@
-import { Meta } from "@storybook/addon-docs";
+import { Canvas, Meta } from "@storybook/addon-docs";
 import { Autocomplete } from "@jobber/components/Autocomplete";
+import { Content } from "@jobber/components/Content";
+import { Heading } from "@jobber/components/Heading";
+import { Button } from "@jobber/components/Button";
+import { useState } from "react";
 
 <Meta
   title="Components/Forms and Inputs/Autocomplete/Web (v2)"
@@ -22,14 +26,104 @@ Section headings can be added to an Autocomplete to break up the options into
 groups. This can be useful if there are a lot of options or if the options are
 related to different things.
 
+### Sectioned
+
+export const AutocompleteV2SectionedExample = () => {
+  const [value, setValue] = useState();
+  const [inputValue, setInputValue] = useState("");
+  const menu = [
+    {
+      type: "section",
+      label: "Indoor",
+      options: [
+        { label: "Drain Cleaning" },
+        { label: "Pipe Replacement" },
+        { label: "Sewer Line Repair" },
+        { label: "Window Cleaning" },
+      ],
+    },
+    {
+      type: "section",
+      label: "Outdoor",
+      options: [
+        { label: "Window Cleaning" },
+        { label: "Roof Inspection" },
+        { label: "Lawn Mowing" },
+        { label: "Hedge Trimming" },
+      ],
+    },      
+    {
+      type: "section",
+      label: "Misc",
+      options: [
+        { label: "Assessment" },
+        { label: "Inspection" },
+        { label: "2nd Opinion" },
+      ],
+    },
+  ];
+
+return ( <Autocomplete
+      version={2}
+      placeholder="Search"
+      value={value}
+      onChange={setValue}
+      inputValue={inputValue}
+      onInputChange={setInputValue}
+      menu={menu}
+    /> ); };
+
+<Canvas>
+  <AutocompleteV2SectionedExample />
+</Canvas>
+
 Headers and Footers can be used to present persistent information or actions
 that should always be available regardless of results, or scroll location in the
 list of options. While there is no limit to how many can be present, it is
 advisable to use them sparringly to prevent the options from being the primary
 focus of the Autocomplete.
 
+export const AutocompleteV2HeaderFooterExample = () => {
+  const [value, setValue] = useState();
+  const [inputValue, setInputValue] = useState("");
+
+return ( <Content> <Heading level={5}>Header/Footer</Heading> <Autocomplete
+version={2} placeholder="Search" value={value} onChange={setValue}
+inputValue={inputValue} onInputChange={setInputValue} menu={[ { type: "header",
+label: "Pinned header", shouldClose: false }, { type: "options", options: [ {
+label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label: "Sewer Line
+Repair" }, { label: "Window Cleaning" }, { label: "Roof Inspection" }, { label:
+"Lawn Mowing" }, { label: "Hedge Trimming" }, ], }, { type: "footer", label:
+"Interactive footer", onClick: () => { alert("Clicked") } }, ]} /> </Content> );
+};
+
+<Canvas>
+  <AutocompleteV2HeaderFooterExample />
+</Canvas>
+
 Empty actions can be used to present a user with relevant actions to take when
 no options exist.
+
+export const AutocompleteV2EmptyActionsExample = () => {
+  const [value, setValue] = useState();
+  const [inputValue, setInputValue] = useState("");
+  const [open, setOpen] = useState(false);
+  const [newService, setNewService] = useState("");
+
+return ( <Content> <Heading level={5}>Empty actions</Heading> <Autocomplete
+version={2} placeholder="Try a term with no matches" value={value}
+onChange={setValue} inputValue={inputValue} onInputChange={setInputValue}
+emptyStateMessage="No services found" emptyActions={[ { type: "action", label:
+"Create service", onClick: () => setOpen(true), }, ]} menu={[ { type: "options",
+options: [ { label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label:
+"Sewer Line Repair" }, ], }, ]} /> {open ? ( <Content> <Heading level={5}>Create
+service</Heading> <input value={newService} onChange={e =>
+setNewService(e.target.value)} /> <Button label="Create" onClick={() =>
+setOpen(false)} /> </Content> ) : null} </Content> ); };
+
+<Canvas>
+  <AutocompleteV2EmptyActionsExample />
+</Canvas>
 
 ### FreeForm
 
@@ -42,10 +136,45 @@ An alternate approach with complex data, is to leverage the empty actions,
 actions, or header/footer actions to launch a creation flow to populate the
 fields.
 
+export const AutocompleteV2FreeFormExample = () => {
+  const [value, setValue] = useState();
+  const [inputValue, setInputValue] = useState("");
+  const options = [
+    { label: "Drain Cleaning" },
+    { label: "Pipe Replacement" },
+    { label: "Sewer Line Repair" },
+    { label: "Window Cleaning" },
+  ];
+
+return ( <> <p>Your selection is: {value?.label ?? "" }</p> <Autocomplete
+version={2} placeholder="Type anything" value={value} onChange={setValue}
+inputValue={inputValue} onInputChange={setInputValue} allowFreeForm
+createFreeFormValue={label => ({ label })} menu={[{ type: "options", options }]}
+/> </> ); };
+
+<Canvas>
+  <AutocompleteV2FreeFormExample />
+</Canvas>
 ### Stay Open Behavior
 
 Actions can be individually configured to keep the menu open when used if
 desired.
+
+export const AutocompleteV2StayOpenExample = () => {
+  const [value, setValue] = useState();
+  const [inputValue, setInputValue] = useState("");
+
+return ( <Content> <Heading level={5}>Stay Open Action</Heading> <Autocomplete
+version={2} placeholder="Search" value={value} onChange={setValue}
+inputValue={inputValue} onInputChange={setInputValue} menu={[ { type: "options",
+options: [ { label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label:
+"Sewer Line Repair" }, ], actions: [ { type: "action", label: "Add Service
+(stays open)", shouldClose: false, onClick: () => alert("Add Service"), }, ], },
+]} /> </Content> ); };
+
+<Canvas>
+  <AutocompleteV2StayOpenExample />
+</Canvas>
 
 ### Interactive Content
 
@@ -64,7 +193,7 @@ options with a border bottom to improve readability of the options.
 ### Content Consistency
 
 Items of the same type should appear consistently ie. if an Autocomplete has
-options, sections and actions avoid making the apperance of some options
+options, sections and actions avoid making the appearance of some options
 different from the rest.
 
 ## Related components

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -156,7 +156,7 @@ input for further refinements to the search term.
 
 #### Actions
 
-Ontop of the basics, there are also "actions" that can be used either on the
+On top of the basics, there are also "actions" that can be used either on the
 "options" or "section" type. These will always be rendered at the bottom of
 their respective grouping whether that is a section or flat top level options.
 

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -279,7 +279,7 @@ exactly matches an option.
 
 ### Keys
 
-By default, each element's `label` is used as its React key. If Any two items
+By default, each element's `label` is used as its React key. If any two items
 have the same label, or label can otherwise not be guaranteed to be unique -
 then you must provide a `key` on the object. This key on the objects is
 reserved, and used exclusively for this purpose.

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -51,7 +51,7 @@ generally not recommended. The inconsistency of having sections for only some
 options can lead to a confusing user experience.
 
 Options can be selected with the enter key if it active/highlighted, or with a
-mouse click. Space will do nothing becase focus is intentionally kept in the
+mouse click. Space will do nothing because focus is intentionally kept in the
 input for further refinements to the search term.
 
 <details>

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -277,6 +277,13 @@ actively chose to remove the selection.
 If free form is not allowed, blurring will clear the input unless the content
 exactly matches an option.
 
+### Keys
+
+By default, each element's `label` is used as its React key. If Any two items
+have the same label, or label can otherwise not be guaranteed to be unique -
+then you must provide a `key` on the object. This key on the objects is
+reserved, and used exclusively for this purpose.
+
 ### Multiple
 
 This is not yet implemented fully. Avoid using.

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -8,7 +8,7 @@ what can be done with the experience.
 V2 is entirely controlled, having both sets of `inputValue`, `onInputChange`,
 `value` and `onChange`.
 
-Fitering is now built in to Autocomplete v2. It has a default filter of
+Filtering is now built into Autocomplete v2. It has a default filter of
 comparing the input value to the case insensitive "label" value. If using custom
 data, where we might want to search a different field, or even multiple fields,
 providing filterOptions allows customization of the filter logic. For cases with

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -260,29 +260,23 @@ where you must provide the value for these additional fields.
 `allowFreeForm` with simple items having only "label" is the easiest way to
 leverage this prop.
 
-### "Commit Signals"
+### "onChange"
 
 Autocomplete has some nuance as far as `onChange` and when we consider the
-Autocomplete's selection to have changed. It is important to note that this is
-not always the same as the input value.
+Autocomplete's selection to have changed.
 
-For example consider an option of "Fall" in the options, and an input value of
-"all" - with `allowFreeForm` at this point we cannot know if "all" is being used
-as a search term to narrow the results to "Fall" or if "all" is a new, free form
-value.
+Since we can't know if the input value is only being used to refine results to
+an option to select, or if it will be used as a free form value itself - we must
+wait until blur to definitively say a non-explicit selection has been made.
 
-Since we cannot know during use, we wait until blur to inform `onChange` that
-"all" was selected. This is an implicit commit signal. We have other implicit
-signals like having a selection and then deleting it. We also have explicit
-commit signals from clicking an option, or using the Enter key to make a
-selection.
+There are of course some explicit commit signals such as selecting an option
+with a click, or Enter press with an item highlighted. Another is if there is an
+existing selection, clearing it is considered an `onChange` because the user
+actively chose to remove the selection.
 
-Conversely when free form is disabled and the input is blurred, if the input
-value does not match an option we will consider this as meaning that no valid
-selection was made and will clear the input.
-
-Typing an option value exactly also works, but will only be evaluated on blur.
+If free form is not allowed, blurring will clear the input unless the content
+exactly matches an option.
 
 ### Multiple
 
-This is not yet implemented fully. Avoid using for now.
+This is not yet implemented fully. Avoid using.

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -192,7 +192,7 @@ typing.
 
 While `options`, `section`s, `action`s, `footer`s, and `header`s all have a
 minimum of `label` they can all be enhanced with additional key/values of your
-choosing. These value will be accessible in their respective `customRender`
+choosing. These values will be accessible in their respective `customRender`
 methods.
 
 Each `customRender` will have slightly different arguments, with interactive

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -1,17 +1,288 @@
-### Implement
+### V1 to v2
 
-Usage for the rebuilt `Autocomplete`:
+V1 has a single mechanism to update the options. Only `initialOptions` are
+directly controlled, then `getOptions` is used to populate the options based on
+the input term. This is managed with internal state that creates barriers as to
+what can be done with the experience.
 
-```tsx
-<Autocomplete
-  version={2}
-  placeholder="Search"
-  value={value}
-  onChange={setValue}
-  inputValue={inputValue}
-  onInputChange={setInputValue}
-  menu={[{ type: "options", options: [{ label: "One" }] }]}
-/>
+V2 is entirely controlled, having both sets of `inputValue`, `onInputChange`,
+`value` and `onChange`.
+
+Fitering is now built in to Autocomplete v2. It has a default filter of
+comparing the input value to the case insensitive "label" value. If using custom
+data, where we might want to search a different field, or even multiple fields,
+providing filterOptions allows customization of the filter logic. For cases with
+async data it is recommended to opt out of filtering entirely, and manage that
+yourself with the results you return and pass as options. This can be done with
+`filterOptions={false}`.
+
+V2 has been decoupled from React Hook Form, and has no built in validation. To
+validate, you must create your own logic and use either `error` or `invalid` to
+set the visually invalid state on the input. `onBlur`, `value`, `onChange`,
+`inputValue`, `onInputChange` provide all the necessary callbacks to determine
+the state of the Autocomplete. These callbacks will integrate with a schema like
+Zod, and an external instance of RHF.
+
+Filtering is now built in, and not necessary to implement yourself. You are able
+to opt out or customize it if desired, see more about this in the filtering
+section.
+
+While sections still exist, the additional pre defined "details" and
+"description" variations are not directly available by default. They can be
+re-created with custom data, custom layouts, and modified option/section styles.
+
+All options will by default continue to be visible after making a selection
+whereas v1 would limit your options to the selected option if a selection is
+present.
+
+### Structure, `menu` and `type`s
+
+The `menu` prop accepts 2 different possible "top level" types: "options" and
+"section". For a "flat" set of options, simply provide "options" where the
+minimum required data is `label: string`. For a sectioned set of options,
+provide "section" which also has a minimum `label: string` in addition to an
+`options` key.
+
+Each section will be rendered in the order provided, the same is true of the
+options.
+
+While it is possible to combine both flat options and sectioned options, it is
+generally not recommended. The inconsistency of having sections for only some
+options can lead to a confusing user experience.
+
+Options can be selected with the enter key if it active/highlighted, or with a
+mouse click. Space will do nothing becase focus is intentionally kept in the
+input for further refinements to the search term.
+
+<details>
+ <summary>V1 Section vs V2</summary>
+
+```
+ const SectionHeadingOptions = [
+   {
+     label: "Ships",
+     options: [
+       { value: 1, label: "Sulaco" },
+       { value: 2, label: "Nostromo" },
+       { value: 3, label: "Serenity" },
+       { value: 4, label: "Sleeper Service" },
+       { value: 5, label: "Enterprise" },
+       { value: 6, label: "Enterprise-D" },
+     ],
+   },
+   {
+     label: "Planets",
+     options: [
+       { value: 7, label: "Endor" },
+       { value: 8, label: "Vulcan" },
+       { value: 9, label: "Bespin" },
+       { value: 10, label: "Tatooine" },
+     ],
+   },
+ ];
+
+ const [value, setValue] = useState<Option | undefined>();
+
+ return (
+   <Autocomplete
+     initialOptions={SectionHeadingOptions}
+     placeholder="Search for something under a section heading"
+     value={value}
+     onChange={newValue => setValue(newValue)}
+     getOptions={getOptions}
+   />
+ );
+
+ function getOptions(text: string) {
+   if (text === "") {
+     return headingOptions;
+   }
+   const filterRegex = new RegExp(text, "i");
+
+   return headingOptions.map(section => ({
+     ...section,
+     options: section.options.filter(option =>
+       option.label.match(filterRegex),
+     ),
+   }));
+ }
+
+ // VERSION 2 BELOW
+
+ const sectionMenu = [
+   {
+     type: "section",
+     label: "Ships",
+     options: [
+       { label: "Sulaco" },
+       { label: "Nostromo" },
+       { label: "Serenity" },
+       { label: "Sleeper Service" },
+       { label: "Enterprise" },
+       { label: "Enterprise-D" },
+     ]
+   },
+   {
+     type: "section",
+     label: "Planets",
+     options: [
+       { label: "Endor" },
+       { label: "Vulcan" },
+       { label: "Bespin" },
+       { label: "Tatooine" },
+     ],
+   },
+ ];
+
+ const [value, setValue] = useState(undefined);
+ const [inputValue, setInputValue] = useState("");
+
+ return(
+   <Autocomplete
+     version={2}
+     menu={sectionMenu}
+     value={value}
+     onChange={setValue}
+     inputValue={inputValue}
+     onInputChange={setInputValue}
+     placeholder="Search for something under a section heading"
+   />
+ );
 ```
 
-Additional guidance and migration notes from v1 to v2 will be added here.
+</details>
+
+### Additional Elements
+
+#### Actions
+
+Ontop of the basics, there are also "actions" that can be used either on the
+"options" or "section" type. These will always be rendered at the bottom of
+their respective grouping whether that is a section or flat top level options.
+
+Actions have the same interaction mechanisms. They require a `type: "action"`,
+`label` and an `onClick`.
+
+Actions have an additional optional key of `shouldClose` that is `true` by
+default. This causes the open menu to close when an option is interacted with.
+It can be set to true on each individual option to customize each action's
+desired behavior.
+
+#### Header/Footer
+
+These elements can be either text-only, or interactive like actions. They
+implement the same API as actions with `shouldClose`, `onClick`, and `label`. In
+the absence of an `onClick` it will be a non interactive Header/Footer,
+providing `onClick` is the signal for it to be interactive.
+
+These elements do not respond to scrolling, they are always at the top or bottom
+and will continue to be displayed even if no options exist after filtering and
+the empty state is visible.
+
+### Highlighting/Active Index
+
+All interactive items can be navigated with arrow keys. Sections, and other
+elements like non interactive Headers and Footers will be skipped by arrow key
+navigation.
+
+We reset the active index during the majority of interactions with respect to
+typing.
+
+### Custom Data & Rendering
+
+While `options`, `section`s, `action`s, `footer`s, and `header`s all have a
+minimum of `label` they can all be enhanced with additional key/values of your
+choosing. These value will be accessible in their respective `customRender`
+methods.
+
+Each `customRender` will have slightly different arguments, with interactive
+elements receiving `isActive` and `option`s receiving `isSelected`. See the prop
+types for more details. Any custom data will be passed to these render functions
+allowing you to use the data as needed to create a customized layout.
+
+In addition to the aforementioned elements, there are also `customRender`
+methods for the input itself, and the loading state.
+
+UNSAFE styles and classnames exist to override the styles of all the main
+elements.
+
+With simple data, "label" is used for most operations and logic, if with custom
+data the "label" is no longer the data to use there are methods such as
+`getOptionLabel`, `inputEqualsOption` and `isOptionEqualToValue` to customize
+the logic to use something other than "label".
+
+### Empty State
+
+There is a default empty state of "No options" that can be modified with the
+`emptyStateMessage` prop, which can also accept more complex markup than a
+string if desired.
+
+Additionally, if one or more actions that only appear when no options are found
+is desired, the `emptyActions` prop can be used. The actions implement the same
+API as other Actions and interactive Header/Footers.
+
+### Async
+
+Taking full control of the options and fetching new/different options from an
+API query is possible.
+
+Since the `menu` controls what options are displayed, when implementing an async
+instance it is advisable to opt out of the internal filtering, and reduce the
+`debounce` value to 0 so that filtering is effectively managed outside the
+component and only the options relevant to the search term are passed to `menu`.
+
+### Navigation
+
+For keyboard users, navigation is done entirely through arrow keys. Tabbing will
+move focus onto the next focusable element that is not the Autocomplete.
+
+When providing custom content, it is imperative to avoid providing any elements
+that would require keyboard focus to activate. For example providing 2 buttons
+within a single row, or even a single button would be impossible to access with
+keyboard. If you require an interactive element, please use an Action,
+interactive Header, or interactive Footer.
+
+### Allow FreeForm
+
+This is `false` by default, and allows a user to provide a value that is not an
+option in the list.
+
+⚠️ Caution: Using free form with custom data introduces complexity due to the
+fact that the input can of course only be a string, so if your custom data has
+additional fields like `details` for example, we have no way to know what might
+make sense.
+
+To help wih this, we require a `createFreeFormValue` method when using
+`allowFreeForm`. This method will be used with the `onChange` to change the
+shape of the returned value into the same shape as the incoming custom data,
+where you must provide the value for these additional fields.
+
+`allowFreeForm` with simple items having only "label" is the easiest way to
+leverage this prop.
+
+### "Commit Signals"
+
+Autocomplete has some nuance as far as `onChange` and when we consider the
+Autocomplete's selection to have changed. It is important to note that this is
+not always the same as the input value.
+
+For example consider an option of "Fall" in the options, and an input value of
+"all" - with `allowFreeForm` at this point we cannot know if "all" is being used
+as a search term to narrow the results to "Fall" or if "all" is a new, free form
+value.
+
+Since we cannot know during use, we wait until blur to inform `onChange` that
+"all" was selected. This is an implicit commit signal. We have other implicit
+signals like having a selection and then deleting it. We also have explicit
+commit signals from clicking an option, or using the Enter key to make a
+selection.
+
+Conversely when free form is disabled and the input is blurred, if the input
+value does not match an option we will consider this as meaning that no valid
+selection was made and will clear the input.
+
+Typing an option value exactly also works, but will only be evaluated on blur.
+
+### Multiple
+
+This is not yet implemented fully. Avoid using for now.

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -1,3 +1,5 @@
+import { Banner } from "@jobber/components/Banner";
+
 ## Configuration
 
 ### V1 to V2
@@ -249,18 +251,21 @@ interactive Header, or interactive Footer.
 This is `false` by default, and allows a user to provide a value that is not an
 option in the list.
 
-⚠️ Caution: Using free form with custom data introduces complexity due to the
-fact that the input can of course only be a string, so if your custom data has
-additional fields like `details` for example, we have no way to know what might
-make sense.
+<Banner type="warning" dismissible={false}>
+  Using free form with custom data introduces complexity due to the fact that
+  the input's value can only be a string, so if your custom data has additional
+  fields like `details` for example, we have no way to populate that field.
+</Banner>
 
 To help wih this, we require a `createFreeFormValue` method when using
-`allowFreeForm`. This method will be used with the `onChange` to change the
-shape of the returned value into the same shape as the incoming custom data,
-where you must provide the value for these additional fields.
+`allowFreeForm`. This method is applied to the outgoing value before it is
+passed to `onChange` to change the shape of the returned value into the same
+shape as the incoming custom data, where you must provide the value for these
+additional fields.
 
 `allowFreeForm` with simple items having only "label" is the easiest way to
-leverage this prop.
+leverage this prop. More complex creation flows may be better suited for complex
+data.
 
 ### "onChange"
 

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -267,7 +267,7 @@ additional fields.
 leverage this prop. More complex creation flows may be better suited for complex
 data.
 
-### "onChange"
+### onChange
 
 Autocomplete has some nuance as far as `onChange` and when we consider the
 Autocomplete's selection to have changed.

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -1,0 +1,17 @@
+### Implement
+
+Usage for the rebuilt `Autocomplete`:
+
+```tsx
+<Autocomplete
+  version={2}
+  placeholder="Search"
+  value={value}
+  onChange={setValue}
+  inputValue={inputValue}
+  onInputChange={setInputValue}
+  menu={[{ type: "options", options: [{ label: "One" }] }]}
+/>
+```
+
+Additional guidance and migration notes from v1 to v2 will be added here.

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -1,4 +1,6 @@
-### V1 to v2
+## Configuration
+
+### V1 to V2
 
 V1 has a single mechanism to update the options. Only `initialOptions` are
 directly controlled, then `getOptions` is used to populate the options based on

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -1,4 +1,7 @@
 import { Banner } from "@jobber/components/Banner";
+import { Canvas } from "@storybook/addon-docs";
+import { Autocomplete } from "@jobber/components/Autocomplete";
+import { useState } from "react";
 
 ## Configuration
 

--- a/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
+++ b/packages/site/src/content/AutocompleteV2/AutocompleteV2Notes.mdx
@@ -1,7 +1,4 @@
 import { Banner } from "@jobber/components/Banner";
-import { Canvas } from "@storybook/addon-docs";
-import { Autocomplete } from "@jobber/components/Autocomplete";
-import { useState } from "react";
 
 ## Configuration
 

--- a/packages/site/src/content/AutocompleteV2/index.tsx
+++ b/packages/site/src/content/AutocompleteV2/index.tsx
@@ -1,0 +1,39 @@
+import Content from "./AutocompleteV2.stories.mdx";
+import Props from "./AutocompleteV2.props.json";
+import Notes from "./AutocompleteV2Notes.mdx";
+import { ContentExport } from "../../types/content";
+import { getStorybookUrl } from "../../layout/getStorybookUrl";
+
+export default {
+  content: () => <Content />,
+  props: Props,
+  component: {
+    element: `const [value, setValue] = useState();
+const [inputValue, setInputValue] = useState("");
+const menu = [{ type: "section", label: "Services", options: [{ label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label: "Sewer Line Repair" }, { label: "Seasonal Refreshment" }, { label: "Window Cleaning" }, { label: "Roof Inspection" }, { label: "Flooring Installation" }, { label: "Baseboard Installation" }, { label: "HVAC Repair" }, { label: "HVAC Installation" }] }];
+
+return (
+<div style={{width: "100%"}}>
+  <Autocomplete
+    version={2}
+    placeholder="Search"
+    value={value}
+    onChange={setValue}
+    inputValue={inputValue}
+    onInputChange={setInputValue}
+    menu={menu}
+  />
+</div>
+);`,
+  },
+  title: "Autocomplete (v2)",
+  links: [
+    {
+      label: "Storybook",
+      url: getStorybookUrl(
+        "?path=/docs/components-forms-and-inputs-autocomplete-web-v2--docs",
+      ),
+    },
+  ],
+  notes: () => <Notes />,
+} as const satisfies ContentExport;

--- a/packages/site/src/content/AutocompleteV2/index.tsx
+++ b/packages/site/src/content/AutocompleteV2/index.tsx
@@ -10,7 +10,12 @@ export default {
   component: {
     element: `const [value, setValue] = useState();
 const [inputValue, setInputValue] = useState("");
-const menu = [{ type: "section", label: "Services", options: [{ label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label: "Sewer Line Repair" }, { label: "Seasonal Refreshment" }, { label: "Window Cleaning" }, { label: "Roof Inspection" }, { label: "Flooring Installation" }, { label: "Baseboard Installation" }, { label: "HVAC Repair" }, { label: "HVAC Installation" }] }];
+const menu = [{ 
+  type: "section", 
+  label: "Services", 
+  options: [
+    { label: "Drain Cleaning" }, { label: "Pipe Replacement" }, { label: "Sewer Line Repair" }, { label: "Seasonal Refreshment" }, { label: "Window Cleaning" }, { label: "Roof Inspection" }, { label: "Flooring Installation" }, { label: "Baseboard Installation" }, { label: "HVAC Repair" }, { label: "HVAC Installation" }] 
+}];
 
 return (
 <div style={{width: "100%"}}>

--- a/packages/site/src/content/AutocompleteV2/index.tsx
+++ b/packages/site/src/content/AutocompleteV2/index.tsx
@@ -36,7 +36,7 @@ return (
     {
       label: "Storybook",
       url: getStorybookUrl(
-        "?path=/docs/components-forms-and-inputs-autocomplete-web-v2--docs",
+        "?path=/story/components-forms-and-inputs-autocomplete-web-v2--flat",
       ),
     },
   ],

--- a/packages/site/src/content/index.ts
+++ b/packages/site/src/content/index.ts
@@ -7,6 +7,7 @@ import AnimatedSwitcherContent from "./AnimatedSwitcher";
 import AvatarContent from "./Avatar";
 import AutoLinkContent from "./AutoLink";
 import AutoCompleteContent from "./Autocomplete";
+import AutocompleteV2Content from "./AutocompleteV2";
 import BannerContent from "./Banner";
 import BottomSheetContent from "./BottomSheet";
 import BoxContent from "./Box";
@@ -126,6 +127,9 @@ export const SiteContent: Record<string, ContentExport> = {
   },
   Autocomplete: {
     ...AutoCompleteContent,
+  },
+  "Autocomplete (v2)": {
+    ...AutocompleteV2Content,
   },
   AutoLink: {
     ...AutoLinkContent,

--- a/packages/site/src/preview/useAtlantisPreviewSkeleton.tsx
+++ b/packages/site/src/preview/useAtlantisPreviewSkeleton.tsx
@@ -389,6 +389,7 @@ export const useAtlantisPreviewSkeleton = (type: "web" | "mobile") => {
           if (iframeDocument) {
             selectedFrame.current.style.height =
               iframeDocument.body.scrollHeight + 60 + "px";
+            selectedFrame.current.style.resize = "vertical";
           }
           updateIframeCode(selectedFrame.current, transpiledCode);
         }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Autocomplete v2 has quite a few notable differences from v1 and how to build with it. we should have this documented, with examples

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

added a separate docs site entry for v2 including all tab content

added some better webstory examples showing how to build various combinations

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

while building an example I found a bug with empty section logic. fixed it and added a test. happy to move this to its own PR if we'd prefer since it's not related to the docs at all, I just happened to come across it.

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
