### PR TITLE
fix(components): Improve breakpoint handling for ContentBlock, Cluster and Sidekick 

### DIFF
--- a/packages/components/src/ContentBlock/ContentBlock.tsx
+++ b/packages/components/src/ContentBlock/ContentBlock.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import classNames from "classnames";
-import { Breakpoints } from "@jobber/hooks/useResizeObserver";
 import styles from "./ContentBlock.module.css";
 import type { ContentBlockProps } from "./types";
 import { getMappedAtlantisSpaceToken } from "../sharedHelpers/getMappedAtlantisSpaceToken";
@@ -8,7 +7,7 @@ import { getMappedBreakpointWidth } from "../sharedHelpers/getMappedBreakpointWi
 
 export function ContentBlock({
   children,
-  maxWidth = Breakpoints.smaller,
+  maxWidth = "sm",
   andText,
   gutters,
   justify = "left",

--- a/packages/components/src/ContentBlock/types.ts
+++ b/packages/components/src/ContentBlock/types.ts
@@ -15,6 +15,8 @@ export interface ContentBlockProps extends CommonAtlantisProps {
 
   /**
    * The maximum width of the centered content.
+   *
+   * @default "sm"
    */
   readonly maxWidth?:
     | keyof typeof AtlantisBreakpoints

--- a/packages/components/src/sharedHelpers/getMappedBreakpointWidth.test.ts
+++ b/packages/components/src/sharedHelpers/getMappedBreakpointWidth.test.ts
@@ -1,0 +1,70 @@
+import type { AtlantisBreakpoints } from "./getMappedBreakpointWidth";
+import { getMappedBreakpointWidth } from "./getMappedBreakpointWidth";
+
+describe("getMappedBreakpointWidth", () => {
+  describe("when maxWidth is a number", () => {
+    it("should return the number with px suffix", () => {
+      expect(getMappedBreakpointWidth(100)).toBe("100px");
+      expect(getMappedBreakpointWidth(0)).toBe("0px");
+      expect(getMappedBreakpointWidth(1440)).toBe("1440px");
+    });
+
+    it("should handle negative numbers", () => {
+      expect(getMappedBreakpointWidth(-50)).toBe("-50px");
+    });
+
+    it("should handle decimal numbers", () => {
+      expect(getMappedBreakpointWidth(123.45)).toBe("123.45px");
+    });
+  });
+
+  describe("when maxWidth is a valid breakpoint key", () => {
+    it("should return the correct pixel value for sm breakpoint", () => {
+      expect(getMappedBreakpointWidth("sm")).toBe("490px");
+    });
+
+    it("should return the correct pixel value for md breakpoint", () => {
+      expect(getMappedBreakpointWidth("md")).toBe("768px");
+    });
+
+    it("should return the correct pixel value for lg breakpoint", () => {
+      expect(getMappedBreakpointWidth("lg")).toBe("1080px");
+    });
+
+    it("should return the correct pixel value for xl breakpoint", () => {
+      expect(getMappedBreakpointWidth("xl")).toBe("1440px");
+    });
+  });
+
+  describe("when maxWidth is an invalid breakpoint key", () => {
+    it("should return the string as-is for unknown breakpoint keys", () => {
+      expect(
+        getMappedBreakpointWidth("unknown" as keyof typeof AtlantisBreakpoints),
+      ).toBe("unknown");
+      expect(
+        getMappedBreakpointWidth("xxl" as keyof typeof AtlantisBreakpoints),
+      ).toBe("xxl");
+    });
+  });
+
+  describe("when maxWidth is an arbitrary string", () => {
+    it("should return CSS values as-is", () => {
+      expect(getMappedBreakpointWidth("100%")).toBe("100%");
+      expect(getMappedBreakpointWidth("50vw")).toBe("50vw");
+      expect(getMappedBreakpointWidth("auto")).toBe("auto");
+      expect(getMappedBreakpointWidth("inherit")).toBe("inherit");
+      expect(getMappedBreakpointWidth("calc(100% - 20px)")).toBe(
+        "calc(100% - 20px)",
+      );
+    });
+
+    it("should handle empty string", () => {
+      expect(getMappedBreakpointWidth("")).toBe("");
+    });
+
+    it("should handle strings that look like numbers but aren't", () => {
+      expect(getMappedBreakpointWidth("100px")).toBe("100px");
+      expect(getMappedBreakpointWidth("123")).toBe("123");
+    });
+  });
+});

--- a/packages/components/src/sharedHelpers/getMappedBreakpointWidth.ts
+++ b/packages/components/src/sharedHelpers/getMappedBreakpointWidth.ts
@@ -1,5 +1,4 @@
 export const AtlantisBreakpoints = {
-  xs: 0,
   sm: 490,
   md: 768,
   lg: 1080,
@@ -13,7 +12,7 @@ export const getMappedBreakpointWidth = (
     return `${maxWidth}px`;
   }
 
-  if (AtlantisBreakpoints[maxWidth as keyof typeof AtlantisBreakpoints]) {
+  if (maxWidth in AtlantisBreakpoints) {
     return (
       AtlantisBreakpoints[maxWidth as keyof typeof AtlantisBreakpoints] + "px"
     );

--- a/packages/site/src/content/Cluster/Cluster.props.json
+++ b/packages/site/src/content/Cluster/Cluster.props.json
@@ -55,7 +55,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\""
+          "name": "\"sm\" | \"md\" | \"lg\" | \"xl\""
         }
       },
       "collapsed": {

--- a/packages/site/src/content/ContentBlock/ContentBlock.props.json
+++ b/packages/site/src/content/ContentBlock/ContentBlock.props.json
@@ -23,7 +23,7 @@
       },
       "maxWidth": {
         "defaultValue": {
-          "value": "Breakpoints.smaller"
+          "value": "sm"
         },
         "description": "The maximum width of the centered content.",
         "name": "maxWidth",
@@ -33,7 +33,7 @@
         },
         "required": false,
         "type": {
-          "name": "number | \"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | (string & {})"
+          "name": "number | \"sm\" | \"md\" | \"lg\" | \"xl\" | (string & {})"
         }
       },
       "andText": {

--- a/packages/site/src/content/SideKick/SideKick.props.json
+++ b/packages/site/src/content/SideKick/SideKick.props.json
@@ -72,7 +72,7 @@
         },
         "required": false,
         "type": {
-          "name": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\""
+          "name": "\"sm\" | \"md\" | \"lg\" | \"xl\""
         }
       },
       "collapsed": {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

I was trying to use `ContentBlock` and I noticed some small bugs with the breakpoints on `ContentBlock`, `Cluster` and `SideKick`. One of the options in `AtlantisBreakpoints` for this component was "xs" = 0px which doesn't make sense for a `maxWidth` or `collapseBelow` prop. Furthermore, you couldn't actually set something to `xs` because the following logic was used:
```
  if (AtlantisBreakpoints[maxWidth as keyof typeof AtlantisBreakpoints]) {
    return (
      AtlantisBreakpoints[maxWidth as keyof typeof AtlantisBreakpoints] + "px"
    );
```
Since `AtlantisBreakpoints[maxWidth as keyof typeof AtlantisBreakpoints] = 0` and 0 is falsey this conditional wouldn't actually be entered for `xs`. 

### Removed

- Removed the `xs` breakpoint option

### Fixed

- The conditional so that falsey breakpoint values wouldn't prevent the conditional from being entered

### Changed

- The default value `maxWidth` on `ContentBlock` from `Breakpoints.smaller` which has a value of 265 and is not a valid `AtlantisBreakpoints` value to `"sm"`. I went through the JFE and JO code to ensure this default value change wouldn't impact any implementations

## Testing

Play around with these components in Storybook to ensure they work as expected. 

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
