### PR TITLE
fix(components): Defaults first in DataTable atoms

### DIFF
--- a/packages/components/src/DataTable/components/DataTableActions.tsx
+++ b/packages/components/src/DataTable/components/DataTableActions.tsx
@@ -6,7 +6,7 @@ export function DataTableActions(
   props: PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>,
 ) {
   return (
-    <div className={classNames(styles.actions, props.className)} {...props}>
+    <div {...props} className={classNames(styles.actions, props.className)}>
       {props.children}
     </div>
   );

--- a/packages/components/src/DataTable/components/DataTableBody.tsx
+++ b/packages/components/src/DataTable/components/DataTableBody.tsx
@@ -5,7 +5,7 @@ export function DataTableBody(
   props: PropsWithChildren<React.HTMLAttributes<HTMLTableSectionElement>>,
 ) {
   return (
-    <tbody className={classNames(props.className)} {...props}>
+    <tbody {...props} className={classNames(props.className)}>
       {props.children}
     </tbody>
   );

--- a/packages/components/src/DataTable/components/DataTableContainer.tsx
+++ b/packages/components/src/DataTable/components/DataTableContainer.tsx
@@ -6,7 +6,7 @@ export function DataTableContainer(
   props: PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>,
 ) {
   return (
-    <div className={classNames(styles.container, props.className)} {...props}>
+    <div {...props} className={classNames(styles.container, props.className)}>
       {props.children}
     </div>
   );

--- a/packages/components/src/DataTable/components/DataTableFooter.tsx
+++ b/packages/components/src/DataTable/components/DataTableFooter.tsx
@@ -18,7 +18,7 @@ export function DataTableFooter({
   ...props
 }: DataTableFooterProps) {
   return (
-    <tfoot className={classNames(styles.footer, className)} {...props}>
+    <tfoot {...props} className={classNames(styles.footer, className)}>
       <tr>
         <td colSpan={colSpan}>{children}</td>
       </tr>

--- a/packages/components/src/DataTable/components/DataTableHeader.tsx
+++ b/packages/components/src/DataTable/components/DataTableHeader.tsx
@@ -6,7 +6,7 @@ export function DataTableHeader(
   props: PropsWithChildren<React.HTMLAttributes<HTMLTableSectionElement>>,
 ) {
   return (
-    <thead className={classNames(styles.header, props.className)} {...props}>
+    <thead {...props} className={classNames(styles.header, props.className)}>
       <tr>{props.children}</tr>
     </thead>
   );

--- a/packages/components/src/DataTable/components/DataTablePagination.tsx
+++ b/packages/components/src/DataTable/components/DataTablePagination.tsx
@@ -13,7 +13,7 @@ export function DataTablePagination({
   ...props
 }: DataTablePaginationProps) {
   return (
-    <div className={classNames(styles.pagination, className)} {...props}>
+    <div {...props} className={classNames(styles.pagination, className)}>
       {children}
     </div>
   );

--- a/packages/components/src/DataTable/components/DataTableRow.tsx
+++ b/packages/components/src/DataTable/components/DataTableRow.tsx
@@ -8,9 +8,9 @@ export const DataTableRow = forwardRef<
 >((props, ref) => {
   return (
     <tr
+      {...props}
       className={classNames(styles.row, props.className)}
       ref={ref}
-      {...props}
     >
       {props.children}
     </tr>

--- a/packages/components/src/DataTable/components/DataTableTable.tsx
+++ b/packages/components/src/DataTable/components/DataTableTable.tsx
@@ -7,8 +7,8 @@ export function DataTableTable(
 ) {
   return (
     <table
-      className={classNames(styles.tableElement, props.className)}
       {...props}
+      className={classNames(styles.tableElement, props.className)}
     >
       {props.children}
     </table>


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
In some of the `DataTable` atom components, the `{...props}` spread was happening after the component props. This meant if someone used a `className` in `<DataTable.Actions>` for example, that `className` would overwrite any previously set `className`, including what's baked into the component. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->


### Fixed

- switched order of props spread in a few `DataTable` atom components

### Before

`className` in implementation completely overrides the component `className`, removing styling, etc
Only `class="sticky-header"` appears in the DOM

<img width="1066" height="100" alt="Screenshot 2025-09-11 at 12 17 52 PM" src="https://github.com/user-attachments/assets/3d2ebaff-6720-4362-84d5-60a3b6b0bd5b" />

## After

<!-- How to test your changes. -->

Both classes are preserved:

`class="DataTableStyles-module__header--wRvUo sticky-header"`

<img width="1075" height="155" alt="Screenshot 2025-09-11 at 12 15 22 PM" src="https://github.com/user-attachments/assets/3e1755b0-5855-467e-b26c-597e46c6a286" />

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
