### PR TITLE
fix(components): Reorganize Composed Modal to Solve Focus Management

### DIFF
--- a/.storybook/assets/css/preview.css
+++ b/.storybook/assets/css/preview.css
@@ -1,7 +1,7 @@
-:focus,
+/* :focus,
 :focus-visible {
   outline: transparent;
-}
+} */
 
 :global(a) {
   color: var(--color-interactive);

--- a/.storybook/assets/css/preview.css
+++ b/.storybook/assets/css/preview.css
@@ -1,7 +1,7 @@
-/* :focus,
+:focus,
 :focus-visible {
   outline: transparent;
-} */
+}
 
 :global(a) {
   color: var(--color-interactive);

--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -304,41 +304,40 @@ const NestedExampleTemplate: ComponentStory<typeof Modal> = args => {
               fullWidth
             />
           </Content>
+          <Modal.Provider
+            open={innerModalOpen}
+            onRequestClose={() => setInnerModalOpen(false)}
+          >
+            <Modal.Content>
+              <Modal.Header title="Inner Modal" />
+              <Content>
+                <Flex template={["shrink", "shrink"]}>
+                  <Text>This is the inner modal!</Text>
+                  <Tooltip message="Exercise caution when nesting modals beyond this level.">
+                    <Icon name="info" color="yellow" />
+                  </Tooltip>
+                </Flex>
+                <Text>
+                  You can close this modal independently, or close both modals
+                  together.
+                </Text>
+              </Content>
+              <Modal.Actions
+                primary={{
+                  label: "Close Inner Modal",
+                  onClick: () => setInnerModalOpen(false),
+                }}
+                secondary={{
+                  label: "Close Both Modals",
+                  onClick: () => {
+                    setInnerModalOpen(false);
+                    setOuterModalOpen(false);
+                  },
+                }}
+              />
+            </Modal.Content>
+          </Modal.Provider>
         </Modal.Content>
-
-        <Modal.Provider
-          open={innerModalOpen}
-          onRequestClose={() => setInnerModalOpen(false)}
-        >
-          <Modal.Content>
-            <Modal.Header title="Inner Modal" />
-            <Content>
-              <Flex template={["shrink", "shrink"]}>
-                <Text>This is the inner modal!</Text>
-                <Tooltip message="Exercise caution when nesting modals beyond this level.">
-                  <Icon name="info" color="yellow" />
-                </Tooltip>
-              </Flex>
-              <Text>
-                You can close this modal independently, or close both modals
-                together.
-              </Text>
-            </Content>
-            <Modal.Actions
-              primary={{
-                label: "Close Inner Modal",
-                onClick: () => setInnerModalOpen(false),
-              }}
-              secondary={{
-                label: "Close Both Modals",
-                onClick: () => {
-                  setInnerModalOpen(false);
-                  setOuterModalOpen(false);
-                },
-              }}
-            />
-          </Modal.Content>
-        </Modal.Provider>
       </Modal.Provider>
     </Content>
   );

--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -10,6 +10,7 @@ import {
   Banner,
   Box,
   Combobox,
+  Flex,
   Heading,
   Icon,
   InputDate,
@@ -312,7 +313,12 @@ const NestedExampleTemplate: ComponentStory<typeof Modal> = args => {
           <Modal.Content>
             <Modal.Header title="Inner Modal" />
             <Content>
-              <Text>This is the inner modal!</Text>
+              <Flex template={["shrink", "shrink"]}>
+                <Text>This is the inner modal!</Text>
+                <Tooltip message="Exercise caution when nesting modals beyond this level.">
+                  <Icon name="info" color="yellow" />
+                </Tooltip>
+              </Flex>
               <Text>
                 You can close this modal independently, or close both modals
                 together.

--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -269,75 +269,65 @@ const NestedExamplesTemplate: ComponentStory<typeof Modal> = args => {
   console.log(args);
 
   return (
-    <>
-      <style>
-        {`
-    :focus,
-    :focus-visible {
-      outline: 2px solid var(--color-focus)!important;
-    }
-    `}
-      </style>
-      <Content>
-        <Button
-          label="Open Outer Modal"
-          onClick={() => setOuterModalOpen(true)}
-        />
+    <Content>
+      <Button
+        label="Open Outer Modal"
+        onClick={() => setOuterModalOpen(true)}
+      />
+
+      <Modal.Provider
+        open={outerModalOpen}
+        onRequestClose={() => {
+          setOuterModalOpen(false);
+        }}
+      >
+        <Modal.Content>
+          <Modal.Header title="Outer Modal" />
+          <Content>
+            <Text>
+              This is the outer modal. You can interact with components here and
+              open another modal inside it.
+            </Text>
+
+            <Button
+              label="Open Inner Modal"
+              onClick={() => setInnerModalOpen(true)}
+              type="secondary"
+              fullWidth
+            />
+          </Content>
+        </Modal.Content>
 
         <Modal.Provider
-          open={outerModalOpen}
-          onRequestClose={() => {
-            setOuterModalOpen(false);
-          }}
+          open={innerModalOpen}
+          onRequestClose={() => setInnerModalOpen(false)}
         >
           <Modal.Content>
-            <Modal.Header title="Outer Modal" />
+            <Modal.Header title="Inner Modal" />
             <Content>
+              <Text>This is the inner modal!</Text>
               <Text>
-                This is the outer modal. You can interact with components here
-                and open another modal inside it.
+                You can close this modal independently, or close both modals
+                together.
               </Text>
-
-              <Button
-                label="Open Inner Modal"
-                onClick={() => setInnerModalOpen(true)}
-                type="secondary"
-                fullWidth
-              />
             </Content>
+            <Modal.Actions
+              primary={{
+                label: "Close Inner Modal",
+                onClick: () => setInnerModalOpen(false),
+              }}
+              secondary={{
+                label: "Close Both Modals",
+                onClick: () => {
+                  setInnerModalOpen(false);
+                  setOuterModalOpen(false);
+                },
+              }}
+            />
           </Modal.Content>
-
-          <Modal.Provider
-            open={innerModalOpen}
-            onRequestClose={() => setInnerModalOpen(false)}
-          >
-            <Modal.Content>
-              <Modal.Header title="Inner Modal" />
-              <Content>
-                <Text>This is the inner modal!</Text>
-                <Text>
-                  You can close this modal independently, or close both modals
-                  together.
-                </Text>
-              </Content>
-              <Modal.Actions
-                primary={{
-                  label: "Close Inner Modal",
-                  onClick: () => setInnerModalOpen(false),
-                }}
-                secondary={{
-                  label: "Close Both Modals",
-                  onClick: () => {
-                    setInnerModalOpen(false);
-                    setOuterModalOpen(false);
-                  },
-                }}
-              />
-            </Modal.Content>
-          </Modal.Provider>
         </Modal.Provider>
-      </Content>
-    </>
+      </Modal.Provider>
+    </Content>
   );
 };
 export const NestedExamples = NestedExamplesTemplate.bind({});

--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -287,7 +287,6 @@ const NestedExamplesTemplate: ComponentStory<typeof Modal> = args => {
           open={outerModalOpen}
           onRequestClose={() => {
             setOuterModalOpen(false);
-            setInnerModalOpen(false);
           }}
         >
           <Modal.Content>

--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -272,6 +272,7 @@ const NestedExamplesTemplate: ComponentStory<typeof Modal> = args => {
     <>
       <style>
         {`
+    :focus,
     :focus-visible {
       outline: 2px solid var(--color-focus)!important;
     }

--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -7,6 +7,7 @@ import { Text } from "@jobber/components/Text";
 import { InputText } from "@jobber/components/InputText";
 import {
   Autocomplete,
+  Banner,
   Box,
   Combobox,
   Heading,
@@ -263,13 +264,19 @@ export const ModalWithProviderExample = ModalWithProviderExampleTemplate.bind(
   {},
 );
 
-const NestedExamplesTemplate: ComponentStory<typeof Modal> = args => {
+const NestedExampleTemplate: ComponentStory<typeof Modal> = args => {
   const [outerModalOpen, setOuterModalOpen] = useState(false);
   const [innerModalOpen, setInnerModalOpen] = useState(false);
-  console.log(args);
 
   return (
     <Content>
+      <Banner type="warning" dismissible={false}>
+        <Banner.Content>
+          Nesting Modals beyond two levels is strongly discouraged. It often
+          leads to a poor user experience. This example is demonstrating how to
+          do it, not necessarily recommending it.
+        </Banner.Content>
+      </Banner>
       <Button
         label="Open Outer Modal"
         onClick={() => setOuterModalOpen(true)}
@@ -282,7 +289,7 @@ const NestedExamplesTemplate: ComponentStory<typeof Modal> = args => {
         }}
       >
         <Modal.Content>
-          <Modal.Header title="Outer Modal" />
+          <Modal.Header title={args.title} />
           <Content>
             <Text>
               This is the outer modal. You can interact with components here and
@@ -330,7 +337,7 @@ const NestedExamplesTemplate: ComponentStory<typeof Modal> = args => {
     </Content>
   );
 };
-export const NestedExamples = NestedExamplesTemplate.bind({});
-NestedExamples.args = {
-  title: "We've updated Jobber",
+export const NestedExample = NestedExampleTemplate.bind({});
+NestedExample.args = {
+  title: "Outer Modal",
 };

--- a/docs/components/Modal/Web.stories.tsx
+++ b/docs/components/Modal/Web.stories.tsx
@@ -262,3 +262,85 @@ const ModalWithProviderExampleTemplate: ComponentStory<typeof Modal> = () => {
 export const ModalWithProviderExample = ModalWithProviderExampleTemplate.bind(
   {},
 );
+
+const NestedExamplesTemplate: ComponentStory<typeof Modal> = args => {
+  const [outerModalOpen, setOuterModalOpen] = useState(false);
+  const [innerModalOpen, setInnerModalOpen] = useState(false);
+  console.log(args);
+
+  return (
+    <>
+      <style>
+        {`
+    :focus-visible {
+      outline: 2px solid var(--color-focus)!important;
+    }
+    `}
+      </style>
+      <Content>
+        <Button
+          label="Open Outer Modal"
+          onClick={() => setOuterModalOpen(true)}
+        />
+
+        <Modal.Provider
+          open={outerModalOpen}
+          onRequestClose={() => {
+            setOuterModalOpen(false);
+            setInnerModalOpen(false);
+          }}
+        >
+          <Modal.Content>
+            <Modal.Header title="Outer Modal" />
+            <Content>
+              <Text>
+                This is the outer modal. You can interact with components here
+                and open another modal inside it.
+              </Text>
+
+              <Button
+                label="Open Inner Modal"
+                onClick={() => setInnerModalOpen(true)}
+                type="secondary"
+                fullWidth
+              />
+            </Content>
+          </Modal.Content>
+
+          <Modal.Provider
+            open={innerModalOpen}
+            onRequestClose={() => setInnerModalOpen(false)}
+          >
+            <Modal.Content>
+              <Modal.Header title="Inner Modal" />
+              <Content>
+                <Text>This is the inner modal!</Text>
+                <Text>
+                  You can close this modal independently, or close both modals
+                  together.
+                </Text>
+              </Content>
+              <Modal.Actions
+                primary={{
+                  label: "Close Inner Modal",
+                  onClick: () => setInnerModalOpen(false),
+                }}
+                secondary={{
+                  label: "Close Both Modals",
+                  onClick: () => {
+                    setInnerModalOpen(false);
+                    setOuterModalOpen(false);
+                  },
+                }}
+              />
+            </Modal.Content>
+          </Modal.Provider>
+        </Modal.Provider>
+      </Content>
+    </>
+  );
+};
+export const NestedExamples = NestedExamplesTemplate.bind({});
+NestedExamples.args = {
+  title: "We've updated Jobber",
+};

--- a/packages/components/src/Modal/Modal.rebuilt.module.css
+++ b/packages/components/src/Modal/Modal.rebuilt.module.css
@@ -46,6 +46,11 @@
   outline-color: var(--color-focus);
 }
 
+.modal:-moz-focusring {
+  box-shadow: var(--shadow-focus);
+  outline: 1px solid var(--color-focus);
+}
+
 /* Adjust `Content` and `Tab` components public padding to match the modal */
 
 .modal > * {

--- a/packages/components/src/Modal/Modal.rebuilt.module.css
+++ b/packages/components/src/Modal/Modal.rebuilt.module.css
@@ -49,11 +49,6 @@
   box-shadow: var(--shadow-focus);
 }
 
-/* Cant combine with the above because it's Mozilla only and breaks the others when in a single rule */
-.modal:-moz-focusring {
-  box-shadow: var(--shadow-focus);
-}
-
 /* Adjust `Content` and `Tab` components public padding to match the modal */
 
 .modal > * {

--- a/packages/components/src/Modal/Modal.rebuilt.module.css
+++ b/packages/components/src/Modal/Modal.rebuilt.module.css
@@ -22,14 +22,7 @@
 }
 
 .overlayBackground {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: var(--elevation-modal);
-  background-color: var(--color-overlay);
-  opacity: 0.8;
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .modal {

--- a/packages/components/src/Modal/Modal.rebuilt.module.css
+++ b/packages/components/src/Modal/Modal.rebuilt.module.css
@@ -41,14 +41,17 @@
   padding: var(--space-small);
   border: var(--border-base) solid var(--color-border);
   border-radius: var(--radius-base);
+  outline: none;
   background-color: var(--color-surface);
   flex: 0 0 auto;
-  outline-color: var(--color-focus);
+}
+.modal:focus-visible {
+  box-shadow: var(--shadow-focus);
 }
 
+/* Cant combine with the above because it's Mozilla only and breaks the others when in a single rule */
 .modal:-moz-focusring {
   box-shadow: var(--shadow-focus);
-  outline: 1px solid var(--color-focus);
 }
 
 /* Adjust `Content` and `Tab` components public padding to match the modal */

--- a/packages/components/src/Modal/Modal.rebuilt.module.css
+++ b/packages/components/src/Modal/Modal.rebuilt.module.css
@@ -17,12 +17,6 @@
 
 .overlay {
   display: grid;
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: var(--elevation-modal);
   place-items: center;
 }
 

--- a/packages/components/src/Modal/Modal.rebuilt.module.css
+++ b/packages/components/src/Modal/Modal.rebuilt.module.css
@@ -17,12 +17,24 @@
 
 .overlay {
   display: grid;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: var(--elevation-modal);
   place-items: center;
 }
 
 .overlayBackground {
-  background-color: rgba(0, 0, 0, 0.4);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  outline: none;
+  background-color: var(--color-overlay);
+  will-change: opacity;
 }
 
 .modal {

--- a/packages/components/src/Modal/Modal.rebuilt.module.css
+++ b/packages/components/src/Modal/Modal.rebuilt.module.css
@@ -21,7 +21,7 @@
 }
 
 .overlayBackground {
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
   bottom: 0;

--- a/packages/components/src/Modal/Modal.rebuilt.test.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.test.tsx
@@ -147,7 +147,6 @@ describe("Composable Modal", () => {
     expect(handleRequestClose).toHaveBeenCalledTimes(1);
   });
 
-  // eslint-disable-next-line max-statements
   it("nested: clicking inner backdrop closes only inner modal", async () => {
     const outerCloseSpy = jest.fn();
     const innerCloseSpy = jest.fn();

--- a/packages/components/src/Modal/Modal.rebuilt.test.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.test.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Modal } from ".";
 import { Content } from "../Content";
 import { Text } from "../Text";
+import { Button } from "../Button";
 
 describe("Composable Modal", () => {
   it("should render the modal content", () => {
@@ -117,5 +118,192 @@ describe("Composable Modal", () => {
     expect(screen.getByRole("dialog")).toHaveTextContent(
       "Custom Header Content",
     );
+  });
+
+  it("closes when clicking the backdrop and stays open when clicking inside", async () => {
+    const handleRequestClose = jest.fn();
+
+    render(
+      <Modal.Provider open={true} onRequestClose={handleRequestClose}>
+        <Modal.Content>
+          <Modal.Header title="Modal Title" />
+          <Content>
+            <button type="button">Inside</button>
+          </Content>
+        </Modal.Content>
+      </Modal.Provider>,
+    );
+
+    // Click inside the modal panel should NOT close
+    await userEvent.click(screen.getByRole("button", { name: "Inside" }));
+    expect(handleRequestClose).not.toHaveBeenCalled();
+
+    // Click the backdrop (overlayBackground inside the branch)
+    const branches = document.querySelectorAll("[data-atlantis-modal-branch]");
+    const topBranch = branches[branches.length - 1] as HTMLElement;
+    const backdrop = topBranch.querySelector('[aria-hidden="true"]') as Element;
+    await userEvent.click(backdrop);
+
+    expect(handleRequestClose).toHaveBeenCalledTimes(1);
+  });
+
+  // eslint-disable-next-line max-statements
+  it("nested: clicking inner backdrop closes only inner modal", async () => {
+    const outerCloseSpy = jest.fn();
+    const innerCloseSpy = jest.fn();
+
+    function NestedHarness() {
+      const [outerOpen, setOuterOpen] = React.useState(true);
+      const [innerOpen, setInnerOpen] = React.useState(true);
+
+      return (
+        <Modal.Provider
+          open={outerOpen}
+          onRequestClose={() => {
+            outerCloseSpy();
+            setOuterOpen(false);
+          }}
+        >
+          <Modal.Content>
+            <Modal.Header title="Outer" />
+            <Content>
+              <Text>Outer content</Text>
+            </Content>
+          </Modal.Content>
+
+          <Modal.Provider
+            open={innerOpen}
+            onRequestClose={() => {
+              innerCloseSpy();
+              setInnerOpen(false);
+            }}
+          >
+            <Modal.Content>
+              <Modal.Header title="Inner" />
+              <Content>
+                <Text>Inner content</Text>
+                <button type="button">Inner Focus</button>
+              </Content>
+            </Modal.Content>
+          </Modal.Provider>
+        </Modal.Provider>
+      );
+    }
+
+    render(<NestedHarness />);
+
+    // Two dialogs present (include hidden while animations/inert are applied)
+    const initialDialogs = await screen.findAllByRole("dialog", {
+      hidden: true,
+    });
+    expect(initialDialogs).toHaveLength(2);
+
+    // Click inner backdrop (pointerdown to match outsidePressEvent)
+    const branches = document.querySelectorAll("[data-atlantis-modal-branch]");
+    const topBranch = branches[branches.length - 1] as HTMLElement;
+    const backdrop = topBranch.querySelector('[aria-hidden="true"]') as Element;
+    await userEvent.pointer({ keys: "[MouseLeft]", target: backdrop });
+
+    // Inner closed, outer remains
+    await waitFor(() => expect(innerCloseSpy).toHaveBeenCalledTimes(1));
+    expect(outerCloseSpy).not.toHaveBeenCalled();
+  });
+
+  // eslint-disable-next-line max-statements
+  it("nested: Escape closes only the topmost modal first", async () => {
+    const outerCloseSpy = jest.fn();
+    const innerCloseSpy = jest.fn();
+
+    function NestedHarness() {
+      const [outerOpen, setOuterOpen] = React.useState(true);
+      const [innerOpen, setInnerOpen] = React.useState(true);
+
+      return (
+        <Modal.Provider
+          open={outerOpen}
+          onRequestClose={() => {
+            outerCloseSpy();
+            setOuterOpen(false);
+          }}
+        >
+          <Modal.Content>
+            <Modal.Header title="Outer" />
+          </Modal.Content>
+
+          <Modal.Provider
+            open={innerOpen}
+            onRequestClose={() => {
+              innerCloseSpy();
+              setInnerOpen(false);
+            }}
+          >
+            <Modal.Content>
+              <Modal.Header title="Inner" />
+              <button type="button" data-testid="Inner Focus">
+                Inner Focus
+              </button>
+            </Modal.Content>
+          </Modal.Provider>
+        </Modal.Provider>
+      );
+    }
+
+    render(<NestedHarness />);
+
+    const startDialogs = await screen.findAllByRole("dialog", {
+      hidden: true,
+    });
+    expect(startDialogs).toHaveLength(2);
+
+    // Focus inside inner modal then press Escape
+    const innerFocus = await screen.findByTestId("Inner Focus");
+    await userEvent.click(innerFocus);
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(innerCloseSpy).toHaveBeenCalledTimes(1));
+    expect(outerCloseSpy).not.toHaveBeenCalled();
+
+    // Focus the remaining (outer) dialog explicitly by accessible name
+    const outerDialog = (await screen.findByRole("dialog", {
+      name: /Outer/i,
+      hidden: true,
+    })) as HTMLElement;
+    outerDialog.focus();
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(outerCloseSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it("returns focus to the activator when closed", async () => {
+    function Harness() {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <Modal.Provider open={open} onRequestClose={() => setOpen(false)}>
+          <Modal.Content>
+            <Modal.Header title="Focus Test" />
+          </Modal.Content>
+          <Modal.Activator>
+            <Button
+              label="Open Modal"
+              onClick={() => setOpen(true)}
+              type="secondary"
+            />
+          </Modal.Activator>
+        </Modal.Provider>
+      );
+    }
+
+    render(<Harness />);
+
+    const activator = screen.getByRole("button", { name: "Open Modal" });
+    activator.focus();
+    await userEvent.click(activator);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await userEvent.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(activator);
+    });
   });
 });

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -7,7 +7,6 @@ import {
   FloatingOverlay,
   FloatingPortal,
 } from "@floating-ui/react";
-import classNames from "classnames";
 import { useModalContext } from "./ModalContext.rebuilt";
 import type {
   HeaderProps,
@@ -85,26 +84,22 @@ export function ModalActivator({ children }: PropsWithChildren) {
  * Background overlay for the modal. Used in the ModalContent.
  */
 
-export function ModalOverlay({
-  children,
-  styleClasses,
-}: PropsWithChildren<{ readonly styleClasses: string }>) {
-  const { onRequestClose } = useModalContext();
+export function ModalOverlay({ children }: PropsWithChildren) {
+  const { overlay } = useModalStyles();
   const { overlayBackground } = useModalStyles();
 
   return (
-    <motion.div
-      onClick={onRequestClose}
-      className={overlayBackground}
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 0.8 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.2 }}
-    >
-      <FloatingOverlay lockScroll className={styleClasses}>
-        {children}
-      </FloatingOverlay>
-    </motion.div>
+    <FloatingOverlay lockScroll className={overlay}>
+      <motion.div
+        aria-hidden="true"
+        className={overlayBackground}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+      />
+      {children}
+    </FloatingOverlay>
   );
 }
 
@@ -119,7 +114,7 @@ export function ModalContent({ children }: ModalContainerProps) {
     modalLabelledBy,
     getFloatingProps,
   } = useModalContext();
-  const { modal, overlay, overlayBackground } = useModalStyles(size);
+  const { modal } = useModalStyles(size);
 
   return (
     <AnimatePresence>
@@ -127,9 +122,7 @@ export function ModalContent({ children }: ModalContainerProps) {
         <FloatingNode id={floatingNodeId}>
           <FloatingPortal>
             <AtlantisPortalContent>
-              <ModalOverlay
-                styleClasses={classNames(overlay, overlayBackground)}
-              >
+              <ModalOverlay>
                 <FloatingFocusManager
                   context={floatingContext}
                   returnFocus={activatorRef?.current ? activatorRef : true}

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -7,6 +7,7 @@ import {
   FloatingOverlay,
   FloatingPortal,
 } from "@floating-ui/react";
+import classNames from "classnames";
 import { useModalContext } from "./ModalContext.rebuilt";
 import type {
   HeaderProps,
@@ -84,7 +85,10 @@ export function ModalActivator({ children }: PropsWithChildren) {
  * Background overlay for the modal. Used in the ModalContent.
  */
 
-export function ModalOverlay() {
+export function ModalOverlay({
+  children,
+  styleClasses,
+}: PropsWithChildren<{ readonly styleClasses: string }>) {
   const { onRequestClose } = useModalContext();
   const { overlayBackground } = useModalStyles();
 
@@ -96,7 +100,11 @@ export function ModalOverlay() {
       animate={{ opacity: 0.8 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.2 }}
-    />
+    >
+      <FloatingOverlay lockScroll className={styleClasses}>
+        {children}
+      </FloatingOverlay>
+    </motion.div>
   );
 }
 
@@ -111,7 +119,7 @@ export function ModalContent({ children }: ModalContainerProps) {
     modalLabelledBy,
     getFloatingProps,
   } = useModalContext();
-  const { modal, overlay } = useModalStyles(size);
+  const { modal, overlay, overlayBackground } = useModalStyles(size);
 
   return (
     <AnimatePresence>
@@ -119,36 +127,36 @@ export function ModalContent({ children }: ModalContainerProps) {
         <FloatingNode id={floatingNodeId}>
           <FloatingPortal>
             <AtlantisPortalContent>
-              <FloatingOverlay className={overlay}>
+              <ModalOverlay
+                styleClasses={classNames(overlay, overlayBackground)}
+              >
                 <FloatingFocusManager
                   context={floatingContext}
                   returnFocus={activatorRef?.current ? activatorRef : true}
-                  initialFocus={floatingRefs?.floating}
+                  initialFocus={0}
                 >
-                  <div
-                    ref={floatingRefs?.setFloating}
-                    role="dialog"
-                    tabIndex={0}
-                    aria-labelledby={modalLabelledBy}
-                    {...getFloatingProps()}
+                  <motion.div
+                    className={modal}
+                    initial={{ scale: 0.9, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    exit={{ scale: 0.9, opacity: 0 }}
+                    transition={{
+                      duration: 0.2,
+                      ease: "easeInOut",
+                    }}
                   >
-                    <ModalOverlay />
-                    <motion.div
-                      data-floating-ui-focusable
-                      className={modal}
-                      initial={{ scale: 0.9, opacity: 0 }}
-                      animate={{ scale: 1, opacity: 1 }}
-                      exit={{ scale: 0.9, opacity: 0 }}
-                      transition={{
-                        duration: 0.2,
-                        ease: "easeInOut",
-                      }}
+                    <div
+                      ref={floatingRefs?.setFloating}
+                      {...getFloatingProps({
+                        role: "dialog",
+                        "aria-labelledby": modalLabelledBy,
+                      })}
                     >
                       {children}
-                    </motion.div>
-                  </div>
+                    </div>
+                  </motion.div>
                 </FloatingFocusManager>
-              </FloatingOverlay>
+              </ModalOverlay>
             </AtlantisPortalContent>
           </FloatingPortal>
         </FloatingNode>

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -86,7 +86,6 @@ export function ModalActivator({ children }: PropsWithChildren) {
 
 export function ModalOverlay({ children }: PropsWithChildren) {
   const { overlay, overlayBackground } = useModalStyles();
-  const { onRequestClose } = useModalContext();
 
   return (
     <FloatingOverlay lockScroll className={overlay} data-atlantis-modal-branch>
@@ -97,10 +96,6 @@ export function ModalOverlay({ children }: PropsWithChildren) {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.2 }}
-        onClick={e => {
-          e.stopPropagation();
-          onRequestClose?.();
-        }}
       />
       {children}
     </FloatingOverlay>

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -86,9 +86,14 @@ export function ModalActivator({ children }: PropsWithChildren) {
 
 export function ModalOverlay({ children }: PropsWithChildren) {
   const { overlay, overlayBackground } = useModalStyles();
+  const { floatingNodeId } = useModalContext();
 
   return (
-    <FloatingOverlay lockScroll className={overlay} data-atlantis-modal-branch>
+    <FloatingOverlay
+      lockScroll
+      className={overlay}
+      data-modal-node-id={floatingNodeId}
+    >
       <motion.div
         aria-hidden="true"
         className={overlayBackground}
@@ -96,6 +101,7 @@ export function ModalOverlay({ children }: PropsWithChildren) {
         animate={{ opacity: 0.8 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.2 }}
+        data-modal-node-id={floatingNodeId}
       />
       {children}
     </FloatingOverlay>
@@ -138,6 +144,7 @@ export function ModalContent({ children }: ModalContainerProps) {
                   >
                     <div
                       ref={floatingRefs?.setFloating}
+                      data-modal-node-id={floatingNodeId}
                       {...getFloatingProps({
                         role: "dialog",
                         className: modal,

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -93,7 +93,7 @@ export function ModalOverlay({ children }: PropsWithChildren) {
         aria-hidden="true"
         className={overlayBackground}
         initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
+        animate={{ opacity: 0.8 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.2 }}
       />

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -128,7 +128,6 @@ export function ModalContent({ children }: ModalContainerProps) {
                   initialFocus={0}
                 >
                   <motion.div
-                    className={modal}
                     initial={{ scale: 0.9, opacity: 0 }}
                     animate={{ scale: 1, opacity: 1 }}
                     exit={{ scale: 0.9, opacity: 0 }}
@@ -141,6 +140,7 @@ export function ModalContent({ children }: ModalContainerProps) {
                       ref={floatingRefs?.setFloating}
                       {...getFloatingProps({
                         role: "dialog",
+                        className: modal,
                         "aria-labelledby": modalLabelledBy,
                       })}
                     >

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -85,11 +85,11 @@ export function ModalActivator({ children }: PropsWithChildren) {
  */
 
 export function ModalOverlay({ children }: PropsWithChildren) {
-  const { overlay } = useModalStyles();
-  const { overlayBackground } = useModalStyles();
+  const { overlay, overlayBackground } = useModalStyles();
+  const { onRequestClose } = useModalContext();
 
   return (
-    <FloatingOverlay lockScroll className={overlay}>
+    <FloatingOverlay lockScroll className={overlay} data-atlantis-modal-branch>
       <motion.div
         aria-hidden="true"
         className={overlayBackground}
@@ -97,6 +97,10 @@ export function ModalOverlay({ children }: PropsWithChildren) {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.2 }}
+        onClick={e => {
+          e.stopPropagation();
+          onRequestClose?.();
+        }}
       />
       {children}
     </FloatingOverlay>

--- a/packages/components/src/Modal/Modal.rebuilt.tsx
+++ b/packages/components/src/Modal/Modal.rebuilt.tsx
@@ -125,7 +125,7 @@ export function ModalContent({ children }: ModalContainerProps) {
                 <FloatingFocusManager
                   context={floatingContext}
                   returnFocus={activatorRef?.current ? activatorRef : true}
-                  initialFocus={0}
+                  order={["floating", "content"]}
                 >
                   <motion.div
                     initial={{ scale: 0.9, opacity: 0 }}

--- a/packages/components/src/Modal/useModal.ts
+++ b/packages/components/src/Modal/useModal.ts
@@ -38,17 +38,6 @@ export function useModal({
     outsidePressEvent: "pointerdown",
     escapeKey: true,
     bubbles: false,
-    // Ignore clicks that originate from a descendant modal branch
-    outsidePress: event => {
-      const target = event.target as Element | null;
-      const branch = target?.closest("[data-atlantis-modal-branch]");
-      const myFloating = floatingRefs.floating?.current as Node | null;
-      // If there is no branch marker, allow dismissal.
-      if (!branch || !myFloating) return true;
-
-      // Only allow if the branch contains our floating (i.e., it's our own branch)
-      return branch.contains(myFloating);
-    },
   });
   const role = useRole(floatingContext);
 

--- a/packages/components/src/Modal/useModal.ts
+++ b/packages/components/src/Modal/useModal.ts
@@ -35,9 +35,20 @@ export function useModal({
   });
 
   const dismiss = useDismiss(floatingContext, {
-    outsidePressEvent: "click",
+    outsidePressEvent: "pointerdown",
     escapeKey: true,
     bubbles: false,
+    // Ignore clicks that originate from a descendant modal branch
+    outsidePress: event => {
+      const target = event.target as Element | null;
+      const branch = target?.closest("[data-atlantis-modal-branch]");
+      const myFloating = floatingRefs.floating?.current as Node | null;
+      // If there is no branch marker, allow dismissal.
+      if (!branch || !myFloating) return true;
+
+      // Only allow if the branch contains our floating (i.e., it's our own branch)
+      return branch.contains(myFloating);
+    },
   });
   const role = useRole(floatingContext);
 

--- a/packages/components/src/Modal/useModal.ts
+++ b/packages/components/src/Modal/useModal.ts
@@ -1,5 +1,4 @@
 import {
-  useClick,
   useDismiss,
   useFloating,
   useFloatingNodeId,
@@ -35,7 +34,6 @@ export function useModal({
     open: open,
   });
 
-  const click = useClick(floatingContext);
   const dismiss = useDismiss(floatingContext, {
     outsidePressEvent: "click",
     escapeKey: true,
@@ -43,7 +41,7 @@ export function useModal({
   });
   const role = useRole(floatingContext);
 
-  const { getFloatingProps } = useInteractions([click, dismiss, role]);
+  const { getFloatingProps } = useInteractions([dismiss, role]);
   const parentId = useFloatingParentNodeId();
 
   return {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

the catalyst for this was the fact that when dismissing nested modals, we were seeing an outline around the modal.

this is intentional, for accessibility purposes. however what is not intentional is that the focus was persisting after the element had visually been removed, resulting in an odd outline shape of where the modal used to be

the reason for this gets pretty complicated, but essentially we are half using floating to manage focus and half doing it ourselves, and we have a layout that floating really doesn't expect.

https://www.codeguage.com/blog/focus-vs-focus-visible-vs-focus-within
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

**useClick**
this is used to open/close the floating element when the reference is clicked
https://floating-ui.com/docs/useClick

however our reference is a button or some other interactive element. possibly we even just show a modal at the end of a flow programmatically. then we put an overlay on top of things. so you're never going to be able to click your reference element again to close it unless your reference is somehow inside your floating element which isn't something we should do.

so that's half of it's use. the other half is opening. however Modal is a controlled component only. we explicitly call things like `setOpen(true)` so having `useClick` is just double dipping. unless you want to have a Modal that cannot be closed AKA no open state, then you must be providing open, and if you must manage setting open to false then you should really set open the same way.

there is an interesting idea here though for how we could use it in the future. offer a controlled and uncontrolled version. if you omit `open` entirely it's uncontrolled and we can make use of `useClick` then.

**modal structure**

previously we were setting the floating element to be a parent of our 2nd overlay. this offers some benefits but also causes a problem with a couple things. floating will treat clicking on the overlay as non clicking outside, so our `useDismiss` with onpress isn't actually ever going to fire. we could remove that if we wanted and use the `onRequestClose` on click exclusively. I'm assuming we'd prefer to keep it so as many things as possible are managed by floating , but that is an option.

because what we've told floating is the "modal" isn't actually the modal, it's a wrapper for the overlay and the modal the `order` and initialfocus get a little weird. it's possible that we could mark more elements as non focusable, but there are other issues we need to solve anyway.

**double overlays**
we have both FloatingOverlay and ModalOverlay, where FloatingOverlay is really just behaving like a layout element. I've merged them together with the animation inside preserving the same visual experience but with a single overlay responsibility element

the onClick in this was not needed since we have `onOpenChange` calling `onRequestClose` anyway. if we let FloatingUI handle more, such as dismissing then it can all use that same code path.

**animation and "modal" styles**
because we had an opacity animation around the element we apply the modal styles to, including the outline, that means that as the opacity approaches 0 the modal is visually gone for us but the focus and outline are still on the DOM element

we just need to separate and slightly reorganize these with a small inversion so they can both happen without interfering with each other

**getFloatingProps**
minor but we were making duplicate tabIndex and role assignments because we weren't using the args to merge things together

**outSidePress**

this is the functionality the other setup handled allowing 2 modals to have distinct closing methods. basically since we weren't using clicking outside previously, instead using the direct `onClick` of the ModalOverlay, the new setup needs something to stop the event from closing 2 open modals if they are nested.

we now use the floatingTree as expected, with almost all of the focus and dismiss functionality in its hands - it is able to reliably manage this as we'd like it to

**initialFocus**
previously we were setting this to the floating element, but keep in mind the floating element was an invisible wrapper for the overlay and modal. if we want to do that, there's a better way via `order` on the floating focus manager
https://floating-ui.com/docs/FloatingFocusManager#order

then combined with the default `initialFocus` it'll move the focus to the content
https://floating-ui.com/docs/FloatingFocusManager#initialfocus

I'm going to leverage the order to preserve the behavior, and if we ever choose to alter it. it's now safe with the animation being distinct from the modal with the outline.
### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

go to the temp web story where I have a nested modal setup with some focus styles, try opening/closing them individually with all the various methods: esc press, click outside, clicking the dismiss button in the header, clicking the buttons saying they'll close them

for the focus visible, this is only triggered when something becomes focused by programmatic or non interactive reasons
https://www.codeguage.com/blog/focus-vs-focus-visible-vs-focus-within

so to test this, use your keyboard to activate the modal button(s) you should see that we now correctly show the outline on the modal this is important for accessibility and probably what we were trying to do all along looking at our style code.

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
