### PR TITLE
fix(components): ComboboxAction visibility logic to properly handle false values

### DIFF
--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.test.tsx
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.test.tsx
@@ -66,4 +66,49 @@ describe("ComboboxAction", () => {
 
     expect(handleClose).toHaveBeenCalledTimes(1);
   });
+
+  describe("visible prop", () => {
+    it("renders the action when visible is not provided", () => {
+      renderAction([{ label: "Action", onClick }]);
+
+      expect(screen.getByText("Action")).toBeInTheDocument();
+    });
+
+    it("renders the action when visible is true", () => {
+      renderAction([{ label: "Action", onClick, visible: true }]);
+
+      expect(screen.getByText("Action")).toBeInTheDocument();
+    });
+
+    it("does not render the action when visible is false", () => {
+      renderAction([{ label: "Action", onClick, visible: false }]);
+
+      expect(screen.queryByText("Action")).not.toBeInTheDocument();
+    });
+
+    it("renders the action when visible function shows action for empty searchValue", () => {
+      renderAction([
+        {
+          label: "Action",
+          onClick,
+          visible: ({ searchValue }: { searchValue: string }) => !searchValue,
+        },
+      ]);
+
+      expect(screen.getByText("Action")).toBeInTheDocument();
+    });
+
+    it("does not render the action when visible function returns false for empty searchValue", () => {
+      renderAction([
+        {
+          label: "Action",
+          onClick,
+          visible: ({ searchValue }: { searchValue: string }) =>
+            Boolean(searchValue),
+        },
+      ]);
+
+      expect(screen.queryByText("Action")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
+++ b/packages/components/src/Combobox/components/ComboboxAction/ComboboxAction.tsx
@@ -7,11 +7,13 @@ import { ComboboxContext } from "../../ComboboxProvider";
 export function ComboboxAction(props: ComboboxActionProps) {
   const { searchValue, handleClose } = useContext(ComboboxContext);
 
-  if (props.visible) {
+  if (props.visible !== undefined) {
     const isVisible =
-      typeof props.visible === "function" && !props.visible({ searchValue });
+      typeof props.visible === "function"
+        ? props.visible({ searchValue })
+        : props.visible;
 
-    if (isVisible || !props.visible) {
+    if (!isVisible) {
       return null;
     }
   }


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
The `ComboboxAction` component's `visible` prop was not working correctly when set to `false`. The visibility logic had a bug where it only checked visibility when `props.visible` was truthy, causing `visible={false}` to be completely ignored and actions to always render.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

Fixed visibility logic in `ComboboxAction.tsx` to properly handle boolean false values
✅ visible={true} → Shows action
✅ visible={false} → Hides action
✅ visible={function} → Shows/hides based on function result
✅ No visible prop → Shows action by default

## Testing

<!-- How to test your changes. -->
- Render `visible={false]` in any story with `Combobox.Action` and see that the action is not visible
- Render `visible={true}` in any story and confirm the action is visible
- Render without visible prop and confirm the action is visible by default
- Test with `visible={() => false}` (function returning false)
- Test with `visible={() => true}` (function returning true)
- Check that the `Dynamic Action` story still works as intended
- Check that the `Keep Open On Click` story still works as intended

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
