### PR TITLE
feat(components): Surface id prop to Heading

### DIFF
--- a/packages/components/src/Heading/Heading.test.tsx
+++ b/packages/components/src/Heading/Heading.test.tsx
@@ -110,6 +110,17 @@ it("renders with maxLines prop", () => {
   `);
 });
 
+it("renders with id prop", () => {
+  const { container } = render(
+    <Heading level={1} id="test-heading">
+      Heading with ID
+    </Heading>,
+  );
+
+  const heading = container.querySelector("h1");
+  expect(heading).toHaveAttribute("id", "test-heading");
+});
+
 describe("UNSAFE_props", () => {
   it("should apply the UNSAFE_className to the element", () => {
     render(

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -6,6 +6,7 @@ import { Typography } from "../Typography";
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface HeadingProps {
+  readonly id?: string;
   /**
    * @default 5
    */
@@ -46,6 +47,7 @@ export interface HeadingProps {
 export type LevelMap = Record<HeadingLevel, TypographyOptions>;
 
 export function Heading({
+  id,
   level = 5,
   children,
   element,
@@ -104,6 +106,7 @@ export function Heading({
 
   return (
     <Typography
+      id={id}
       {...levelMap[level]}
       element={element || levelMap[level].element}
       numberOfLines={maxLineToNumber[maxLines]}

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -6,6 +6,11 @@ import { Typography } from "../Typography";
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface HeadingProps {
+  /**
+   * Adds a unique identifier to the heading.
+   * Useful when the heading needs to be referenced by another element.
+   * Not intended for styling.
+   */
   readonly id?: string;
   /**
    * @default 5

--- a/packages/site/src/content/Heading/Heading.props.json
+++ b/packages/site/src/content/Heading/Heading.props.json
@@ -6,6 +6,19 @@
     "displayName": "Heading",
     "methods": [],
     "props": {
+      "id": {
+        "defaultValue": null,
+        "description": "",
+        "name": "id",
+        "parent": {
+          "fileName": "../components/src/Heading/Heading.tsx",
+          "name": "HeadingProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
       "level": {
         "defaultValue": {
           "value": 5

--- a/packages/site/src/content/Heading/Heading.props.json
+++ b/packages/site/src/content/Heading/Heading.props.json
@@ -8,7 +8,7 @@
     "props": {
       "id": {
         "defaultValue": null,
-        "description": "",
+        "description": "Adds a unique identifier to the heading.\nUseful when the heading needs to be referenced by another element.\nNot intended for styling.",
         "name": "id",
         "parent": {
           "fileName": "../components/src/Heading/Heading.tsx",

--- a/packages/site/src/content/Heading/HeadingNotes.mdx
+++ b/packages/site/src/content/Heading/HeadingNotes.mdx
@@ -40,3 +40,18 @@ breakages.
     ```
   </Tab>
 </Tabs>
+
+### Using the id prop
+
+#### Do:
+
+- ✅ Navigation anchors: Link directly to a specific section of the page (e.g.
+  /docs#getting-started).
+- ✅ Accessible regions: Provide an `id` so page regions (like `<section>`,
+  `<fieldset>`, or form groups) can reference the heading via `aria-labelledby`,
+  ensuring clear announcements without duplication.
+
+#### Don't:
+
+- ❌ CSS styling: Use design system props or `UNSAFE_className`/`UNSAFE_style`
+  instead.


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
Surface `id` prop from `Typography` to `Heading`

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- optional `id` prop to `Heading`
- simple test for new `id` prop


## Testing

<!-- How to test your changes. -->
- go to `Heading` story
- in `docs/components/Heading/Web.stories.tsx` put an `id` in one of the Headings in the story
- verify it shows up in the dom

<img width="553" height="70" alt="Screenshot 2025-09-17 at 11 25 15 PM" src="https://github.com/user-attachments/assets/45ab1050-e0f3-4c1b-bc9e-f616a995d340" />


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
