### PR TITLE
feat(components): Add name to InputFile

### DIFF
--- a/packages/components/src/InputFile/InputFile.test.tsx
+++ b/packages/components/src/InputFile/InputFile.test.tsx
@@ -528,4 +528,13 @@ describe("Content", () => {
       expect(handleUploadStart).toHaveBeenCalled();
     });
   });
+
+  it("passes the name prop to the underlying input element", () => {
+    const { container } = render(
+      <InputFile getUploadParams={fetchUploadParams} name="file-upload" />,
+    );
+
+    const input = container.querySelector("input[type=file]");
+    expect(input).toHaveAttribute("name", "file-upload");
+  });
 });

--- a/packages/components/src/InputFile/InputFile.tsx
+++ b/packages/components/src/InputFile/InputFile.tsx
@@ -113,6 +113,11 @@ interface InputFileProps {
   readonly size?: "small" | "base";
 
   /**
+   * Sets the `name` attribute on the underlying `<input>` element.
+   */
+  readonly name?: string;
+
+  /**
    * Label for the InputFile's button.
    * @default Automatic
    */
@@ -225,6 +230,7 @@ interface CreateAxiosConfigParams extends Omit<UploadParams, "key"> {
 export function InputFile({
   variation = "dropzone",
   size = "base",
+  name,
   buttonLabel: providedButtonLabel,
   allowMultiple = false,
   allowedTypes = "all",
@@ -370,7 +376,11 @@ export function InputFile({
         {...getRootProps({ className: dropZone })}
         tabIndex={variation === "button" ? -1 : 0}
       >
-        <input {...getInputProps()} data-testid="input-file-input" />
+        <input
+          {...getInputProps()}
+          data-testid="input-file-input"
+          name={name}
+        />
         <InputFileContentContext.Provider value={contentContext}>
           {children || defaultContent}
         </InputFileContentContext.Provider>

--- a/packages/site/src/content/InputFile/InputFile.props.json
+++ b/packages/site/src/content/InputFile/InputFile.props.json
@@ -36,6 +36,19 @@
           "name": "\"small\" | \"base\""
         }
       },
+      "name": {
+        "defaultValue": null,
+        "description": "Sets the `name` attribute on the underlying `<input>` element.",
+        "name": "name",
+        "parent": {
+          "fileName": "../components/src/InputFile/InputFile.tsx",
+          "name": "InputFileProps"
+        },
+        "required": false,
+        "type": {
+          "name": "string"
+        }
+      },
       "buttonLabel": {
         "defaultValue": {
           "value": "Automatic"


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

<!-- Why did you do what you did? -->
This PR adds a `name` prop to the `InputFile` component that allows setting the name attribute on the underlying HTML input element. 

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added optional name?: string prop to InputFileProps interface
- Updated InputFile component to accept and apply the name prop to the input element
- Added test coverage to verify the name attribute is properly set
- Updated component documentation with prop description

Usage:
```
<InputFile 
  name="file-upload" 
  getUploadParams={fetchUploadParams} 
/>
```

## Testing

<!-- How to test your changes. -->
- go to any `InputFile` storybook example
- enter a `name` via Controls and inspect the `InputFile` to see the `name` on the `input` element

<img width="1174" height="412" alt="Screenshot 2025-09-18 at 10 55 34 PM" src="https://github.com/user-attachments/assets/726330cf-084b-443a-a7f8-42aa345d8de0" />


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
