### PR TITLE
build(components): Externalize react/jsx-runtime

### DIFF
--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -137,6 +137,7 @@ export default {
   ],
   external: [
     "react",
+    "react/jsx-runtime",
     "react-hook-form",
     "react-router-dom",
     "react-dom",

--- a/packages/hooks/rollup.config.mjs
+++ b/packages/hooks/rollup.config.mjs
@@ -35,6 +35,7 @@ export default {
     "@apollo/client",
     "@jobber/formatters",
     "react",
+    "react/jsx-runtime",
     "react-dom",
     "tslib",
   ],


### PR DESCRIPTION


<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

We’re bundling react/jsx-runtime and not externalizing it. Since jsx-runtime is shipped with React and consumers supply their own React version, we should not be bundling jsx-runtime.

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `react/jsx-runtime` is added to `external` array of rollup config of components and hooks

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Build from master first, then switch to this branch
- comment out `dist ` from `.gitignore` so you can diff against it
- Build from the branch
- Confirm that react/jsx-runtime are not imported from a relative file like `jsx-runtime-cjs.js` or bundled directly in each output file. It should be imported like 
<img width="419" height="125" alt="Screenshot 2025-09-22 at 3 21 52 PM" src="https://github.com/user-attachments/assets/64ffbaa4-e706-409a-86c0-6826f923b2cb" />


Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
