### PR TITLE
fix(components-native): Keep the zindex stable between both regular and mini label styles

### DIFF
--- a/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
+++ b/packages/components-native/src/InputFieldWrapper/InputFieldWrapper.style.ts
@@ -43,6 +43,7 @@ export const useStyles = buildThemedStyles(tokens => {
       right: 0,
       bottom: 0,
       left: 0,
+      zIndex: 1,
     },
 
     miniLabel: {
@@ -53,7 +54,6 @@ export const useStyles = buildThemedStyles(tokens => {
       maxHeight:
         (typographyStyles.defaultSize.lineHeight || 0) +
         tokens["space-smaller"],
-      zIndex: 1,
     },
     // Prevents the miniLabel from cutting off the ClearAction button
     miniLabelShowClearAction: {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

McMobile is working on migrating Jobber Mobile to [React Native's New Architecture](https://reactnative.dev/architecture/landing-page). The new arch brings with it a new rendering engine, [Fabric](https://reactnative.dev/architecture/fabric-renderer). It is mostly a drop in replacement, but in some edge cases behaviours have changed and we need to adapt. 

In this case the `zIndex` in the `miniLabel` style was causing focus to be lost on `InputText` fields when transitioning from 0 characters to 1 on iOS.

https://github.com/user-attachments/assets/e8e7b277-8f9d-4538-9111-d22bd07a67db

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- Moved the `zIndex` to the base `Placeholder` style to keep it stable regardless of whether its in its big or mini form 

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

I tested this change on both the new and old architectures of RN, both behave as expected

#### New Arch

https://github.com/user-attachments/assets/98069347-6288-40bf-be67-740d926fa766

#### Old Arch

https://github.com/user-attachments/assets/9dd53d17-2824-4dc6-8ad8-76f24736edbd

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml) 

GetJobber/jobber-mobile#11113 will have a prerelease with this version integrated. 

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
