### PR TITLE
feat(components-native): Add support for Banner success type 

### DIFF
--- a/docs/components/Banner/Mobile.stories.tsx
+++ b/docs/components/Banner/Mobile.stories.tsx
@@ -14,6 +14,9 @@ export default {
 
 const BasicTemplate: ComponentStory<typeof Banner> = () => (
   <Content>
+    <Banner type="success">
+      <Text>Your import is complete</Text>
+    </Banner>
     <Banner type="notice">
       <Text>Your import is in progress</Text>
     </Banner>

--- a/packages/components-native/src/Banner/Banner.test.tsx
+++ b/packages/components-native/src/Banner/Banner.test.tsx
@@ -35,6 +35,18 @@ describe("Banner", () => {
       expect(getByText("Notice me")).toBeDefined();
       expect(icon.props.children.props.name).toBe("starburst");
     });
+
+    it("renders a success Banner", () => {
+      const { getByText, getByTestId } = render(
+        <Banner type="success">
+          <Text>Your import is complete</Text>
+        </Banner>,
+      );
+
+      const icon = getByTestId("ATL-Banner-Icon");
+      expect(getByText("Your import is complete")).toBeDefined();
+      expect(icon.props.children.props.name).toBe("checkmark");
+    });
   });
 
   describe("Children", () => {

--- a/packages/components-native/src/Banner/Banner.tsx
+++ b/packages/components-native/src/Banner/Banner.tsx
@@ -97,5 +97,7 @@ function getBannerIcon(type: BannerTypes): IconNames | undefined {
       return "help";
     case "error":
       return "alert";
+    case "success":
+      return "checkmark";
   }
 }

--- a/packages/components-native/src/Banner/components/BannerIcon/BannerIcon.style.ts
+++ b/packages/components-native/src/Banner/components/BannerIcon/BannerIcon.style.ts
@@ -15,5 +15,8 @@ export const useStyles = buildThemedStyles(tokens => {
     notice: {
       backgroundColor: tokens["color-informative"],
     },
+    success: {
+      backgroundColor: tokens["color-success"],
+    },
   };
 });

--- a/packages/components-native/src/Banner/types.ts
+++ b/packages/components-native/src/Banner/types.ts
@@ -2,7 +2,7 @@ import type { IconNames } from "@jobber/design";
 import type { ReactElement } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
 
-export type BannerTypes = "error" | "warning" | "notice";
+export type BannerTypes = "error" | "warning" | "notice" | "success";
 
 export interface BannerStyleProps {
   /**

--- a/packages/site/src/content/Banner/Banner.stories.mdx
+++ b/packages/site/src/content/Banner/Banner.stories.mdx
@@ -8,12 +8,12 @@ import { Icon } from "@jobber/components/Icon";
 
 ## Summary
 
-Banners are persistent messages used to communicate important changes, ongoing conditions, or
-system errors. They appear at the top of a screen or near related content and remain visible
-until dismissed or the condition is resolved.
+Banners are persistent messages used to communicate important changes, ongoing
+conditions, or system errors. They appear at the top of a screen or near related
+content and remain visible until dismissed or the condition is resolved.
 
-At Jobber, Banners help service providers (SPs) stay informed about updates that impact their
-business, without unnecessarily interrupting their flow. 
+At Jobber, Banners help service providers (SPs) stay informed about updates that
+impact their business, without unnecessarily interrupting their flow.
 
 ## Anatomy
 
@@ -28,48 +28,55 @@ A Banner typically includes:
 
 ## Behaviour
 
-- Alignment: Banner should align with the left and right of the content it relates to. In a
-modal or page layout, this means aligning with text, inputs, or other components beneath it.
-Use the [Content](/components/Content) to ensure consistent vertical spacing between
-the Banner and adjacent elements.
+- Alignment: Banner should align with the left and right of the content it
+  relates to. In a modal or page layout, this means aligning with text, inputs,
+  or other components beneath it. Use the [Content](/components/Content) to
+  ensure consistent vertical spacing between the Banner and adjacent elements.
 
-- Dismissal: Banners remain visible until they are dismissed or the condition resolves. Include
-a dismiss button only when no further user action is required.
+- Dismissal: Banners remain visible until they are dismissed or the condition
+  resolves. Include a dismiss button only when no further user action is
+  required.
 
-#### Global Banner (Web and Mobile) 
-Use Global banner for system-wide messages that need to persist beyond a specific view or layout.
+#### Global Banner (Web and Mobile)
+
+Use Global banner for system-wide messages that need to persist beyond a
+specific view or layout.
 
 <ul>
- <li>It should be positioned above the top navigation bar</li>
- <li>It should be full-width, flush with the screen edges</li>
+  <li>It should be positioned above the top navigation bar</li>
+  <li>It should be full-width, flush with the screen edges</li>
 </ul>
 
-Note that Global Banner is a separate component (there's a version of it in Jobber and Jobber Online repos). 
+Note that Global Banner is a separate component (there's a version of it in
+Jobber and Jobber Online repos).
 
 ## Variants
 
 Banners come in four types; `success`, `notice`, `warning` and `error`. Each
 type has guidelines for usage:
 
-### Success (Web only)
+### Success
 
 <Canvas>
-  <Banner type="success">You've connected your bank account and can start receiving payouts.</Banner>
+  <Banner type="success">
+    You've connected your bank account and can start receiving payouts.
+  </Banner>
 </Canvas>
 
 Success banners are appropriate when:
 
 <ul>
-  <li>A meaningful user action is complete and feedback is delayed or needs to persist</li>
-  <li>It’s important for SPs to understand that a key change has been applied</li>
+  <li>
+    A meaningful user action is complete and feedback is delayed or needs to
+    persist
+  </li>
+  <li>
+    It’s important for SPs to understand that a key change has been applied
+  </li>
 </ul>
 
 Otherwise, use [Toast](/components/Toast) as the default for success messages.
 Do not use the term "Success" when writing a success banner.
-
-### Success (Mobile)
-
-On mobile, use [Toast](/components/Toast) for a success message.
 
 ### Notice (Info)
 
@@ -113,22 +120,22 @@ blocking or redirecting a workflow.
 #### Warning banner vs. Confirmation modal
 
 On web, you should use [ConfirmationModal](/components/ConfirmationModal) when
-you need to get explicit confirmation from the SP before they complete an
-action that is difficult to reverse.
+you need to get explicit confirmation from the SP before they complete an action
+that is difficult to reverse.
 
-| Use a **Warning Banner** when...                     | Use a **Confirmation Modal** when...                   |
-|------------------------------------------------------|--------------------------------------------------------|
-| You’re communicating a persistent or upcoming state  | You need to confirm intent before proceeding           |
-| The SP needs to act, but isn’t initiating the risk   | The SP is triggering a high-impact change              |
-| The risk persists until resolved (e.g. paused plan)  | The action could disrupt billing, payments, or data    |
-| You want the message visible across sessions         | You want to keep context to current action             |
-| The SP may need time to decide or follow up          | The SP must make a choice before continuing            |
+| Use a **Warning Banner** when...                    | Use a **Confirmation Modal** when...                |
+| --------------------------------------------------- | --------------------------------------------------- |
+| You’re communicating a persistent or upcoming state | You need to confirm intent before proceeding        |
+| The SP needs to act, but isn’t initiating the risk  | The SP is triggering a high-impact change           |
+| The risk persists until resolved (e.g. paused plan) | The action could disrupt billing, payments, or data |
+| You want the message visible across sessions        | You want to keep context to current action          |
+| The SP may need time to decide or follow up         | The SP must make a choice before continuing         |
 
 ### Error message
 
 <Canvas>
   <Banner type="error" icon="alert">
-   Your changes couldn't be saved. Check your connection and try again.
+    Your changes couldn't be saved. Check your connection and try again.
   </Banner>
 </Canvas>
 
@@ -176,61 +183,87 @@ individual input(s).
 
 ## Content guidelines
 
-Banner messages should be concise, clear, and actionable. They inform users of system states,
-requirements, or follow-ups—especially ones that persist until resolved.
+Banner messages should be concise, clear, and actionable. They inform users of
+system states, requirements, or follow-ups—especially ones that persist until
+resolved.
 
-This guidance helps ensure Banners are useful for all users, and particularly for SPs who may be
-multitasking, working on mobile, or managing their business on the go.
+This guidance helps ensure Banners are useful for all users, and particularly
+for SPs who may be multitasking, working on mobile, or managing their business
+on the go.
 
 #### General guidance
+
 <ul>
- <li>Use plain, direct language.</li>
- <li>Limit to 1–2 short sentences (ideally under 200 characters).</li>
- <li>Start with what’s happening, then what’s needed (if anything).</li>
- <li>Be specific—avoid vague phrases like “something went wrong.”</li>
- <li>You can reuse key terms from the message in the CTA, especially to reinforce the action.</li>
- <li>Use full sentences for clarity. Avoid fragments or trailing thoughts.</li>
+  <li>Use plain, direct language.</li>
+  <li>Limit to 1–2 short sentences (ideally under 200 characters).</li>
+  <li>Start with what’s happening, then what’s needed (if anything).</li>
+  <li>Be specific—avoid vague phrases like “something went wrong.”</li>
+  <li>
+    You can reuse key terms from the message in the CTA, especially to reinforce
+    the action.
+  </li>
+  <li>Use full sentences for clarity. Avoid fragments or trailing thoughts.</li>
 </ul>
 
 #### SP specific tips
 
 <ul>
- <li>Prioritize clarity over cleverness. SPs need fast, scannable guidance.</li>
- <li>Avoid backend or system terms (e.g. “system error,” “processing failed”).</li>
- <li>Frame language around outcomes: payouts, scheduling, client experience.</li>
- <li>Keep urgency proportional to actual impact.</li>
+  <li>
+    Prioritize clarity over cleverness. SPs need fast, scannable guidance.
+  </li>
+  <li>
+    Avoid backend or system terms (e.g. “system error,” “processing failed”).
+  </li>
+  <li>
+    Frame language around outcomes: payouts, scheduling, client experience.
+  </li>
+  <li>Keep urgency proportional to actual impact.</li>
 </ul>
 
 #### Language Rules
 
 <ul>
- <li>Avoid exclamation points. They add unnecessary emotion and visual noise.</li>
- <li>Don’t use “Heads up,” “FYI,” or “Just so you know.” These take space but say nothing.</li>
- <li>Get to the point as quickly as possible. Start with the action required if there is one.</li>
- <li>Avoid apologizing in system messages. Focus on clarity and resolution rather than sentiment.</li>
+  <li>
+    Avoid exclamation points. They add unnecessary emotion and visual noise.
+  </li>
+  <li>
+    Don’t use “Heads up,” “FYI,” or “Just so you know.” These take space but say
+    nothing.
+  </li>
+  <li>
+    Get to the point as quickly as possible. Start with the action required if
+    there is one.
+  </li>
+  <li>
+    Avoid apologizing in system messages. Focus on clarity and resolution rather
+    than sentiment.
+  </li>
 </ul>
 
 #### Language examples
 
-| Type    | ✅ Better phrasing                                                                   | ❌ Less clear phrasing                         |
-|---------|--------------------------------------------------------------------------------------|------------------------------------------------|
-| Success | “You've connected your bank account and can start recieving payouts.”                | “Bank connection successful!”                  |
-|         | “Your logo has been added to your invoices.”                                         | “Update saved successfully.”                   |
-| Notice  | “Client reminders now include a booking link.”                                       | “We’ve made updates to reminders.”             |
-|         | “You can now double-book visits on your calendar.”                                   | “New scheduling feature added.”                |
-| Warning | “To receive payouts, you need to add your bank account details.” CTA: “Add bank account”  | “Missing payout details!”                 |
-|         | “Your trial ends in 2 days. Select a plan to keep your account active.” CTA: “Select plan” | “Trial ending—don’t forget to upgrade!”  |
-| Error   | “We couldn’t sync your calendar. Try reconnecting your account.”                     | “Calendar sync failed: error 503.”             |
-|         | “We couldn’t save your changes. Check your connection and try again.”                | “Something went wrong. Please try again later.”|
+| Type    | ✅ Better phrasing                                                                         | ❌ Less clear phrasing                          |
+| ------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| Success | “You've connected your bank account and can start recieving payouts.”                      | “Bank connection successful!”                   |
+|         | “Your logo has been added to your invoices.”                                               | “Update saved successfully.”                    |
+| Notice  | “Client reminders now include a booking link.”                                             | “We’ve made updates to reminders.”              |
+|         | “You can now double-book visits on your calendar.”                                         | “New scheduling feature added.”                 |
+| Warning | “To receive payouts, you need to add your bank account details.” CTA: “Add bank account”   | “Missing payout details!”                       |
+|         | “Your trial ends in 2 days. Select a plan to keep your account active.” CTA: “Select plan” | “Trial ending—don’t forget to upgrade!”         |
+| Error   | “We couldn’t sync your calendar. Try reconnecting your account.”                           | “Calendar sync failed: error 503.”              |
+|         | “We couldn’t save your changes. Check your connection and try again.”                      | “Something went wrong. Please try again later.” |
 
-Use these examples as starting points. Focus on clarity, relevance, and next steps.
-For actions that must be taken, make the language outcome-focused, rather than technical or emotional.
+Use these examples as starting points. Focus on clarity, relevance, and next
+steps. For actions that must be taken, make the language outcome-focused, rather
+than technical or emotional.
 
 ## Dos and Don'ts
 
-In summary, here are some general rules to follow when working with the banner component:
+In summary, here are some general rules to follow when working with the banner
+component:
 
 #### Do:
+
 <ul>
   <li> ✅ Use for persistent and important messages </li>
   <li> ✅ Try to keep the content to under 200 characters </li>
@@ -240,8 +273,12 @@ In summary, here are some general rules to follow when working with the banner c
 </ul>
 
 #### Don't:
+
 <ul>
-  <li> ❌ Use Banners for short-lived success feedback (use the Toast component instead) </li>
+  <li>
+    {" "}
+    ❌ Use Banners for short-lived success feedback (use the Toast component instead){" "}
+  </li>
   <li> ❌ Stack multiple Banners without clear visual hierarchy </li>
   <li> ❌ Add filler intros like “Heads up” or “FYI" </li>
   <li> ❌ Over-explain or apologize; stay focused and practical </li>
@@ -249,9 +286,13 @@ In summary, here are some general rules to follow when working with the banner c
 
 ## Accessibility notes
 
- <ul>
+{" "}
+<ul>
   <li>Banners should be announced to screen readers when rendered</li>
-  <li>Ensure high contrast between background and text—especially for error and warning states</li>
+  <li>
+    Ensure high contrast between background and text—especially for error and
+    warning states
+  </li>
   <li>Avoid positioning mobile Banners over navigation or actionable UI</li>
 </ul>
 
@@ -261,5 +302,6 @@ In summary, here are some general rules to follow when working with the banner c
   use [Toast](/components/Toast) instead.
 - Use [ConfirmationModal](/components/ConfirmationModal) when you need to get
   explicit confirmation from the user before they complete an action.
-- As stated in the Behaviour section, Global Banner is a a separate component 
-  (shared component, a version exists in both the Jobber and Jobber Online repos).
+- As stated in the Behaviour section, Global Banner is a a separate component
+  (shared component, a version exists in both the Jobber and Jobber Online
+  repos).


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

Field Experience team has an instance where a success Banner could make sense in mobile:
- SP is trying to save a form
  - Form has images that are still uploading
  - We inform them via an informative Banner that they need to wait until the images are uploading
  - Once the images are finished uploading, we update the Banner type and message to let them know they can save now

The docs site shows a success variant, but it is not supported in the props type
<img width="706" height="628" alt="image" src="https://github.com/user-attachments/assets/3c277d18-4e96-4958-88b0-afe6e90f2a5d" />

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

`success` type for Banner and relevant styles following [Banner Figma](figma.com/design/avvgu5SkbBvS8lGVePBsqO/Product-Mobile?node-id=15068-19381&t=sdQBxlRiDMrmCgw7-0)

## Testing

Banner type is supported and shows correct icon and colour
<img width="658" height="393" alt="Screenshot 2025-09-29 at 12 28 39 PM" src="https://github.com/user-attachments/assets/a9ccc5dc-eb95-4946-a7a8-8775db92def2" />

<img width="658" height="389" alt="Screenshot 2025-09-29 at 12 30 04 PM" src="https://github.com/user-attachments/assets/f17cb546-bd97-497c-a63c-188fe152db5d" />

Docs updated to reflect both web and mobile usage
<img width="1312" height="775" alt="Screenshot 2025-09-29 at 12 30 32 PM" src="https://github.com/user-attachments/assets/cb701c84-9faf-4f85-8acc-28b0cdaaf908" />

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
