### PR TITLE
fix(components-native): Fix typescript error in components native

### DIFF
--- a/packages/components-native/src/InputText/InputText.tsx
+++ b/packages/components-native/src/InputText/InputText.tsx
@@ -8,10 +8,9 @@ import React, {
   useState,
 } from "react";
 import type {
-  NativeSyntheticEvent,
+  FocusEvent,
   ReturnKeyTypeOptions,
   StyleProp,
-  TextInputFocusEventData,
   TextInputProps,
   TextStyle,
 } from "react-native";
@@ -113,9 +112,7 @@ export interface InputTextProps
    * Callback that is called when the text input is focused
    * @param event
    */
-  readonly onFocus?: (
-    event?: NativeSyntheticEvent<TextInputFocusEventData>,
-  ) => void;
+  readonly onFocus?: (event?: FocusEvent) => void;
 
   /**
    * Callback that is called when the text input is blurred
@@ -423,7 +420,6 @@ function InputTextInternal(
         onFocus={event => {
           _name && setFocusedInput(_name);
           setFocused(true);
-          // @ts-expect-error - TODO: fix this!
           onFocus?.(event);
         }}
         onBlur={() => {

--- a/packages/site/src/content/InputEmail/InputEmail.props-mobile.json
+++ b/packages/site/src/content/InputEmail/InputEmail.props-mobile.json
@@ -224,7 +224,7 @@
         },
         "required": false,
         "type": {
-          "name": "(event?: NativeSyntheticEvent<TextInputFocusEventData>) => void"
+          "name": "(event?: FocusEvent) => void"
         }
       },
       "onBlur": {

--- a/packages/site/src/content/InputNumber/InputNumber.props-mobile.json
+++ b/packages/site/src/content/InputNumber/InputNumber.props-mobile.json
@@ -250,7 +250,7 @@
         },
         "required": false,
         "type": {
-          "name": "(event?: NativeSyntheticEvent<TextInputFocusEventData>) => void"
+          "name": "(event?: FocusEvent) => void"
         }
       },
       "onBlur": {

--- a/packages/site/src/content/InputPassword/InputPassword.props-mobile.json
+++ b/packages/site/src/content/InputPassword/InputPassword.props-mobile.json
@@ -239,7 +239,7 @@
         },
         "required": false,
         "type": {
-          "name": "(event?: NativeSyntheticEvent<TextInputFocusEventData>) => void"
+          "name": "(event?: FocusEvent) => void"
         }
       },
       "onBlur": {

--- a/packages/site/src/content/InputText/InputText.props-mobile.json
+++ b/packages/site/src/content/InputText/InputText.props-mobile.json
@@ -185,7 +185,7 @@
         },
         "required": false,
         "type": {
-          "name": "(event?: NativeSyntheticEvent<TextInputFocusEventData>) => void"
+          "name": "(event?: FocusEvent) => void"
         }
       },
       "onBlur": {


### PR DESCRIPTION
<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

The old `onFocus` callback event type `NativeSyntheticEvent<TextInputFocusEventData>` is deprecated. This PR updates it to `FocusEvent` (which is of type `NativeSyntheticEvent<TargetedEvent>`)
<img width="769" height="128" alt="Screenshot 2025-10-01 at 2 34 24 PM" src="https://github.com/user-attachments/assets/0baa6834-22c0-427c-b032-febb7b3348e8" />


## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- `onFocus` callback is now of type `(event?: FocusEvent) => void`

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

- Ensure CI passes
- Smoke test around `InputText`

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
