### PR TITLE
feat(components): Swap Menu Navigation to Arrow Keys

### DIFF
--- a/packages/components/src/Menu/__tests__/Menu.test.tsx
+++ b/packages/components/src/Menu/__tests__/Menu.test.tsx
@@ -308,7 +308,7 @@ describe("Menu", () => {
   });
 });
 
-it("should focus first action item from the menu when activated", async () => {
+it("should focus first action item from the menu when activated by keyboard", async () => {
   render(
     <Menu
       activator={<Button label="Menu" />}
@@ -329,8 +329,14 @@ it("should focus first action item from the menu when activated", async () => {
       ]}
     />,
   );
+  const trigger = screen.getByRole("button");
 
-  await userEvent.click(screen.getByRole("button"));
-  const firstMenuItem = screen.getAllByRole("menuitem")[0];
-  expect(firstMenuItem).toHaveFocus();
+  trigger.focus();
+
+  await userEvent.keyboard("{Enter}");
+  const allItems = await screen.findAllByRole("menuitem");
+
+  await waitFor(() => {
+    expect(allItems[0]).toHaveFocus();
+  });
 });


### PR DESCRIPTION
… test

<!--
  Atlantis uses Conventional Commits to track versions.
  Pull request titles should follow the following format.

  For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

  <TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

  eg.
    fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
    feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
    feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

  TYPE should consist of:
    - fix: a commit of the type fix patches a bug in your codebase
    - feat: a commit of the type feat introduces a new feature to the codebase
    - docs: documentation only changes
    - build: improvements to the build system
    - refactor: a change that neither fixes a bug nor introduces a feature
    - chore: other changes that don't modify src or test files

  SCOPE should be one of:
    - components
    - components-native
    - deps
    - deps-dev
    - design
    - docx
    - eslint
    - formatters
    - generators
    - hooks
    - stylelint


  If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

  Further Reading:
    - https://www.conventionalcommits.org
    - https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

because the new Menu uses arrow keys like we've always wanted, it would be good for the old version to work the same way. it would be a bit strange, and annoying for them to be different when they look identical visually and conceptually.

also it's something we've wanted as mentione

## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

Menu is now navigated with arrow keys instead of tabs. arrow keys also open the Menu, but do not close them. only ESC, selections, or clicking outside will close.

we no longer use the focus trap because that's for Tabs.

the first item continues to receive focus on open when using keyboard.

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

- <!-- for any bug fixes -->

### Security

- <!-- in case of vulnerabilities -->

## Testing

<!-- How to test your changes. -->

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
