### PR TITLE
fix(components): Fix Autocomplete Single Char Delete Issue

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.pom.ts
+++ b/packages/components/src/Autocomplete/Autocomplete.pom.ts
@@ -1,7 +1,16 @@
 import { screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 
-const user = userEvent.setup();
+let user = userEvent.setup();
+
+/**
+ * Reconfigure the shared userEvent instance used by all POM helpers.
+ * Call with options (e.g. `{ advanceTimers: jest.advanceTimersByTime }`) before
+ * tests that use fake timers, and call with no arguments afterwards to restore defaults.
+ */
+export function configureUser(options?: Parameters<typeof userEvent.setup>[0]) {
+  user = userEvent.setup(options);
+}
 
 /**
  * Open the Autocomplete menu

--- a/packages/components/src/Autocomplete/useAutocomplete.ts
+++ b/packages/components/src/Autocomplete/useAutocomplete.ts
@@ -139,6 +139,9 @@ export function useAutocomplete<
   useEffect(() => {
     // Skip debounce when clearing input for immediate feedback, preventing flickering of last selected item
     if (debounceMs === 0 || inputValue === "") {
+      // Cancel any pending debounced call so a stale intermediate value
+      // (e.g. "P" while deleting "Pipe…") doesn't overwrite the immediate set.
+      debouncedSetter.cancel();
       setDebouncedInputValue(inputValue);
 
       return;


### PR DESCRIPTION
<!--
## Important notes

* Atlantis is a PUBLIC repo. Please avoid sharing internal details/context.
* If you haven't yet, please create a slack thread to ensure UXF is aware of this PR.

## PR title formatting

Atlantis uses Conventional Commits to track versions.
Pull request titles should follow the following format.

For help creating your pull request, you can [use this tool](https://atlantis.getjobber.com/guides/pull-request-title-generator)

<TYPE>(<optional SCOPE>): <conditionally BREAKING CHANGE:> <description>

eg.
fix(SCOPE): stop graphite breaking when too much pressure applied — Patch Release
feat(SCOPE): add 'graphiteWidth' option — (Minor) Feature Release
feat(SCOPE): BREAKING CHANGE: remove graphiteWidth option — (Major) Breaking Release

TYPE should consist of:
- fix: a commit of the type fix patches a bug in your codebase
- feat: a commit of the type feat introduces a new feature to the codebase
- docs: documentation only changes
- build: improvements to the build system
- refactor: a change that neither fixes a bug nor introduces a feature
- chore: other changes that don't modify src or test files

SCOPE should be one of:
- components
- components-native
- deps
- deps-dev
- design
- docx
- eslint
- formatters
- generators
- hooks
- stylelint


If your pull request introduces a breaking change please append `BREAKING CHANGE:` following type / scope.

Further Reading:
- https://www.conventionalcommits.org
- https://github.com/commitizen/conventional-commit-types/blob/master/index.json
-->

## Motivations

while looking into another issue I noticed that Autocomplete was misbehaving when I deleted characters one by one rather than clearing all with a select-all and delete
## Changes

<!-- https://keepachangelog.com/en/1.0.0/ -->

### Added

- <!-- new features -->

### Changed

- <!-- changes in existing functionality -->

### Deprecated

- <!-- soon-to-be removed features -->

### Removed

- <!-- now removed features -->

### Fixed

also cancel the debounced setter so that when we are removing characters, it's both instantaneous and doesn't get stuck in an invalid state where the UI is empty but our debounce sets the filter value to be the last character we had, resulting in a filtered list that doesn't make sense visually

### Security

- <!-- in case of vulnerabilities -->

## Testing

pretty straightforward. with a debounce, the default is fine, type something - then delete the characters with consecutive backspaces. on master you'll see that the list becomes filtered. on this branch, it should correctly return to the default, unfiltered state.

the test I wrote was failing, so you can try that against master - and then see that it now passes!

Changes can be
[tested via Pre-release](https://github.com/GetJobber/atlantis/actions/workflows/trigger-qa-build.yml)

---

[In Atlantis we use Github's built in pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews).
